### PR TITLE
Fix failed tests using Gossip protocol in Github Actions

### DIFF
--- a/e2e/broadcast_test.go
+++ b/e2e/broadcast_test.go
@@ -67,6 +67,9 @@ func TestBroadcast(t *testing.T) {
 				}
 			}
 
+			// wait until gossip protocol build mesh network
+			time.Sleep(time.Second * 2)
+
 			tx, err := signer.SignTx(&types.Transaction{
 				Nonce:    0,
 				From:     senderAddr,

--- a/e2e/broadcast_test.go
+++ b/e2e/broadcast_test.go
@@ -67,7 +67,7 @@ func TestBroadcast(t *testing.T) {
 				}
 			}
 
-			// wait until gossip protocol build mesh network
+			// wait until gossip protocol build mesh network (https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md)
 			time.Sleep(time.Second * 2)
 
 			tx, err := signer.SignTx(&types.Transaction{


### PR DESCRIPTION
# Description

This PR fixes failed tests in Github Actions. According to specification of Gossip protocol in libp2p https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md#heartbeat, there is a delay to get peer's subscribed topics because nodes exchange this by heartbeat every 1 second as default.

This PR adds a function to wait until peer subscribe topic in unit test and sleep in e2e.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
