### PR TITLE
Fix crash issue on moving to new epoch due to no snapshot in memory

### DIFF
--- a/consensus/ibft/snapshot.go
+++ b/consensus/ibft/snapshot.go
@@ -128,10 +128,6 @@ func (i *Ibft) processHeaders(headers []*types.Header) error {
 
 	// saveSnap is a callback function for saving the passed in header to the snapshot store
 	saveSnap := func(h *types.Header) error {
-		if snap.Equal(parentSnap) {
-			return nil
-		}
-
 		snap.Number = h.Number
 		snap.Hash = h.Hash.String()
 
@@ -242,8 +238,10 @@ func (i *Ibft) processHeaders(headers []*types.Header) error {
 			})
 		}
 
-		if err := saveSnap(h); err != nil {
-			return nil
+		if !snap.Equal(parentSnap) {
+			if err := saveSnap(h); err != nil {
+				return nil
+			}
 		}
 	}
 

--- a/consensus/ibft/snapshot_test.go
+++ b/consensus/ibft/snapshot_test.go
@@ -123,12 +123,13 @@ func TestSnapshot_ProcessHeaders(t *testing.T) {
 	}
 
 	var cases = []struct {
+		name       string
 		epoch      uint64
 		validators []string
 		headers    []mockHeader
 	}{
 		{
-			// single validator casts no vote
+			name: "single validator casts no vote",
 			validators: []string{
 				"A",
 			},
@@ -142,7 +143,7 @@ func TestSnapshot_ProcessHeaders(t *testing.T) {
 			},
 		},
 		{
-			// single validator votes to add two peers
+			name:       "single validator votes to add two peers",
 			validators: []string{"A"},
 			headers: []mockHeader{
 				{
@@ -170,7 +171,7 @@ func TestSnapshot_ProcessHeaders(t *testing.T) {
 			},
 		},
 		{
-			// single validator dropping himself
+			name:       "single validator dropping himself",
 			validators: []string{"A"},
 			headers: []mockHeader{
 				{
@@ -182,7 +183,7 @@ func TestSnapshot_ProcessHeaders(t *testing.T) {
 			},
 		},
 		{
-			// two validators, dropping requires consensus
+			name:       "two validators, dropping requires consensus",
 			validators: []string{"A", "B"},
 			headers: []mockHeader{
 				{
@@ -203,7 +204,7 @@ func TestSnapshot_ProcessHeaders(t *testing.T) {
 			},
 		},
 		{
-			// adding votes are only counted once per validator and target
+			name:       "adding votes are only counted once per validator and target",
 			validators: []string{"A", "B"},
 			headers: []mockHeader{
 				{
@@ -227,7 +228,7 @@ func TestSnapshot_ProcessHeaders(t *testing.T) {
 			},
 		},
 		{
-			// delete votes are only counted once per validator and target
+			name:       "delete votes are only counted once per validator and target",
 			validators: []string{"A", "B", "C"},
 			headers: []mockHeader{
 				{
@@ -251,7 +252,7 @@ func TestSnapshot_ProcessHeaders(t *testing.T) {
 			},
 		},
 		{
-			// multiple (add, delete) votes are possible
+			name:       "multiple (add, delete) votes are possible",
 			validators: []string{"A", "B", "C"},
 			headers: []mockHeader{
 				{
@@ -287,7 +288,7 @@ func TestSnapshot_ProcessHeaders(t *testing.T) {
 			},
 		},
 		{
-			// votes from desauthorized nodes are discarded inmediately
+			name:       "votes from deauthorized nodes are discarded immediately",
 			validators: []string{"A", "B", "C"},
 			headers: []mockHeader{
 				// validator C makes two votes (add and delete)
@@ -333,7 +334,7 @@ func TestSnapshot_ProcessHeaders(t *testing.T) {
 			},
 		},
 		{
-			// epoch transition resets all votes
+			name:       "epoch transition resets all votes",
 			epoch:      3,
 			validators: []string{"A", "B", "C"},
 			headers: []mockHeader{
@@ -369,7 +370,7 @@ func TestSnapshot_ProcessHeaders(t *testing.T) {
 			},
 		},
 		{
-			// epoch transition creates new snapshot
+			name:       "epoch transition creates new snapshot",
 			epoch:      1,
 			validators: []string{"A", "B", "C"},
 			headers: []mockHeader{
@@ -401,7 +402,7 @@ func TestSnapshot_ProcessHeaders(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		t.Run("", func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			epoch := c.epoch
 			if epoch == 0 {
 				epoch = 1000

--- a/consensus/ibft/snapshot_test.go
+++ b/consensus/ibft/snapshot_test.go
@@ -368,6 +368,37 @@ func TestSnapshot_ProcessHeaders(t *testing.T) {
 				},
 			},
 		},
+		{
+			// epoch transition creates new snapshot
+			epoch:      1,
+			validators: []string{"A", "B", "C"},
+			headers: []mockHeader{
+				{
+					// block 1
+					action: mine("A"),
+					snapshot: &mockSnapshot{
+						validators: []string{"A", "B", "C"},
+						votes:      []mockVote{},
+					},
+				},
+				{
+					// block 2
+					action: mine("B"),
+					snapshot: &mockSnapshot{
+						validators: []string{"A", "B", "C"},
+						votes:      []mockVote{},
+					},
+				},
+				{
+					// block 3
+					action: mine("C"),
+					snapshot: &mockSnapshot{
+						validators: []string{"A", "B", "C"},
+						votes:      []mockVote{},
+					},
+				},
+			},
+		},
 	}
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
@@ -432,6 +463,7 @@ func TestSnapshot_ProcessHeaders(t *testing.T) {
 				// get latest snapshot
 				snap, err := ibft.getSnapshot(header.Number)
 				assert.NoError(t, err)
+				assert.NotNil(t, snap)
 
 				result := c.headers[indx].snapshot
 				if result != nil {


### PR DESCRIPTION
# Description

This PR fixes the issue to crash process due to no snapshot in memory.

## Issue Description

The issue happens when the sequence reaches `3*EpochSize` if validators and votes are not changed from beginning. It causes panic with following message. (I changed EpochSize to 10 for debug)

```shell
2021-06-11T15:33:46.024+0900 [INFO]  polygon.consensus.ibft.acceptState: Accept state: sequence=31
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x18b38f2]

goroutine 152 [running]:
github.com/0xPolygon/minimal/consensus/ibft.(*Ibft).runAcceptState(0xc0008a4750)
        /Users/kourin/go/src/github.com/0xPolygon/polygon-sdk/consensus/ibft/ibft.go:449 +0x332
github.com/0xPolygon/minimal/consensus/ibft.(*Ibft).runCycle(0xc0008a4750)
        /Users/kourin/go/src/github.com/0xPolygon/polygon-sdk/consensus/ibft/ibft.go:247 +0x4d
github.com/0xPolygon/minimal/consensus/ibft.(*Ibft).start(0xc0008a4750)
        /Users/kourin/go/src/github.com/0xPolygon/polygon-sdk/consensus/ibft/ibft.go:233 +0x11d
created by github.com/0xPolygon/minimal/consensus/ibft.(*Ibft).Start
        /Users/kourin/go/src/github.com/0xPolygon/polygon-sdk/consensus/ibft/ibft.go:128 +0x89
exit status 2
make: *** [run] Error 1
```

The reason is that node deletes old snapshots from memory every epoch but will reuse same snapshot if snapshot doesn't change.

Snapshot is the data of validators and votes at a certain `sequence`. IBFT consensus has a list of snapshot, and votes are reset when move to new epoch. (So epoch size means the period when votes are available) 

Snapshot is appended to the list when snapshot change (validators or votes change) or new epoch. But snapshot is not appended to the list if it equals to previous snapshot. Snapshots with lower number than `(current epoch - 2)*(epoch size)` are removed from the list on new epoch.

Let's say validators and votes are not changed from beginning. In this case, snapshot list has only a snapshot with 0 number (genesis one). No new snapshot is added to the list because new snapshot equals to previous one. When the sequence reaches (epoch size)*3, all snapshots with lower number than (epoch size) is removed from the list. As a result, the list doesn't have any snapshot and crashes from next sequence.

## Change of this PR

This PR fixes this issue and makes sure snapshot is created on new epoch. For that, I moved conditional branch for equality of snapshot.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
