### PR TITLE
Remove TODO comment for the verification of committed seals

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -627,7 +627,7 @@ func (i *Ibft) runValidateState() {
 func (i *Ibft) insertBlock(block *types.Block) error {
 	committedSeals := [][]byte{}
 	for _, commit := range i.state.committed {
-		// no need to check the format of seal is correct here because writeCommittedSeals will check
+		// no need to check the format of seal here because writeCommittedSeals will check
 		committedSeals = append(committedSeals, hex.MustDecodeHex(commit.Seal))
 	}
 

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -627,11 +627,8 @@ func (i *Ibft) runValidateState() {
 func (i *Ibft) insertBlock(block *types.Block) error {
 	committedSeals := [][]byte{}
 	for _, commit := range i.state.committed {
-		sealBytes := hex.MustDecodeHex(commit.Seal)
-		if len(sealBytes) != IstanbulExtraSeal {
-			return fmt.Errorf("invalid committed seal")
-		}
-		committedSeals = append(committedSeals, sealBytes)
+		// no need to check the format of seal is correct here because writeCommittedSeals will check
+		committedSeals = append(committedSeals, hex.MustDecodeHex(commit.Seal))
 	}
 
 	header, err := writeCommittedSeals(block.Header, committedSeals)

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -627,7 +627,11 @@ func (i *Ibft) runValidateState() {
 func (i *Ibft) insertBlock(block *types.Block) error {
 	committedSeals := [][]byte{}
 	for _, commit := range i.state.committed {
-		committedSeals = append(committedSeals, hex.MustDecodeHex(commit.Seal)) // TODO: Validate
+		sealBytes := hex.MustDecodeHex(commit.Seal)
+		if len(sealBytes) != IstanbulExtraSeal {
+			return fmt.Errorf("invalid committed seal")
+		}
+		committedSeals = append(committedSeals, sealBytes)
 	}
 
 	header, err := writeCommittedSeals(block.Header, committedSeals)

--- a/consensus/ibft/sign.go
+++ b/consensus/ibft/sign.go
@@ -93,7 +93,7 @@ func writeCommittedSeals(h *types.Header, seals [][]byte) (*types.Header, error)
 
 	for _, seal := range seals {
 		if len(seal) != IstanbulExtraSeal {
-			return nil, fmt.Errorf("bad")
+			return nil, fmt.Errorf("invalid committed seal")
 		}
 	}
 

--- a/consensus/ibft/sign.go
+++ b/consensus/ibft/sign.go
@@ -93,7 +93,7 @@ func writeCommittedSeals(h *types.Header, seals [][]byte) (*types.Header, error)
 
 	for _, seal := range seals {
 		if len(seal) != IstanbulExtraSeal {
-			return nil, fmt.Errorf("invalid committed seal")
+			return nil, fmt.Errorf("invalid committed seal length")
 		}
 	}
 

--- a/consensus/ibft/sign.go
+++ b/consensus/ibft/sign.go
@@ -88,7 +88,7 @@ func writeCommittedSeals(h *types.Header, seals [][]byte) (*types.Header, error)
 	h = h.Copy()
 
 	if len(seals) == 0 {
-		return nil, fmt.Errorf("bad")
+		return nil, fmt.Errorf("empty committed seals")
 	}
 
 	for _, seal := range seals {
@@ -171,7 +171,7 @@ func verifyCommitedFields(snap *Snapshot, header *types.Header) error {
 		return err
 	}
 
-	// TODO: Check locking mechanism impl
+	// Committed seals shouldn't be empty
 	if len(extra.CommittedSeal) == 0 {
 		return fmt.Errorf("empty committed seals")
 	}


### PR DESCRIPTION
# Description

This PR removes TODO comment from verifyCommitedFields because the behavior is correct
The changes as follows:
* Remove TODO comment from verifyCommitedFields in consensus/ibft/sign.go because this check is correct
* Add some comments
* Fix unfriendly error message

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
