### PR TITLE
Improve various JSON-RPC/Geth responses

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -939,6 +939,10 @@ func (b *Blockchain) GetBlockByNumber(blockNumber uint64, full bool) (*types.Blo
 		return nil, false
 	}
 
+	// if blockNumber 0 (genesis block), do not try and get the full block
+	if blockNumber == uint64(0) {
+		full = false
+	}
 	return b.GetBlockByHash(blockHash, full)
 }
 

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -169,7 +169,7 @@ func (e *Eth) GetTransactionReceipt(hash types.Hash) (interface{}, error) {
 		Root:              raw.Root,
 		CumulativeGasUsed: argUint64(raw.CumulativeGasUsed),
 		LogsBloom:         raw.LogsBloom,
-		Status:            raw.Status,
+		Status:            argUint64(*raw.Status),
 		TxHash:            txn.Hash,
 		TxIndex:           argUint64(indx),
 		BlockHash:         block.Hash(),

--- a/jsonrpc/net_endpoint.go
+++ b/jsonrpc/net_endpoint.go
@@ -1,5 +1,7 @@
 package jsonrpc
 
+import "strconv"
+
 // Net is the net jsonrpc endpoint
 type Net struct {
 	d *Dispatcher
@@ -7,8 +9,7 @@ type Net struct {
 
 // Version returns the current network id
 func (n *Net) Version() (interface{}, error) {
-	//return fmt.Sprintf("%x", n.d.chainID), nil
-	return argUintPtr(n.d.chainID), nil
+	return strconv.FormatUint(n.d.chainID, 10), nil
 }
 
 // Listening returns true if client is actively listening for network connections

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -46,42 +46,46 @@ func toTransaction(t *types.Transaction, b *types.Block, txIndex int) *transacti
 }
 
 type uncle struct {
-	ParentHash    types.Hash    `json:"parentHash"`
-	Sha3Uncles    types.Hash    `json:"sha3Uncles"`
-	Miner         types.Address `json:"miner"`
-	StateRoot     types.Hash    `json:"stateRoot"`
-	TxRoot        types.Hash    `json:"transactionsRoot"`
-	ReceiptsRoot  types.Hash    `json:"receiptsRoot"`
-	LogsBloom     types.Bloom   `json:"logsBloom"`
-	Difficulty    argUint64     `json:"difficulty"`
-	Number        argUint64     `json:"number"`
-	GasLimit      argUint64     `json:"gasLimit"`
-	GasUsed       argUint64     `json:"gasUsed"`
-	Timestamp     argUint64     `json:"timestamp"`
-	ExtraData     argBytes      `json:"extraData"`
-	MixHash       types.Hash    `json:"mixHash"`
-	Nonce         types.Nonce   `json:"nonce"`
-	Hash          types.Hash    `json:"hash"`
+	ParentHash        types.Hash    `json:"parentHash"`
+	Sha3Uncles        types.Hash    `json:"sha3Uncles"`
+	Miner             types.Address `json:"miner"`
+	StateRoot         types.Hash    `json:"stateRoot"`
+	TxRoot            types.Hash    `json:"transactionsRoot"`
+	ReceiptsRoot      types.Hash    `json:"receiptsRoot"`
+	LogsBloom         types.Bloom   `json:"logsBloom"`
+	Difficulty        argUint64     `json:"difficulty"`
+  TotalDifficulty   argUint64     `json:"totalDifficulty"`
+  Size              argUint64     `json:"size"`
+	Number            argUint64     `json:"number"`
+	GasLimit          argUint64     `json:"gasLimit"`
+	GasUsed           argUint64     `json:"gasUsed"`
+	Timestamp         argUint64     `json:"timestamp"`
+	ExtraData         argBytes      `json:"extraData"`
+	MixHash           types.Hash    `json:"mixHash"`
+	Nonce             types.Nonce   `json:"nonce"`
+	Hash              types.Hash    `json:"hash"`
 }
 
 func toUncle(u *types.Header) *uncle {
 	return &uncle{
-		ParentHash:   u.ParentHash,
-		Sha3Uncles:   u.Sha3Uncles,
-		Miner:        u.Miner,
-		StateRoot:    u.StateRoot,
-		TxRoot:       u.TxRoot,
-		ReceiptsRoot: u.ReceiptsRoot,
-		LogsBloom:    u.LogsBloom,
-		Difficulty:   argUint64(u.Difficulty),
-		Number:       argUint64(u.Number),
-		GasLimit:     argUint64(u.GasLimit),
-		GasUsed:      argUint64(u.GasUsed),
-		Timestamp:    argUint64(u.Timestamp),
-		ExtraData:    argBytes(u.ExtraData),
-		MixHash:      u.MixHash,
-		Nonce:        u.Nonce,
-		Hash:         u.Hash,
+		ParentHash:       u.ParentHash,
+		Sha3Uncles:       u.Sha3Uncles,
+		Miner:            u.Miner,
+		StateRoot:        u.StateRoot,
+		TxRoot:           u.TxRoot,
+		ReceiptsRoot:     u.ReceiptsRoot,
+		LogsBloom:        u.LogsBloom,
+		Difficulty:       argUint64(u.Difficulty),
+		TotalDifficulty:  argUint64(u.Difficulty),  // not needed for POS 
+		Size:             argUint64(0),             // should derive actual size
+		Number:           argUint64(u.Number),
+		GasLimit:         argUint64(u.GasLimit),
+		GasUsed:          argUint64(u.GasUsed),
+		Timestamp:        argUint64(u.Timestamp),
+		ExtraData:        argBytes(u.ExtraData),
+		MixHash:          u.MixHash,
+		Nonce:            u.Nonce,
+		Hash:             u.Hash,
 	}
 }
 

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -91,16 +91,16 @@ func toUncle(u *types.Header) *uncle {
 
 type block struct {
 	uncle
-	Transactions    []*transaction `json:"transactions"`
-	Uncles          []*uncle       `json:"uncles"`
+	Transactions []*transaction `json:"transactions"`
+	Uncles       []*uncle       `json:"uncles"`
 }
 
 func toBlock(b *types.Block) *block {
 	h := b.Header
 	res := &block{
-		uncle:           *toUncle(h),
-		Transactions:    []*transaction{},
-		Uncles:          []*uncle{},
+		uncle:        *toUncle(h),
+		Transactions: []*transaction{},
+		Uncles:       []*uncle{},
 	}
 	for idx, txn := range b.Transactions {
 		res.Transactions = append(res.Transactions, toTransaction(txn, b, idx))

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -46,95 +46,95 @@ func toTransaction(t *types.Transaction, b *types.Block, txIndex int) *transacti
 }
 
 type uncle struct {
-	ParentHash        types.Hash    `json:"parentHash"`
-	Sha3Uncles        types.Hash    `json:"sha3Uncles"`
-	Miner             types.Address `json:"miner"`
-	StateRoot         types.Hash    `json:"stateRoot"`
-	TxRoot            types.Hash    `json:"transactionsRoot"`
-	ReceiptsRoot      types.Hash    `json:"receiptsRoot"`
-	LogsBloom         types.Bloom   `json:"logsBloom"`
-	Difficulty        argUint64     `json:"difficulty"`
-  TotalDifficulty   argUint64     `json:"totalDifficulty"`
-  Size              argUint64     `json:"size"`
-	Number            argUint64     `json:"number"`
-	GasLimit          argUint64     `json:"gasLimit"`
-	GasUsed           argUint64     `json:"gasUsed"`
-	Timestamp         argUint64     `json:"timestamp"`
-	ExtraData         argBytes      `json:"extraData"`
-	MixHash           types.Hash    `json:"mixHash"`
-	Nonce             types.Nonce   `json:"nonce"`
-	Hash              types.Hash    `json:"hash"`
+	ParentHash      types.Hash    `json:"parentHash"`
+	Sha3Uncles      types.Hash    `json:"sha3Uncles"`
+	Miner           types.Address `json:"miner"`
+	StateRoot       types.Hash    `json:"stateRoot"`
+	TxRoot          types.Hash    `json:"transactionsRoot"`
+	ReceiptsRoot    types.Hash    `json:"receiptsRoot"`
+	LogsBloom       types.Bloom   `json:"logsBloom"`
+	Difficulty      argUint64     `json:"difficulty"`
+	TotalDifficulty argUint64     `json:"totalDifficulty"`
+	Size            argUint64     `json:"size"`
+	Number          argUint64     `json:"number"`
+	GasLimit        argUint64     `json:"gasLimit"`
+	GasUsed         argUint64     `json:"gasUsed"`
+	Timestamp       argUint64     `json:"timestamp"`
+	ExtraData       argBytes      `json:"extraData"`
+	MixHash         types.Hash    `json:"mixHash"`
+	Nonce           types.Nonce   `json:"nonce"`
+	Hash            types.Hash    `json:"hash"`
 }
 
 func toUncle(u *types.Header) *uncle {
 	return &uncle{
-		ParentHash:       u.ParentHash,
-		Sha3Uncles:       u.Sha3Uncles,
-		Miner:            u.Miner,
-		StateRoot:        u.StateRoot,
-		TxRoot:           u.TxRoot,
-		ReceiptsRoot:     u.ReceiptsRoot,
-		LogsBloom:        u.LogsBloom,
-		Difficulty:       argUint64(u.Difficulty),
-		TotalDifficulty:  argUint64(u.Difficulty),  // not needed for POS 
-		Size:             argUint64(0),             // should derive actual size
-		Number:           argUint64(u.Number),
-		GasLimit:         argUint64(u.GasLimit),
-		GasUsed:          argUint64(u.GasUsed),
-		Timestamp:        argUint64(u.Timestamp),
-		ExtraData:        argBytes(u.ExtraData),
-		MixHash:          u.MixHash,
-		Nonce:            u.Nonce,
-		Hash:             u.Hash,
+		ParentHash:      u.ParentHash,
+		Sha3Uncles:      u.Sha3Uncles,
+		Miner:           u.Miner,
+		StateRoot:       u.StateRoot,
+		TxRoot:          u.TxRoot,
+		ReceiptsRoot:    u.ReceiptsRoot,
+		LogsBloom:       u.LogsBloom,
+		Difficulty:      argUint64(u.Difficulty),
+		TotalDifficulty: argUint64(u.Difficulty), // not needed for POS
+		Size:            argUint64(0),            // should derive actual size
+		Number:          argUint64(u.Number),
+		GasLimit:        argUint64(u.GasLimit),
+		GasUsed:         argUint64(u.GasUsed),
+		Timestamp:       argUint64(u.Timestamp),
+		ExtraData:       argBytes(u.ExtraData),
+		MixHash:         u.MixHash,
+		Nonce:           u.Nonce,
+		Hash:            u.Hash,
 	}
 }
 
 type block struct {
-	ParentHash        types.Hash     `json:"parentHash"`
-	Sha3Uncles        types.Hash     `json:"sha3Uncles"`
-	Miner             types.Address  `json:"miner"`
-	StateRoot         types.Hash     `json:"stateRoot"`
-	TxRoot            types.Hash     `json:"transactionsRoot"`
-	ReceiptsRoot      types.Hash     `json:"receiptsRoot"`
-	LogsBloom         types.Bloom    `json:"logsBloom"`
-	Difficulty        argUint64      `json:"difficulty"`
-  TotalDifficulty   argUint64      `json:"totalDifficulty"`
-  Size              argUint64      `json:"size"`
-	Number            argUint64      `json:"number"`
-	GasLimit          argUint64      `json:"gasLimit"`
-	GasUsed           argUint64      `json:"gasUsed"`
-	Timestamp         argUint64      `json:"timestamp"`
-	ExtraData         argBytes       `json:"extraData"`
-	MixHash           types.Hash     `json:"mixHash"`
-	Nonce             types.Nonce    `json:"nonce"`
-	Hash              types.Hash     `json:"hash"`
-	Transactions      []*transaction `json:"transactions"`
-	Uncles            []*uncle       `json:"uncles"`
+	ParentHash      types.Hash     `json:"parentHash"`
+	Sha3Uncles      types.Hash     `json:"sha3Uncles"`
+	Miner           types.Address  `json:"miner"`
+	StateRoot       types.Hash     `json:"stateRoot"`
+	TxRoot          types.Hash     `json:"transactionsRoot"`
+	ReceiptsRoot    types.Hash     `json:"receiptsRoot"`
+	LogsBloom       types.Bloom    `json:"logsBloom"`
+	Difficulty      argUint64      `json:"difficulty"`
+	TotalDifficulty argUint64      `json:"totalDifficulty"`
+	Size            argUint64      `json:"size"`
+	Number          argUint64      `json:"number"`
+	GasLimit        argUint64      `json:"gasLimit"`
+	GasUsed         argUint64      `json:"gasUsed"`
+	Timestamp       argUint64      `json:"timestamp"`
+	ExtraData       argBytes       `json:"extraData"`
+	MixHash         types.Hash     `json:"mixHash"`
+	Nonce           types.Nonce    `json:"nonce"`
+	Hash            types.Hash     `json:"hash"`
+	Transactions    []*transaction `json:"transactions"`
+	Uncles          []*uncle       `json:"uncles"`
 }
 
 func toBlock(b *types.Block) *block {
 	h := b.Header
 	res := &block{
-		ParentHash:       h.ParentHash,
-		Sha3Uncles:       h.Sha3Uncles,
-		Miner:            h.Miner,
-		StateRoot:        h.StateRoot,
-		TxRoot:           h.TxRoot,
-		ReceiptsRoot:     h.ReceiptsRoot,
-		LogsBloom:        h.LogsBloom,
-		Difficulty:       argUint64(h.Difficulty),
-		TotalDifficulty:  argUint64(h.Difficulty),  // not needed for POS 
-		Size:             argUint64(0),             // should derive actual size
-		Number:           argUint64(h.Number),
-		GasLimit:         argUint64(h.GasLimit),
-		GasUsed:          argUint64(h.GasUsed),
-		Timestamp:        argUint64(h.Timestamp),
-		ExtraData:        argBytes(h.ExtraData),
-		MixHash:          h.MixHash,
-		Nonce:            h.Nonce,
-		Hash:             h.Hash,
-		Transactions:     []*transaction{},
-		Uncles:           []*uncle{},
+		ParentHash:      h.ParentHash,
+		Sha3Uncles:      h.Sha3Uncles,
+		Miner:           h.Miner,
+		StateRoot:       h.StateRoot,
+		TxRoot:          h.TxRoot,
+		ReceiptsRoot:    h.ReceiptsRoot,
+		LogsBloom:       h.LogsBloom,
+		Difficulty:      argUint64(h.Difficulty),
+		TotalDifficulty: argUint64(h.Difficulty), // not needed for POS
+		Size:            argUint64(0),            // should derive actual size
+		Number:          argUint64(h.Number),
+		GasLimit:        argUint64(h.GasLimit),
+		GasUsed:         argUint64(h.GasUsed),
+		Timestamp:       argUint64(h.Timestamp),
+		ExtraData:       argBytes(h.ExtraData),
+		MixHash:         h.MixHash,
+		Nonce:           h.Nonce,
+		Hash:            h.Hash,
+		Transactions:    []*transaction{},
+		Uncles:          []*uncle{},
 	}
 	for idx, txn := range b.Transactions {
 		res.Transactions = append(res.Transactions, toTransaction(txn, b, idx))
@@ -146,19 +146,19 @@ func toBlock(b *types.Block) *block {
 }
 
 type receipt struct {
-	Root              types.Hash           `json:"root"`
-	CumulativeGasUsed argUint64            `json:"cumulativeGasUsed"`
-	LogsBloom         types.Bloom          `json:"logsBloom"`
-	Logs              []*Log               `json:"logs"`
-	Status            argUint64            `json:"status"`
-	TxHash            types.Hash           `json:"transactionHash"`
-	TxIndex           argUint64            `json:"transactionIndex"`
-	BlockHash         types.Hash           `json:"blockHash"`
-	BlockNumber       argUint64            `json:"blockNumber"`
-	GasUsed           argUint64            `json:"gasUsed"`
-	ContractAddress   types.Address        `json:"contractAddress"`
-	FromAddr          types.Address        `json:"from"`
-	ToAddr            *types.Address       `json:"to"`
+	Root              types.Hash     `json:"root"`
+	CumulativeGasUsed argUint64      `json:"cumulativeGasUsed"`
+	LogsBloom         types.Bloom    `json:"logsBloom"`
+	Logs              []*Log         `json:"logs"`
+	Status            argUint64      `json:"status"`
+	TxHash            types.Hash     `json:"transactionHash"`
+	TxIndex           argUint64      `json:"transactionIndex"`
+	BlockHash         types.Hash     `json:"blockHash"`
+	BlockNumber       argUint64      `json:"blockNumber"`
+	GasUsed           argUint64      `json:"gasUsed"`
+	ContractAddress   types.Address  `json:"contractAddress"`
+	FromAddr          types.Address  `json:"from"`
+	ToAddr            *types.Address `json:"to"`
 }
 
 type Log struct {

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -45,49 +45,98 @@ func toTransaction(t *types.Transaction, b *types.Block, txIndex int) *transacti
 	}
 }
 
+type uncle struct {
+	ParentHash    types.Hash    `json:"parentHash"`
+	Sha3Uncles    types.Hash    `json:"sha3Uncles"`
+	Miner         types.Address `json:"miner"`
+	StateRoot     types.Hash    `json:"stateRoot"`
+	TxRoot        types.Hash    `json:"transactionsRoot"`
+	ReceiptsRoot  types.Hash    `json:"receiptsRoot"`
+	LogsBloom     types.Bloom   `json:"logsBloom"`
+	Difficulty    argUint64     `json:"difficulty"`
+	Number        argUint64     `json:"number"`
+	GasLimit      argUint64     `json:"gasLimit"`
+	GasUsed       argUint64     `json:"gasUsed"`
+	Timestamp     argUint64     `json:"timestamp"`
+	ExtraData     argBytes      `json:"extraData"`
+	MixHash       types.Hash    `json:"mixHash"`
+	Nonce         types.Nonce   `json:"nonce"`
+	Hash          types.Hash    `json:"hash"`
+}
+
+func toUncle(u *types.Header) *uncle {
+	return &uncle{
+		ParentHash:   u.ParentHash,
+		Sha3Uncles:   u.Sha3Uncles,
+		Miner:        u.Miner,
+		StateRoot:    u.StateRoot,
+		TxRoot:       u.TxRoot,
+		ReceiptsRoot: u.ReceiptsRoot,
+		LogsBloom:    u.LogsBloom,
+		Difficulty:   argUint64(u.Difficulty),
+		Number:       argUint64(u.Number),
+		GasLimit:     argUint64(u.GasLimit),
+		GasUsed:      argUint64(u.GasUsed),
+		Timestamp:    argUint64(u.Timestamp),
+		ExtraData:    argBytes(u.ExtraData),
+		MixHash:      u.MixHash,
+		Nonce:        u.Nonce,
+		Hash:         u.Hash,
+	}
+}
+
 type block struct {
-	ParentHash   types.Hash     `json:"parentHash"`
-	Sha3Uncles   types.Hash     `json:"sha3Uncles"`
-	Miner        types.Address  `json:"miner"`
-	StateRoot    types.Hash     `json:"stateRoot"`
-	TxRoot       types.Hash     `json:"transactionsRoot"`
-	ReceiptsRoot types.Hash     `json:"receiptsRoot"`
-	LogsBloom    types.Bloom    `json:"logsBloom"`
-	Difficulty   argUint64      `json:"difficulty"`
-	Number       argUint64      `json:"number"`
-	GasLimit     argUint64      `json:"gasLimit"`
-	GasUsed      argUint64      `json:"gasUsed"`
-	Timestamp    argUint64      `json:"timestamp"`
-	ExtraData    argBytes       `json:"extraData"`
-	MixHash      types.Hash     `json:"mixHash"`
-	Nonce        types.Nonce    `json:"nonce"`
-	Hash         types.Hash     `json:"hash"`
-	Transactions []*transaction `json:"transactions"`
+	ParentHash        types.Hash     `json:"parentHash"`
+	Sha3Uncles        types.Hash     `json:"sha3Uncles"`
+	Miner             types.Address  `json:"miner"`
+	StateRoot         types.Hash     `json:"stateRoot"`
+	TxRoot            types.Hash     `json:"transactionsRoot"`
+	ReceiptsRoot      types.Hash     `json:"receiptsRoot"`
+	LogsBloom         types.Bloom    `json:"logsBloom"`
+	Difficulty        argUint64      `json:"difficulty"`
+  TotalDifficulty   argUint64      `json:"totalDifficulty"`
+  Size              argUint64      `json:"size"`
+	Number            argUint64      `json:"number"`
+	GasLimit          argUint64      `json:"gasLimit"`
+	GasUsed           argUint64      `json:"gasUsed"`
+	Timestamp         argUint64      `json:"timestamp"`
+	ExtraData         argBytes       `json:"extraData"`
+	MixHash           types.Hash     `json:"mixHash"`
+	Nonce             types.Nonce    `json:"nonce"`
+	Hash              types.Hash     `json:"hash"`
+	Transactions      []*transaction `json:"transactions"`
+	Uncles            []*uncle       `json:"uncles"`
 }
 
 func toBlock(b *types.Block) *block {
 	h := b.Header
 	res := &block{
-		ParentHash:   h.ParentHash,
-		Sha3Uncles:   h.Sha3Uncles,
-		Miner:        h.Miner,
-		StateRoot:    h.StateRoot,
-		TxRoot:       h.TxRoot,
-		ReceiptsRoot: h.ReceiptsRoot,
-		LogsBloom:    h.LogsBloom,
-		Difficulty:   argUint64(h.Difficulty),
-		Number:       argUint64(h.Number),
-		GasLimit:     argUint64(h.GasLimit),
-		GasUsed:      argUint64(h.GasUsed),
-		Timestamp:    argUint64(h.Timestamp),
-		ExtraData:    argBytes(h.ExtraData),
-		MixHash:      h.MixHash,
-		Nonce:        h.Nonce,
-		Hash:         h.Hash,
-		Transactions: []*transaction{},
+		ParentHash:       h.ParentHash,
+		Sha3Uncles:       h.Sha3Uncles,
+		Miner:            h.Miner,
+		StateRoot:        h.StateRoot,
+		TxRoot:           h.TxRoot,
+		ReceiptsRoot:     h.ReceiptsRoot,
+		LogsBloom:        h.LogsBloom,
+		Difficulty:       argUint64(h.Difficulty),
+		TotalDifficulty:  argUint64(h.Difficulty),  // not needed for POS 
+		Size:             argUint64(0),             // should derive actual size
+		Number:           argUint64(h.Number),
+		GasLimit:         argUint64(h.GasLimit),
+		GasUsed:          argUint64(h.GasUsed),
+		Timestamp:        argUint64(h.Timestamp),
+		ExtraData:        argBytes(h.ExtraData),
+		MixHash:          h.MixHash,
+		Nonce:            h.Nonce,
+		Hash:             h.Hash,
+		Transactions:     []*transaction{},
+		Uncles:           []*uncle{},
 	}
 	for idx, txn := range b.Transactions {
 		res.Transactions = append(res.Transactions, toTransaction(txn, b, idx))
+	}
+	for _, uncle := range b.Uncles {
+		res.Uncles = append(res.Uncles, toUncle(uncle))
 	}
 	return res
 }
@@ -97,7 +146,7 @@ type receipt struct {
 	CumulativeGasUsed argUint64            `json:"cumulativeGasUsed"`
 	LogsBloom         types.Bloom          `json:"logsBloom"`
 	Logs              []*Log               `json:"logs"`
-	Status            *types.ReceiptStatus `json:"status"`
+	Status            argUint64            `json:"status"`
 	TxHash            types.Hash           `json:"transactionHash"`
 	TxIndex           argUint64            `json:"transactionIndex"`
 	BlockHash         types.Hash           `json:"blockHash"`

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -90,24 +90,7 @@ func toUncle(u *types.Header) *uncle {
 }
 
 type block struct {
-	ParentHash      types.Hash     `json:"parentHash"`
-	Sha3Uncles      types.Hash     `json:"sha3Uncles"`
-	Miner           types.Address  `json:"miner"`
-	StateRoot       types.Hash     `json:"stateRoot"`
-	TxRoot          types.Hash     `json:"transactionsRoot"`
-	ReceiptsRoot    types.Hash     `json:"receiptsRoot"`
-	LogsBloom       types.Bloom    `json:"logsBloom"`
-	Difficulty      argUint64      `json:"difficulty"`
-	TotalDifficulty argUint64      `json:"totalDifficulty"`
-	Size            argUint64      `json:"size"`
-	Number          argUint64      `json:"number"`
-	GasLimit        argUint64      `json:"gasLimit"`
-	GasUsed         argUint64      `json:"gasUsed"`
-	Timestamp       argUint64      `json:"timestamp"`
-	ExtraData       argBytes       `json:"extraData"`
-	MixHash         types.Hash     `json:"mixHash"`
-	Nonce           types.Nonce    `json:"nonce"`
-	Hash            types.Hash     `json:"hash"`
+	uncle
 	Transactions    []*transaction `json:"transactions"`
 	Uncles          []*uncle       `json:"uncles"`
 }
@@ -115,24 +98,7 @@ type block struct {
 func toBlock(b *types.Block) *block {
 	h := b.Header
 	res := &block{
-		ParentHash:      h.ParentHash,
-		Sha3Uncles:      h.Sha3Uncles,
-		Miner:           h.Miner,
-		StateRoot:       h.StateRoot,
-		TxRoot:          h.TxRoot,
-		ReceiptsRoot:    h.ReceiptsRoot,
-		LogsBloom:       h.LogsBloom,
-		Difficulty:      argUint64(h.Difficulty),
-		TotalDifficulty: argUint64(h.Difficulty), // not needed for POS
-		Size:            argUint64(0),            // should derive actual size
-		Number:          argUint64(h.Number),
-		GasLimit:        argUint64(h.GasLimit),
-		GasUsed:         argUint64(h.GasUsed),
-		Timestamp:       argUint64(h.Timestamp),
-		ExtraData:       argBytes(h.ExtraData),
-		MixHash:         h.MixHash,
-		Nonce:           h.Nonce,
-		Hash:            h.Hash,
+		uncle:           *toUncle(h),
 		Transactions:    []*transaction{},
 		Uncles:          []*uncle{},
 	}


### PR DESCRIPTION
# Description

While working with some of the json-rpc response bodies, I noticed that several fields caused problems when testing with an explorer as they do not adhere to the official eth and geth json-rpc specs. This PR contains fixes for those fields and also addresses the scenario where users would always see an error response when attempting to call `eth_getBlockByNumber` on block `0x0` (see number 1 below). 

Changes include:

1. Currently, requests made to the method `eth_getBlockByNumber` with the block number '0' will always result in an internal error. Now, the following request will only attempt to return the header for the genesis block as expected, avoiding the error and returning a valid response:
```
{"id":1,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x0", true]}
```

2. Currently, calling `eth_getTransactionReceipt` will return a response body including a `status` field as an integer decimal string. The eth spec (see https://eth.wiki/json-rpc/API#eth_gettransactionreceipt) expects that this field be a hex string which is now the case.

3. Currently, calling `net_version` will return a response body including a `result` value as a hex string. The eth spec (see https://eth.wiki/json-rpc/API#net_version) expects that this field be an integer decimal string which is now the case.

4. Currently, calling `eth_getBlockByNumber` or `eth_getBlockByHash` returns a block object that doesn't contain `totalDifficulty`, `size`, and an `uncles` array. The eth spec (see https://eth.wiki/json-rpc/API#eth_getblockbyhash) expects that these fields be present which is now the case. 


# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs
