### PR TITLE
added txpool methods

### DIFF
--- a/jsonrpc/blockchain.go
+++ b/jsonrpc/blockchain.go
@@ -40,6 +40,9 @@ type blockchainInterface interface {
 	// AddTx adds a new transaction to the tx pool
 	AddTx(tx *types.Transaction) error
 
+	// Gets tx pool transactions currently pending for inclusion and currently queued for validation
+	GetTxs() (map[types.Address]map[uint64]*types.Transaction, map[types.Address]map[uint64]*types.Transaction)
+
 	// GetBlockByHash gets a block using the provided hash
 	GetBlockByHash(hash types.Hash, full bool) (*types.Block, bool)
 
@@ -88,6 +91,10 @@ func (b *nullBlockchainInterface) GetAvgGasPrice() *big.Int {
 
 func (b *nullBlockchainInterface) AddTx(tx *types.Transaction) error {
 	return nil
+}
+
+func (b *nullBlockchainInterface) GetTxs() (map[types.Address]map[uint64]*types.Transaction, map[types.Address]map[uint64]*types.Transaction) {
+	return nil, nil
 }
 
 func (b *nullBlockchainInterface) State() state.State {

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -41,6 +41,7 @@ type endpoints struct {
 	Eth  *Eth
 	Web3 *Web3
 	Net  *Net
+	Txpool *Txpool
 }
 
 // Dispatcher handles jsonrpc requests
@@ -83,10 +84,12 @@ func (d *Dispatcher) registerEndpoints() {
 	d.endpoints.Eth = &Eth{d}
 	d.endpoints.Net = &Net{d}
 	d.endpoints.Web3 = &Web3{d}
+	d.endpoints.Txpool = &Txpool{d}
 
 	d.registerService("eth", d.endpoints.Eth)
 	d.registerService("net", d.endpoints.Net)
 	d.registerService("web3", d.endpoints.Web3)
+	d.registerService("txpool", d.endpoints.Txpool)
 }
 
 func (d *Dispatcher) getFnHandler(req Request) (*serviceData, *funcData, error) {

--- a/jsonrpc/txpool_endpoint.go
+++ b/jsonrpc/txpool_endpoint.go
@@ -35,30 +35,20 @@ func (t *Txpool) Content() (interface{}, error) {
 	for address, nonces := range pendingTxs {
 		pendingRpcTxns[address] = make(map[uint64]*transaction)
 		for nonce, tx := range nonces {
-			// placeholder block to pass toTransaction
-			mockBlock := &types.Block{
-				Header: &types.Header{
-					Hash: types.Hash{0x0},
-					Number: uint64(0),
-				},
-			}
+			blockHash, _ := t.d.store.ReadTxLookup(tx.Hash)
+			block, _ := t.d.store.GetBlockByHash(blockHash, false)
 			// using 0 as txIndex
-			pendingRpcTxns[address][nonce] = toTransaction(tx, mockBlock, 0)
+			pendingRpcTxns[address][nonce] = toTransaction(tx, block, 0)
 		}
   }
 	queuedRpcTxns := make(map[types.Address]map[uint64]*transaction)
 	for address, nonces := range queuedTxs {
 		queuedRpcTxns[address] = make(map[uint64]*transaction)
 		for nonce, tx := range nonces {
-			// placeholder block to pass toTransaction
-			mockBlock := &types.Block{
-				Header: &types.Header{
-					Hash: types.Hash{0x0},
-					Number: uint64(0),
-				},
-			}
+			blockHash, _ := t.d.store.ReadTxLookup(tx.Hash)
+			block, _ := t.d.store.GetBlockByHash(blockHash, false)
 			// using 0 as txIndex
-			queuedRpcTxns[address][nonce] = toTransaction(tx, mockBlock, 0)
+			queuedRpcTxns[address][nonce] = toTransaction(tx, block, 0)
 		}
   }
 

--- a/jsonrpc/txpool_endpoint.go
+++ b/jsonrpc/txpool_endpoint.go
@@ -2,62 +2,100 @@ package jsonrpc
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/0xPolygon/minimal/types"
 )
 
 // Txpool is the txpool jsonrpc endpoint
 type Txpool struct {
-	d *Dispatcher
+  d *Dispatcher
 }
 
 type ContentResponse struct {
-	Pending   map[types.Address]map[uint64]*transaction		`json:"pending"`
-	Queued 		map[types.Address]map[uint64]*transaction		`json:"queued"`
+  Pending   map[types.Address]map[uint64]*gethTransaction   `json:"pending"`
+  Queued    map[types.Address]map[uint64]*gethTransaction   `json:"queued"`
 }
 
 type InspectResponse struct {
-	Pending   map[string]map[string]string	`json:"pending"`
-	Queued		map[string]map[string]string	`json:"queued"`
+  Pending   map[string]map[string]string  `json:"pending"`
+  Queued    map[string]map[string]string  `json:"queued"`
 }
 
 type StatusResponse struct {
-	Pending   uint64	`json:"pending"`
-	Queued 		uint64	`json:"queued"`
+  Pending   uint64  `json:"pending"`
+  Queued    uint64  `json:"queued"`
+}
+
+type gethTransaction struct {
+  Nonce       argUint64      `json:"nonce"`
+  GasPrice    argBig         `json:"gasPrice"`
+  Gas         argUint64      `json:"gas"`
+  To          *types.Address `json:"to"`
+  Value       argBig         `json:"value"`
+  Input       argBytes       `json:"input"`
+  V           argByte        `json:"v"`
+  R           argBytes       `json:"r"`
+  S           argBytes       `json:"s"`
+  Hash        types.Hash     `json:"hash"`
+  From        types.Address  `json:"from"`
+  BlockHash   types.Hash     `json:"blockHash"`
+  BlockNumber interface{}    `json:"blockNumber"`
+  TxIndex     interface{}    `json:"transactionIndex"`
+}
+
+func toGethTransaction(t *types.Transaction) *gethTransaction {
+  if t.R == nil {
+    t.R = []byte{0}
+  }
+  if t.S == nil {
+    t.S = []byte{0}
+  }
+
+  return &gethTransaction{
+    Nonce:        argUint64(t.Nonce),
+    GasPrice:     argBig(*t.GasPrice),
+    Gas:          argUint64(t.Gas),
+    To:           t.To,
+    Value:        argBig(*t.Value),
+    Input:        argBytes(t.Input),
+    V:            argByte(t.V),
+    R:            argBytes(t.R),
+    S:            argBytes(t.S),
+    Hash:         t.Hash,
+    From:         t.From,
+    BlockHash:    types.ZeroHash,
+    BlockNumber:  nil,
+    TxIndex:      nil,
+  }
 }
 
 /** 
  * Content - implemented according to https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_content
  */
 func (t *Txpool) Content() (interface{}, error) {
-	pendingTxs, queuedTxs := t.d.store.GetTxs()
-	pendingRpcTxns := make(map[types.Address]map[uint64]*transaction)
-	for address, nonces := range pendingTxs {
-		pendingRpcTxns[address] = make(map[uint64]*transaction)
-		for nonce, tx := range nonces {
-			blockHash, _ := t.d.store.ReadTxLookup(tx.Hash)
-			block, _ := t.d.store.GetBlockByHash(blockHash, false)
-			// using 0 as txIndex
-			pendingRpcTxns[address][nonce] = toTransaction(tx, block, 0)
-		}
+  pendingTxs, queuedTxs := t.d.store.GetTxs()
+  pendingRpcTxns := make(map[types.Address]map[uint64]*gethTransaction)
+  for address, nonces := range pendingTxs {
+    pendingRpcTxns[address] = make(map[uint64]*gethTransaction)
+    for nonce, tx := range nonces {
+      pendingRpcTxns[address][nonce] = toGethTransaction(tx)
+    }
   }
-	queuedRpcTxns := make(map[types.Address]map[uint64]*transaction)
-	for address, nonces := range queuedTxs {
-		queuedRpcTxns[address] = make(map[uint64]*transaction)
-		for nonce, tx := range nonces {
-			blockHash, _ := t.d.store.ReadTxLookup(tx.Hash)
-			block, _ := t.d.store.GetBlockByHash(blockHash, false)
-			// using 0 as txIndex
-			queuedRpcTxns[address][nonce] = toTransaction(tx, block, 0)
-		}
+  queuedRpcTxns := make(map[types.Address]map[uint64]*gethTransaction)
+  for address, nonces := range queuedTxs {
+    queuedRpcTxns[address] = make(map[uint64]*gethTransaction)
+    for nonce, tx := range nonces {
+      queuedRpcTxns[address][nonce] = toGethTransaction(tx)
+    }
   }
 
-	resp := ContentResponse{
-		Pending: pendingRpcTxns,
-		Queued: queuedRpcTxns,
-	}
-	
-	return resp, nil
+  resp := ContentResponse{
+    Pending: pendingRpcTxns,
+    Queued: queuedRpcTxns,
+  }
+  
+  return resp, nil
 }
 
 /** 
@@ -65,51 +103,51 @@ func (t *Txpool) Content() (interface{}, error) {
  */
 func (t *Txpool) Inspect() (interface{}, error) {
 
-	pendingTxs, queuedTxs := t.d.store.GetTxs()
-	pendingRpcTxns := make(map[string]map[string]string)
-	for address, nonces := range pendingTxs {
-		pendingRpcTxns[address.String()] = make(map[string]string)
-		for nonce, tx := range nonces {
-			msg := fmt.Sprintf("%d wei + %d gas x %d wei", tx.Value, tx.Gas, tx.GasPrice)
-			pendingRpcTxns[address.String()][fmt.Sprint(nonce)] = msg
-		}
+  pendingTxs, queuedTxs := t.d.store.GetTxs()
+  pendingRpcTxns := make(map[string]map[string]string)
+  for address, nonces := range pendingTxs {
+    pendingRpcTxns[address.String()] = make(map[string]string)
+    for nonce, tx := range nonces {
+      msg := fmt.Sprintf("%d wei + %d gas x %d wei", tx.Value, tx.Gas, tx.GasPrice)
+      pendingRpcTxns[address.String()][strconv.FormatUint(nonce, 10)] = msg
+    }
   }
 
-	queuedRpcTxns := make(map[string]map[string]string)
-	for address, nonces := range queuedTxs {
-		queuedRpcTxns[address.String()] = make(map[string]string)
-		for nonce, tx := range nonces {
-			msg := fmt.Sprintf("%d wei + %d gas x %d wei", tx.Value, tx.Gas, tx.GasPrice)
-			queuedRpcTxns[address.String()][fmt.Sprint(nonce)] = msg
-		}
+  queuedRpcTxns := make(map[string]map[string]string)
+  for address, nonces := range queuedTxs {
+    queuedRpcTxns[address.String()] = make(map[string]string)
+    for nonce, tx := range nonces {
+      msg := fmt.Sprintf("%d wei + %d gas x %d wei", tx.Value, tx.Gas, tx.GasPrice)
+      queuedRpcTxns[address.String()][strconv.FormatUint(nonce, 10)] = msg
+    }
   }
 
-	resp := InspectResponse{
-		Pending: pendingRpcTxns,
-		Queued: queuedRpcTxns,
-	}
+  resp := InspectResponse{
+    Pending: pendingRpcTxns,
+    Queued: queuedRpcTxns,
+  }
 
-	return resp, nil
+  return resp, nil
 }
 
 /** 
  * Status - implemented according to https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_content
  */
 func (t *Txpool) Status() (interface{}, error) {
-	pendingTxs, queuedTxs := t.d.store.GetTxs()
-	var pendingCount int
+  pendingTxs, queuedTxs := t.d.store.GetTxs()
+  var pendingCount int
   for _, t := range pendingTxs {
     pendingCount += len(t)
   }
-	var queuedCount int
+  var queuedCount int
   for _, t := range queuedTxs {
     queuedCount += len(t)
   }
 
-	resp := StatusResponse{
-		Pending: uint64(pendingCount),
-		Queued: uint64(queuedCount),
-	}
+  resp := StatusResponse{
+    Pending: uint64(pendingCount),
+    Queued: uint64(queuedCount),
+  }
 
-	return resp, nil
+  return resp, nil
 }

--- a/jsonrpc/txpool_endpoint.go
+++ b/jsonrpc/txpool_endpoint.go
@@ -9,145 +9,129 @@ import (
 
 // Txpool is the txpool jsonrpc endpoint
 type Txpool struct {
-  d *Dispatcher
+	d *Dispatcher
 }
 
 type ContentResponse struct {
-  Pending   map[types.Address]map[uint64]*gethTransaction   `json:"pending"`
-  Queued    map[types.Address]map[uint64]*gethTransaction   `json:"queued"`
+	Pending map[types.Address]map[uint64]*txpoolTransaction `json:"pending"`
+	Queued  map[types.Address]map[uint64]*txpoolTransaction `json:"queued"`
 }
 
 type InspectResponse struct {
-  Pending   map[string]map[string]string  `json:"pending"`
-  Queued    map[string]map[string]string  `json:"queued"`
+	Pending map[string]map[string]string `json:"pending"`
+	Queued  map[string]map[string]string `json:"queued"`
 }
 
 type StatusResponse struct {
-  Pending   uint64  `json:"pending"`
-  Queued    uint64  `json:"queued"`
+	Pending uint64 `json:"pending"`
+	Queued  uint64 `json:"queued"`
 }
 
-type gethTransaction struct {
-  Nonce       argUint64      `json:"nonce"`
-  GasPrice    argBig         `json:"gasPrice"`
-  Gas         argUint64      `json:"gas"`
-  To          *types.Address `json:"to"`
-  Value       argBig         `json:"value"`
-  Input       argBytes       `json:"input"`
-  V           argByte        `json:"v"`
-  R           argBytes       `json:"r"`
-  S           argBytes       `json:"s"`
-  Hash        types.Hash     `json:"hash"`
-  From        types.Address  `json:"from"`
-  BlockHash   types.Hash     `json:"blockHash"`
-  BlockNumber interface{}    `json:"blockNumber"`
-  TxIndex     interface{}    `json:"transactionIndex"`
+type txpoolTransaction struct {
+	Nonce       argUint64      `json:"nonce"`
+	GasPrice    argBig         `json:"gasPrice"`
+	Gas         argUint64      `json:"gas"`
+	To          *types.Address `json:"to"`
+	Value       argBig         `json:"value"`
+	Input       argBytes       `json:"input"`
+	Hash        types.Hash     `json:"hash"`
+	From        types.Address  `json:"from"`
+	BlockHash   types.Hash     `json:"blockHash"`
+	BlockNumber interface{}    `json:"blockNumber"`
+	TxIndex     interface{}    `json:"transactionIndex"`
 }
 
-func toGethTransaction(t *types.Transaction) *gethTransaction {
-  if t.R == nil {
-    t.R = []byte{0}
-  }
-  if t.S == nil {
-    t.S = []byte{0}
-  }
-
-  return &gethTransaction{
-    Nonce:        argUint64(t.Nonce),
-    GasPrice:     argBig(*t.GasPrice),
-    Gas:          argUint64(t.Gas),
-    To:           t.To,
-    Value:        argBig(*t.Value),
-    Input:        argBytes(t.Input),
-    V:            argByte(t.V),
-    R:            argBytes(t.R),
-    S:            argBytes(t.S),
-    Hash:         t.Hash,
-    From:         t.From,
-    BlockHash:    types.ZeroHash,
-    BlockNumber:  nil,
-    TxIndex:      nil,
-  }
+func toTxPoolTransaction(t *types.Transaction) *txpoolTransaction {
+	return &txpoolTransaction{
+		Nonce:       argUint64(t.Nonce),
+		GasPrice:    argBig(*t.GasPrice),
+		Gas:         argUint64(t.Gas),
+		To:          t.To,
+		Value:       argBig(*t.Value),
+		Input:       argBytes(t.Input),
+		Hash:        t.Hash,
+		From:        t.From,
+		BlockHash:   types.ZeroHash,
+		BlockNumber: nil,
+		TxIndex:     nil,
+	}
 }
 
-/** 
- * Content - implemented according to https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_content
- */
+// Create response for txpool_content request.
+// See https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_content.
 func (t *Txpool) Content() (interface{}, error) {
-  pendingTxs, queuedTxs := t.d.store.GetTxs()
-  pendingRpcTxns := make(map[types.Address]map[uint64]*gethTransaction)
-  for address, nonces := range pendingTxs {
-    pendingRpcTxns[address] = make(map[uint64]*gethTransaction)
-    for nonce, tx := range nonces {
-      pendingRpcTxns[address][nonce] = toGethTransaction(tx)
-    }
-  }
-  queuedRpcTxns := make(map[types.Address]map[uint64]*gethTransaction)
-  for address, nonces := range queuedTxs {
-    queuedRpcTxns[address] = make(map[uint64]*gethTransaction)
-    for nonce, tx := range nonces {
-      queuedRpcTxns[address][nonce] = toGethTransaction(tx)
-    }
-  }
+	pendingTxs, queuedTxs := t.d.store.GetTxs()
+	pendingRpcTxns := make(map[types.Address]map[uint64]*txpoolTransaction)
+	for address, nonces := range pendingTxs {
+		pendingRpcTxns[address] = make(map[uint64]*txpoolTransaction)
+		for nonce, tx := range nonces {
+			pendingRpcTxns[address][nonce] = toTxPoolTransaction(tx)
+		}
+	}
+	queuedRpcTxns := make(map[types.Address]map[uint64]*txpoolTransaction)
+	for address, nonces := range queuedTxs {
+		queuedRpcTxns[address] = make(map[uint64]*txpoolTransaction)
+		for nonce, tx := range nonces {
+			queuedRpcTxns[address][nonce] = toTxPoolTransaction(tx)
+		}
+	}
 
-  resp := ContentResponse{
-    Pending: pendingRpcTxns,
-    Queued: queuedRpcTxns,
-  }
-  
-  return resp, nil
+	resp := ContentResponse{
+		Pending: pendingRpcTxns,
+		Queued:  queuedRpcTxns,
+	}
+
+	return resp, nil
 }
 
-/** 
- * Inspect - implemented according to https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_inspect
- */
+// Create response for txpool_inspect request.
+// See https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_inspect.
 func (t *Txpool) Inspect() (interface{}, error) {
 
-  pendingTxs, queuedTxs := t.d.store.GetTxs()
-  pendingRpcTxns := make(map[string]map[string]string)
-  for address, nonces := range pendingTxs {
-    pendingRpcTxns[address.String()] = make(map[string]string)
-    for nonce, tx := range nonces {
-      msg := fmt.Sprintf("%d wei + %d gas x %d wei", tx.Value, tx.Gas, tx.GasPrice)
-      pendingRpcTxns[address.String()][strconv.FormatUint(nonce, 10)] = msg
-    }
-  }
+	pendingTxs, queuedTxs := t.d.store.GetTxs()
+	pendingRpcTxns := make(map[string]map[string]string)
+	for address, nonces := range pendingTxs {
+		pendingRpcTxns[address.String()] = make(map[string]string)
+		for nonce, tx := range nonces {
+			msg := fmt.Sprintf("%d wei + %d gas x %d wei", tx.Value, tx.Gas, tx.GasPrice)
+			pendingRpcTxns[address.String()][strconv.FormatUint(nonce, 10)] = msg
+		}
+	}
 
-  queuedRpcTxns := make(map[string]map[string]string)
-  for address, nonces := range queuedTxs {
-    queuedRpcTxns[address.String()] = make(map[string]string)
-    for nonce, tx := range nonces {
-      msg := fmt.Sprintf("%d wei + %d gas x %d wei", tx.Value, tx.Gas, tx.GasPrice)
-      queuedRpcTxns[address.String()][strconv.FormatUint(nonce, 10)] = msg
-    }
-  }
+	queuedRpcTxns := make(map[string]map[string]string)
+	for address, nonces := range queuedTxs {
+		queuedRpcTxns[address.String()] = make(map[string]string)
+		for nonce, tx := range nonces {
+			msg := fmt.Sprintf("%d wei + %d gas x %d wei", tx.Value, tx.Gas, tx.GasPrice)
+			queuedRpcTxns[address.String()][strconv.FormatUint(nonce, 10)] = msg
+		}
+	}
 
-  resp := InspectResponse{
-    Pending: pendingRpcTxns,
-    Queued: queuedRpcTxns,
-  }
+	resp := InspectResponse{
+		Pending: pendingRpcTxns,
+		Queued:  queuedRpcTxns,
+	}
 
-  return resp, nil
+	return resp, nil
 }
 
-/** 
- * Status - implemented according to https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_content
- */
+// Create response for txpool_status request.
+// See https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_status.
 func (t *Txpool) Status() (interface{}, error) {
-  pendingTxs, queuedTxs := t.d.store.GetTxs()
-  var pendingCount int
-  for _, t := range pendingTxs {
-    pendingCount += len(t)
-  }
-  var queuedCount int
-  for _, t := range queuedTxs {
-    queuedCount += len(t)
-  }
+	pendingTxs, queuedTxs := t.d.store.GetTxs()
+	var pendingCount int
+	for _, t := range pendingTxs {
+		pendingCount += len(t)
+	}
+	var queuedCount int
+	for _, t := range queuedTxs {
+		queuedCount += len(t)
+	}
 
-  resp := StatusResponse{
-    Pending: uint64(pendingCount),
-    Queued: uint64(queuedCount),
-  }
+	resp := StatusResponse{
+		Pending: uint64(pendingCount),
+		Queued:  uint64(queuedCount),
+	}
 
-  return resp, nil
+	return resp, nil
 }

--- a/jsonrpc/txpool_endpoint.go
+++ b/jsonrpc/txpool_endpoint.go
@@ -1,0 +1,125 @@
+package jsonrpc
+
+import (
+	"fmt"
+
+	"github.com/0xPolygon/minimal/types"
+)
+
+// Txpool is the txpool jsonrpc endpoint
+type Txpool struct {
+	d *Dispatcher
+}
+
+type ContentResponse struct {
+	Pending   map[types.Address]map[uint64]*transaction		`json:"pending"`
+	Queued 		map[types.Address]map[uint64]*transaction		`json:"queued"`
+}
+
+type InspectResponse struct {
+	Pending   map[string]map[string]string	`json:"pending"`
+	Queued		map[string]map[string]string	`json:"queued"`
+}
+
+type StatusResponse struct {
+	Pending   uint64	`json:"pending"`
+	Queued 		uint64	`json:"queued"`
+}
+
+/** 
+ * Content - implemented according to https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_content
+ */
+func (t *Txpool) Content() (interface{}, error) {
+	pendingTxs, queuedTxs := t.d.store.GetTxs()
+	pendingRpcTxns := make(map[types.Address]map[uint64]*transaction)
+	for address, nonces := range pendingTxs {
+		pendingRpcTxns[address] = make(map[uint64]*transaction)
+		for nonce, tx := range nonces {
+			// placeholder block to pass toTransaction
+			mockBlock := &types.Block{
+				Header: &types.Header{
+					Hash: types.Hash{0x0},
+					Number: uint64(0),
+				},
+			}
+			// using 0 as txIndex
+			pendingRpcTxns[address][nonce] = toTransaction(tx, mockBlock, 0)
+		}
+  }
+	queuedRpcTxns := make(map[types.Address]map[uint64]*transaction)
+	for address, nonces := range queuedTxs {
+		queuedRpcTxns[address] = make(map[uint64]*transaction)
+		for nonce, tx := range nonces {
+			// placeholder block to pass toTransaction
+			mockBlock := &types.Block{
+				Header: &types.Header{
+					Hash: types.Hash{0x0},
+					Number: uint64(0),
+				},
+			}
+			// using 0 as txIndex
+			queuedRpcTxns[address][nonce] = toTransaction(tx, mockBlock, 0)
+		}
+  }
+
+	resp := ContentResponse{
+		Pending: pendingRpcTxns,
+		Queued: queuedRpcTxns,
+	}
+	
+	return resp, nil
+}
+
+/** 
+ * Inspect - implemented according to https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_inspect
+ */
+func (t *Txpool) Inspect() (interface{}, error) {
+
+	pendingTxs, queuedTxs := t.d.store.GetTxs()
+	pendingRpcTxns := make(map[string]map[string]string)
+	for address, nonces := range pendingTxs {
+		pendingRpcTxns[address.String()] = make(map[string]string)
+		for nonce, tx := range nonces {
+			msg := fmt.Sprintf("%d wei + %d gas x %d wei", tx.Value, tx.Gas, tx.GasPrice)
+			pendingRpcTxns[address.String()][fmt.Sprint(nonce)] = msg
+		}
+  }
+
+	queuedRpcTxns := make(map[string]map[string]string)
+	for address, nonces := range queuedTxs {
+		queuedRpcTxns[address.String()] = make(map[string]string)
+		for nonce, tx := range nonces {
+			msg := fmt.Sprintf("%d wei + %d gas x %d wei", tx.Value, tx.Gas, tx.GasPrice)
+			queuedRpcTxns[address.String()][fmt.Sprint(nonce)] = msg
+		}
+  }
+
+	resp := InspectResponse{
+		Pending: pendingRpcTxns,
+		Queued: queuedRpcTxns,
+	}
+
+	return resp, nil
+}
+
+/** 
+ * Status - implemented according to https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_content
+ */
+func (t *Txpool) Status() (interface{}, error) {
+	pendingTxs, queuedTxs := t.d.store.GetTxs()
+	var pendingCount int
+  for _, t := range pendingTxs {
+    pendingCount += len(t)
+  }
+	var queuedCount int
+  for _, t := range queuedTxs {
+    queuedCount += len(t)
+  }
+
+	resp := StatusResponse{
+		Pending: uint64(pendingCount),
+		Queued: uint64(queuedCount),
+	}
+
+	return resp, nil
+}

--- a/jsonrpc/txpool_endpoint_test.go
+++ b/jsonrpc/txpool_endpoint_test.go
@@ -1,0 +1,56 @@
+package jsonrpc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContentEndpoint(t *testing.T) {
+	s := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0)
+	s.registerEndpoints()
+
+	resp, err := s.Handle([]byte(`{
+		"method": "txpool_content",
+		"params": []
+	}`))
+	assert.NoError(t, err)
+
+	var res ContentResponse
+	assert.NoError(t, expectJSONResult(resp, &res))
+	assert.Len(t, res.Pending, 0)
+	assert.Len(t, res.Queued, 0)
+}
+
+func TestInspectEndpoint(t *testing.T) {
+	s := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0)
+	s.registerEndpoints()
+
+	resp, err := s.Handle([]byte(`{
+		"method": "txpool_inspect",
+		"params": []
+	}`))
+	assert.NoError(t, err)
+
+	var res InspectResponse
+	assert.NoError(t, expectJSONResult(resp, &res))
+	assert.Len(t, res.Pending, 0)
+	assert.Len(t, res.Queued, 0)
+}
+
+func TestStatusEndpoint(t *testing.T) {
+	s := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0)
+	s.registerEndpoints()
+
+	resp, err := s.Handle([]byte(`{
+		"method": "txpool_status",
+		"params": []
+	}`))
+	assert.NoError(t, err)
+
+	var res StatusResponse
+	assert.NoError(t, expectJSONResult(resp, &res))
+	assert.Equal(t, res.Pending, uint64(0))
+	assert.Equal(t, res.Queued, uint64(0))
+}

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -205,6 +205,27 @@ func (t *TxPool) addImpl(ctx string, txns ...*types.Transaction) error {
 	return nil
 }
 
+// GetTxs gets both queued and pending transactions
+func (t *TxPool) GetTxs() (map[types.Address]map[uint64]*types.Transaction, map[types.Address]map[uint64]*types.Transaction) {
+	queuedTxs := make(map[types.Address]map[uint64]*types.Transaction)
+	queue := t.queue
+	for addr, queuedTxn := range queue {
+		for _, tx := range queuedTxn.txs {
+			queuedTxs[addr] = make(map[uint64]*types.Transaction)
+			queuedTxs[addr][tx.Nonce] = tx
+		}
+	}
+
+	pendingTxs := make(map[types.Address]map[uint64]*types.Transaction)
+	sortedPricedTxs := t.sorted.index
+	for _, sortedPricedTx := range sortedPricedTxs {
+		pendingTxs[sortedPricedTx.from] = make(map[uint64]*types.Transaction)
+		pendingTxs[sortedPricedTx.from][sortedPricedTx.tx.Nonce] = sortedPricedTx.tx
+	}
+
+	return queuedTxs, pendingTxs
+}
+
 func (t *TxPool) Length() uint64 {
 	return t.sorted.Length()
 }

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -4,11 +4,12 @@ import (
 	"container/heap"
 	"errors"
 	"fmt"
-	"github.com/0xPolygon/minimal/chain"
 	"math/big"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/0xPolygon/minimal/chain"
 
 	"github.com/0xPolygon/minimal/blockchain"
 	"github.com/0xPolygon/minimal/network"
@@ -209,7 +210,9 @@ func (t *TxPool) GetTxs() (map[types.Address]map[uint64]*types.Transaction, map[
 	queue := t.queue
 	for addr, queuedTxn := range queue {
 		for _, tx := range queuedTxn.txs {
-			queuedTxs[addr] = make(map[uint64]*types.Transaction)
+			if _, ok := queuedTxs[addr]; !ok {
+				queuedTxs[addr] = make(map[uint64]*types.Transaction)
+			}
 			queuedTxs[addr][tx.Nonce] = tx
 		}
 	}
@@ -217,7 +220,9 @@ func (t *TxPool) GetTxs() (map[types.Address]map[uint64]*types.Transaction, map[
 	pendingTxs := make(map[types.Address]map[uint64]*types.Transaction)
 	sortedPricedTxs := t.sorted.index
 	for _, sortedPricedTx := range sortedPricedTxs {
-		pendingTxs[sortedPricedTx.from] = make(map[uint64]*types.Transaction)
+		if _, ok := pendingTxs[sortedPricedTx.from]; !ok {
+			pendingTxs[sortedPricedTx.from] = make(map[uint64]*types.Transaction)
+		}
 		pendingTxs[sortedPricedTx.from][sortedPricedTx.tx.Nonce] = sortedPricedTx.tx
 	}
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -117,7 +117,7 @@ func TestMultipleTransactions(t *testing.T) {
 	assert.Equal(t, pool.Length(), uint64(1))
 }
 
-func TestGetQueuedAndPendingTransactions(t *testing.T) {
+func TestGetPendingAndQueuedTransactions(t *testing.T) {
 	pool, err := NewTxPool(hclog.NewNullLogger(), false, forks.At(0), &mockStore{}, nil, nil)
 	assert.NoError(t, err)
 	pool.EnableDev()
@@ -142,27 +142,30 @@ func TestGetQueuedAndPendingTransactions(t *testing.T) {
 	}
 	assert.NoError(t, pool.addImpl("", txn1))
 
+	from3 := types.Address{0x3}
 	txn2 := &types.Transaction{
-		From:     from2,
+		From:     from3,
 		Nonce:    2,
 		Gas:      validGasLimit,
+		Value:    big.NewInt(107),
 		GasPrice: big.NewInt(1),
 	}
 	assert.NoError(t, pool.addImpl("", txn2))
 
-	from3 := types.Address{0x3}
+	from4 := types.Address{0x4}
 	txn3 := &types.Transaction{
-		From:     from3,
-		Nonce:    3,
+		From:     from4,
+		Nonce:    5,
 		Gas:      validGasLimit,
+		Value:    big.NewInt(108),
 		GasPrice: big.NewInt(1),
 	}
 	assert.NoError(t, pool.addImpl("", txn3))
 
-	queuedTxs, pendingTxs := pool.GetTxs()
+	pendingTxs, queuedTxs := pool.GetTxs()
 
-	assert.Len(t, queuedTxs, 2)
 	assert.Len(t, pendingTxs, 1)
+	assert.Len(t, queuedTxs, 3)
 	assert.Equal(t, pendingTxs[from1][txn0.Nonce].Value, big.NewInt(106))
 }
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -127,7 +127,7 @@ func TestGetQueuedAndPendingTransactions(t *testing.T) {
 		From:     from1,
 		Nonce:    0,
 		Gas:      validGasLimit,
-		Value:		big.NewInt(106),
+		Value:    big.NewInt(106),
 		GasPrice: big.NewInt(1),
 	}
 	assert.NoError(t, pool.addImpl("", txn0))
@@ -135,28 +135,35 @@ func TestGetQueuedAndPendingTransactions(t *testing.T) {
 	from2 := types.Address{0x2}
 	txn1 := &types.Transaction{
 		From:     from2,
-		Nonce:	1,
+		Nonce:    1,
 		Gas:      validGasLimit,
+		Value:    big.NewInt(106),
 		GasPrice: big.NewInt(1),
 	}
 	assert.NoError(t, pool.addImpl("", txn1))
 
-	from3 := types.Address{0x3}
 	txn2 := &types.Transaction{
-		From:     from3,
-		Nonce:	2,
+		From:     from2,
+		Nonce:    2,
 		Gas:      validGasLimit,
 		GasPrice: big.NewInt(1),
 	}
 	assert.NoError(t, pool.addImpl("", txn2))
 
+	from3 := types.Address{0x3}
+	txn3 := &types.Transaction{
+		From:     from3,
+		Nonce:    3,
+		Gas:      validGasLimit,
+		GasPrice: big.NewInt(1),
+	}
+	assert.NoError(t, pool.addImpl("", txn3))
+
 	queuedTxs, pendingTxs := pool.GetTxs()
-	
+
 	assert.Len(t, queuedTxs, 2)
 	assert.Len(t, pendingTxs, 1)
-	for key := range pendingTxs {
-		assert.Equal(t, pendingTxs[key][0].Value, big.NewInt(106))
-	}	
+	assert.Equal(t, pendingTxs[from1][txn0.Nonce].Value, big.NewInt(106))
 }
 
 func TestBroadcast(t *testing.T) {

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -2,10 +2,11 @@ package txpool
 
 import (
 	"fmt"
-	"github.com/0xPolygon/minimal/chain"
 	"math/big"
 	"strconv"
 	"testing"
+
+	"github.com/0xPolygon/minimal/chain"
 
 	"github.com/0xPolygon/minimal/crypto"
 	"github.com/0xPolygon/minimal/helper/tests"
@@ -117,7 +118,7 @@ func TestMultipleTransactions(t *testing.T) {
 }
 
 func TestGetQueuedAndPendingTransactions(t *testing.T) {
-	pool, err := NewTxPool(hclog.NewNullLogger(), false, &mockStore{}, nil, nil)
+	pool, err := NewTxPool(hclog.NewNullLogger(), false, forks.At(0), &mockStore{}, nil, nil)
 	assert.NoError(t, err)
 	pool.EnableDev()
 
@@ -125,6 +126,7 @@ func TestGetQueuedAndPendingTransactions(t *testing.T) {
 	txn0 := &types.Transaction{
 		From:     from1,
 		Nonce:    0,
+		Gas:      validGasLimit,
 		Value:		big.NewInt(106),
 		GasPrice: big.NewInt(1),
 	}
@@ -134,6 +136,7 @@ func TestGetQueuedAndPendingTransactions(t *testing.T) {
 	txn1 := &types.Transaction{
 		From:     from2,
 		Nonce:	1,
+		Gas:      validGasLimit,
 		GasPrice: big.NewInt(1),
 	}
 	assert.NoError(t, pool.addImpl("", txn1))
@@ -142,6 +145,7 @@ func TestGetQueuedAndPendingTransactions(t *testing.T) {
 	txn2 := &types.Transaction{
 		From:     from3,
 		Nonce:	2,
+		Gas:      validGasLimit,
 		GasPrice: big.NewInt(1),
 	}
 	assert.NoError(t, pool.addImpl("", txn2))


### PR DESCRIPTION
# Description

Added the 3 geth RPC endpoints for `txpool` to support `txpool_content`, `txpool_inspect`, and `txpool_status` (see https://geth.ethereum.org/docs/rpc/ns-txpool).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

