### PR TITLE
Fixed issues with eth_call, estimateGas and sendTransaction

### DIFF
--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -403,7 +403,7 @@ func (d *Dispatcher) getNextNonce(address types.Address, number BlockNumber) (ui
 func (d *Dispatcher) decodeTxn(arg *txnArgs) (*types.Transaction, error) {
 	// set default values
 	if arg.From == nil {
-		return nil, fmt.Errorf("from is empty")
+		arg.From = &types.Address{}
 	}
 	if arg.Data != nil && arg.Input != nil {
 		return nil, fmt.Errorf("both input and data cannot be set")

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -477,7 +477,7 @@ func (d *Dispatcher) getNextNonce(address types.Address, number BlockNumber) (ui
 func (d *Dispatcher) decodeTxn(arg *txnArgs) (*types.Transaction, error) {
 	// set default values
 	if arg.From == nil {
-		arg.From = &types.Address{}
+		arg.From = &types.ZeroAddress
 	}
 	if arg.Data != nil && arg.Input != nil {
 		return nil, fmt.Errorf("both input and data cannot be set")

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -440,8 +440,7 @@ func (d *Dispatcher) decodeTxn(arg *txnArgs) (*types.Transaction, error) {
 	}
 
 	if arg.Gas == nil {
-		// TODO
-		arg.Gas = argUintPtr(1000000)
+		arg.Gas = argUintPtr(0)
 	}
 
 	txn := &types.Transaction{

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -275,7 +275,7 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 	valueInt := new(big.Int).Set(transaction.Value)
 
 	// If the sender address is present, recalculate the ceiling to his balance
-	if transaction.GasPrice != nil && gasPriceInt.BitLen() != 0 {
+	if transaction.From != types.ZeroAddress && transaction.GasPrice != nil && gasPriceInt.BitLen() != 0 {
 
 		// Get the account balance
 		acc, err := e.d.store.GetAccount(header.StateRoot, transaction.From)

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -220,6 +220,11 @@ func (e *Eth) Call(arg *txnArgs, number BlockNumber) (interface{}, error) {
 		return nil, err
 	}
 
+	// If the caller didn't supply the gas limit in the message, then we set it to maximum possible => block gas limit
+	if transaction.Gas == 0 {
+		transaction.Gas = header.GasLimit
+	}
+
 	// The return value of the execution is saved in the transition (returnValue field)
 	result, err := e.d.store.ApplyTxn(header, transaction)
 	if err != nil {


### PR DESCRIPTION
# Description

Please provide a detailed description of what was done in this PR:

## Removing missing from check

`decodeTxn` function was relying on having the from address set which is a weird behaviour when you're trying to do a simple eth_call, for example to get the `symbol()` of an ERC20 as mentioned in https://github.com/0xPolygon/polygon-sdk/issues/108

As the decodeTxn is only used in cases of:
 - EstimateGas => which now has handling for when from address is not set, it just skips the balance checks
 - SendTransaction => which will either way override the From by recovering the address from the signature
 - Call (eth_call) => which caused issues in this case as the from address is never read

It was safe to remove the missing `from` field check from the `decodeTxn`.

## Setting sane defaults for transaction `gas` (gasLimit) field

Currently, if we don't specify the gas when sending the transactions to the 3 functions mentioned above (estimateGas, sendTransaction, eth_call) it was set by default to an extremely large value.

This had 2 implications:
- A valid sendTransaction call would be able to spend a large amount of your funds on gas, which should never be the default.
- The default value specified could be larger than your blockLimit which would prevent you from executing eth_calls or estimateGas calls on blockchains with lower blockLimits.

The issue was fixed by setting the default gasLimit when not specified in `eth_call` & `estimateGas` to blockLimit, and leaving it as 0 when `sendTransaction` is in question, letting your transaction fail with the intrinsic gas check.
 
# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
