### PR TITLE
Fix GetFilterChanges doesn't return every log from NewFilter

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -574,7 +574,6 @@ func (b *Blockchain) WriteBlocks(blocks []*types.Block) error {
 		if err := b.writeHeaderImpl(evnt, header); err != nil {
 			return err
 		}
-		b.dispatchEvent(evnt)
 
 		// write the receipts, do it only after the header has been written.
 		// Otherwise, a client might ask for a header once the receipt is valid
@@ -582,6 +581,8 @@ func (b *Blockchain) WriteBlocks(blocks []*types.Block) error {
 		if err := b.db.WriteReceipts(block.Hash(), res.Receipts); err != nil {
 			return err
 		}
+
+		b.dispatchEvent(evnt)
 
 		// Update the average gas price
 		b.UpdateGasPriceAvg(new(big.Int).SetUint64(header.GasUsed))

--- a/e2e/logs_test.go
+++ b/e2e/logs_test.go
@@ -40,8 +40,7 @@ func TestNewFilter_Logs(t *testing.T) {
 
 	res, err := client.Eth().GetFilterChanges(id)
 	assert.NoError(t, err)
-	// todo: need to check implementation because there is a possibility of losing some logs
-	assert.GreaterOrEqual(t, len(res), numCalls/2)
+	assert.Equal(t, len(res), numCalls)
 }
 
 func TestNewFilter_Block(t *testing.T) {


### PR DESCRIPTION
# Description

This PR fixes the issue of missing some logs in response of `eth_getFilterChanges`.
Number of logs doesn't equal to the number of transactions which are sent after call `eth_newFilter` before call `eth_getFilterChanges`

This issue caused by wrong order of some codes.
Following codes are a part of codes in `WriteBlocks` of `Blockchain` in blockchain/blockchain.go
https://github.com/0xPolygon/polygon-sdk/blob/4df9810cb85fcf69b5f777a33eb5fd1f8c6c9224/blockchain/blockchain.go#L577-L584

`dispatchEvent` dispatches an event to notify that new header is included and `WriteReceipts` writes receipts of transactions in block into storage (leveldb or memory).
`FilterManager` defined in jsonrpc/filter_manager.go subscribes to the event and get receipts for transaction by `GetReceiptsByHash` and append to each filter. So there's a possibility that FilterManager loads receipts before saving receipts in current code.

This PR swaps the order of these two call. `WriteReceipts` is used only in this method and `GetReceiptsByHash` is called from FilterManager, jsonrpc, and grpc. So perhaps there is no side effect without issue fix.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
