### PR TITLE
Add missing fields to result of eth_getTransactionByHash

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -100,10 +100,9 @@ func (e *Eth) GetTransactionByHash(hash types.Hash) (interface{}, error) {
 		// block receipts not found
 		return nil, nil
 	}
-	for _, txn := range block.Transactions {
+	for idx, txn := range block.Transactions {
 		if txn.Hash == hash {
-			// todo: need to add blockHash, blockNumber, and transactionIndex
-			return toTransaction(txn), nil
+			return toTransaction(txn, block, idx), nil
 		}
 	}
 	// txn not found (this should not happen)

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -10,32 +10,38 @@ import (
 )
 
 type transaction struct {
-	Nonce    argUint64      `json:"nonce"`
-	GasPrice argBig         `json:"gasPrice"`
-	Gas      argUint64      `json:"gas"`
-	To       *types.Address `json:"to"`
-	Value    argBig         `json:"value"`
-	Input    argBytes       `json:"input"`
-	V        argByte        `json:"v"`
-	R        argBytes       `json:"r"`
-	S        argBytes       `json:"s"`
-	Hash     types.Hash     `json:"hash"`
-	From     types.Address  `json:"from"`
+	Nonce       argUint64      `json:"nonce"`
+	GasPrice    argBig         `json:"gasPrice"`
+	Gas         argUint64      `json:"gas"`
+	To          *types.Address `json:"to"`
+	Value       argBig         `json:"value"`
+	Input       argBytes       `json:"input"`
+	V           argByte        `json:"v"`
+	R           argBytes       `json:"r"`
+	S           argBytes       `json:"s"`
+	Hash        types.Hash     `json:"hash"`
+	From        types.Address  `json:"from"`
+	BlockHash   types.Hash     `json:"blockHash"`
+	BlockNumber argUint64      `json:"blockNumber"`
+	TxIndex     argUint64      `json:"transactionIndex"`
 }
 
-func toTransaction(t *types.Transaction) *transaction {
+func toTransaction(t *types.Transaction, b *types.Block, txIndex int) *transaction {
 	return &transaction{
-		Nonce:    argUint64(t.Nonce),
-		GasPrice: argBig(*t.GasPrice),
-		Gas:      argUint64(t.Gas),
-		To:       t.To,
-		Value:    argBig(*t.Value),
-		Input:    argBytes(t.Input),
-		V:        argByte(t.V),
-		R:        argBytes(t.R),
-		S:        argBytes(t.S),
-		Hash:     t.Hash,
-		From:     t.From,
+		Nonce:       argUint64(t.Nonce),
+		GasPrice:    argBig(*t.GasPrice),
+		Gas:         argUint64(t.Gas),
+		To:          t.To,
+		Value:       argBig(*t.Value),
+		Input:       argBytes(t.Input),
+		V:           argByte(t.V),
+		R:           argBytes(t.R),
+		S:           argBytes(t.S),
+		Hash:        t.Hash,
+		From:        t.From,
+		BlockHash:   b.Hash(),
+		BlockNumber: argUint64(b.Number()),
+		TxIndex:     argUint64(txIndex),
 	}
 }
 
@@ -80,8 +86,8 @@ func toBlock(b *types.Block) *block {
 		Hash:         h.Hash,
 		Transactions: []*transaction{},
 	}
-	for _, txn := range b.Transactions {
-		res.Transactions = append(res.Transactions, toTransaction(txn))
+	for idx, txn := range b.Transactions {
+		res.Transactions = append(res.Transactions, toTransaction(txn, b, idx))
 	}
 	return res
 }


### PR DESCRIPTION
# Description

This PR adds some fields to result of `eth_getTransactionByHash` in jsonrpc.
Fixes issue that `GetTransactionByHash` in `umbracle/go-web3` throws error due to missing fields in response of jsonrpc request.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

Add new fields `blockHash`, `blockNumber`, `transactionIndex` in transaction object of following json_rpc request
* eth_getTransactionByHash
* eth_getBlockByNumber (only when 2nd args is true)
* eth_getBlockByHash (only when 2nd args is true)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it

Official document for eth_getTransactionByHash
https://eth.wiki/json-rpc/API#eth_gettransactionbyhash
