### PR TITLE
Fix/error getting storage snapshot

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -560,12 +560,13 @@ func (b *Blockchain) WriteBlocks(blocks []*types.Block) error {
 	for indx, block := range blocks {
 		header := block.Header
 
-		if err := b.writeBody(block); err != nil {
-			return err
-		}
 		// Process and validate the block
 		res, err := b.processBlock(blocks[indx])
 		if err != nil {
+			return err
+		}
+
+		if err := b.writeBody(block); err != nil {
 			return err
 		}
 

--- a/minimal/server.go
+++ b/minimal/server.go
@@ -239,16 +239,13 @@ func (j *jsonRPCHub) getState(root types.Hash, slot []byte) ([]byte, error) {
 }
 
 func (j *jsonRPCHub) GetAccount(root types.Hash, addr types.Address) (*state.Account, error) {
-	obj, err := j.getState(root, addr.Bytes())
+	obj, _ := j.getState(root, addr.Bytes())
 	var account state.Account
-
-	if err != nil {
-		return &account, nil
-	}
 
 	if err := account.UnmarshalRlp(obj); err != nil {
 		return nil, err
 	}
+
 	return &account, nil
 }
 

--- a/minimal/server.go
+++ b/minimal/server.go
@@ -2,6 +2,7 @@ package minimal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -233,19 +234,20 @@ func (j *jsonRPCHub) getState(root types.Hash, slot []byte) ([]byte, error) {
 	}
 	result, ok := snap.Get(key)
 	if !ok {
-		return nil, fmt.Errorf("error getting storage snapshot")
+		return nil, errors.New("given root and slot not found in storage")
 	}
 	return result, nil
 }
 
 func (j *jsonRPCHub) GetAccount(root types.Hash, addr types.Address) (*state.Account, error) {
-	obj, _ := j.getState(root, addr.Bytes())
+	obj, err := j.getState(root, addr.Bytes())
+	if err != nil {
+		return nil, err
+	}
 	var account state.Account
-
 	if err := account.UnmarshalRlp(obj); err != nil {
 		return nil, err
 	}
-
 	return &account, nil
 }
 

--- a/minimal/server.go
+++ b/minimal/server.go
@@ -240,10 +240,12 @@ func (j *jsonRPCHub) getState(root types.Hash, slot []byte) ([]byte, error) {
 
 func (j *jsonRPCHub) GetAccount(root types.Hash, addr types.Address) (*state.Account, error) {
 	obj, err := j.getState(root, addr.Bytes())
-	if err != nil {
-		return nil, err
-	}
 	var account state.Account
+
+	if err != nil {
+		return &account, nil
+	}
+
 	if err := account.UnmarshalRlp(obj); err != nil {
 		return nil, err
 	}

--- a/network/server.go
+++ b/network/server.go
@@ -93,7 +93,7 @@ func NewServer(logger hclog.Logger, config *Config) (*Server, error) {
 			addr, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", config.NatAddr.String(), config.Addr.Port))
 
 			if addr != nil {
-				addrs = append(addrs, addr)
+				addrs = []multiaddr.Multiaddr{addr}
 			}
 		}
 
@@ -583,19 +583,10 @@ func StringToAddrInfo(addr string) (*peer.AddrInfo, error) {
 
 // AddrInfoToString converts an AddrInfo into a string representation that can be dialed from another node
 func AddrInfoToString(addr *peer.AddrInfo) string {
-	result := ""
-
-	end := len(addr.Addrs) - 1
-
-	for i, a := range addr.Addrs {
-		result += fmt.Sprintf("%s/p2p/%s", a, addr.ID.String())
-
-		if i != end {
-			result += ", "
-		}
+	if len(addr.Addrs) != 1 {
+		panic("Not supported")
 	}
-
-	return result
+	return addr.Addrs[0].String() + "/p2p/" + addr.ID.String()
 }
 
 type PeerConnectedEvent struct {

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -176,7 +176,7 @@ func TestNat(t *testing.T) {
 	t.Run("there should be multiple listening addresses", func(t *testing.T) {
 		listenAddresses := srv.host.Network().ListenAddresses()
 
-		assert.GreaterOrEqual(t, len(listenAddresses), 1)
+		assert.Greater(t, len(listenAddresses), 1)
 	})
 
 	t.Run("there should only be a single registered server address", func(t *testing.T) {

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -158,6 +158,19 @@ func TestNat(t *testing.T) {
 	})
 	defer srv.Close()
 
+	t.Run("there should be multiple listening addresses", func(t *testing.T) {
+		listenAddresses := srv.host.Network().ListenAddresses()
+
+		assert.GreaterOrEqual(t, len(listenAddresses), 1)
+	})
+
+	t.Run("there should only be a single registered server address", func(t *testing.T) {
+		addrInfo := srv.AddrInfo()
+		registeredAddresses := addrInfo.Addrs
+
+		assert.Equal(t, len(registeredAddresses), 1)
+	})
+
 	t.Run("NAT IP should not be found in listen addresses", func(t *testing.T) {
 		listenAddresses := srv.host.Network().ListenAddresses()
 
@@ -168,10 +181,10 @@ func TestNat(t *testing.T) {
 
 	t.Run("NAT IP should be found in registered server addresses", func(t *testing.T) {
 		addrInfo := srv.AddrInfo()
-		listenAddresses := addrInfo.Addrs
+		registeredAddresses := addrInfo.Addrs
 
 		found := false
-		for _, addr := range listenAddresses {
+		for _, addr := range registeredAddresses {
 			if addr.String() == testMultiAddrString {
 				found = true
 				break

--- a/state/executor.go
+++ b/state/executor.go
@@ -337,9 +337,9 @@ func (t *Transition) preCheck(msg *types.Transaction) (uint64, error) {
 	// validate nonce
 	nonce := t.state.GetNonce(msg.From)
 	if nonce < msg.Nonce {
-		return 0, fmt.Errorf("nonce is too low: %d < %d", nonce, msg.Nonce)
+		return 0, fmt.Errorf("nonce is too big: %d < %d", nonce, msg.Nonce)
 	} else if nonce > msg.Nonce {
-		return 0, fmt.Errorf("nonce is too big: %d > %d", nonce, msg.Nonce)
+		return 0, fmt.Errorf("nonce is too low: %d > %d", nonce, msg.Nonce)
 	}
 
 	// deduct the upfront max gas cost


### PR DESCRIPTION
# Description

This PR encompasses fixing 3 bugs that I found while deploying Polygon smart contracts (as per the conversation on #64).

## Limit registered libp2p server addresses to 1

While implementing the `--nat` flag a while ago, I appended the NAT address to the list of all registered addresses (which if you are listening on 0.0.0.0 are all network interfaces). I also changed the `AddrInfoToString` as it needed to serialize more than 1 registered address.

This caused an issue since while gossiping, the servers would share multiple multiaddrs when in fact they only need to share their NAT address.

The sharing of the known nodes while gossiping is done with the `AddrInfoToString` fn.

## Not printing an error if the account is uninitialized

Currently on every lookup in the storage using the root hash and the slot, if we are unable to find anything at that location, we will print "error getting storage snapshot".

The error handling for different server calls which may fail gracefully is done outside of the `getState()` method, making the `fmt.Errorf("error getting storage snapshot")` a false positive for an error, when in fact caller functions will handle gracefully if they can (such as `GetBalance` and `getNextNonce`).

## When storing a block from another validator the `From` address should be properly set 

Previously, the `From` was set to ZeroAddress.

The reason behind this is that we are writing the block body (with txs) first into the storage, and only then recovering the `From` address from the signature of the transaction.

I have changed the order of these operations so that we first process the block (effectively recovering the `From` address for each transaction) and only then write it in the TxLookup & block databases.


# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
