### PR TITLE
Support batch jsonrpc http requests

### DIFF
--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -225,7 +225,7 @@ func (d *Dispatcher) Handle(reqBody []byte) ([]byte, error) {
 	for _, req := range requests {
 		var response, err = d.handleReq(req)
 		if err != nil {
-			d.logger.Debug("failed to dispatch", "method", "batch method", "err", err)
+			d.internalError("batch method", err)
 			errorResponse := Response{
 				ID: req.ID,
 				JSONRPC: "2.0",

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -238,7 +238,7 @@ func (d *Dispatcher) Handle(reqBody []byte) ([]byte, error) {
 		// unmarshal response from handleReq so that we can re-marshal as batch responses
 		var resp Response
 		if err := json.Unmarshal(response, &resp); err != nil {
-			d.logger.Debug("failed to dispatch", "method", "batch method", "err", err)
+			d.internalError("batch method", err)
 			errorResponse := Response{
 				ID: req.ID,
 				JSONRPC: "2.0",

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -205,7 +205,10 @@ func (d *Dispatcher) HandleWs(reqBody []byte, conn wsConn) ([]byte, error) {
 func (d *Dispatcher) Handle(reqBody []byte) ([]byte, error) {
 
 	x := bytes.TrimLeft(reqBody, " \t\r\n")
-	if len(x) == 0 || x[0] != '[' {
+	if len(x) == 0 {
+		return nil, invalidJSONRequest
+	}
+	if x[0] == '{' {
 		var req Request
 		if err := json.Unmarshal(reqBody, &req); err != nil {
 			return nil, invalidJSONRequest

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -216,13 +216,13 @@ func (d *Dispatcher) Handle(reqBody []byte) ([]byte, error) {
 	// handle batch requests
 	var requests []Request
 	if err := json.Unmarshal(reqBody, &requests); err != nil {
-		return nil, d.internalError("batched method", err)
+		return nil, d.internalError("batch method", err)
 	}
 	var responses []Response
 	for _, req := range requests {
 		var response, err = d.handleReq(req)
 		if err != nil {
-			d.logger.Debug("failed to dispatch", "method", "batched method", "err", err)
+			d.logger.Debug("failed to dispatch", "method", "batch method", "err", err)
 			errorResponse := Response{
 				ID: req.ID,
 				JSONRPC: "2.0",
@@ -232,10 +232,10 @@ func (d *Dispatcher) Handle(reqBody []byte) ([]byte, error) {
 			continue
 		}
 	
-		// unmarshal response from handleReq so that we can re-marshal as batched responses
+		// unmarshal response from handleReq so that we can re-marshal as batch responses
 		var resp Response
 		if err := json.Unmarshal(response, &resp); err != nil {
-			d.logger.Debug("failed to dispatch", "method", "batched method", "err", err)
+			d.logger.Debug("failed to dispatch", "method", "batch method", "err", err)
 			errorResponse := Response{
 				ID: req.ID,
 				JSONRPC: "2.0",
@@ -249,7 +249,7 @@ func (d *Dispatcher) Handle(reqBody []byte) ([]byte, error) {
 	
 	respBytes, err := json.Marshal(responses)
 	if err != nil {
-		return nil, d.internalError("batched method", err)
+		return nil, d.internalError("batch method", err)
 	}
 	return respBytes, nil
 }

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -1,6 +1,7 @@
 package jsonrpc
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -202,11 +203,55 @@ func (d *Dispatcher) HandleWs(reqBody []byte, conn wsConn) ([]byte, error) {
 }
 
 func (d *Dispatcher) Handle(reqBody []byte) ([]byte, error) {
-	var req Request
-	if err := json.Unmarshal(reqBody, &req); err != nil {
-		return nil, invalidJSONRequest
+
+	x := bytes.TrimLeft(reqBody, " \t\r\n")
+	if len(x) == 0 || x[0] != '[' {
+		var req Request
+		if err := json.Unmarshal(reqBody, &req); err != nil {
+			return nil, invalidJSONRequest
+		}
+		return d.handleReq(req)
 	}
-	return d.handleReq(req)
+
+	// handle batch requests
+	var requests []Request
+	if err := json.Unmarshal(reqBody, &requests); err != nil {
+		return nil, d.internalError("batched method", err)
+	}
+	var responses []Response
+	for _, req := range requests {
+		var response, err = d.handleReq(req)
+		if err != nil {
+			d.logger.Debug("failed to dispatch", "method", "batched method", "err", err)
+			errorResponse := Response{
+				ID: req.ID,
+				JSONRPC: "2.0",
+				Error: internalError,
+			}
+			responses = append(responses, errorResponse)
+			continue
+		}
+	
+		// unmarshal response from handleReq so that we can re-marshal as batched responses
+		var resp Response
+		if err := json.Unmarshal(response, &resp); err != nil {
+			d.logger.Debug("failed to dispatch", "method", "batched method", "err", err)
+			errorResponse := Response{
+				ID: req.ID,
+				JSONRPC: "2.0",
+				Error: invalidJSONRequest,
+			}
+			responses = append(responses, errorResponse)
+			continue
+		}
+		responses = append(responses, resp)
+	}
+	
+	respBytes, err := json.Marshal(responses)
+	if err != nil {
+		return nil, d.internalError("batched method", err)
+	}
+	return respBytes, nil
 }
 
 func (d *Dispatcher) handleReq(req Request) ([]byte, error) {

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -26,7 +26,7 @@ func expectJSONResult(data []byte, v interface{}) error {
 }
 
 func expectBatchJSONResult(data []byte, v interface{}) error {
-	if err := json.Unmarshal(data, v); err != nil {
+	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 	return nil
@@ -168,12 +168,14 @@ func TestDispatcherBatchRequest(t *testing.T) {
 	resp, err := s.Handle([]byte(`[
     {"id":1,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x1", true]},
     {"id":2,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x2", true]},
-    {"id":3,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x3", true]}
+    {"id":3,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x3", true]},
+		{"id":4,"jsonrpc":"2.0","method": "web3_sha3","params": ["0x68656c6c6f20776f726c64"]}
 ]`))
 	assert.NoError(t, err)
 
 	var res []Response
 	assert.NoError(t, expectBatchJSONResult(resp, &res))
-	assert.Len(t, res, 3)
+	assert.Len(t, res, 4)
 	assert.Equal(t, res[0].Error, internalError)
+	assert.Nil(t, res[3].Error)
 }

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -25,6 +25,13 @@ func expectJSONResult(data []byte, v interface{}) error {
 	return nil
 }
 
+func expectBatchJSONResult(data []byte, v interface{}) error {
+	if err := json.Unmarshal(data, v); err != nil {
+		return err
+	}
+	return nil
+}
+
 func TestDispatcherWebsocket(t *testing.T) {
 	store := newMockStore()
 
@@ -152,4 +159,21 @@ func TestDispatcherFuncDecode(t *testing.T) {
 			t.Fatal("bad")
 		}
 	}
+}
+
+func TestDispatcherBatchRequest(t *testing.T) {
+	s := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0)
+	s.registerEndpoints()
+
+	resp, err := s.Handle([]byte(`[
+    {"id":1,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x1", true]},
+    {"id":2,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x2", true]},
+    {"id":3,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x3", true]}
+]`))
+	assert.NoError(t, err)
+
+	var res []Response
+	assert.NoError(t, expectBatchJSONResult(resp, &res))
+	assert.Len(t, res, 3)
+	assert.Equal(t, res[0].Error, internalError)
 }

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -165,12 +165,14 @@ func TestDispatcherBatchRequest(t *testing.T) {
 	s := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0)
 	s.registerEndpoints()
 
-	resp, err := s.Handle([]byte(`[
+	// test with leading whitespace ("  \t\n\n\r")
+	leftBytes := []byte{0x20, 0x20, 0x09, 0x0A, 0x0A, 0x0D}
+	resp, err := s.Handle(append(leftBytes, []byte(`[
     {"id":1,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x1", true]},
     {"id":2,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x2", true]},
     {"id":3,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x3", true]},
 		{"id":4,"jsonrpc":"2.0","method": "web3_sha3","params": ["0x68656c6c6f20776f726c64"]}
-]`))
+]`)...))
 	assert.NoError(t, err)
 
 	var res []Response

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -1,6 +1,7 @@
 package jsonrpc
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -210,10 +211,19 @@ func (j *JSONRPC) handle(w http.ResponseWriter, req *http.Request) {
 		handleErr(err)
 		return
 	}
+
+	// log request
+	req.Body = ioutil.NopCloser(bytes.NewReader(data))
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(req.Body)
+	newStr := buf.String()
+	j.logger.Debug("handle", "request", newStr)
+
 	resp, err := j.dispatcher.Handle(data)
 	if err != nil {
 		handleErr(err)
 		return
 	}
+	j.logger.Debug("handle", "response", string(resp))
 	w.Write(resp)
 }

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -213,11 +213,7 @@ func (j *JSONRPC) handle(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// log request
-	req.Body = ioutil.NopCloser(bytes.NewReader(data))
-	buf := new(bytes.Buffer)
-	buf.ReadFrom(req.Body)
-	newStr := buf.String()
-	j.logger.Debug("handle", "request", newStr)
+	j.logger.Debug("handle", "request", string(data))
 
 	resp, err := j.dispatcher.Handle(data)
 	if err != nil {

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -1,7 +1,6 @@
 package jsonrpc
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net"


### PR DESCRIPTION
# Description

Added support to handle batch JSON-RPC requests to align more closely with JSON-RPC support of geth (https://ethereum.org/en/developers/docs/apis/json-rpc/#json-rpc-support), iterating and dispatching each request in sequence for now. Also added more logging to log the request and response bodies.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs
