### PR TITLE
Fix memory leak in discovery protocol

### DIFF
--- a/network/discovery.go
+++ b/network/discovery.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -23,12 +24,45 @@ var discProto = "/disc/0.1"
 
 const defaultBucketSize = 20
 
+// referencePeer is a representation of the peer the node is requesting for new peers
+type referencePeer struct {
+	id     peer.ID
+	stream interface{}
+}
+
+type referencePeers []*referencePeer
+
+func (ps *referencePeers) find(id peer.ID) *referencePeer {
+	for _, p := range *ps {
+		if p.id == id {
+			return p
+		}
+	}
+	return nil
+}
+
+func (ps *referencePeers) delete(id peer.ID) *referencePeer {
+	idx := -1
+	for i, p := range *ps {
+		if p.id == id {
+			idx = i
+			break
+		}
+	}
+	if idx != -1 {
+		deletePeer := (*ps)[idx]
+		(*ps) = append((*ps)[:idx], (*ps)[idx+1:]...)
+		return deletePeer
+	}
+	return nil
+}
+
 type discovery struct {
 	proto.UnimplementedDiscoveryServer
 	srv          *Server
 	routingTable *kb.RoutingTable
 
-	peers     []peer.ID
+	peers     referencePeers
 	peersLock sync.Mutex
 
 	notifyCh chan struct{}
@@ -43,7 +77,7 @@ func (d *discovery) setBootnodes(bootnodes []*peer.AddrInfo) {
 
 func (d *discovery) setup() error {
 	d.notifyCh = make(chan struct{}, 5)
-	d.peers = []peer.ID{}
+	d.peers = referencePeers{}
 
 	keyID := kb.ConvertPeerID(d.srv.host.ID())
 
@@ -69,21 +103,26 @@ func (d *discovery) setup() error {
 
 	// send all the nodes we connect to the routing table
 	err = d.srv.SubscribeFn(func(evnt *PeerEvent) {
-		if evnt.Type != PeerEventConnected {
-			return
-		}
 		peerID := evnt.PeerID
-
-		// add peer to the routing table and to our local peer
-		_, err := d.routingTable.TryAddPeer(peerID, false, false)
-		if err != nil {
-			d.srv.logger.Error("failed to add peer to routing table", "err", err)
-			return
+		switch evnt.Type {
+		case PeerEventConnected:
+			// add peer to the routing table and to our local peer
+			_, err := d.routingTable.TryAddPeer(peerID, false, false)
+			if err != nil {
+				d.srv.logger.Error("failed to add peer to routing table", "err", err)
+				return
+			}
+			d.peersLock.Lock()
+			d.peers = append(d.peers, &referencePeer{
+				id:     peerID,
+				stream: nil,
+			})
+			d.peersLock.Unlock()
+		case PeerEventDisconnected:
+			d.peersLock.Lock()
+			d.peers.delete(peerID)
+			d.peersLock.Unlock()
 		}
-
-		d.peersLock.Lock()
-		d.peers = append(d.peers, peerID)
-		d.peersLock.Unlock()
 	})
 	if err != nil {
 		return err
@@ -113,12 +152,35 @@ func (d *discovery) call(peerID peer.ID) error {
 	return nil
 }
 
-func (d *discovery) findPeersCall(peerID peer.ID) ([]*peer.AddrInfo, error) {
-	conn, err := d.srv.NewProtoStream(discProto, peerID)
+func (d *discovery) getStream(peerID peer.ID) (interface{}, error) {
+	d.peersLock.Lock()
+	defer d.peersLock.Unlock()
+
+	p := d.peers.find(peerID)
+	if p == nil {
+		return nil, fmt.Errorf("peer not found in peers")
+	}
+
+	// return the existing stream if stream has been opened
+	if p.stream != nil {
+		return p.stream, nil
+	}
+
+	stream, err := d.srv.NewProtoStream(discProto, peerID)
 	if err != nil {
 		return nil, err
 	}
-	clt := proto.NewDiscoveryClient(conn.(*rawGrpc.ClientConn))
+	p.stream = stream
+
+	return p.stream, nil
+}
+
+func (d *discovery) findPeersCall(peerID peer.ID) ([]*peer.AddrInfo, error) {
+	stream, err := d.getStream(peerID)
+	if err != nil {
+		return nil, err
+	}
+	clt := proto.NewDiscoveryClient(stream.(*rawGrpc.ClientConn))
 
 	resp, err := clt.FindPeers(context.Background(), &proto.FindPeersReq{Count: 16})
 	if err != nil {
@@ -161,7 +223,7 @@ func (d *discovery) handleDiscovery() {
 		// take a random peer and find peers
 		if len(d.peers) > 0 {
 			target := d.peers[rand.Intn(len(d.peers))]
-			if err := d.call(target); err != nil {
+			if err := d.call(target.id); err != nil {
 				d.srv.logger.Error("failed to dial bootnode", "err", err)
 			}
 		}

--- a/network/discovery.go
+++ b/network/discovery.go
@@ -158,7 +158,7 @@ func (d *discovery) getStream(peerID peer.ID) (interface{}, error) {
 
 	p := d.peers.find(peerID)
 	if p == nil {
-		return nil, fmt.Errorf("peer not found in peers")
+		return nil, fmt.Errorf("peer not found in list")
 	}
 
 	// return the existing stream if stream has been opened


### PR DESCRIPTION
# Description

Relevant issue: #91

This PR fixes memory leak issue in discovery of network package. This problem occurred by creating new stream frequently. discovery protocol picks a random peer up, establishes new stream, and queries for close peers reguraly. (default period is every 5 seconds) Stream in libp2p is a bidirectional data channel that exists over the actual connection, but buffer in transport won't be released if node opens new streams frequently. As a result, buffer will accumulate data and memory leak happens. In the latest code (2f50a194f21d972b542ccd1e1571ccba40c5c810), node will allocate about 60 MB new heap within 1 hour in this part.

The new code keeps streams during whole process instead of creating new one. This change suppresses the heap allocation by discovery.

## Result

I measured the change of heap allocation for a few hours and check how this PR affects the memory leak. I set up 4 IBFT nodes, run them from genesis, and send transfer transaction every 5s. Used `pprof` (https://pkg.go.dev/net/http/pprof) to get profiles.

Environment
```
CPU: Intel Core i5 1.4 GHz Quad Core
RAM: 16 GB 2133 MHz LPDDR3
OS: macOS BigSur 11.4 (20F71)
Go version: go version go1.15.7 darwin/amd64
```


The tables below shows the change of heap allocation over hours. The data is separated by each allocated heap and column name is the name of root function. (Note there are other heap allocations but they are not related to this issue, so I don't show them)

The change of heap allocation in latest code.

| Elapsed Time \[hour\] | grpc (\*Server) Serve func3 \[MB\] | grpc (\*addrConn) resetTransport \[MB\] | network (\*discovery) run \[MB\] | transport newHTTP2Client func3 \[MB\] | transport (\*http2Server) keepalive \[MB\] |
| --------------------- | ---------------------------------- | --------------------------------------- | -------------------------------- | ------------------------------------- | ------------------------------------------ |
| 0                     |                                    |                                         |                                  |                                       |                                            |
| 0.5                   | 42.13                              | 35.27                                   |                                  | 2.50                                  |                                            |
| 1                     | 77.84                              | 62.03                                   | 1.00                             | 3.00                                  | 1.00                                       |
| 1.5                   | 110.85                             | 89.32                                   | 2.00                             | 5.00                                  | 1.50                                       |
| 2                     | 142.91                             | 121.89                                  | 5.00                             | 5.00                                  | 2.00                                       |
| 2.5                   | 182.91                             | 156.53                                  | 7.00                             | 5.50                                  | 3.00                                       |
| 3                     | 204.54                             | 188.12                                  | 8.00                             | 6.00                                  | 3.50                                       |
| 3.5                   | 241.31                             | 219.68                                  | 9.00                             | 7.50                                  | 3.50                                       |
| 4                     | 269.14                             | 256.93                                  | 10.00                            | 8.00                                  | 4.00                                       |
| 4.5                   | 307.47                             | 287.38                                  | 11.00                            | 8.50                                  | 4.00                                       |

The change of heap allocation in this PR.

| Elapsed Time \[hour\] | grpc (\*Server) Serve func3 \[MB\] | grpc (\*addrConn) resetTransport \[MB\] | network (\*discovery) run \[MB\] | transport newHTTP2Client func3 \[MB\] | transport (\*http2Server) keepalive \[MB\] |
| --------------------- | ---------------------------------- | --------------------------------------- | -------------------------------- | ------------------------------------- | ------------------------------------------ |
| 0                     |                                    |                                         |                                  |                                       |                                            |
| 0.5                   | 0.53                               | 1.03                                    |                                  |                                       |                                            |
| 1                     | 0.53                               | 1.03                                    |                                  |                                       |                                            |
| 1.5                   | 0.53                               | 1.03                                    |                                  |                                       |                                            |
| 2                     | 0.53                               | 1.03                                    |                                  |                                       |                                            |
| 2.5                   | 0.53                               | 1.03                                    |                                  |                                       |                                            |
| 3                     | 0.53                               | 1.03                                    |                                  |                                       |                                            |
| 3.5                   | 0.53                               | 1.03                                    |                                  |                                       |                                            |
| 4                     | 0.53                               | 1.03                                    |                                  |                                       |                                            |
| 4.5                   | 0.53                               | 1.03                                    |                                  |                                       |

The result shows this PR prevents `grpc (*Server) Serve func3` and `grpc (*addrConn) resetTransport` from continuous heap allocating. (Note these 2 functions share some heap, so the sum of these 2 sizes is not same to the size of actual heap allocation) In addition, other heap allocations will be released soon.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
