### PR TITLE
Add comments and rename method name to improve code readability

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -515,9 +515,7 @@ func (b *Blockchain) WriteBlocks(blocks []*types.Block) error {
 	}
 
 	// Validate the chain
-	for i := 0; i < size; i++ { // TODO: Check why didn't we range here
-		block := blocks[i]
-
+	for i, block := range blocks {
 		// Check the parent numbers
 		if block.Number()-1 != parent.Number {
 			return fmt.Errorf(

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -744,7 +744,7 @@ func (i *Ibft) runRoundChangeState() {
 			// start a new round inmediatly
 			i.state.view.Round = msg.View.Round
 			i.setState(AcceptState)
-		} else if num == i.state.validators.MinFaultyNodes()+1 {
+		} else if num == i.state.validators.MaxFaultyNodes()+1 {
 			// weak certificate, try to catch up if our round number is smaller
 			if i.state.view.Round < msg.View.Round {
 				// update timer

--- a/consensus/ibft/sign.go
+++ b/consensus/ibft/sign.go
@@ -14,8 +14,8 @@ import (
 
 func commitMsg(b []byte) []byte {
 	// message that the nodes need to sign to commit to a block
-	// TODO: EIP-650 says the COMMIT_MSG_CODE is 1, not 2
-	return crypto.Keccak256(b, []byte{byte(2)})
+	// hash with COMMIT_MSG_CODE which is the same value used in quorum
+	return crypto.Keccak256(b, []byte{byte(proto.MessageReq_Commit)})
 }
 
 func ecrecoverImpl(sig, msg []byte) (types.Address, error) {
@@ -34,7 +34,7 @@ func ecrecoverFromHeader(h *types.Header) (types.Address, error) {
 		return types.Address{}, err
 	}
 	// get the sig
-	msg, err := signHash(h)
+	msg, err := getHeaderHash(h)
 	if err != nil {
 		return types.Address{}, err
 	}
@@ -43,7 +43,7 @@ func ecrecoverFromHeader(h *types.Header) (types.Address, error) {
 }
 
 func signSealImpl(prv *ecdsa.PrivateKey, h *types.Header, committed bool) ([]byte, error) {
-	sig, err := signHash(h)
+	sig, err := getHeaderHash(h)
 	if err != nil {
 		return nil, err
 	}
@@ -110,8 +110,7 @@ func writeCommittedSeals(h *types.Header, seals [][]byte) (*types.Header, error)
 	return h, nil
 }
 
-// TODO: This function is called signHash, we are doing no signing
-func signHash(h *types.Header) ([]byte, error) {
+func getHeaderHash(h *types.Header) ([]byte, error) {
 	//hash := istanbulHeaderHash(h)
 	//return hash.Bytes(), nil
 
@@ -178,15 +177,15 @@ func verifyCommitedFields(snap *Snapshot, header *types.Header) error {
 
 	// get the message that needs to be signed
 	// this not signing! just removing the fields that should be signed
-	signMsg, err := signHash(header)
+	hash, err := getHeaderHash(header)
 	if err != nil {
 		return err
 	}
-	signMsg = commitMsg(signMsg) // TODO: Rename signMsg to msgToSign or rawMsg
+	rawMsg := commitMsg(hash)
 
 	visited := map[types.Address]struct{}{}
 	for _, seal := range extra.CommittedSeal {
-		addr, err := ecrecoverImpl(seal, signMsg)
+		addr, err := ecrecoverImpl(seal, rawMsg)
 		if err != nil {
 			return err
 		}
@@ -205,7 +204,7 @@ func verifyCommitedFields(snap *Snapshot, header *types.Header) error {
 	// 	2F 	is the required number of honest validators who provided the commited seals
 	// 	+1	is the proposer
 	validSeals := len(visited)
-	if validSeals <= 2*snap.Set.MinFaultyNodes() {
+	if validSeals <= 2*snap.Set.MaxFaultyNodes() {
 		return fmt.Errorf("not enough seals to seal block")
 	}
 

--- a/consensus/ibft/sign.go
+++ b/consensus/ibft/sign.go
@@ -34,7 +34,7 @@ func ecrecoverFromHeader(h *types.Header) (types.Address, error) {
 		return types.Address{}, err
 	}
 	// get the sig
-	msg, err := getHeaderHash(h)
+	msg, err := calculateHeaderHash(h)
 	if err != nil {
 		return types.Address{}, err
 	}
@@ -43,16 +43,17 @@ func ecrecoverFromHeader(h *types.Header) (types.Address, error) {
 }
 
 func signSealImpl(prv *ecdsa.PrivateKey, h *types.Header, committed bool) ([]byte, error) {
-	sig, err := getHeaderHash(h)
+	hash, err := calculateHeaderHash(h)
 	if err != nil {
 		return nil, err
 	}
 
 	// if we are singing the commited seals we need to do something more
+	msg := hash
 	if committed {
-		sig = commitMsg(sig)
+		msg = commitMsg(hash)
 	}
-	seal, err := crypto.Sign(prv, crypto.Keccak256(sig))
+	seal, err := crypto.Sign(prv, crypto.Keccak256(msg))
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func writeCommittedSeals(h *types.Header, seals [][]byte) (*types.Header, error)
 	return h, nil
 }
 
-func getHeaderHash(h *types.Header) ([]byte, error) {
+func calculateHeaderHash(h *types.Header) ([]byte, error) {
 	//hash := istanbulHeaderHash(h)
 	//return hash.Bytes(), nil
 
@@ -177,7 +178,7 @@ func verifyCommitedFields(snap *Snapshot, header *types.Header) error {
 
 	// get the message that needs to be signed
 	// this not signing! just removing the fields that should be signed
-	hash, err := getHeaderHash(header)
+	hash, err := calculateHeaderHash(header)
 	if err != nil {
 		return err
 	}

--- a/consensus/ibft/state.go
+++ b/consensus/ibft/state.go
@@ -99,7 +99,7 @@ func (c *currentState) setState(s IbftState) {
 
 // NumValid returns the number of required messages
 func (c *currentState) NumValid() int {
-	return 2 * c.validators.MinFaultyNodes()
+	return 2 * c.validators.MaxFaultyNodes()
 }
 
 // getErr returns the current error, if any, and consumes it
@@ -111,7 +111,7 @@ func (c *currentState) getErr() error {
 }
 
 func (c *currentState) maxRound() (maxRound uint64, found bool) {
-	num := c.validators.MinFaultyNodes() + 1
+	num := c.validators.MaxFaultyNodes() + 1
 
 	for k, round := range c.roundMessages {
 		if len(round) < num {
@@ -282,9 +282,8 @@ func (v *ValidatorSet) Includes(addr types.Address) bool {
 	return v.Index(addr) != -1
 }
 
-// TODO: Rename to MAX instead of MIN faulty nodes
-// MinFaultyNodes returns the required minimum number of faulty nodes, based on the current validator set
-func (v *ValidatorSet) MinFaultyNodes() int {
+// MaxFaultyNodes returns the maximum number of allowed faulty nodes, based on the current validator set
+func (v *ValidatorSet) MaxFaultyNodes() int {
 	// numberOfValidators / 3
 	return int(math.Ceil(float64(len(*v))/3)) - 1
 }

--- a/consensus/ibft/state_test.go
+++ b/consensus/ibft/state_test.go
@@ -24,7 +24,7 @@ func TestState_FaultyNodes(t *testing.T) {
 	for _, c := range cases {
 		pool := newTesterAccountPool(int(c.Network))
 		vals := pool.ValidatorSet()
-		assert.Equal(t, vals.MinFaultyNodes(), int(c.Faulty))
+		assert.Equal(t, vals.MaxFaultyNodes(), int(c.Faulty))
 	}
 }
 

--- a/state/executor.go
+++ b/state/executor.go
@@ -339,8 +339,7 @@ func (t *Transition) preCheck(msg *types.Transaction) (uint64, error) {
 
 	// deduct the upfront max gas cost
 	upfrontGasCost := new(big.Int).Set(msg.GasPrice)
-	// TODO: No need to reassign upfrontGasCost on the left
-	upfrontGasCost = upfrontGasCost.Mul(upfrontGasCost, new(big.Int).SetUint64(msg.Gas))
+	upfrontGasCost.Mul(upfrontGasCost, new(big.Int).SetUint64(msg.Gas))
 	balance := t.state.GetBalance(msg.From)
 
 	// TODO: Remove if, let SubBalance return error
@@ -369,10 +368,6 @@ func (t *Transition) apply(msg *types.Transaction) (
 	leftoverGas, err := t.preCheck(msg)
 	if err != nil {
 		return nil, 0, false, err
-	}
-	// TODO: Check if this is even possible
-	if leftoverGas > msg.Gas {
-		return nil, 0, false, errorVMOutOfGas
 	}
 
 	gasPrice := new(big.Int).Set(msg.GasPrice)

--- a/state/executor.go
+++ b/state/executor.go
@@ -15,6 +15,10 @@ const (
 	spuriousDragonMaxCodeSize = 24576
 )
 
+var (
+	errorVMOutOfGas = fmt.Errorf("out of gas")
+)
+
 var emptyCodeHashTwo = types.BytesToHash(crypto.Keccak256(nil))
 
 // GetHashByNumber returns the hash function of a block number
@@ -364,6 +368,10 @@ func (t *Transition) apply(msg *types.Transaction) (
 	leftoverGas, err := t.preCheck(msg)
 	if err != nil {
 		return nil, 0, false, err
+	}
+	// TODO: Check if this is even possible
+	if leftoverGas > msg.Gas {
+		return nil, 0, false, errorVMOutOfGas
 	}
 
 	gasPrice := new(big.Int).Set(msg.GasPrice)

--- a/state/executor.go
+++ b/state/executor.go
@@ -15,10 +15,6 @@ const (
 	spuriousDragonMaxCodeSize = 24576
 )
 
-var (
-	errorVMOutOfGas = fmt.Errorf("out of gas")
-)
-
 var emptyCodeHashTwo = types.BytesToHash(crypto.Keccak256(nil))
 
 // GetHashByNumber returns the hash function of a block number

--- a/state/txn.go
+++ b/state/txn.go
@@ -93,7 +93,7 @@ func (txn *Txn) GetAccount(addr types.Address) (*Account, bool) {
 }
 
 func (txn *Txn) getStateObject(addr types.Address) (*StateObject, bool) {
-	// Check what this first fetch tries to do? Why is it here?
+	// Try to get state from radix tree which holds transient states during block processing first
 	val, exists := txn.txn.Get(addr.Bytes())
 	if exists {
 		obj := val.(*StateObject)
@@ -324,6 +324,7 @@ func (txn *Txn) GetState(addr types.Address, key types.Hash) types.Hash {
 		return types.Hash{}
 	}
 
+	// Get account state from radix tree
 	if object.Txn != nil {
 		if val, ok := object.Txn.Get(key.Bytes()); ok {
 			if val == nil {
@@ -333,7 +334,7 @@ func (txn *Txn) GetState(addr types.Address, key types.Hash) types.Hash {
 		}
 	}
 
-	// Under which condition is this called?
+	// Get account state from trie tree
 	k := txn.hashit(key.Bytes())
 	return object.GetCommitedState(types.BytesToHash(k))
 }


### PR DESCRIPTION
# Description

This PR adds some comments, fixes the codes without any impact, and renames some method names to improve code readability

## Explanation about some changes

Keeps a record of the reason of some changes.

### Message code used in committed seal

> Committed seal is calculated by each of the validator signing the hash along with COMMIT_MSG_CODE message code of its private key

`COMMIT_MSG_CODE` is 1 according to EIP-650, but it's 2 in Quorum implementation because they added PREPREPARE_MSG_CODE. PolygonSDK is using same set of message codes to Quorum implementation. So we can calculate committed seal by 2.

https://docs.goquorum.consensys.net/en/stable/Concepts/Consensus/IBFT/

### Remaining gas check in apply of Transition

This PR removes following code:
https://github.com/0xPolygon/polygon-sdk/blob/2f50a194f21d972b542ccd1e1571ccba40c5c810/state/executor.go#L373-L376

The reason is that `leftoverGas` is calculated by `msg.gas - (constant value) - (size of Input with non-zero value)`, which means leftoverGas is always less than msg.gas. So will never enter the branch.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
