### PR TITLE
Correctly format filter ws requests

### DIFF
--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -112,6 +112,19 @@ type wsConn interface {
 	WriteMessage(messageType int, data []byte) error
 }
 
+
+// as per https://www.jsonrpc.org/specification, the `id` in JSON-RPC 2.0 can only be a string or a non-decimal integer
+func formatFilterResponse(id interface{}, resp string) (string, error) {
+	switch t := id.(type) {
+	case string:
+		return fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":"%s"}`, t, resp), nil
+	case float64:
+		return fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"result":"%s"}`, int(t), resp), nil
+	default:
+		return "", invalidJSONRequest
+	}
+}
+
 func (d *Dispatcher) handleSubscribe(req Request, conn wsConn) (string, error) {
 	var params []interface{}
 	if err := json.Unmarshal(req.Params, &params); err != nil {
@@ -175,7 +188,10 @@ func (d *Dispatcher) HandleWs(reqBody []byte, conn wsConn) ([]byte, error) {
 			return nil, err
 		}
 
-		resp := fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"result":"%s"}`, req.ID, filterID)
+		resp, err := formatFilterResponse(req.ID, filterID)
+		if err != nil {
+			return nil, err
+		}
 		return []byte(resp), nil
 	}
 
@@ -189,7 +205,10 @@ func (d *Dispatcher) HandleWs(reqBody []byte, conn wsConn) ([]byte, error) {
 		if ok {
 			res = "true"
 		}
-		resp := fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"result":"%s"}`, req.ID, res)
+		resp, err := formatFilterResponse(req.ID, res)
+		if err != nil {
+			return nil, err
+		}
 		return []byte(resp), nil
 	}
 

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -2,7 +2,6 @@ package jsonrpc
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"testing"
 	"time"


### PR DESCRIPTION
# Description

Currently the websocket subscriptions fail because the unmarshaller unmarshals JSON numbers into float64 and not integer, which is what the formatting function expects, resulting in stuff like this

```
CONNECTED

SENT: {"id": 1, "method": "eth_subscribe", "params": ["newHeads", {}]}

RECEIVED: {"jsonrpc":"2.0","id":%!d(float64=1),"result":"4e31841a-c61e-442a-b1a8-de998db7f164"}
```

Moreover, it does not correctly consider strings, which are also valid under the spec. 

https://www.jsonrpc.org/specification

This results in websocket requests over JSON-RPC to timeout because it never sees a response with the same `id` sent in.

See this as to the unmarshalling behaviour

https://stackoverflow.com/questions/55436628/json-decoded-value-is-treated-as-float64-instead-of-int/55436758. 

I will also add error checking so that the `id` field is the correct format. 

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

