### PR TITLE
Add performance metrics in logs

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -600,7 +600,7 @@ func (b *Blockchain) WriteBlocks(blocks []*types.Block) error {
 		}
 		if prevHeader, ok := b.GetHeaderByNumber(header.Number - 1); ok {
 			diff := header.Timestamp - prevHeader.Timestamp
-			logArgs = append(logArgs, "generation_time", fmt.Sprintf("%d [s]", diff))
+			logArgs = append(logArgs, "generation_time_in_sec", diff)
 		}
 		b.logger.Info("new block", logArgs...)
 	}

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -592,6 +592,17 @@ func (b *Blockchain) WriteBlocks(blocks []*types.Block) error {
 
 		// Update the average gas price
 		b.UpdateGasPriceAvg(new(big.Int).SetUint64(header.GasUsed))
+
+		logArgs := []interface{}{
+			"number", header.Number,
+			"hash", header.Hash,
+			"txns", len(block.Transactions),
+		}
+		if prevHeader, ok := b.GetHeaderByNumber(header.Number - 1); ok {
+			diff := header.Timestamp - prevHeader.Timestamp
+			logArgs = append(logArgs, "generation_time", fmt.Sprintf("%d [s]", diff))
+		}
+		b.logger.Info("new block", logArgs...)
 	}
 
 	b.logger.Info("new head", "hash", b.Header().Hash, "number", b.Header().Number)

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -619,14 +619,6 @@ func (i *Ibft) runValidateState() {
 			i.logger.Error("failed to insert block", "err", err)
 			i.handleStateErr(errFailedToInsertBlock)
 		} else {
-			i.logger.Info(
-				"final committed",
-				"sequence", i.state.view.Sequence,
-				"hash", block.Hash(),
-				"validators", len(i.state.validators),
-				"rounds", i.state.view.Round+1,
-				"committed", i.state.numCommitted(),
-			)
 			// move ahead to the next block
 			i.setState(AcceptState)
 		}
@@ -652,6 +644,15 @@ func (i *Ibft) insertBlock(block *types.Block) error {
 	if err := i.blockchain.WriteBlocks([]*types.Block{block}); err != nil {
 		return err
 	}
+
+	i.logger.Info(
+		"final committed",
+		"sequence", i.state.view.Sequence,
+		"hash", block.Hash(),
+		"validators", len(i.state.validators),
+		"rounds", i.state.view.Round+1,
+		"committed", i.state.numCommitted(),
+	)
 
 	// increase the sequence number and reset the round if any
 	i.state.view = &proto.View{

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -646,7 +646,7 @@ func (i *Ibft) insertBlock(block *types.Block) error {
 	}
 
 	i.logger.Info(
-		"final committed",
+		"block committed",
 		"sequence", i.state.view.Sequence,
 		"hash", block.Hash(),
 		"validators", len(i.state.validators),

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -394,6 +394,7 @@ func (i *Ibft) buildBlock(snap *Snapshot, parent *types.Header) (*types.Block, e
 		}
 		txns = append(txns, txn)
 	}
+	i.logger.Info("picked out txns from pool", "num", len(txns), "remaining", i.txpool.Length())
 
 	_, root := transition.Commit()
 	header.StateRoot = root
@@ -618,6 +619,14 @@ func (i *Ibft) runValidateState() {
 			i.logger.Error("failed to insert block", "err", err)
 			i.handleStateErr(errFailedToInsertBlock)
 		} else {
+			i.logger.Info(
+				"final committed",
+				"sequence", i.state.view.Sequence,
+				"hash", block.Hash(),
+				"validators", len(i.state.validators),
+				"rounds", i.state.view.Round+1,
+				"committed", i.state.numCommitted(),
+			)
 			// move ahead to the next block
 			i.setState(AcceptState)
 		}


### PR DESCRIPTION
# Description

This PR adds some logs to get some basic performance metrics like:
* Total transactions in new block
* Number of transactions in txn pool
* Number of validators
* Number of rounds in a block
* Time difference between previous block and current block

Example of new logs:
```go
2021-07-20T16:26:45.022+0900 [INFO]  polygon.consensus.ibft: picked out txns from pool: num=10 remaining=0
...
2021-07-20T16:26:47.020+0900 [INFO]  polygon.blockchain: new block: number=14 hash=0xbbd6d6393837eca0620f74c0dd1a7163ace030012f6104bc43b5c949b46e3158 txns=10 generation_time_in_sec=2
...
2021-07-20T16:26:47.022+0900 [INFO]  polygon.consensus.ibft: block committed: sequence=14 hash=0xbbd6d6393837eca0620f74c0dd1a7163ace030012f6104bc43b5c949b46e3158 validators=4 rounds=1 committed=3

```

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
