### PR TITLE
Add support for higher nonce transactions

### DIFF
--- a/e2e/framework/config.go
+++ b/e2e/framework/config.go
@@ -32,6 +32,7 @@ type TestServerConfig struct {
 	PremineAccts  []*SrvAccount // Accounts with existing balances (genesis accounts)
 	Consensus     ConsensusType // Consensus Type
 	Bootnodes     []string      // Bootnode Addresses
+	DevInterval   int           // Dev consensus update interval [s]
 	ShowsLog      bool
 }
 
@@ -50,6 +51,11 @@ func (t *TestServerConfig) Premine(addr types.Address, amount *big.Int) {
 // SetConsensus callback sets consensus
 func (t *TestServerConfig) SetConsensus(c ConsensusType) {
 	t.Consensus = c
+}
+
+// SetDevInterval sets the update interval for the dev consensus
+func (t *TestServerConfig) SetDevInterval(interval int) {
+	t.DevInterval = interval
 }
 
 // SetIBFTDirPrefix callback sets prefix of IBFT directories

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -2,7 +2,6 @@ package framework
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -29,14 +28,6 @@ func EthToWei(ethValue int64) *big.Int {
 	return new(big.Int).Mul(
 		big.NewInt(ethValue),
 		new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
-}
-
-func GenerateKeyAndAddr(t *testing.T) (*ecdsa.PrivateKey, types.Address) {
-	t.Helper()
-	key, err := crypto.GenerateKey()
-	assert.NoError(t, err)
-	addr := crypto.PubKeyToAddress(&key.PublicKey)
-	return key, addr
 }
 
 // GetAccountBalance is a helper method for fetching the Balance field of an account

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -17,6 +18,9 @@ import (
 	txpoolProto "github.com/0xPolygon/minimal/txpool/proto"
 	"github.com/0xPolygon/minimal/types"
 	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/stretchr/testify/assert"
+	"github.com/umbracle/go-web3"
+	"github.com/umbracle/go-web3/jsonrpc"
 	"golang.org/x/crypto/sha3"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -25,6 +29,30 @@ func EthToWei(ethValue int64) *big.Int {
 	return new(big.Int).Mul(
 		big.NewInt(ethValue),
 		new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
+}
+
+func GenerateKeyAndAddr(t *testing.T) (*ecdsa.PrivateKey, types.Address) {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	assert.NoError(t, err)
+	addr := crypto.PubKeyToAddress(&key.PublicKey)
+	return key, addr
+}
+
+// GetAccountBalance is a helper method for fetching the Balance field of an account
+func GetAccountBalance(
+	address types.Address,
+	rpcClient *jsonrpc.Client,
+	t *testing.T,
+) *big.Int {
+	accountBalance, err := rpcClient.Eth().GetBalance(
+		web3.Address(address),
+		web3.Latest,
+	)
+
+	assert.NoError(t, err)
+
+	return accountBalance
 }
 
 func EcrecoverFromBlockhash(hash types.Hash, signature []byte) (types.Address, error) {

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -230,6 +231,13 @@ func (t *TestServer) Start(ctx context.Context) error {
 		args = append(args, "--data-dir", t.Config.RootDir, "--dev")
 	case ConsensusDummy:
 		args = append(args, "--data-dir", t.Config.RootDir)
+	}
+
+	if t.Config.Consensus == ConsensusDev {
+		args = append(args, "--dev")
+		if t.Config.DevInterval != 0 {
+			args = append(args, "--dev-interval", strconv.Itoa(t.Config.DevInterval))
+		}
 	}
 
 	if t.Config.Seal {

--- a/e2e/txpool_test.go
+++ b/e2e/txpool_test.go
@@ -1,0 +1,124 @@
+package e2e
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/0xPolygon/minimal/crypto"
+	"github.com/0xPolygon/minimal/e2e/framework"
+	txpoolOp "github.com/0xPolygon/minimal/txpool/proto"
+	"github.com/0xPolygon/minimal/types"
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTxPool_TransactionCoalescing(t *testing.T) {
+	// Test scenario:
+	// Add tx with nonce 0
+	// -> Check if tx has been parsed
+	// Add tx with nonce 2
+	// -> tx shouldn't be executed, but shelved for later
+	// Add tx with nonce 1
+	// -> check if both tx with nonce 1 and tx with nonce 2 are parsed
+
+	// Predefined values
+	gasPrice := big.NewInt(10000)
+
+	referenceKey, referenceAddr := framework.GenerateKeyAndAddr(t)
+	defaultBalance := framework.EthToWei(10)
+
+	devInterval := 5
+
+	// Set up the test server
+	srvs := framework.NewTestServers(t, 1, func(config *framework.TestServerConfig) {
+		config.SetConsensus(framework.ConsensusDev)
+		config.SetSeal(true)
+		config.SetDevInterval(devInterval)
+		config.Premine(referenceAddr, defaultBalance)
+	})
+	srv := srvs[0]
+	client := srv.JSONRPC()
+
+	// Required default values
+	signer := crypto.NewEIP155Signer(100)
+
+	// TxPool client
+	clt := srv.TxnPoolOperator()
+	toAddress := types.StringToAddress("1")
+	oneEth := framework.EthToWei(1)
+
+	generateTx := func(nonce uint64) *types.Transaction {
+		signedTx, signErr := signer.SignTx(&types.Transaction{
+			Nonce:    nonce,
+			From:     referenceAddr,
+			To:       &toAddress,
+			GasPrice: gasPrice,
+			Gas:      1000000,
+			Value:    oneEth,
+			V:        1, // it is necessary to encode in rlp
+		}, referenceKey)
+
+		if signErr != nil {
+			t.Fatalf("Unable to sign transaction, %v", signErr)
+		}
+
+		return signedTx
+	}
+
+	generateReq := func(nonce uint64) *txpoolOp.AddTxnReq {
+		var msg *txpoolOp.AddTxnReq
+		unstakeTxn := generateTx(nonce)
+		msg = &txpoolOp.AddTxnReq{
+			Raw: &any.Any{
+				Value: unstakeTxn.MarshalRLP(),
+			},
+			From: types.ZeroAddress.String(),
+		}
+
+		return msg
+	}
+
+	// Add the transactions with the following nonce order
+	nonces := []uint64{0, 2}
+	for i := 0; i < len(nonces); i++ {
+		addReq := generateReq(nonces[i])
+
+		_, addErr := clt.AddTxn(context.Background(), addReq)
+		if addErr != nil {
+			t.Fatalf("Unable to add txn, %v", addErr)
+		}
+	}
+
+	// Mandatory sleep for the dev consensus and executor to go through the txns
+	time.Sleep(time.Duration(devInterval+1) * time.Second)
+
+	// Get to account balance
+	// Only the first tx should've gone through
+	toAccountBalance := framework.GetAccountBalance(toAddress, client, t)
+	assert.Equalf(t,
+		oneEth.String(),
+		toAccountBalance.String(),
+		"To address balance mismatch after series of transactions",
+	)
+
+	// Add the transaction with the gap nonce value
+	addReq := generateReq(1)
+
+	_, addErr := clt.AddTxn(context.Background(), addReq)
+	if addErr != nil {
+		t.Fatalf("Unable to add txn, %v", addErr)
+	}
+
+	// Mandatory sleep for the dev consensus and executor to go through the txns
+	time.Sleep(time.Duration(devInterval+1) * time.Second)
+
+	// Now both the added tx and the shelved tx should've gone through
+	toAccountBalance = framework.GetAccountBalance(toAddress, client, t)
+	assert.Equalf(t,
+		framework.EthToWei(3).String(),
+		toAccountBalance.String(),
+		"To address balance mismatch after gap transaction",
+	)
+}

--- a/e2e/txpool_test.go
+++ b/e2e/txpool_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/0xPolygon/minimal/crypto"
 	"github.com/0xPolygon/minimal/e2e/framework"
+	"github.com/0xPolygon/minimal/helper/tests"
 	txpoolOp "github.com/0xPolygon/minimal/txpool/proto"
 	"github.com/0xPolygon/minimal/types"
 	"github.com/golang/protobuf/ptypes/any"
@@ -26,7 +27,7 @@ func TestTxPool_TransactionCoalescing(t *testing.T) {
 	// Predefined values
 	gasPrice := big.NewInt(10000)
 
-	referenceKey, referenceAddr := framework.GenerateKeyAndAddr(t)
+	referenceKey, referenceAddr := tests.GenerateKeyAndAddr(t)
 	defaultBalance := framework.EthToWei(10)
 
 	devInterval := 5

--- a/txpool/operator.go
+++ b/txpool/operator.go
@@ -11,7 +11,7 @@ import (
 // Status implements the GRPC status endpoint. Returns the number of transactions in the pool
 func (t *TxPool) Status(ctx context.Context, req *empty.Empty) (*proto.TxnPoolStatusResp, error) {
 	resp := &proto.TxnPoolStatusResp{
-		Length: t.validTxHeap.Length(),
+		Length: t.pendingQueue.Length(),
 	}
 
 	return resp, nil

--- a/txpool/operator.go
+++ b/txpool/operator.go
@@ -11,7 +11,7 @@ import (
 // Status implements the GRPC status endpoint. Returns the number of transactions in the pool
 func (t *TxPool) Status(ctx context.Context, req *empty.Empty) (*proto.TxnPoolStatusResp, error) {
 	resp := &proto.TxnPoolStatusResp{
-		Length: t.sorted.Length(),
+		Length: t.validTxHeap.Length(),
 	}
 
 	return resp, nil

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -175,8 +175,8 @@ func (t *TxPool) AddTx(tx *types.Transaction) error {
 	return nil
 }
 
-// addImpl validates the tx and adds it to the appropriate account pool.
-// Additionally, it updates the global valid transactions list
+// addImpl validates the tx and adds it to the appropriate account transaction queue.
+// Additionally, it updates the global valid transactions queue
 func (t *TxPool) addImpl(ctx string, tx *types.Transaction) error {
 	// Since this is a single point of inclusion for new transactions both
 	// to the promoted queue and pending queue we use this point to calculate the hash

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -380,13 +380,6 @@ func (t *txHeapWrapper) Promote() []*types.Transaction {
 		tx = nextTx
 	}
 
-	if len(promote) == 0 {
-		// Nothing to promote
-		reinsertFunc()
-
-		return nil
-	}
-
 	// Find the last transaction to be promoted
 	lastTxn := promote[len(promote)-1]
 	// Grab its nonce value and set it as the reference next nonce

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -352,11 +352,11 @@ func (t *txHeapWrapper) Promote() []*types.Transaction {
 	}
 
 	promote := []*types.Transaction{}
-	higherNonceTx := []*types.Transaction{}
+	higherNonceTxs := []*types.Transaction{}
 
 	reinsertFunc := func() {
 		// Reinsert the tx back to the account specific transaction queue
-		for _, highNonceTx := range higherNonceTx {
+		for _, highNonceTx := range higherNonceTxs {
 			t.Push(highNonceTx)
 		}
 	}
@@ -373,7 +373,7 @@ func (t *txHeapWrapper) Promote() []*types.Transaction {
 		if tx.Nonce+1 != nextTx.Nonce {
 			// Tx that have a higher nonce are shelved for later
 			// when they can actually be parsed
-			higherNonceTx = append(higherNonceTx, nextTx)
+			higherNonceTxs = append(higherNonceTxs, nextTx)
 			break
 		}
 

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -365,8 +365,8 @@ func (t *txHeapWrapper) Promote() []*types.Transaction {
 		promote = append(promote, tx)
 		t.Pop()
 
-		nextTx := t.Peek()
-		if nextTx == nil {
+		var nextTx *types.Transaction
+		if nextTx = t.Peek(); nextTx == nil {
 			break
 		}
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -74,7 +74,7 @@ func TestAddingTransaction(t *testing.T) {
 			if tc.shouldSucceed {
 				assert.NoError(t, err, "Expected adding transaction to succeed")
 				assert.NotEmpty(t, pool.Length(), "Expected pool to not be empty")
-				assert.True(t, pool.validTxHeap.Contains(signedTx), "Expected pool to contain added transaction")
+				assert.True(t, pool.pendingQueue.Contains(signedTx), "Expected pool to contain added transaction")
 			} else {
 				assert.ErrorIs(t, err, ErrIntrinsicGas, "Expected adding transaction to fail")
 				assert.Empty(t, pool.Length(), "Expected pool to be empty")
@@ -100,7 +100,7 @@ func TestMultipleTransactions(t *testing.T) {
 	assert.NoError(t, pool.addImpl("", txn0))
 	assert.NoError(t, pool.addImpl("", txn0))
 
-	assert.Len(t, pool.accountTxHeapMap[from1].txs, 1)
+	assert.Len(t, pool.accountQueues[from1].txs, 1)
 	assert.Equal(t, pool.Length(), uint64(0))
 
 	from2 := types.Address{0x2}
@@ -112,7 +112,7 @@ func TestMultipleTransactions(t *testing.T) {
 	assert.NoError(t, pool.addImpl("", txn1))
 	assert.NoError(t, pool.addImpl("", txn1))
 
-	assert.Len(t, pool.accountTxHeapMap[from2].txs, 0)
+	assert.Len(t, pool.accountQueues[from2].txs, 0)
 	assert.Equal(t, pool.Length(), uint64(1))
 }
 
@@ -185,7 +185,7 @@ func TestTxnQueue_Promotion(t *testing.T) {
 	assert.Equal(t, nonce, uint64(1))
 
 	// though txn0 is not being processed yet and the current nonce is 0
-	// we need to consider that txn0 is on the validTxHeap pool so this one is promoted too
+	// we need to consider that txn0 is on the pendingQueue pool so this one is promoted too
 	pool.addImpl("", &types.Transaction{
 		From:     addr1,
 		Nonce:    1,

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -2,11 +2,11 @@ package txpool
 
 import (
 	"fmt"
-	"github.com/0xPolygon/minimal/chain"
 	"math/big"
 	"strconv"
 	"testing"
 
+	"github.com/0xPolygon/minimal/chain"
 	"github.com/0xPolygon/minimal/crypto"
 	"github.com/0xPolygon/minimal/helper/tests"
 	"github.com/0xPolygon/minimal/network"
@@ -74,7 +74,7 @@ func TestAddingTransaction(t *testing.T) {
 			if tc.shouldSucceed {
 				assert.NoError(t, err, "Expected adding transaction to succeed")
 				assert.NotEmpty(t, pool.Length(), "Expected pool to not be empty")
-				assert.True(t, pool.sorted.Contains(signedTx), "Expected pool to contain added transaction")
+				assert.True(t, pool.validTxHeap.Contains(signedTx), "Expected pool to contain added transaction")
 			} else {
 				assert.ErrorIs(t, err, ErrIntrinsicGas, "Expected adding transaction to fail")
 				assert.Empty(t, pool.Length(), "Expected pool to be empty")
@@ -100,7 +100,7 @@ func TestMultipleTransactions(t *testing.T) {
 	assert.NoError(t, pool.addImpl("", txn0))
 	assert.NoError(t, pool.addImpl("", txn0))
 
-	assert.Len(t, pool.queue[from1].txs, 1)
+	assert.Len(t, pool.accountTxHeapMap[from1].txs, 1)
 	assert.Equal(t, pool.Length(), uint64(0))
 
 	from2 := types.Address{0x2}
@@ -112,7 +112,7 @@ func TestMultipleTransactions(t *testing.T) {
 	assert.NoError(t, pool.addImpl("", txn1))
 	assert.NoError(t, pool.addImpl("", txn1))
 
-	assert.Len(t, pool.queue[from2].txs, 0)
+	assert.Len(t, pool.accountTxHeapMap[from2].txs, 0)
 	assert.Equal(t, pool.Length(), uint64(1))
 }
 
@@ -185,7 +185,7 @@ func TestTxnQueue_Promotion(t *testing.T) {
 	assert.Equal(t, nonce, uint64(1))
 
 	// though txn0 is not being processed yet and the current nonce is 0
-	// we need to consider that txn0 is on the sorted pool so this one is promoted too
+	// we need to consider that txn0 is on the validTxHeap pool so this one is promoted too
 	pool.addImpl("", &types.Transaction{
 		From:     addr1,
 		Nonce:    1,


### PR DESCRIPTION
# Description

This PR adds support for keeping added transactions that have a higher nonce value that what is expected.
For example, transactions with these nonces are waiting to be added to the pool:
`TX 0 [Nonce 0]`
`TX 1 [Nonce 2]`
`TX 2 [Nonce 1]`

The flow of them being added for execution should be:
* TX 0 is valid because the nextNonce is 0. Increment the nextNonce to 1
* TX 1 has a higher nonce value than expected, keep it for now, since it is not valid, nextNonce is still 1
* TX 2 has a nonce that is equal to the expected next nonce, it is deemed as a valid transaction. Furthermore, after TX 2 is deemed valid, TX 1 which was previously in the pool because of the higher nonce, is now deemed valid as well. nextNonce is now 3.


# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs
