### PR TITLE
Add eth_getTransaction and fix eth_getTransactionReceipt

### DIFF
--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -82,6 +82,7 @@ func (d *Dev) do(parent *types.Header) error {
 		return err
 	}
 
+	txns := []*types.Transaction{}
 	for {
 		txn, retFn := d.txpool.Pop()
 		if txn == nil {
@@ -94,6 +95,7 @@ func (d *Dev) do(parent *types.Header) error {
 			retFn()
 			break
 		}
+		txns = append(txns, txn)
 	}
 
 	_, root := transition.Commit()
@@ -102,7 +104,7 @@ func (d *Dev) do(parent *types.Header) error {
 	header.GasUsed = transition.TotalGas()
 
 	// header hash is computed inside buildBlock
-	block := consensus.BuildBlock(header, nil, transition.Receipts())
+	block := consensus.BuildBlock(header, txns, transition.Receipts())
 
 	if err := d.blockchain.WriteBlocks([]*types.Block{block}); err != nil {
 		panic(err)

--- a/jsonrpc/blockchain.go
+++ b/jsonrpc/blockchain.go
@@ -22,8 +22,11 @@ type blockchainInterface interface {
 	// Header returns the current header of the chain (genesis if empty)
 	Header() *types.Header
 
-	// GetReceiptsByHash returns the receipts for a hash
+	// GetReceiptsByHash returns the receipts for a block hash
 	GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error)
+
+	// ReadTxLookup returns a block hash in which a given txn was mined
+	ReadTxLookup(txnHash types.Hash) (types.Hash, bool)
 
 	// SubscribeEvents subscribes for chain head events
 	SubscribeEvents() blockchain.Subscription
@@ -51,6 +54,10 @@ type nullBlockchainInterface struct {
 
 func (b *nullBlockchainInterface) Header() *types.Header {
 	return nil
+}
+
+func (b *nullBlockchainInterface) ReadTxLookup(txnHash types.Hash) (types.Hash, bool) {
+	return types.Hash{}, false
 }
 
 func (b *nullBlockchainInterface) GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error) {

--- a/txpool/operator.go
+++ b/txpool/operator.go
@@ -2,7 +2,6 @@ package txpool
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/0xPolygon/minimal/txpool/proto"
 	"github.com/0xPolygon/minimal/types"
@@ -29,11 +28,6 @@ func (t *TxPool) AddTxn(ctx context.Context, raw *proto.AddTxnReq) (*empty.Empty
 		}
 		txn.From = from
 	}
-
-	fmt.Println("XXX")
-	fmt.Println(txn.From)
-	fmt.Println(txn.To)
-
 	if err := t.AddTx(txn); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

The Transactions are stored as part of the body of the block as:
<body_namespace>_\<block hash> : <txn1, txn2, txn3...>

Similarly, the receipts are stored as:
<receipts_namespace>_\<block hash>: <receipt1, receipt2, receipt3...>

However, note that with this schema it is hard to:
1. Query for a transaction by his hash.
2. Figure out the receipt for a transaction.

Thus, this PR includes a new transaction index of the form:
<tx_index_namespace>_\<txn hash>: \<block hash>

Now, the aforementioned queries are possible.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
