### PR TITLE
Add help output for grpc-address flag when using operator commands.

### DIFF
--- a/command/ibft_candidates.go
+++ b/command/ibft_candidates.go
@@ -20,6 +20,8 @@ func (p *IbftCandidates) GetHelperText() string {
 
 // Help implements the cli.IbftCandidates interface
 func (p *IbftCandidates) Help() string {
+	p.Meta.DefineFlags()
+
 	usage := "ibft candidates"
 
 	return p.GenerateHelp(p.Synopsis(), usage)

--- a/command/ibft_init.go
+++ b/command/ibft_init.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"flag"
 	"fmt"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"path/filepath"
@@ -35,7 +36,7 @@ func (p *IbftInit) Synopsis() string {
 
 // Run implements the cli.IbftInit interface
 func (p *IbftInit) Run(args []string) int {
-	flags := p.FlagSet("ibft init")
+	flags := flag.NewFlagSet("ibft init", flag.ContinueOnError)
 	if err := flags.Parse(args); err != nil {
 		p.UI.Error(err.Error())
 		return 1

--- a/command/ibft_propose.go
+++ b/command/ibft_propose.go
@@ -20,11 +20,6 @@ func (p *IbftPropose) DefineFlags() {
 		p.flagMap = make(map[string]FlagDescriptor)
 	}
 
-	if len(p.flagMap) > 0 {
-		// No need to redefine the flags again
-		return
-	}
-
 	p.flagMap["add"] = FlagDescriptor{
 		description: "Proposes a new validator to be added to the validator set",
 		arguments: []string{
@@ -49,9 +44,10 @@ func (p *IbftPropose) GetHelperText() string {
 
 // Help implements the cli.IbftPropose interface
 func (p *IbftPropose) Help() string {
+	p.Meta.DefineFlags()
 	p.DefineFlags()
-	usage := "ibft propose [--add ETH_ADDRESS]\n\t"
-	usage += "ibft propose [--del ETH_ADDRESS]"
+
+	usage := "ibft propose [--add ETH_ADDRESS | --del ETH_ADDRESS]"
 
 	return p.GenerateHelp(p.Synopsis(), usage)
 }

--- a/command/ibft_snapshot.go
+++ b/command/ibft_snapshot.go
@@ -20,11 +20,6 @@ func (p *IbftSnapshot) DefineFlags() {
 		p.flagMap = make(map[string]FlagDescriptor)
 	}
 
-	if len(p.flagMap) > 0 {
-		// No need to redefine the flags again
-		return
-	}
-
 	p.flagMap["number"] = FlagDescriptor{
 		description: "The block height (number) for the snapshot",
 		arguments: []string{
@@ -41,7 +36,9 @@ func (p *IbftSnapshot) GetHelperText() string {
 
 // Help implements the cli.IbftSnapshot interface
 func (p *IbftSnapshot) Help() string {
+	p.Meta.DefineFlags()
 	p.DefineFlags()
+
 	usage := "ibft snapshot [--number BLOCK_NUMBER]"
 
 	return p.GenerateHelp(p.Synopsis(), usage)

--- a/command/ibft_status.go
+++ b/command/ibft_status.go
@@ -19,6 +19,8 @@ func (p *IbftStatus) GetHelperText() string {
 
 // Help implements the cli.IbftStatus interface
 func (p *IbftStatus) Help() string {
+	p.Meta.DefineFlags()
+
 	usage := "ibft status"
 
 	return p.GenerateHelp(p.Synopsis(), usage)
@@ -32,10 +34,6 @@ func (p *IbftStatus) Synopsis() string {
 // Run implements the cli.IbftStatus interface
 func (p *IbftStatus) Run(args []string) int {
 	flags := p.FlagSet("ibft propose")
-
-	var add, del bool
-	flags.BoolVar(&add, "add", false, "add")
-	flags.BoolVar(&del, "del", false, "del")
 
 	if err := flags.Parse(args); err != nil {
 		p.UI.Error(err.Error())

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -23,6 +23,8 @@ func (m *MonitorCommand) GetHelperText() string {
 
 // Help implements the cli.Command interface
 func (m *MonitorCommand) Help() string {
+	m.Meta.DefineFlags()
+
 	usage := "monitor"
 
 	return m.GenerateHelp(m.Synopsis(), usage)

--- a/command/peers_add.go
+++ b/command/peers_add.go
@@ -18,6 +18,8 @@ func (p *PeersAdd) GetHelperText() string {
 
 // Help implements the cli.PeersAdd interface
 func (p *PeersAdd) Help() string {
+	p.Meta.DefineFlags()
+
 	usage := "peers add PEER_ADDRESS"
 
 	return p.GenerateHelp(p.Synopsis(), usage)

--- a/command/peers_list.go
+++ b/command/peers_list.go
@@ -20,6 +20,8 @@ func (p *PeersList) GetHelperText() string {
 
 // Help implements the cli.PeersList interface
 func (p *PeersList) Help() string {
+	p.Meta.DefineFlags()
+
 	usage := "peers list"
 
 	return p.GenerateHelp(p.Synopsis(), usage)

--- a/command/peers_status.go
+++ b/command/peers_status.go
@@ -19,6 +19,8 @@ func (p *PeersStatus) GetHelperText() string {
 
 // Help implements the cli.PeersStatus interface
 func (p *PeersStatus) Help() string {
+	p.Meta.DefineFlags()
+
 	usage := "peers status PEER_ID"
 
 	return p.GenerateHelp(p.Synopsis(), usage)

--- a/command/status.go
+++ b/command/status.go
@@ -20,6 +20,8 @@ func (c *StatusCommand) GetHelperText() string {
 
 // Help implements the cli.Command interface
 func (c *StatusCommand) Help() string {
+	c.Meta.DefineFlags()
+
 	usage := "status"
 
 	return c.GenerateHelp(c.Synopsis(), usage)

--- a/command/txpool_add.go
+++ b/command/txpool_add.go
@@ -22,11 +22,6 @@ func (p *TxPoolAdd) DefineFlags() {
 		p.flagMap = make(map[string]FlagDescriptor)
 	}
 
-	if len(p.flagMap) > 0 {
-		// No need to redefine the flags again
-		return
-	}
-
 	p.flagMap["from"] = FlagDescriptor{
 		description: "The sender address",
 		arguments: []string{
@@ -83,8 +78,11 @@ func (p *TxPoolAdd) GetHelperText() string {
 
 // Help implements the cli.TxPoolAdd interface
 func (p *TxPoolAdd) Help() string {
+	p.Meta.DefineFlags()
 	p.DefineFlags()
-	usage := "txpool add --from ADDRESS --to ADDRESS --value VALUE\n\t--gasPrice GASPRICE [--gasLimit LIMIT] [--nonce NONCE]"
+
+	usage := `txpool add --from ADDRESS --to ADDRESS --value VALUE
+	--gasPrice GASPRICE [--gasLimit LIMIT] [--nonce NONCE]`
 
 	return p.GenerateHelp(p.Synopsis(), usage)
 }

--- a/command/txpool_status.go
+++ b/command/txpool_status.go
@@ -20,6 +20,8 @@ func (p *TxPoolStatus) GetHelperText() string {
 
 // Help implements the cli.TxPoolStatus interface
 func (p *TxPoolStatus) Help() string {
+	p.Meta.DefineFlags()
+
 	usage := "txpool status"
 
 	return p.GenerateHelp(p.Synopsis(), usage)


### PR DESCRIPTION
# Description

Multiple operator commands had the flag for gRPC address, it just wasn't added to the `--help` output.
It had the default value of `127.0.0.1:8545` if not set. Since users didn't know they can set it, they would call the commands without it, resulting in the commands failing, since their gRPC was running on a different port if they followed ibft guide.

This PR enables the use of "global flags" - for now only `--grpc-address`.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

PR to modify SDK docs: [link](https://github.com/0xPolygon/polygon-sdk-docs/pull/5)
