### PR TITLE
Fix the popped order for priced transactions

### DIFF
--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -56,8 +56,14 @@ type TxPool struct {
 	proto.UnimplementedTxnPoolOperatorServer
 }
 
-// NewTxPool creates a new pool of transactios
-func NewTxPool(logger hclog.Logger, sealing bool, store store, grpcServer *grpc.Server, network *network.Server) (*TxPool, error) {
+// NewTxPool creates a new pool for transactions
+func NewTxPool(
+	logger hclog.Logger,
+	sealing bool,
+	store store,
+	grpcServer *grpc.Server,
+	network *network.Server,
+) (*TxPool, error) {
 	txPool := &TxPool{
 		logger:     logger.Named("txpool"),
 		store:      store,
@@ -485,7 +491,8 @@ func (t txPriceHeapImpl) Less(i, j int) bool {
 	if t[i].from == t[j].from {
 		return t[i].tx.Nonce < t[j].tx.Nonce
 	}
-	return t[i].price.Cmp((t[j].price)) < 0
+
+	return t[i].price.Cmp(t[j].price) >= 0
 }
 
 func (t txPriceHeapImpl) Swap(i, j int) {

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -3,6 +3,7 @@ package txpool
 import (
 	"fmt"
 	"math/big"
+	"strconv"
 	"testing"
 
 	"github.com/0xPolygon/minimal/crypto"
@@ -120,4 +121,101 @@ func TestTxnQueue_Promotion(t *testing.T) {
 	nonce, _ = pool.GetNonce(addr1)
 	assert.Equal(t, nonce, uint64(2))
 	assert.Equal(t, pool.Length(), uint64(2))
+}
+
+func TestTxnQueue_Heap(t *testing.T) {
+	type TestCase struct {
+		From     types.Address
+		GasPrice *big.Int
+		Nonce    uint64
+		Index    int
+	}
+
+	addr1 := types.Address{0x1}
+	addr2 := types.Address{0x2}
+
+	test := func(t *testing.T, testTable []TestCase) {
+		pool, err := NewTxPool(hclog.NewNullLogger(), false, &mockStore{}, nil, nil)
+		assert.NoError(t, err)
+		pool.EnableDev()
+
+		for _, testCase := range testTable {
+			err := pool.addImpl("", &types.Transaction{
+				From:     testCase.From,
+				GasPrice: testCase.GasPrice,
+				Nonce:    testCase.Nonce,
+			})
+			assert.NoError(t, err)
+		}
+
+		for _, testCase := range testTable {
+			transaction, _ := pool.Pop()
+
+			assert.NotNil(t, transaction)
+
+			actual := TestCase{
+				From:     transaction.From,
+				GasPrice: transaction.GasPrice,
+				Nonce:    transaction.Nonce,
+			}
+
+			assert.EqualValues(t, testCase, actual)
+		}
+
+		empty, _ := pool.Pop()
+		assert.Nil(t, empty)
+	}
+
+	t.Run("the higher priced transaction should be popped first", func(t *testing.T) {
+		test(t, []TestCase{
+			{
+				From:     addr1,
+				GasPrice: big.NewInt(2),
+			},
+			{
+				From:     addr2,
+				GasPrice: big.NewInt(1),
+			},
+		})
+
+	})
+
+	t.Run("sort by nonce when same from address", func(t *testing.T) {
+		test(t, []TestCase{
+			{
+				From:     addr1,
+				GasPrice: big.NewInt(2),
+				Nonce:    0,
+			},
+			{
+				From:     addr1,
+				GasPrice: big.NewInt(1),
+				Nonce:    1,
+			},
+		})
+	})
+
+	t.Run("make sure that heap is not functioning as a FIFO", func(t *testing.T) {
+		pool, err := NewTxPool(hclog.NewNullLogger(), false, &mockStore{}, nil, nil)
+		assert.NoError(t, err)
+		pool.EnableDev()
+
+		numTxns := 5
+		txns := make([]*types.Transaction, numTxns)
+
+		for i := 0; i < numTxns; i++ {
+			txns[i] = &types.Transaction{
+				From:     types.StringToAddress(strconv.Itoa(i + 1)),
+				GasPrice: big.NewInt(int64(i + 1)),
+			}
+
+			addErr := pool.addImpl("", txns[i])
+			assert.Nilf(t, addErr, "Unable to add transaction to pool")
+		}
+
+		for i := numTxns - 1; i >= 0; i-- {
+			txn, _ := pool.Pop()
+			assert.Equalf(t, txns[i].GasPrice, txn.GasPrice, "Expected output mismatch")
+		}
+	})
 }

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -189,7 +189,7 @@ func TestTxnQueue_Heap(t *testing.T) {
 			},
 			{
 				From:     addr1,
-				GasPrice: big.NewInt(1),
+				GasPrice: big.NewInt(3),
 				Nonce:    1,
 			},
 		})


### PR DESCRIPTION
# Description

This PR fixes a minor bug with the ordering of popped transactions from the price-sorted transaction heap (txpool).
Now, the heap pops transactions which have a **greater** price first.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs