### PR TITLE
IBFT proposer reward not assigned to a block proposer

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -47,10 +47,11 @@ type Blockchain struct {
 
 type Verifier interface {
 	VerifyHeader(parent, header *types.Header) error
+	GetBlockCreator(header *types.Header) (types.Address, error)
 }
 
 type Executor interface {
-	ProcessBlock(parentRoot types.Hash, block *types.Block) (*state.BlockResult, error)
+	ProcessBlock(parentRoot types.Hash, block *types.Block, blockCreator types.Address) (*state.BlockResult, error)
 }
 
 // UpdateGasPriceAvg Updates the rolling average value of the gas price
@@ -168,6 +169,10 @@ func (b *Blockchain) ComputeGenesis() error {
 	b.logger.Info("genesis", "hash", b.config.Genesis.Hash())
 
 	return nil
+}
+
+func (b *Blockchain) GetConsensus() Verifier {
+	return b.consensus
 }
 
 // SetConsensus sets the consensus
@@ -629,7 +634,12 @@ func (b *Blockchain) processBlock(block *types.Block) (*state.BlockResult, error
 		return nil, fmt.Errorf("unknown ancestor")
 	}
 
-	result, err := b.executor.ProcessBlock(parent.StateRoot, block)
+	blockCreator, err := b.consensus.GetBlockCreator(header)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := b.executor.ProcessBlock(parent.StateRoot, block, blockCreator)
 	if err != nil {
 		return nil, err
 	}

--- a/blockchain/testing.go
+++ b/blockchain/testing.go
@@ -184,10 +184,14 @@ func (m *MockVerifier) VerifyHeader(parent, header *types.Header) error {
 	return nil
 }
 
+func (m *MockVerifier) GetBlockCreator(header *types.Header) (types.Address, error) {
+	return header.Miner, nil
+}
+
 type mockExecutor struct {
 }
 
-func (m *mockExecutor) ProcessBlock(parentRoot types.Hash, block *types.Block) (*state.BlockResult, error) {
+func (m *mockExecutor) ProcessBlock(parentRoot types.Hash, block *types.Block, blockCreator types.Address) (*state.BlockResult, error) {
 	return &state.BlockResult{}, nil
 }
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -20,6 +20,9 @@ type Consensus interface {
 	// VerifyHeader verifies the header is correct
 	VerifyHeader(parent, header *types.Header) error
 
+	// GetBlockCreator retrieves the block creator (or signer) given the block header
+	GetBlockCreator(header *types.Header) (types.Address, error)
+
 	// Start starts the consensus
 	Start() error
 

--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -121,7 +121,11 @@ func (d *Dev) writeNewBlock(parent *types.Header) error {
 		Timestamp:  uint64(time.Now().Unix()),
 	}
 
-	transition, err := d.executor.BeginTxn(parent.StateRoot, header)
+	miner, err := d.GetBlockCreator(header)
+	if err != nil {
+		return err
+	}
+	transition, err := d.executor.BeginTxn(parent.StateRoot, header, miner)
 	if err != nil {
 		return err
 	}
@@ -173,6 +177,10 @@ func (d *Dev) writeNewBlock(parent *types.Header) error {
 func (d *Dev) VerifyHeader(parent *types.Header, header *types.Header) error {
 	// All blocks are valid
 	return nil
+}
+
+func (d *Dev) GetBlockCreator(header *types.Header) (types.Address, error) {
+	return header.Miner, nil
 }
 
 func (d *Dev) Prepare(header *types.Header) error {

--- a/consensus/dummy/dummy.go
+++ b/consensus/dummy/dummy.go
@@ -51,6 +51,10 @@ func (d *Dummy) VerifyHeader(parent *types.Header, header *types.Header) error {
 	return nil
 }
 
+func (d *Dummy) GetBlockCreator(header *types.Header) (types.Address, error) {
+	return header.Miner, nil
+}
+
 func (d *Dummy) Close() error {
 	close(d.closeCh)
 	return nil

--- a/consensus/ibft/extra.go
+++ b/consensus/ibft/extra.go
@@ -12,10 +12,10 @@ var (
 	// to identify whether the block is from Istanbul consensus engine
 	IstanbulDigest = types.StringToHash("0x63746963616c2062797a616e74696e65206661756c7420746f6c6572616e6365")
 
-	// IstanbulExtraVanity represents a fixed number of extra-data bytes reserved for validator vanity
+	// IstanbulExtraVanity represents a fixed number of extra-data bytes reserved for proposer vanity
 	IstanbulExtraVanity = 32
 
-	// IstanbulExtraSeal represents the fixed number of extra-data bytes reserved for validator seal
+	// IstanbulExtraSeal represents the fixed number of extra-data bytes reserved for proposer seal
 	IstanbulExtraSeal = 65
 )
 

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -374,7 +374,7 @@ func (i *Ibft) buildBlock(snap *Snapshot, parent *types.Header) (*types.Block, e
 	// we need to include in the extra field the current set of validators
 	putIbftExtraValidators(header, snap.Set)
 
-	transition, err := i.executor.BeginTxn(parent.StateRoot, header)
+	transition, err := i.executor.BeginTxn(parent.StateRoot, header, i.validatorKeyAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -909,6 +909,11 @@ func (i *Ibft) VerifyHeader(parent, header *types.Header) error {
 	}
 
 	return nil
+}
+
+// GetBlockCreator retrieves the block signer from the extra data field
+func (i *Ibft) GetBlockCreator(header *types.Header) (types.Address, error) {
+	return ecrecoverFromHeader(header)
 }
 
 // Close closes the IBFT consensus mechanism, and does write back to disk

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -422,8 +422,6 @@ func (i *Ibft) buildBlock(snap *Snapshot, parent *types.Header) (*types.Block, e
 // The Accept state always checks the snapshot, and the validator set. If the current node is not in the validators set,
 // it moves back to the Sync state. On the other hand, if the node is a validator, it calculates the proposer.
 // If it turns out that the current node is the proposer, it builds a block, and sends preprepare and then prepare messages.
-// On the other hand, if the node is a validator, it calculates the proposer. If it turns out that the current node is the proposer,
-// it builds a block, and sends preprepare and then prepare messages.
 func (i *Ibft) runAcceptState() { // start new round
 	logger := i.logger.Named("acceptState")
 	logger.Info("Accept state", "sequence", i.state.view.Sequence)

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -158,8 +158,8 @@ func MethodSig(name string) []byte {
 	return b[:4]
 }
 
-// TempDir returns direcotry path in tmp with random directory name
-func TempDir() (string, error) {
+// tempDir returns directory path in tmp with random directory name
+func tempDir() (string, error) {
 	return ioutil.TempDir("/tmp", "polygon-sdk-e2e-")
 }
 
@@ -233,7 +233,7 @@ func NewTestServers(t *testing.T, num int, conf func(*TestServerConfig)) []*Test
 	})
 
 	for i := 0; i < num; i++ {
-		dataDir, err := TempDir()
+		dataDir, err := tempDir()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -37,6 +37,14 @@ func GenerateKeyAndAddr(t *testing.T) (*ecdsa.PrivateKey, types.Address) {
 	return key, addr
 }
 
+func EcrecoverFromBlockhash(hash types.Hash, signature []byte) (types.Address, error) {
+	pubKey, err := crypto.RecoverPubkey(signature, crypto.Keccak256(hash.Bytes()))
+	if err != nil {
+		return types.Address{}, err
+	}
+	return crypto.PubKeyToAddress(pubKey), nil
+}
+
 func MultiJoinSerial(t *testing.T, srvs []*TestServer) {
 	t.Helper()
 	dials := []*TestServer{}

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -2,10 +2,13 @@ package framework
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/0xPolygon/minimal/types"
 	"io"
+	"math/big"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -302,6 +305,46 @@ func (t *TestServer) SendTxn(ctx context.Context, txn *web3.Transaction) (*web3.
 		return nil, err
 	}
 	return t.WaitForReceipt(ctx, hash)
+}
+
+type PreparedTransaction struct {
+	From     types.Address
+	GasPrice *big.Int
+	Gas      uint64
+	To       *types.Address
+	Value    *big.Int
+	Input    []byte
+}
+
+// SendRawTx signs the transaction with the provided private key, executes it, and returns the receipt
+func (t *TestServer) SendRawTx(ctx context.Context, tx *PreparedTransaction, signerKey *ecdsa.PrivateKey) (*web3.Receipt, error) {
+	signer := &crypto.FrontierSigner{}
+	client := t.JSONRPC()
+
+	nextNonce, err := client.Eth().GetNonce(web3.Address(tx.From), web3.Latest)
+	if err != nil {
+		return nil, err
+	}
+
+	signedTx, err := signer.SignTx(&types.Transaction{
+		From:     tx.From,
+		GasPrice: tx.GasPrice,
+		Gas:      tx.Gas,
+		To:       tx.To,
+		Value:    tx.Value,
+		Input:    tx.Input,
+		Nonce:    nextNonce,
+	}, signerKey)
+	if err != nil {
+		return nil, err
+	}
+
+	txHash, err := client.Eth().SendRawTransaction(signedTx.MarshalRLP())
+	if err != nil {
+		return nil, err
+	}
+
+	return t.WaitForReceipt(ctx, txHash)
 }
 
 func (t *TestServer) WaitForReceipt(ctx context.Context, hash web3.Hash) (*web3.Receipt, error) {

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -318,7 +318,7 @@ type PreparedTransaction struct {
 
 // SendRawTx signs the transaction with the provided private key, executes it, and returns the receipt
 func (t *TestServer) SendRawTx(ctx context.Context, tx *PreparedTransaction, signerKey *ecdsa.PrivateKey) (*web3.Receipt, error) {
-	signer := &crypto.FrontierSigner{}
+	signer := crypto.NewEIP155Signer(100)
 	client := t.JSONRPC()
 
 	nextNonce, err := client.Eth().GetNonce(web3.Address(tx.From), web3.Latest)

--- a/e2e/ibft_test.go
+++ b/e2e/ibft_test.go
@@ -23,9 +23,6 @@ func TestIbft_Transfer(t *testing.T) {
 		config.Premine(senderAddr, framework.EthToWei(10))
 		config.SetSeal(true)
 	})
-	t.Cleanup(func() {
-		ibftManager.StopServers()
-	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
@@ -69,9 +66,7 @@ func TestIbft_TransactionFeeRecipient(t *testing.T) {
 	ibftManager := framework.NewIBFTServersManager(t, IBFTMinNodes, IBFTDirPrefix, func(i int, config *framework.TestServerConfig) {
 		config.Premine(senderAddr, framework.EthToWei(10))
 		config.SetSeal(true)
-	})
-	t.Cleanup(func() {
-		ibftManager.StopServers()
+		config.SetShowsLog(true)
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)

--- a/e2e/ibft_test.go
+++ b/e2e/ibft_test.go
@@ -66,7 +66,6 @@ func TestIbft_TransactionFeeRecipient(t *testing.T) {
 	ibftManager := framework.NewIBFTServersManager(t, IBFTMinNodes, IBFTDirPrefix, func(i int, config *framework.TestServerConfig) {
 		config.Premine(senderAddr, framework.EthToWei(10))
 		config.SetSeal(true)
-		config.SetShowsLog(true)
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
@@ -115,11 +114,8 @@ func TestIbft_TransactionFeeRecipient(t *testing.T) {
 	err = extraData.UnmarshalRLP(extraDataWithoutVanity)
 	assert.NoError(t, err)
 
-	bHash, err := block.Hash.MarshalText()
+	proposerAddr, err := framework.EcrecoverFromBlockhash(types.Hash(block.Hash), extraData.Seal)
 	assert.NoError(t, err)
-	proposerPubKey, err := crypto.RecoverPubkey(extraData.Seal, bHash)
-	assert.NoError(t, err)
-	proposerAddr := crypto.PubKeyToAddress(proposerPubKey)
 
 	// Given that this is the first transaction on the blockchain, proposer's balance should be equal to the tx fee
 	balanceProposer, err := clt.Eth().GetBalance(web3.Address(proposerAddr), web3.Latest)

--- a/e2e/ibft_test.go
+++ b/e2e/ibft_test.go
@@ -23,6 +23,9 @@ func TestIbft_Transfer(t *testing.T) {
 		config.Premine(senderAddr, framework.EthToWei(10))
 		config.SetSeal(true)
 	})
+	t.Cleanup(func() {
+		ibftManager.StopServers()
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
@@ -66,7 +69,9 @@ func TestIbft_TransactionFeeRecipient(t *testing.T) {
 	ibftManager := framework.NewIBFTServersManager(t, IBFTMinNodes, IBFTDirPrefix, func(i int, config *framework.TestServerConfig) {
 		config.Premine(senderAddr, framework.EthToWei(10))
 		config.SetSeal(true)
-		config.SetShowsLog(true)
+	})
+	t.Cleanup(func() {
+		ibftManager.StopServers()
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)

--- a/e2e/ibft_test.go
+++ b/e2e/ibft_test.go
@@ -8,14 +8,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/0xPolygon/minimal/crypto"
 	"github.com/0xPolygon/minimal/e2e/framework"
 	"github.com/0xPolygon/minimal/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestIbft_Transfer(t *testing.T) {
-	signer := &crypto.FrontierSigner{}
 	senderKey, senderAddr := framework.GenerateKeyAndAddr(t)
 	_, receiverAddr := framework.GenerateKeyAndAddr(t)
 
@@ -30,97 +28,111 @@ func TestIbft_Transfer(t *testing.T) {
 
 	srv := ibftManager.GetServer(0)
 	for i := 0; i < IBFTMinNodes-1; i++ {
-		txn := &types.Transaction{
+		txn := &framework.PreparedTransaction{
 			From:     senderAddr,
 			To:       &receiverAddr,
 			GasPrice: big.NewInt(10000),
 			Gas:      1000000,
 			Value:    framework.EthToWei(1),
-			Nonce:    uint64(i),
 		}
-		txn, err := signer.SignTx(txn, senderKey)
-		if err != nil {
-			t.Fatal(err)
-		}
-		data := txn.MarshalRLP()
-
-		hash, err := srv.JSONRPC().Eth().SendRawTransaction(data)
-		assert.NoError(t, err)
-		assert.NotNil(t, hash)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		receipt, err := srv.WaitForReceipt(ctx, hash)
+		receipt, err := srv.SendRawTx(ctx, txn, senderKey)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, receipt)
-		assert.Equal(t, receipt.TransactionHash, hash)
+		assert.NotNil(t, receipt.TransactionHash)
 	}
 }
 
 func TestIbft_TransactionFeeRecipient(t *testing.T) {
-	signer := &crypto.FrontierSigner{}
-	senderKey, senderAddr := framework.GenerateKeyAndAddr(t)
-	_, receiverAddr := framework.GenerateKeyAndAddr(t)
-
-	ibftManager := framework.NewIBFTServersManager(t, IBFTMinNodes, IBFTDirPrefix, func(i int, config *framework.TestServerConfig) {
-		config.Premine(senderAddr, framework.EthToWei(10))
-		config.SetSeal(true)
-	})
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-	ibftManager.StartServers(ctx)
-
-	srv := ibftManager.GetServer(0)
-	clt := srv.JSONRPC()
-
-	// get latest nonce
-	lastNonce, err := clt.Eth().GetNonce(web3.Address(senderAddr), web3.Latest)
-	assert.NoError(t, err)
-
-	txn := &types.Transaction{
-		From:     senderAddr,
-		To:       &receiverAddr,
-		GasPrice: big.NewInt(10000),
-		Gas:      1000000,
-		Value:    framework.EthToWei(1),
-		Nonce:    lastNonce,
+	testCases := []struct {
+		name         string
+		contractCall bool
+		txAmount     *big.Int
+	}{
+		{
+			name:         "transfer transaction",
+			contractCall: false,
+			txAmount:     framework.EthToWei(1),
+		},
+		{
+			name:         "contract function execution",
+			contractCall: true,
+			txAmount:     big.NewInt(0),
+		},
 	}
-	txn, err = signer.SignTx(txn, senderKey)
-	if err != nil {
-		t.Fatal(err)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			senderKey, senderAddr := framework.GenerateKeyAndAddr(t)
+			_, receiverAddr := framework.GenerateKeyAndAddr(t)
+
+			ibftManager := framework.NewIBFTServersManager(t, IBFTMinNodes, IBFTDirPrefix, func(i int, config *framework.TestServerConfig) {
+				config.Premine(senderAddr, framework.EthToWei(10))
+				config.SetSeal(true)
+			})
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			defer cancel()
+			ibftManager.StartServers(ctx)
+
+			srv := ibftManager.GetServer(0)
+			clt := srv.JSONRPC()
+
+			txn := &framework.PreparedTransaction{
+				From:     senderAddr,
+				To:       &receiverAddr,
+				GasPrice: big.NewInt(10000),
+				Gas:      1000000,
+				Value:    tc.txAmount,
+			}
+
+			if tc.contractCall {
+				// Deploy contract
+				deployTx := &framework.PreparedTransaction{
+					From:     senderAddr,
+					GasPrice: big.NewInt(0),
+					Gas:      1000000,
+					Value:    big.NewInt(0),
+					Input:    framework.MethodSig("setA1"),
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				receipt, err := srv.SendRawTx(ctx, deployTx, senderKey)
+				assert.NoError(t, err)
+				assert.NotNil(t, receipt)
+
+				contractAddr := types.Address(receipt.ContractAddress)
+				txn.To = &contractAddr
+				txn.Input = framework.MethodSig("setA1")
+			}
+
+			ctx1, cancel1 := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel1()
+			receipt, err := srv.SendRawTx(ctx1, txn, senderKey)
+			assert.NoError(t, err)
+			assert.NotNil(t, receipt)
+
+			// Get the block proposer from the extra data seal
+			assert.NotNil(t, receipt.BlockHash)
+			block, err := clt.Eth().GetBlockByHash(receipt.BlockHash, false)
+			assert.NoError(t, err)
+			extraData := &ibft.IstanbulExtra{}
+			extraDataWithoutVanity := block.ExtraData[ibft.IstanbulExtraVanity:]
+			err = extraData.UnmarshalRLP(extraDataWithoutVanity)
+			assert.NoError(t, err)
+
+			proposerAddr, err := framework.EcrecoverFromBlockhash(types.Hash(block.Hash), extraData.Seal)
+			assert.NoError(t, err)
+
+			// Given that this is the first transaction on the blockchain, proposer's balance should be equal to the tx fee
+			balanceProposer, err := clt.Eth().GetBalance(web3.Address(proposerAddr), web3.Latest)
+			assert.NoError(t, err)
+
+			txFee := new(big.Int).Mul(new(big.Int).SetUint64(receipt.GasUsed), txn.GasPrice)
+			assert.Equalf(t, txFee, balanceProposer, "Proposer didn't get appropriate transaction fee")
+		})
 	}
-	data := txn.MarshalRLP()
-
-	hash, err := clt.Eth().SendRawTransaction(data)
-	assert.NoError(t, err)
-	assert.NotNil(t, hash)
-
-	ctx1, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	receipt, err := srv.WaitForReceipt(ctx1, hash)
-
-	assert.NoError(t, err)
-	assert.NotNil(t, receipt)
-	assert.Equal(t, receipt.TransactionHash, hash)
-
-	// Get the block proposer from the extra data seal
-	assert.NotNil(t, receipt.BlockHash)
-	block, err := clt.Eth().GetBlockByHash(receipt.BlockHash, false)
-	assert.NoError(t, err)
-	extraData := &ibft.IstanbulExtra{}
-	extraDataWithoutVanity := block.ExtraData[ibft.IstanbulExtraVanity:]
-	err = extraData.UnmarshalRLP(extraDataWithoutVanity)
-	assert.NoError(t, err)
-
-	proposerAddr, err := framework.EcrecoverFromBlockhash(types.Hash(block.Hash), extraData.Seal)
-	assert.NoError(t, err)
-
-	// Given that this is the first transaction on the blockchain, proposer's balance should be equal to the tx fee
-	balanceProposer, err := clt.Eth().GetBalance(web3.Address(proposerAddr), web3.Latest)
-	assert.NoError(t, err)
-
-	txFee := new(big.Int).Mul(new(big.Int).SetUint64(receipt.GasUsed), txn.GasPrice)
-	assert.Equalf(t, txFee, balanceProposer, "Proposer didn't get appropriate transaction fee")
 }

--- a/e2e/transaction_test.go
+++ b/e2e/transaction_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"context"
 	"math/big"
-	"os"
 	"testing"
 	"time"
 
@@ -19,21 +18,10 @@ func TestSignedTransaction(t *testing.T) {
 	senderKey, senderAddr := framework.GenerateKeyAndAddr(t)
 	_, receiverAddr := framework.GenerateKeyAndAddr(t)
 
-	dataDir, err := framework.TempDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	preminedAmount := framework.EthToWei(10)
-	ibftManager := framework.NewIBFTServersManager(t, IBFTMinNodes, dataDir, IBFTDirPrefix, func(i int, config *framework.TestServerConfig) {
+	ibftManager := framework.NewIBFTServersManager(t, IBFTMinNodes, IBFTDirPrefix, func(i int, config *framework.TestServerConfig) {
 		config.Premine(senderAddr, preminedAmount)
 		config.SetSeal(true)
-	})
-	t.Cleanup(func() {
-		ibftManager.StopServers()
-		if err := os.RemoveAll(dataDir); err != nil {
-			t.Log(err)
-		}
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)

--- a/e2e/transaction_test.go
+++ b/e2e/transaction_test.go
@@ -23,9 +23,6 @@ func TestSignedTransaction(t *testing.T) {
 		config.Premine(senderAddr, preminedAmount)
 		config.SetSeal(true)
 	})
-	t.Cleanup(func() {
-		ibftManager.StopServers()
-	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()

--- a/e2e/transaction_test.go
+++ b/e2e/transaction_test.go
@@ -23,6 +23,9 @@ func TestSignedTransaction(t *testing.T) {
 		config.Premine(senderAddr, preminedAmount)
 		config.SetSeal(true)
 	})
+	t.Cleanup(func() {
+		ibftManager.StopServers()
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()

--- a/minimal/server.go
+++ b/minimal/server.go
@@ -277,7 +277,12 @@ func (j *jsonRPCHub) GetCode(hash types.Hash) ([]byte, error) {
 }
 
 func (j *jsonRPCHub) ApplyTxn(header *types.Header, txn *types.Transaction) ([]byte, bool, error) {
-	transition, err := j.BeginTxn(header.StateRoot, header)
+	blockCreator, err := j.GetConsensus().GetBlockCreator(header)
+	if err != nil {
+		return nil, false, err
+	}
+
+	transition, err := j.BeginTxn(header.StateRoot, header, blockCreator)
 
 	if err != nil {
 		return nil, false, err

--- a/state/executor.go
+++ b/state/executor.go
@@ -80,8 +80,8 @@ type BlockResult struct {
 }
 
 // ProcessBlock already does all the handling of the whole process, TODO
-func (e *Executor) ProcessBlock(parentRoot types.Hash, block *types.Block) (*BlockResult, error) {
-	txn, err := e.BeginTxn(parentRoot, block.Header)
+func (e *Executor) ProcessBlock(parentRoot types.Hash, block *types.Block, blockCreator types.Address) (*BlockResult, error) {
+	txn, err := e.BeginTxn(parentRoot, block.Header, blockCreator)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (e *Executor) StateAt(root types.Hash) (Snapshot, error) {
 	return e.state.NewSnapshotAt(root)
 }
 
-func (e *Executor) BeginTxn(parentRoot types.Hash, header *types.Header) (*Transition, error) {
+func (e *Executor) BeginTxn(parentRoot types.Hash, header *types.Header, coinbaseReceiver types.Address) (*Transition, error) {
 	config := e.config.Forks.At(header.Number)
 
 	auxSnap2, err := e.state.NewSnapshotAt(parentRoot)
@@ -123,11 +123,7 @@ func (e *Executor) BeginTxn(parentRoot types.Hash, header *types.Header) (*Trans
 	newTxn := NewTxn(e.state, auxSnap2)
 
 	env2 := runtime.TxContext{
-		// TODO:	This seems like an error as this would mean that whoever we are voting for/against being a validator
-		//			in this block, would get the gas fees spent by transaction executions.
-		//			Quite possibly, we should do an ecrecover of the istanbul extra data in the header to get the
-		//			address of the proposer and set it as a coinbase address in the TxContext.
-		Coinbase:   header.Miner,
+		Coinbase:   coinbaseReceiver,
 		Timestamp:  int64(header.Timestamp),
 		Number:     int64(header.Number),
 		Difficulty: types.BytesToHash(new(big.Int).SetUint64(header.Difficulty).Bytes()),

--- a/state/executor.go
+++ b/state/executor.go
@@ -283,7 +283,7 @@ func (t *Transition) GetTxnHash() types.Hash {
 func (t *Transition) Apply(msg *types.Transaction) (uint64, bool, error) {
 	// TODO: Maybe there is no need for snapshot here, since snapshot is also created inside apply()
 	s := t.state.Snapshot()
-	returnValue, gas, failed, err := t.apply(msg)
+	returnValue, gasUsed, failed, err := t.apply(msg)
 	if err != nil {
 		t.state.RevertToSnapshot(s)
 	}
@@ -293,7 +293,7 @@ func (t *Transition) Apply(msg *types.Transaction) (uint64, bool, error) {
 	}
 
 	t.returnValue = returnValue
-	return gas, failed, err
+	return gasUsed, failed, err
 }
 
 // ContextPtr returns reference of context

--- a/tests/evm_test.go
+++ b/tests/evm_test.go
@@ -58,7 +58,7 @@ func testVMCase(t *testing.T, name string, c *VMCase) {
 		return vmTestBlockHash
 	}
 
-	e, _ := executor.BeginTxn(root, c.Env.ToHeader(t))
+	e, _ := executor.BeginTxn(root, c.Env.ToHeader(t), env.Coinbase)
 	ctx := e.ContextPtr()
 	ctx.GasPrice = types.BytesToHash(env.GasPrice.Bytes())
 	ctx.Origin = env.Origin

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -63,7 +63,7 @@ func RunSpecificTest(file string, t *testing.T, c stateCase, name, fork string, 
 		return vmTestBlockHash
 	}
 
-	executor, _ := xxx.BeginTxn(pastRoot, c.Env.ToHeader(t))
+	executor, _ := xxx.BeginTxn(pastRoot, c.Env.ToHeader(t), env.Coinbase)
 	executor.Apply(msg) //nolint:errcheck
 
 	txn := executor.Txn()


### PR DESCRIPTION
# Description

Currently, block reward is assigned to `Miner` field in the block header.
For regular PoW this is fine, but in IBFT `Miner` field is not used as an address of the block proposer. Instead, it holds the candidate's address during the voting process. If there is no voting process, this field is set to zero address.

You can read more about it in the [Repurposing header fields for signing and voting section](https://github.com/ethereum/EIPs/issues/225) of Clique's EIP

I decided to let consensus be responsible for defining how block creator is fetched.
Most consensuses would simply return `Miner` field, but IBFT ecrecovers it from the `Seal` in the `extradata`

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs
