### PR TITLE
Add Discovery e2e test

### DIFF
--- a/e2e/discovery_test.go
+++ b/e2e/discovery_test.go
@@ -25,6 +25,8 @@ func TestDiscovery(t *testing.T) {
 		}
 	}()
 
+	time.Sleep(5 * time.Second)
+
 	p2pAddrs := make([]string, NumOfNodes)
 	for i, s := range srvs {
 		status, err := s.Operator().GetStatus(context.Background(), &empty.Empty{})

--- a/e2e/discovery_test.go
+++ b/e2e/discovery_test.go
@@ -1,0 +1,78 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/0xPolygon/minimal/e2e/framework"
+	"github.com/0xPolygon/minimal/minimal/proto"
+	"github.com/golang/protobuf/ptypes/empty"
+)
+
+const NumOfNodes = 3
+
+func TestDiscovery(t *testing.T) {
+	srvs := make([]*framework.TestServer, NumOfNodes)
+	for i := range srvs {
+		srvs[i] = framework.NewTestServer(t, func(config *framework.TestServerConfig) {
+		})
+	}
+	defer func() {
+		for _, s := range srvs {
+			s.Stop()
+		}
+	}()
+
+	p2pAddrs := make([]string, NumOfNodes)
+	for i, s := range srvs {
+		status, err := s.Operator().GetStatus(context.Background(), &empty.Empty{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		p2pAddrs[i] = status.P2PAddr
+	}
+
+	for i := 0; i < NumOfNodes-1; i++ {
+		srv, dest := srvs[i], p2pAddrs[i+1]
+		_, err := srv.Operator().PeersAdd(context.Background(), &proto.PeersAddRequest{
+			Id: dest,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	time.Sleep(time.Second * 60)
+
+	for i, s := range srvs {
+		res, err := s.Operator().PeersList(context.Background(), &empty.Empty{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		addrs := make([]string, len(res.Peers))
+		for i, p := range res.Peers {
+			addr, id := p.Addrs[0], p.Id
+			addrs[i] = fmt.Sprintf("%s/p2p/%s", addr, id)
+		}
+
+		for j, target := range p2pAddrs {
+			if i == j {
+				continue
+			}
+
+			found := false
+			for _, addr := range addrs {
+				if addr == target {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("Node %d couldn't find peer %s", i, target)
+			}
+		}
+	}
+}

--- a/minimal/system_service.go
+++ b/minimal/system_service.go
@@ -25,7 +25,7 @@ func (s *systemService) GetStatus(ctx context.Context, req *empty.Empty) (*proto
 			Number: int64(header.Number),
 			Hash:   header.Hash.String(),
 		},
-		// P2PAddr: AddrInfoToString(s.s.AddrInfo()),
+		P2PAddr: network.AddrInfoToString(s.s.network.AddrInfo()),
 	}
 	return status, nil
 }
@@ -77,38 +77,34 @@ func (s *systemService) PeersStatus(ctx context.Context, req *proto.PeersStatusR
 }
 
 func (s *systemService) getPeer(id peer.ID) (*proto.Peer, error) {
-	/*
-		protocols, err := s.s.host.Peerstore().GetProtocols(id)
-		if err != nil {
-			return nil, err
-		}
-		info := s.s.host.Peerstore().PeerInfo(id)
-		addrs := []string{}
-		for _, addr := range info.Addrs {
-			addrs = append(addrs, addr.String())
-		}
-		peer := &proto.Peer{
-			Id:        id.String(),
-			Protocols: protocols,
-			Addrs:     addrs,
-		}
-	*/
-	return nil, nil
+	protocols, err := s.s.network.GetProtocols(id)
+	if err != nil {
+		return nil, err
+	}
+	info := s.s.network.GetPeerInfo(id)
+	addrs := []string{}
+	for _, addr := range info.Addrs {
+		addrs = append(addrs, addr.String())
+	}
+	peer := &proto.Peer{
+		Id:        id.String(),
+		Protocols: protocols,
+		Addrs:     addrs,
+	}
+	return peer, nil
 }
 
 func (s *systemService) PeersList(ctx context.Context, req *empty.Empty) (*proto.PeersListResponse, error) {
 	resp := &proto.PeersListResponse{
 		Peers: []*proto.Peer{},
 	}
-	/*
-		ids := s.s.host.Peerstore().Peers()
-		for _, id := range ids {
-			peer, err := s.getPeer(id)
-			if err != nil {
-				return nil, err
-			}
-			resp.Peers = append(resp.Peers, peer)
+	peers := s.s.network.Peers()
+	for _, p := range peers {
+		peer, err := s.getPeer(p.Info.ID)
+		if err != nil {
+			return nil, err
 		}
-	*/
+		resp.Peers = append(resp.Peers, peer)
+	}
 	return resp, nil
 }

--- a/network/server.go
+++ b/network/server.go
@@ -216,8 +216,27 @@ func (s *Server) numPeers() int64 {
 	return int64(len(s.peers))
 }
 
+func (s *Server) Peers() []*Peer {
+	s.peersLock.Lock()
+	defer s.peersLock.Unlock()
+
+	peers := make([]*Peer, 0, len(s.peers))
+	for _, p := range s.peers {
+		peers = append(peers, p)
+	}
+	return peers
+}
+
 func (s *Server) isConnected(peerID peer.ID) bool {
 	return s.host.Network().Connectedness(peerID) == network.Connected
+}
+
+func (s *Server) GetProtocols(peerID peer.ID) ([]string, error) {
+	return s.host.Peerstore().GetProtocols(peerID)
+}
+
+func (s *Server) GetPeerInfo(peerID peer.ID) peer.AddrInfo {
+	return s.host.Peerstore().PeerInfo(peerID)
 }
 
 func (s *Server) addPeer(id peer.ID) {


### PR DESCRIPTION
# Description

This PR adds e2e test for network discovery, described in https://github.com/0xPolygon/polygon-sdk/issues/23
And this PR fixes the codes commented out in `systemService` so that can get ID and peer list in test.
* Start a fixed number of servers
* Add next peer to server (e.g. 1 -> 2, 2 -> 3, 3 -> 4)
* Wait for a while
* Test all nodes know each other (whether all nodes contains in peer list in each server)

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
