### PR TITLE
Fix transaction receipt failed

### DIFF
--- a/e2e/transaction_test.go
+++ b/e2e/transaction_test.go
@@ -205,8 +205,14 @@ func TestEthTransfer(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 			receipt, err := srv.WaitForReceipt(ctx, txnHash)
-			assert.NoError(t, err)
-			assert.NotNil(t, receipt)
+
+			if testCase.shouldSuccess {
+				assert.NoError(t, err)
+				assert.NotNil(t, receipt)
+			} else { // When an invalid transaction is supplied, there should be no receipt.
+				assert.Error(t, err)
+				assert.Nil(t, receipt)
+			}
 
 			if testCase.shouldSuccess {
 				fee = new(big.Int).Mul(

--- a/e2e/transaction_test.go
+++ b/e2e/transaction_test.go
@@ -214,13 +214,6 @@ func TestEthTransfer(t *testing.T) {
 				assert.Nil(t, receipt)
 			}
 
-			if testCase.shouldSucceed {
-				fee = new(big.Int).Mul(
-					big.NewInt(int64(receipt.GasUsed)),
-					big.NewInt(int64(txnObject.GasPrice)),
-				)
-			}
-
 			// Fetch the balances after sending
 			balanceSender, err = rpcClient.Eth().GetBalance(
 				web3.Address(testCase.sender),
@@ -236,6 +229,11 @@ func TestEthTransfer(t *testing.T) {
 
 			expectedSenderBalance := previousSenderBalance
 			if testCase.shouldSucceed {
+				fee = new(big.Int).Mul(
+					big.NewInt(int64(receipt.GasUsed)),
+					big.NewInt(int64(txnObject.GasPrice)),
+				)
+
 				expectedSenderBalance = previousSenderBalance.Sub(
 					previousSenderBalance,
 					new(big.Int).Add(testCase.amount, fee),

--- a/e2e/transaction_test.go
+++ b/e2e/transaction_test.go
@@ -128,7 +128,7 @@ func TestEthTransfer(t *testing.T) {
 		sender        types.Address
 		recipient     types.Address
 		amount        *big.Int
-		shouldSuccess bool
+		shouldSucceed bool
 	}{
 		{
 			// ACC #1 -> ACC #3
@@ -206,7 +206,7 @@ func TestEthTransfer(t *testing.T) {
 			defer cancel()
 			receipt, err := srv.WaitForReceipt(ctx, txnHash)
 
-			if testCase.shouldSuccess {
+			if testCase.shouldSucceed {
 				assert.NoError(t, err)
 				assert.NotNil(t, receipt)
 			} else { // When an invalid transaction is supplied, there should be no receipt.
@@ -214,7 +214,7 @@ func TestEthTransfer(t *testing.T) {
 				assert.Nil(t, receipt)
 			}
 
-			if testCase.shouldSuccess {
+			if testCase.shouldSucceed {
 				fee = new(big.Int).Mul(
 					big.NewInt(int64(receipt.GasUsed)),
 					big.NewInt(int64(txnObject.GasPrice)),
@@ -235,14 +235,14 @@ func TestEthTransfer(t *testing.T) {
 			assert.NoError(t, err)
 
 			expectedSenderBalance := previousSenderBalance
-			if testCase.shouldSuccess {
+			if testCase.shouldSucceed {
 				expectedSenderBalance = previousSenderBalance.Sub(
 					previousSenderBalance,
 					new(big.Int).Add(testCase.amount, fee),
 				)
 			}
 			expectedReceiverBalance := previousReceiverBalance
-			if testCase.shouldSuccess {
+			if testCase.shouldSucceed {
 				expectedReceiverBalance = previousReceiverBalance.Add(
 					previousReceiverBalance,
 					testCase.amount,

--- a/e2e/websocket_test.go
+++ b/e2e/websocket_test.go
@@ -56,8 +56,8 @@ func TestWS_Response(t *testing.T) {
 		address types.Address
 		balance *big.Int
 	}{
-		{types.StringToAddress("1"), big.NewInt(10)},
-		{types.StringToAddress("2"), big.NewInt(20)},
+		{types.StringToAddress("1"), framework.EthToWei(10)},
+		{types.StringToAddress("2"), framework.EthToWei(20)},
 	}
 
 	srvs := framework.NewTestServers(t, 1, func(config *framework.TestServerConfig) {

--- a/jsonrpc/blockchain.go
+++ b/jsonrpc/blockchain.go
@@ -1,6 +1,7 @@
 package jsonrpc
 
 import (
+	"github.com/0xPolygon/minimal/state/runtime"
 	"math/big"
 
 	"github.com/0xPolygon/minimal/blockchain"
@@ -47,7 +48,7 @@ type blockchainInterface interface {
 	GetBlockByNumber(num uint64, full bool) (*types.Block, bool)
 
 	// ApplyTxn applies a transaction object to the blockchain
-	ApplyTxn(header *types.Header, txn *types.Transaction) ([]byte, bool, error)
+	ApplyTxn(header *types.Header, txn *types.Transaction) (*runtime.ExecutionResult, error)
 
 	// GetNonce returns the next nonce for this address
 	GetNonce(addr types.Address) (uint64, bool)
@@ -106,8 +107,8 @@ func (b *nullBlockchainInterface) GetBlockByNumber(num uint64, full bool) (*type
 	return nil, false
 }
 
-func (b *nullBlockchainInterface) ApplyTxn(header *types.Header, txn *types.Transaction) ([]byte, bool, error) {
-	return nil, false, nil
+func (b *nullBlockchainInterface) ApplyTxn(header *types.Header, txn *types.Transaction) (*runtime.ExecutionResult, error) {
+	return nil, nil
 }
 
 func (b *nullBlockchainInterface) GetCode(hash types.Hash) ([]byte, error) {

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -221,15 +221,15 @@ func (e *Eth) Call(arg *txnArgs, number BlockNumber) (interface{}, error) {
 	}
 
 	// The return value of the execution is saved in the transition (returnValue field)
-	returnValue, failed, err := e.d.store.ApplyTxn(header, transaction)
+	result, err := e.d.store.ApplyTxn(header, transaction)
 	if err != nil {
 		return nil, err
 	}
 
-	if failed {
+	if result.Failed() {
 		return nil, fmt.Errorf("unable to execute call")
 	}
-	return argBytesPtr(returnValue), nil
+	return argBytesPtr(result.ReturnValue), nil
 }
 
 // EstimateGas estimates the gas needed to execute a transaction
@@ -309,12 +309,13 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 		txn := transaction.Copy()
 		txn.Gas = gas
 
-		_, failed, err := e.d.store.ApplyTxn(header, txn)
+		result, err := e.d.store.ApplyTxn(header, txn)
+
 		if err != nil {
-			return failed, err
+			return true, err
 		}
 
-		return failed, nil
+		return result.Failed(), nil
 	}
 
 	// Start the binary search for the lowest possible gas price

--- a/jsonrpc/filter_manager_test.go
+++ b/jsonrpc/filter_manager_test.go
@@ -1,6 +1,7 @@
 package jsonrpc
 
 import (
+	"github.com/0xPolygon/minimal/state/runtime"
 	"sync"
 	"testing"
 	"time"
@@ -215,7 +216,7 @@ type mockStore struct {
 	receipts     map[types.Hash][]*types.Receipt
 }
 
-func (m *mockStore) ApplyTxn(header *types.Header, txn *types.Transaction) ([]byte, bool, error) {
+func (m *mockStore) ApplyTxn(header *types.Header, txn *types.Transaction) (*runtime.ExecutionResult, error) {
 	panic("implement me")
 }
 

--- a/minimal/server.go
+++ b/minimal/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/0xPolygon/minimal/state/runtime"
 	"net"
 	"os"
 	"path/filepath"
@@ -277,25 +278,21 @@ func (j *jsonRPCHub) GetCode(hash types.Hash) ([]byte, error) {
 	return res, nil
 }
 
-func (j *jsonRPCHub) ApplyTxn(header *types.Header, txn *types.Transaction) ([]byte, bool, error) {
+func (j *jsonRPCHub) ApplyTxn(header *types.Header, txn *types.Transaction) (result *runtime.ExecutionResult, err error) {
 	blockCreator, err := j.GetConsensus().GetBlockCreator(header)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
 	transition, err := j.BeginTxn(header.StateRoot, header, blockCreator)
 
 	if err != nil {
-		return nil, false, err
+		return
 	}
 
-	_, failed, err := transition.Apply(txn)
+	result, err = transition.Apply(txn)
 
-	if err != nil {
-		return nil, false, err
-	}
-
-	return transition.ReturnValue(), failed, nil
+	return
 }
 
 // SETUP //

--- a/state/executor.go
+++ b/state/executor.go
@@ -399,9 +399,9 @@ func (t *Transition) apply(msg *types.Transaction) (result *runtime.ExecutionRes
 	}
 
 	// 5. the purchased gas is enough to cover intrinsic usage
-	gasAvailable := msg.Gas - intrinsicGasCost
+	gasLeft := msg.Gas - intrinsicGasCost
 	// Because we are working with unsigned integers for gas, the `>` operator is used instead of the more intuitive `<`
-	if gasAvailable > msg.Gas {
+	if gasLeft > msg.Gas {
 		return nil, ErrNotEnoughIntrinsicGas
 	}
 
@@ -418,10 +418,10 @@ func (t *Transition) apply(msg *types.Transaction) (result *runtime.ExecutionRes
 	t.ctx.Origin = msg.From
 
 	if msg.IsContractCreation() {
-		result = t.Create2(msg.From, msg.Input, value, gasAvailable)
+		result = t.Create2(msg.From, msg.Input, value, gasLeft)
 	} else {
 		txn.IncrNonce(msg.From)
-		result = t.Call2(msg.From, *msg.To, msg.Input, value, gasAvailable)
+		result = t.Call2(msg.From, *msg.To, msg.Input, value, gasLeft)
 	}
 
 	refund := txn.GetRefund()

--- a/state/executor.go
+++ b/state/executor.go
@@ -413,11 +413,12 @@ func (t *Transition) apply(msg *types.Transaction) (result *runtime.ExecutionRes
 	}
 
 	gasUsed := msg.Gas - result.GasLeft
-	refund := gasUsed / 2
+	refund := txn.GetRefund()
 
 	// Refund can go up to half the gas used
-	if refund > txn.GetRefund() {
-		refund = txn.GetRefund()
+	maxRefund := gasUsed / 2
+	if refund > maxRefund {
+		refund = maxRefund
 	}
 
 	result.GasLeft += refund

--- a/state/executor.go
+++ b/state/executor.go
@@ -497,12 +497,6 @@ func (t *Transition) applyCall(c *runtime.Contract, callType runtime.CallType, h
 	result := t.run(c, host)
 	if result.Failed() {
 		t.state.RevertToSnapshot(snapshot)
-		// @TODO: Geth does a ErrExecutionReverted check here, to see if we should zero out gasLeft or not
-		/*
-			if err != ErrExecutionReverted {
-				gas = 0
-			}
-		*/
 	}
 
 	return result

--- a/state/executor.go
+++ b/state/executor.go
@@ -353,9 +353,7 @@ func (t *Transition) nonceCheck(msg *types.Transaction) error {
 	return nil
 }
 
-func (t *Transition) apply(msg *types.Transaction) (
-	result *runtime.ExecutionResult, err error,
-) {
+func (t *Transition) apply(msg *types.Transaction) (result *runtime.ExecutionResult, err error) {
 	result = &runtime.ExecutionResult{}
 
 	// First check this message satisfies all consensus rules before
@@ -395,7 +393,7 @@ func (t *Transition) apply(msg *types.Transaction) (
 
 	// 6. caller has enough balance to cover asset transfer for **topmost** call
 	if balance := txn.GetBalance(msg.From); balance.Cmp(msg.Value) < 0 {
-		return result, fmt.Errorf("Not enough funds for transfer with given value.")
+		return result, fmt.Errorf("not enough funds for transfer with given value")
 	}
 
 	gasPrice := new(big.Int).Set(msg.GasPrice)

--- a/state/executor.go
+++ b/state/executor.go
@@ -330,7 +330,7 @@ func (t *Transition) intrinsicGasCost(msg *types.Transaction) uint64 {
 		cost += uint64(nonZeros) * nonZeroCost
 	}
 
-	return uint64(cost)
+	return cost
 }
 
 func (t *Transition) subGasLimitPrice(msg *types.Transaction) error {

--- a/state/executor.go
+++ b/state/executor.go
@@ -425,7 +425,7 @@ func (t *Transition) apply(msg *types.Transaction) (result *runtime.ExecutionRes
 	}
 
 	refund := txn.GetRefund()
-	result.CalculateGasUsed(msg.Gas, refund)
+	result.UpdateGasUsed(msg.Gas, refund)
 
 	// refund the sender
 	remaining := new(big.Int).Mul(new(big.Int).SetUint64(result.GasLeft), gasPrice)

--- a/state/executor.go
+++ b/state/executor.go
@@ -287,6 +287,10 @@ func (t *Transition) Apply(msg *types.Transaction) (gasUsed uint64, failed bool,
 		t.r.PostHook(t)
 	}
 
+	if result == nil {
+		return 0, false, err
+	}
+
 	t.returnValue = result.ReturnValue
 
 	gasUsed = msg.Gas - result.GasLeft
@@ -354,8 +358,6 @@ func (t *Transition) nonceCheck(msg *types.Transaction) error {
 }
 
 func (t *Transition) apply(msg *types.Transaction) (result *runtime.ExecutionResult, err error) {
-	result = &runtime.ExecutionResult{}
-
 	// First check this message satisfies all consensus rules before
 	// applying the message. The rules include these clauses
 	//
@@ -369,18 +371,18 @@ func (t *Transition) apply(msg *types.Transaction) (result *runtime.ExecutionRes
 	txn := t.state
 
 	// 1. the nonce of the message caller is correct
-	if err := t.nonceCheck(msg); err != nil {
-		return result, err
+	if err = t.nonceCheck(msg); err != nil {
+		return
 	}
 
 	// 2. caller has enough balance to cover transaction fee(gaslimit * gasprice)
-	if err := t.subGasLimitPrice(msg); err != nil {
-		return result, err
+	if err = t.subGasLimitPrice(msg); err != nil {
+		return
 	}
 
 	// 3. the amount of gas required is available in the block
-	if err := t.subGasPool(msg.Gas); err != nil {
-		return result, err
+	if err = t.subGasPool(msg.Gas); err != nil {
+		return
 	}
 
 	// 4. the purchased gas is enough to cover intrinsic usage

--- a/state/runtime/evm/evm.go
+++ b/state/runtime/evm/evm.go
@@ -17,7 +17,7 @@ func NewEVM() *EVM {
 }
 
 // CanRun implements the runtime interface
-func (e *EVM) CanRun(_ *runtime.Contract, _ runtime.Host, _ *chain.ForksInTime) bool {
+func (e *EVM) CanRun(*runtime.Contract, runtime.Host, *chain.ForksInTime) bool {
 	return true
 }
 

--- a/state/runtime/evm/evm.go
+++ b/state/runtime/evm/evm.go
@@ -27,7 +27,7 @@ func (e *EVM) Name() string {
 }
 
 // Run implements the runtime interface
-func (e *EVM) Run(c *runtime.Contract, host runtime.Host, config *chain.ForksInTime) ([]byte, uint64, error) {
+func (e *EVM) Run(c *runtime.Contract, host runtime.Host, config *chain.ForksInTime) (returnValue []byte, gasLeft uint64, err error) {
 
 	contract := acquireState()
 	contract.resetReturnData()
@@ -43,16 +43,16 @@ func (e *EVM) Run(c *runtime.Contract, host runtime.Host, config *chain.ForksInT
 
 	ret, err := contract.Run()
 
-	rett := []byte{}
-	rett = append(rett[:0], ret...)
+	// We are probably doing this append magic to make sure that the slice doesn't have more capacity than it needs
+	returnValue = append(returnValue[:0], ret...)
 
-	gas := contract.gas
+	gasLeft = contract.gas
 
 	releaseState(contract)
 
 	if err != nil && err != runtime.ErrExecutionReverted {
-		gas = 0
+		gasLeft = 0
 	}
 
-	return rett, gas, err
+	return returnValue, gasLeft, err
 }

--- a/state/runtime/evm/evm.go
+++ b/state/runtime/evm/evm.go
@@ -17,7 +17,7 @@ func NewEVM() *EVM {
 }
 
 // CanRun implements the runtime interface
-func (e *EVM) CanRun(c *runtime.Contract, host runtime.Host, config *chain.ForksInTime) bool {
+func (e *EVM) CanRun(_ *runtime.Contract, _ runtime.Host, _ *chain.ForksInTime) bool {
 	return true
 }
 

--- a/state/runtime/evm/evm.go
+++ b/state/runtime/evm/evm.go
@@ -27,7 +27,7 @@ func (e *EVM) Name() string {
 }
 
 // Run implements the runtime interface
-func (e *EVM) Run(c *runtime.Contract, host runtime.Host, config *chain.ForksInTime) (returnValue []byte, gasLeft uint64, err error) {
+func (e *EVM) Run(c *runtime.Contract, host runtime.Host, config *chain.ForksInTime) *runtime.ExecutionResult {
 
 	contract := acquireState()
 	contract.resetReturnData()
@@ -44,9 +44,10 @@ func (e *EVM) Run(c *runtime.Contract, host runtime.Host, config *chain.ForksInT
 	ret, err := contract.Run()
 
 	// We are probably doing this append magic to make sure that the slice doesn't have more capacity than it needs
+	var returnValue []byte
 	returnValue = append(returnValue[:0], ret...)
 
-	gasLeft = contract.gas
+	gasLeft := contract.gas
 
 	releaseState(contract)
 
@@ -54,5 +55,9 @@ func (e *EVM) Run(c *runtime.Contract, host runtime.Host, config *chain.ForksInT
 		gasLeft = 0
 	}
 
-	return returnValue, gasLeft, err
+	return &runtime.ExecutionResult{
+		ReturnValue: returnValue,
+		GasLeft:     gasLeft,
+		Err:         err,
+	}
 }

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -1045,7 +1045,8 @@ func opCreate(op OpCode) instruction {
 		}
 
 		c.gas += result.GasLeft
-		if result.Err == runtime.ErrExecutionReverted {
+
+		if result.Reverted() {
 			c.returnData = append(c.returnData[:0], result.ReturnValue...)
 		}
 	}
@@ -1112,7 +1113,7 @@ func opCall(op OpCode) instruction {
 			v.Set(zero)
 		}
 
-		if result.Succeeded() || result.Err == runtime.ErrExecutionReverted {
+		if result.Succeeded() || result.Reverted() {
 			if len(result.ReturnValue) != 0 {
 				copy(c.memory[offset:offset+size], result.ReturnValue)
 			}

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -1113,7 +1113,7 @@ func opCall(op OpCode) instruction {
 			v.Set(one)
 		}
 
-		if !result.Failed() || result.Err == runtime.ErrExecutionReverted {
+		if result.Succeeded() || result.Err == runtime.ErrExecutionReverted {
 			if len(result.ReturnValue) != 0 {
 				copy(c.memory[offset:offset+size], result.ReturnValue)
 			}

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -1103,14 +1103,13 @@ func opCall(op OpCode) instruction {
 
 		contract.Type = callType
 
-		//ret, gas, err := c.host.Callx(contract, c.host)
 		result := c.host.Callx(contract, c.host)
 
 		v := c.push1()
-		if result.Err != nil {
-			v.Set(zero)
-		} else {
+		if result.Succeeded() {
 			v.Set(one)
+		} else {
+			v.Set(zero)
 		}
 
 		if result.Succeeded() || result.Err == runtime.ErrExecutionReverted {

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -1033,20 +1033,20 @@ func opCreate(op OpCode) instruction {
 		contract.Type = runtime.Create
 
 		// Correct call
-		ret, gas, err := c.host.Callx(contract, c.host)
+		result := c.host.Callx(contract, c.host)
 
 		v := c.push1()
-		if op == CREATE && c.config.Homestead && err == runtime.ErrCodeStoreOutOfGas {
+		if op == CREATE && c.config.Homestead && result.Err == runtime.ErrCodeStoreOutOfGas {
 			v.Set(zero)
-		} else if err != nil && err != runtime.ErrCodeStoreOutOfGas {
+		} else if result.Failed() && result.Err != runtime.ErrCodeStoreOutOfGas {
 			v.Set(zero)
 		} else {
 			v.SetBytes(contract.Address.Bytes())
 		}
 
-		c.gas += gas
-		if err == runtime.ErrExecutionReverted {
-			c.returnData = append(c.returnData[:0], ret...)
+		c.gas += result.GasLeft
+		if result.Err == runtime.ErrExecutionReverted {
+			c.returnData = append(c.returnData[:0], result.ReturnValue...)
 		}
 	}
 }
@@ -1103,23 +1103,24 @@ func opCall(op OpCode) instruction {
 
 		contract.Type = callType
 
-		ret, gas, err := c.host.Callx(contract, c.host)
+		//ret, gas, err := c.host.Callx(contract, c.host)
+		result := c.host.Callx(contract, c.host)
 
 		v := c.push1()
-		if err != nil {
+		if result.Err != nil {
 			v.Set(zero)
 		} else {
 			v.Set(one)
 		}
 
-		if err == nil || err == runtime.ErrExecutionReverted {
-			if len(ret) != 0 {
-				copy(c.memory[offset:offset+size], ret)
+		if !result.Failed() || result.Err == runtime.ErrExecutionReverted {
+			if len(result.ReturnValue) != 0 {
+				copy(c.memory[offset:offset+size], result.ReturnValue)
 			}
 		}
 
-		c.gas += gas
-		c.returnData = append(c.returnData[:0], ret...)
+		c.gas += result.GasLeft
+		c.returnData = append(c.returnData[:0], result.ReturnValue...)
 	}
 }
 

--- a/state/runtime/precompiled/precompiled.go
+++ b/state/runtime/precompiled/precompiled.go
@@ -60,11 +60,7 @@ var (
 )
 
 // CanRun implements the runtime interface
-func (p *Precompiled) CanRun(c *runtime.Contract, host runtime.Host, config *chain.ForksInTime) bool {
-	//fmt.Println("-- can run --")
-	//fmt.Println(config)
-	//fmt.Println(config.Byzantium)
-
+func (p *Precompiled) CanRun(c *runtime.Contract, _ runtime.Host, config *chain.ForksInTime) bool {
 	if _, ok := p.contracts[c.CodeAddress]; !ok {
 		return false
 	}

--- a/state/runtime/precompiled/precompiled.go
+++ b/state/runtime/precompiled/precompiled.go
@@ -92,7 +92,7 @@ func (p *Precompiled) Name() string {
 }
 
 // Run runs an execution
-func (p *Precompiled) Run(c *runtime.Contract, host runtime.Host, config *chain.ForksInTime) ([]byte, uint64, error) {
+func (p *Precompiled) Run(c *runtime.Contract, _ runtime.Host, config *chain.ForksInTime) (returnValue []byte, gasLeft uint64, err error) {
 	contract := p.contracts[c.CodeAddress]
 	gasCost := contract.gas(c.Input, config)
 
@@ -101,11 +101,11 @@ func (p *Precompiled) Run(c *runtime.Contract, host runtime.Host, config *chain.
 	}
 
 	c.Gas = c.Gas - gasCost
-	ret, err := contract.run(c.Input)
+	returnValue, err = contract.run(c.Input)
 	if err != nil {
 		return nil, 0, err
 	}
-	return ret, c.Gas, err
+	return returnValue, c.Gas, err
 }
 
 var zeroPadding = make([]byte, 64)

--- a/state/runtime/runtime.go
+++ b/state/runtime/runtime.go
@@ -80,7 +80,8 @@ type ExecutionResult struct {
 	Err         error  // Any error encountered during the execution, listed below
 }
 
-func (r *ExecutionResult) Failed() bool { return r.Err != nil }
+func (r *ExecutionResult) Succeeded() bool { return r.Err == nil }
+func (r *ExecutionResult) Failed() bool    { return r.Err != nil }
 
 var (
 	ErrGasConsumed              = fmt.Errorf("gas has been consumed")

--- a/state/runtime/runtime.go
+++ b/state/runtime/runtime.go
@@ -67,10 +67,20 @@ type Host interface {
 	GetTxContext() TxContext
 	GetBlockHash(number int64) types.Hash
 	EmitLog(addr types.Address, topics []types.Hash, data []byte)
-	Callx(*Contract, Host) ([]byte, uint64, error)
+	Callx(*Contract, Host) *ExecutionResult
 	Empty(addr types.Address) bool
 	GetNonce(addr types.Address) uint64
 }
+
+// ExecutionResult includes all output after executing given evm
+// message no matter the execution itself is successful or not.
+type ExecutionResult struct {
+	ReturnValue []byte // Returned data from the runtime (function result or data supplied with revert opcode)
+	GasLeft     uint64 // Total gas left as result of execution
+	Err         error  // Any error encountered during the execution, listed below
+}
+
+func (r *ExecutionResult) Failed() bool { return r.Err != nil }
 
 var (
 	ErrGasConsumed              = fmt.Errorf("gas has been consumed")
@@ -101,7 +111,7 @@ const (
 
 // Runtime can process contracts
 type Runtime interface {
-	Run(c *Contract, host Host, config *chain.ForksInTime) ([]byte, uint64, error)
+	Run(c *Contract, host Host, config *chain.ForksInTime) *ExecutionResult
 	CanRun(c *Contract, host Host, config *chain.ForksInTime) bool
 	Name() string
 }

--- a/state/runtime/runtime.go
+++ b/state/runtime/runtime.go
@@ -82,6 +82,7 @@ type ExecutionResult struct {
 
 func (r *ExecutionResult) Succeeded() bool { return r.Err == nil }
 func (r *ExecutionResult) Failed() bool    { return r.Err != nil }
+func (r *ExecutionResult) Reverted() bool  { return r.Err == ErrExecutionReverted }
 
 var (
 	ErrGasConsumed              = fmt.Errorf("gas has been consumed")

--- a/state/runtime/runtime.go
+++ b/state/runtime/runtime.go
@@ -85,7 +85,7 @@ func (r *ExecutionResult) Succeeded() bool { return r.Err == nil }
 func (r *ExecutionResult) Failed() bool    { return r.Err != nil }
 func (r *ExecutionResult) Reverted() bool  { return r.Err == ErrExecutionReverted }
 
-func (r *ExecutionResult) CalculateGasUsed(gasLimit uint64, refund uint64) {
+func (r *ExecutionResult) UpdateGasUsed(gasLimit uint64, refund uint64) {
 	r.GasUsed = gasLimit - r.GasLeft
 
 	// Refund can go up to half the gas used

--- a/state/txn.go
+++ b/state/txn.go
@@ -164,27 +164,28 @@ func (txn *Txn) AddSealingReward(addr types.Address, balance *big.Int) {
 
 // AddBalance adds balance
 func (txn *Txn) AddBalance(addr types.Address, balance *big.Int) {
-	//fmt.Printf("ADD BALANCE: %s %s\n", addr.String(), balance.String())
-	/*
-		if balance.Sign() == 0 {
-			return
-		}
-	*/
 	txn.upsertAccount(addr, true, func(object *StateObject) {
 		object.Account.Balance.Add(object.Account.Balance, balance)
 	})
 }
 
-// SubBalance reduces the balance
-func (txn *Txn) SubBalance(addr types.Address, balance *big.Int) {
-	//fmt.Printf("SUB BALANCE: %s %s\n", addr.String(), balance.String())
-
-	if balance.Sign() == 0 {
-		return
+// SubBalance reduces the balance at address addr by amount
+func (txn *Txn) SubBalance(addr types.Address, amount *big.Int) error {
+	// If we try to reduce balance by 0, then it's a noop
+	if amount.Sign() == 0 {
+		return nil
 	}
+
+	// Check if we have enough balance to deduce amount from
+	if balance := txn.GetBalance(addr); balance.Cmp(amount) < 0 {
+		return runtime.ErrNotEnoughFunds
+	}
+
 	txn.upsertAccount(addr, true, func(object *StateObject) {
-		object.Account.Balance.Sub(object.Account.Balance, balance)
+		object.Account.Balance.Sub(object.Account.Balance, amount)
 	})
+
+	return nil
 }
 
 // SetBalance sets the balance
@@ -591,7 +592,6 @@ func (txn *Txn) Commit(deleteEmptyObjects bool) (Snapshot, []byte) {
 		objs = append(objs, obj)
 		return false
 	})
-	// show(objs)
 
 	t, hash := txn.snapshot.Commit(objs)
 	return t, hash

--- a/tests/evm_test.go
+++ b/tests/evm_test.go
@@ -71,7 +71,7 @@ func testVMCase(t *testing.T, name string, c *VMCase) {
 	result := evmR.Run(contract, e, &config)
 
 	if c.Gas == "" {
-		if !result.Failed() {
+		if result.Succeeded() {
 			t.Fatalf("gas unspecified (indicating an error), but VM returned no error")
 		}
 		if result.GasLeft > 0 {

--- a/tests/evm_test.go
+++ b/tests/evm_test.go
@@ -68,13 +68,13 @@ func testVMCase(t *testing.T, name string, c *VMCase) {
 	code := e.GetCode(c.Exec.Address)
 	contract := runtime.NewContractCall(1, c.Exec.Caller, c.Exec.Caller, c.Exec.Address, c.Exec.Value, c.Exec.GasLimit, code, c.Exec.Data)
 
-	ret, gas, err := evmR.Run(contract, e, &config)
+	result := evmR.Run(contract, e, &config)
 
 	if c.Gas == "" {
-		if err == nil {
+		if !result.Failed() {
 			t.Fatalf("gas unspecified (indicating an error), but VM returned no error")
 		}
-		if gas > 0 {
+		if result.GasLeft > 0 {
 			t.Fatalf("gas unspecified (indicating an error), but VM returned gas remaining > 0")
 		}
 		return
@@ -84,7 +84,7 @@ func testVMCase(t *testing.T, name string, c *VMCase) {
 	if c.Out == "" {
 		c.Out = "0x"
 	}
-	if ret := hex.EncodeToHex(ret); ret != c.Out {
+	if ret := hex.EncodeToHex(result.ReturnValue); ret != c.Out {
 		t.Fatalf("return mismatch: got %s, want %s", ret, c.Out)
 	}
 
@@ -105,8 +105,8 @@ func testVMCase(t *testing.T, name string, c *VMCase) {
 	}
 
 	// check remaining gas
-	if expected := stringToUint64T(t, c.Gas); gas != expected {
-		t.Fatalf("gas remaining mismatch: got %d want %d", gas, expected)
+	if expected := stringToUint64T(t, c.Gas); result.GasLeft != expected {
+		t.Fatalf("gas left mismatch: got %d want %d", result.GasLeft, expected)
 	}
 }
 

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -277,7 +277,11 @@ func (t *TxPool) validateTx(tx *types.Transaction) error {
 		}
 	*/
 	// Make sure the transaction has more gas than the basic transaction fee
-	intrinsicGas := state.TransactionGasCost(tx, t.forks.Homestead, t.forks.Istanbul)
+	intrinsicGas, err := state.TransactionGasCost(tx, t.forks.Homestead, t.forks.Istanbul)
+	if err != nil {
+		return err
+	}
+
 	if tx.Gas < intrinsicGas {
 		return ErrIntrinsicGas
 	}


### PR DESCRIPTION
# Description

Things that were changed in order of impact:

- Fixed a bug where invalid transactions still end up in the block and have transaction receipts.
- Refactored the way VM (Runtime) executions are reported throughout the code to use the `ExecutionResult` struct.
- Added comments and made it clearer which errors are due to VM execution and which due to breaking the consensus rules while processing transactions.
- `Txn.SubBalance` now returns an error itself, avoiding checks whenever it is called
- Added overflow checks when calculating zeroes & ones cost in data in the intrinsic gas cost 
- General code cleanup, refactor and variable renaming.


# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
