### PR TITLE
Feature blockchain subscription

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin/
 pkg/
 
 test-chain
+.idea

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -43,6 +43,8 @@ type Blockchain struct {
 	headersCache    *lru.Cache
 	bodiesCache     *lru.Cache
 	difficultyCache *lru.Cache
+
+	config *chain.Params
 }
 
 var ripemd = types.StringToAddress("0000000000000000000000000000000000000003")
@@ -53,6 +55,7 @@ var ripemdFailedTxn = types.StringToHash("0xcf416c536ec1a19ed1fb89e4ec7ffb3cf73a
 func NewBlockchain(db storage.Storage, config *chain.Params, consensus consensus.Consensus, executor *state.Executor) *Blockchain {
 	b := &Blockchain{
 		db:          db,
+		config:      config,
 		consensus:   consensus,
 		sidechainCh: make(chan *types.Header, 10),
 		listeners:   []chan *types.Header{},
@@ -63,6 +66,31 @@ func NewBlockchain(db storage.Storage, config *chain.Params, consensus consensus
 	b.bodiesCache, _ = lru.New(100)
 	b.difficultyCache, _ = lru.New(100)
 	return b
+}
+
+func (b *Blockchain) Config() *chain.Params {
+	return b.config
+}
+
+func (b *Blockchain) CurrentHeader() (*types.Header, bool) {
+	return b.Header()
+}
+
+func (b *Blockchain) GetHeader(hash types.Hash, number uint64) (*types.Header, bool) {
+	return b.GetHeaderByHash(hash)
+}
+
+func (b *Blockchain) GetBlock(hash types.Hash, number uint64, full bool) (*types.Block, bool) {
+	return b.GetBlockByHash(hash, full)
+}
+
+func (b *Blockchain) ReadTransactionBlockHash(hash types.Hash) (types.Hash, bool) {
+	// TODO
+	return types.Hash{}, false
+}
+
+func (b *Blockchain) GetConsensus() consensus.Consensus {
+	return b.consensus
 }
 
 func (b *Blockchain) Executor() *state.Executor {

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -36,7 +36,7 @@ type Blockchain struct {
 
 	genesis types.Hash
 
-	// TODO: Unify in a single event
+	// TODO: Remove and use eventStream
 	sidechainCh chan *types.Header
 	listeners   []chan *types.Header
 
@@ -45,11 +45,10 @@ type Blockchain struct {
 	difficultyCache *lru.Cache
 
 	config *chain.Params
+
+	// event subscriptions
+	stream *eventStream
 }
-
-var ripemd = types.StringToAddress("0000000000000000000000000000000000000003")
-
-var ripemdFailedTxn = types.StringToHash("0xcf416c536ec1a19ed1fb89e4ec7ffb3cf73aa413b3aa9b77d60e4fd81a4296ba")
 
 // NewBlockchain creates a new blockchain object
 func NewBlockchain(db storage.Storage, config *chain.Params, consensus consensus.Consensus, executor *state.Executor) *Blockchain {
@@ -60,6 +59,7 @@ func NewBlockchain(db storage.Storage, config *chain.Params, consensus consensus
 		sidechainCh: make(chan *types.Header, 10),
 		listeners:   []chan *types.Header{},
 		executor:    executor,
+		stream:      &eventStream{},
 	}
 
 	b.headersCache, _ = lru.New(100)
@@ -169,6 +169,12 @@ func (b *Blockchain) WriteHeaderGenesis(header *types.Header) error {
 	if err := b.db.WriteDiff(header.Hash, big.NewInt(1)); err != nil {
 		return err
 	}
+
+	// write the value to the stream
+	evnt := &Event{}
+	evnt.AddNewHeader(header)
+	b.stream.push(evnt)
+
 	return nil
 }
 
@@ -409,9 +415,11 @@ func (b *Blockchain) WriteHeadersWithBodies(headers []*types.Header) error {
 	}
 
 	for _, h := range headers {
-		if err := b.WriteHeader(h); err != nil {
+		evnt := &Event{}
+		if err := b.writeHeaderImpl(evnt, h); err != nil {
 			return err
 		}
+		b.dispatchEvent(evnt)
 	}
 	return nil
 }
@@ -472,10 +480,13 @@ func (b *Blockchain) WriteBlocks(blocks []*types.Block) error {
 		if err := b.processBlock(blocks[indx]); err != nil {
 			return err
 		}
+
 		// Write the header to the chain
-		if err := b.WriteHeader(header); err != nil {
+		evnt := &Event{}
+		if err := b.writeHeaderImpl(evnt, header); err != nil {
 			return err
 		}
+		b.dispatchEvent(evnt)
 	}
 
 	return nil
@@ -609,11 +620,20 @@ func (b *Blockchain) addHeader(header *types.Header) error {
 
 // WriteBlock writes a block of data
 func (b *Blockchain) WriteBlock(block *types.Block) error {
-	return b.WriteHeader(block.Header)
+	evnt := &Event{}
+	if err := b.writeHeaderImpl(evnt, block.Header); err != nil {
+		return err
+	}
+	b.dispatchEvent(evnt)
+	return nil
+}
+
+func (b *Blockchain) dispatchEvent(evnt *Event) {
+	b.stream.push(evnt)
 }
 
 // WriteHeader writes a block and the data, assumes the genesis is already set
-func (b *Blockchain) WriteHeader(header *types.Header) error {
+func (b *Blockchain) writeHeaderImpl(evnt *Event, header *types.Header) error {
 	head, ok := b.Header()
 	if !ok {
 		return fmt.Errorf("header not found")
@@ -622,6 +642,7 @@ func (b *Blockchain) WriteHeader(header *types.Header) error {
 	// Write the data
 	if header.ParentHash == head.Hash {
 		// Fast path to save the new canonical header
+		evnt.AddNewHeader(header)
 		return b.writeCanonicalHeader(header)
 	}
 
@@ -646,11 +667,12 @@ func (b *Blockchain) WriteHeader(header *types.Header) error {
 	incomingDiff := big.NewInt(1).Add(parentDiff, new(big.Int).SetUint64(header.Difficulty))
 	if incomingDiff.Cmp(headerDiff) > 0 {
 		// new block has higher difficulty than us, reorg the chain
-		if err := b.handleReorg(head, header); err != nil {
+		if err := b.handleReorg(evnt, head, header); err != nil {
 			return err
 		}
 	} else {
 		// new block has lower difficulty than us, create a new fork
+		evnt.AddOldHeader(header)
 		if err := b.writeFork(header); err != nil {
 			return err
 		}
@@ -685,7 +707,7 @@ func (b *Blockchain) writeFork(header *types.Header) error {
 	return nil
 }
 
-func (b *Blockchain) handleReorg(oldHeader *types.Header, newHeader *types.Header) error {
+func (b *Blockchain) handleReorg(evnt *Event, oldHeader *types.Header, newHeader *types.Header) error {
 	newChainHead := newHeader
 	oldChainHead := oldHeader
 
@@ -723,6 +745,16 @@ func (b *Blockchain) handleReorg(oldHeader *types.Header, newHeader *types.Heade
 		oldChain = append(oldChain, oldHeader)
 	}
 
+	for _, b := range oldChain[:len(oldChain)-1] {
+		evnt.AddOldHeader(b)
+	}
+	evnt.AddOldHeader(oldChainHead)
+
+	evnt.AddNewHeader(newChainHead)
+	for _, b := range newChain {
+		evnt.AddNewHeader(b)
+	}
+
 	if err := b.writeFork(oldChainHead); err != nil {
 		return fmt.Errorf("failed to write the old header as fork: %v", err)
 	}
@@ -734,7 +766,7 @@ func (b *Blockchain) handleReorg(oldHeader *types.Header, newHeader *types.Heade
 		}
 	}
 
-	// oldChain headers can become now uncles
+	// oldChain headers can become now uncles, REMOVE
 	go func() {
 		for _, i := range oldChain {
 			select {

--- a/blockchain/subscription.go
+++ b/blockchain/subscription.go
@@ -1,0 +1,131 @@
+package blockchain
+
+import (
+	"sync"
+
+	"github.com/0xPolygon/minimal/types"
+)
+
+type Subscription struct {
+	updateCh chan struct{}
+	closeCh  chan struct{}
+	elem     *eventElem
+}
+
+func (s *Subscription) GetEvent() *Event {
+	for {
+		if s.elem.next != nil {
+			s.elem = s.elem.next
+			evnt := s.elem.event
+			return evnt
+		}
+
+		// wait for an update
+		select {
+		case <-s.updateCh:
+			continue
+		case <-s.closeCh:
+			return nil
+		}
+	}
+}
+
+func (s *Subscription) Close() {
+	close(s.closeCh)
+}
+
+/*
+TODO:
+Different types for the event:
+- Sealer
+- Batch Sync
+- Sync
+- Manual?
+Subscribe for specific event types. For example, the sealer might want
+to get notified for head chain Sync events and the sync protocol (whichever it is)
+wants to know about Sealer block events that it has to send to the network.
+*/
+
+type Event struct {
+	// Old chain removed if there was a reorg
+	OldChain []*types.Header
+
+	// New part of the chain (or a fork)
+	NewChain []*types.Header
+}
+
+func (e *Event) AddNewHeader(h *types.Header) {
+	hh := h.Copy()
+	if e.NewChain == nil {
+		e.NewChain = []*types.Header{}
+	}
+	e.NewChain = append(e.NewChain, hh)
+}
+
+func (e *Event) AddOldHeader(h *types.Header) {
+	hh := h.Copy()
+	if e.OldChain == nil {
+		e.OldChain = []*types.Header{}
+	}
+	e.OldChain = append(e.OldChain, hh)
+}
+
+func (b *Blockchain) SubscribeEvents() *Subscription {
+	return b.stream.subscribe()
+}
+
+type eventElem struct {
+	event *Event
+	next  *eventElem
+}
+
+type eventStream struct {
+	lock sync.Mutex
+	head *eventElem
+
+	// channel to notify updates
+	updateCh []chan struct{}
+}
+
+func (e *eventStream) subscribe() *Subscription {
+	head, updateCh := e.Head()
+	s := &Subscription{
+		elem:     head,
+		updateCh: updateCh,
+	}
+	return s
+}
+
+func (e *eventStream) Head() (*eventElem, chan struct{}) {
+	e.lock.Lock()
+	head := e.head
+
+	ch := make(chan struct{})
+	if e.updateCh == nil {
+		e.updateCh = []chan struct{}{}
+	}
+	e.updateCh = append(e.updateCh, ch)
+
+	e.lock.Unlock()
+	return head, ch
+}
+
+func (e *eventStream) push(event *Event) {
+	e.lock.Lock()
+	newHead := &eventElem{
+		event: event,
+	}
+	if e.head != nil {
+		e.head.next = newHead
+	}
+	e.head = newHead
+
+	// notify the subscriptors
+	for _, update := range e.updateCh {
+		select {
+		case update <- struct{}{}:
+		default:
+		}
+	}
+	e.lock.Unlock()
+}

--- a/blockchain/subscription_test.go
+++ b/blockchain/subscription_test.go
@@ -1,0 +1,75 @@
+package blockchain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/0xPolygon/minimal/types"
+)
+
+func TestSubscriptionLinear(t *testing.T) {
+	e := &eventStream{}
+
+	// add a genesis block to eventstream
+	e.push(&Event{
+		NewChain: []*types.Header{
+			{Number: 0},
+		},
+	})
+
+	sub := e.subscribe()
+
+	eventCh := make(chan *Event)
+	go func() {
+		for {
+			task := sub.GetEvent()
+			eventCh <- task
+		}
+	}()
+
+	for i := 1; i < 10; i++ {
+		evnt := &Event{}
+
+		evnt.AddNewHeader(&types.Header{Number: uint64(i)})
+		e.push(evnt)
+
+		// it should fire updateCh
+		select {
+		case evnt := <-eventCh:
+			if evnt.NewChain[0].Number != uint64(i) {
+				t.Fatal("bad")
+			}
+		case <-time.After(1 * time.Second):
+			t.Fatal("timeout")
+		}
+	}
+}
+
+func TestSubscriptionSlowConsumer(t *testing.T) {
+	e := &eventStream{}
+
+	e.push(&Event{
+		NewChain: []*types.Header{
+			{Number: 0},
+		},
+	})
+
+	sub := e.subscribe()
+
+	// send multiple events
+	for i := 1; i < 10; i++ {
+		e.push(&Event{
+			NewChain: []*types.Header{
+				{Number: uint64(i)},
+			},
+		})
+	}
+
+	// consume events now
+	for i := 1; i < 10; i++ {
+		evnt := sub.GetEvent()
+		if evnt.NewChain[0].Number != uint64(i) {
+			t.Fatal("bad")
+		}
+	}
+}

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -20,7 +20,6 @@ import (
 
 	consensusClique "github.com/0xPolygon/minimal/consensus/clique"
 	consensusEthash "github.com/0xPolygon/minimal/consensus/ethash"
-	consensusIBFT "github.com/0xPolygon/minimal/consensus/ibft/backend"
 	consensusPOW "github.com/0xPolygon/minimal/consensus/pow"
 
 	discoveryConsul "github.com/0xPolygon/minimal/network/discovery/consul"
@@ -44,7 +43,7 @@ var consensusBackends = map[string]consensus.Factory{
 	"clique": consensusClique.Factory,
 	"ethash": consensusEthash.Factory,
 	"pow":    consensusPOW.Factory,
-	"ibft":   consensusIBFT.Factory,
+	// "ibft":   consensusIBFT.Factory,
 }
 
 var discoveryBackends = map[string]discovery.Factory{

--- a/consensus/noproof.go
+++ b/consensus/noproof.go
@@ -16,7 +16,7 @@ type NoProof struct {
 }
 
 // VerifyHeader verifies the header is correct
-func (n *NoProof) VerifyHeader(chain ChainReader, header *types.Header, uncle, seal bool) error {
+func (n *NoProof) VerifyHeader(chain ChainReader, parent, header *types.Header, uncle, seal bool) error {
 	return nil
 }
 

--- a/minimal/minimal.go
+++ b/minimal/minimal.go
@@ -258,9 +258,12 @@ func NewMinimal(logger hclog.Logger, config *Config) (*Minimal, error) {
 		m.apis = append(m.apis, api)
 	}
 
-	if istanbul, ok := m.consensus.(consensus.Istanbul); ok {
-		istanbul.Start(m.Blockchain, m.Blockchain.CurrentBlock, m.Blockchain.HasBadBlock)
-	}
+	/*
+		// TODO: FIX
+		if istanbul, ok := m.consensus.(consensus.Istanbul); ok {
+			istanbul.Start(m.Blockchain, m.Blockchain.CurrentBlock, m.Blockchain.HasBadBlock)
+		}
+	*/
 
 	if err := m.server.Schedule(); err != nil {
 		return nil, err

--- a/protocol/ethereum/backend.go
+++ b/protocol/ethereum/backend.go
@@ -337,7 +337,7 @@ func (b *Backend) announceNewBlock(e *Ethereum, p *fastrlp.Parser, v *fastrlp.Va
 	}
 
 	var block types.Block
-	err = block.UnmarshalRLP(p, elems[1])
+	err = block.UnmarshalRLP(p.Raw(elems[1]))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds support for blockchain subscription events. There is a new function "SubscribeEvents" that receives notifications when new blocks are added to the chain including forks and reorgs.

In the future we want to include two new fields to the event: Type and From. Type represents the type of event (Fork, Reorg, Head, BulkSync) and From signals which part of the system generated the block (Sealer, Syncer...)