### PR TITLE
Avoid useless heap allocation in opCallDataLoad

### DIFF
--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -376,8 +376,11 @@ func opSar(c *state) {
 }
 
 // memory operations
+
 var bufPool = sync.Pool{
 	New: func() interface{} {
+		// Store pointer to avoid heap allocation in caller
+		// Please check SA6002 in StaticCheck for details
 		buf := make([]byte, 128)
 		return &buf
 	},

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -376,10 +376,10 @@ func opSar(c *state) {
 }
 
 // memory operations
-
 var bufPool = sync.Pool{
 	New: func() interface{} {
-		return make([]byte, 128)
+		buf := make([]byte, 128)
+		return &buf
 	},
 }
 
@@ -612,13 +612,11 @@ func min(i, j uint64) uint64 {
 func opCallDataLoad(c *state) {
 	offset := c.top()
 
-	// TODO:	Check what memory allocations do we save with this since
-	// 			sync.Pool requires a pointer to a slice in order to save some memory.
-	// 			see: https://staticcheck.io/docs/checks#SA6002
-	buf := bufPool.Get().([]byte)
+	bufPtr := bufPool.Get().(*[]byte)
+	buf := *bufPtr
 	c.setBytes(buf[:32], c.msg.Input, 32, offset)
 	offset.SetBytes(buf[:32])
-	bufPool.Put(buf) //nolint:staticcheck
+	bufPool.Put(bufPtr)
 }
 
 func opCallDataSize(c *state) {


### PR DESCRIPTION
# Description

This PR avoids useless heap allocation in opCallDataLoad.
StaticCheck, which is go linter for detecting bugs and optimizing, says we shouldn't use value type in sync.Pool.
https://staticcheck.io/docs/checks#SA6002

The reason is that heap allocation happens when you convert value to value of `interface{}` because value of `interface{}` has pointer of data.  An implicit cast from value to `interface{}` occurs when you call `Put` method in sync.Pool, then it allocates memory in heap and move the value there if the value is not pointer.

Please check the below link for details about interface{}:
https://research.swtch.com/interfaces

```go
func opCallDataLoad(c *state) {
	offset := c.top()

	buf := bufPool.Get().([]byte)
	c.setBytes(buf[:32], c.msg.Input, 32, offset)
	offset.SetBytes(buf[:32])
	bufPool.Put(buf) // Implicit cast from []byte to pointer
}
```

This PR changes the type of value sync.Pool stores from `[]byte` to `*[]byte`

```go
func opCallDataLoad(c *state) {
	offset := c.top()

	bufPtr := bufPool.Get().(*[]byte)
	buf := *bufPtr
	c.setBytes(buf[:32], c.msg.Input, 32, offset)
	offset.SetBytes(buf[:32])
	bufPool.Put(bufPtr)
}
```

## Benchmark

I put benchmark code into `state/runtime/evm/instructions_test.go`
```go
// state/runtime/evm/instructions_test.go
func BenchmarkOpCallDataLoad(b *testing.B) {
	s := &state{
		sp: 1,
		stack: []*big.Int{
			big.NewInt(0),
		},
		msg: &runtime.Contract{
			Input: make([]byte, 32),
		},
	}
	b.RunParallel(func(pb *testing.PB) {
		for pb.Next() {
			opCallDataLoad(s)
		}
	})
}
```

Test environment 
```
CPU: Intel Core i5 1.4 GHz Quad Core
RAM: 16 GB 2133 MHz LPDDR3
OS: macOS BigSur 11.4 (20F71)
Go version: go version go1.15.7 darwin/amd64
```

The result before fixing the code is as follows:
```shell
$ go test -bench . ./state/runtime/evm/... -benchmem
goos: darwin
goarch: amd64
pkg: github.com/0xPolygon/minimal/state/runtime/evm
BenchmarkOpCallDataLoad-8       32355459                37.5 ns/op            32 B/op          1 allocs/op
```
The result shows number of calls, average execution time, average amount of allocation per execution, and average number of allocation times per execution.

The result after fixing the code is as follows:
```shell
$ go test -bench . ./state/runtime/evm/... -benchmem
goos: darwin
goarch: amd64
pkg: github.com/0xPolygon/minimal/state/runtime/evm
BenchmarkOpCallDataLoad-8       45255873                27.0 ns/op             0 B/op          0 allocs/op
```

The result shows the fix removes useless allocation in this function.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
