### PR TITLE
Clean up errors on transaction execution

### DIFF
--- a/state/executor.go
+++ b/state/executor.go
@@ -523,7 +523,7 @@ func (t *Transition) applyCreate(c *runtime.Contract, host runtime.Host) *runtim
 	if err := t.transfer(c.Caller, c.Address, c.Value); err != nil {
 		return &runtime.ExecutionResult{
 			GasLeft: gasLimit,
-			Err:     runtime.ErrInsufficientBalance,
+			Err:     err,
 		}
 	}
 

--- a/state/executor.go
+++ b/state/executor.go
@@ -298,10 +298,11 @@ func (t *Transition) subGasLimitPrice(msg *types.Transaction) error {
 	upfrontGasCost := new(big.Int).Set(msg.GasPrice)
 	upfrontGasCost.Mul(upfrontGasCost, new(big.Int).SetUint64(msg.Gas))
 
-	err := t.state.SubBalance(msg.From, upfrontGasCost)
-
-	if err == runtime.ErrNotEnoughFunds {
-		return ErrNotEnoughFundsForGas
+	if err := t.state.SubBalance(msg.From, upfrontGasCost); err != nil {
+		if err == runtime.ErrNotEnoughFunds {
+			return ErrNotEnoughFundsForGas
+		}
+		return err
 	}
 
 	return nil

--- a/state/executor.go
+++ b/state/executor.go
@@ -372,7 +372,7 @@ func (t *Transition) apply(msg *types.Transaction) (result *runtime.ExecutionRes
 
 	// 6. caller has enough balance to cover asset transfer for **topmost** call
 	if balance := txn.GetBalance(msg.From); balance.Cmp(msg.Value) < 0 {
-		return nil, ErrNotEnoughFunds
+		return nil, runtime.ErrInsufficientBalance
 	}
 
 	gasPrice := new(big.Int).Set(msg.GasPrice)
@@ -435,6 +435,9 @@ func (t *Transition) transfer(from, to types.Address, amount *big.Int) error {
 	}
 
 	if err := t.state.SubBalance(from, amount); err != nil {
+		if err == runtime.ErrNotEnoughFunds {
+			return runtime.ErrInsufficientBalance
+		}
 		return err
 	}
 
@@ -519,7 +522,7 @@ func (t *Transition) applyCreate(c *runtime.Contract, host runtime.Host) *runtim
 	if err := t.transfer(c.Caller, c.Address, c.Value); err != nil {
 		return &runtime.ExecutionResult{
 			GasLeft: gasLimit,
-			Err:     runtime.ErrNotEnoughFunds,
+			Err:     runtime.ErrInsufficientBalance,
 		}
 	}
 

--- a/state/runtime/evm/evm.go
+++ b/state/runtime/evm/evm.go
@@ -51,7 +51,7 @@ func (e *EVM) Run(c *runtime.Contract, host runtime.Host, config *chain.ForksInT
 
 	releaseState(contract)
 
-	if err != nil && err != runtime.ErrExecutionReverted {
+	if err != nil && err != errRevert {
 		gasLeft = 0
 	}
 

--- a/state/runtime/evm/evm_test.go
+++ b/state/runtime/evm/evm_test.go
@@ -1,0 +1,161 @@
+package evm
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/0xPolygon/minimal/chain"
+	"github.com/0xPolygon/minimal/state/runtime"
+	"github.com/0xPolygon/minimal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func newMockContract(value *big.Int, gas uint64, code []byte) *runtime.Contract {
+	return runtime.NewContract(
+		1,
+		types.ZeroAddress,
+		types.ZeroAddress,
+		types.ZeroAddress,
+		value,
+		gas,
+		code,
+	)
+}
+
+// mockHost is a struct which meets the requirements of runtime.Host interface but throws panic in each methods
+// we don't test all opcodes in this test
+type mockHost struct{}
+
+func (m *mockHost) AccountExists(addr types.Address) bool {
+	panic("Not implemented in tests")
+}
+
+func (m *mockHost) GetStorage(addr types.Address, key types.Hash) types.Hash {
+	panic("Not implemented in tests")
+}
+
+func (m *mockHost) SetStorage(addr types.Address, key types.Hash, value types.Hash, config *chain.ForksInTime) runtime.StorageStatus {
+	panic("Not implemented in tests")
+}
+
+func (m *mockHost) GetBalance(addr types.Address) *big.Int {
+	panic("Not implemented in tests")
+}
+
+func (m *mockHost) GetCodeSize(addr types.Address) int {
+	panic("Not implemented in tests")
+}
+
+func (m *mockHost) GetCodeHash(addr types.Address) types.Hash {
+	panic("Not implemented in tests")
+}
+
+func (m *mockHost) GetCode(addr types.Address) []byte {
+	panic("Not implemented in tests")
+}
+
+func (m *mockHost) Selfdestruct(addr types.Address, beneficiary types.Address) {
+	panic("Not implemented in tests")
+}
+
+func (m *mockHost) GetTxContext() runtime.TxContext {
+	panic("Not implemented in tests")
+}
+
+func (m *mockHost) GetBlockHash(number int64) types.Hash {
+	panic("Not implemented in tests")
+}
+
+func (m *mockHost) EmitLog(addr types.Address, topics []types.Hash, data []byte) {
+	panic("Not implemented in tests")
+}
+
+func (m *mockHost) Callx(*runtime.Contract, runtime.Host) *runtime.ExecutionResult {
+	panic("Not implemented in tests")
+}
+
+func (m *mockHost) Empty(addr types.Address) bool {
+	panic("Not implemented in tests")
+}
+
+func (m *mockHost) GetNonce(addr types.Address) uint64 {
+	panic("Not implemented in tests")
+}
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    *big.Int
+		gas      uint64
+		code     []byte
+		config   *chain.ForksInTime
+		expected *runtime.ExecutionResult
+	}{
+		{
+			name:  "should succeed because of no codes",
+			value: big.NewInt(0),
+			gas:   5000,
+			code:  []byte{},
+			expected: &runtime.ExecutionResult{
+				ReturnValue: nil,
+				GasLeft:     5000,
+			},
+		},
+		{
+			name:  "should succeed and return result",
+			value: big.NewInt(0),
+			gas:   5000,
+			code: []byte{
+				PUSH1, 0x01, PUSH1, 0x02, ADD,
+				PUSH1, 0x00, MSTORE8,
+				PUSH1, 0x01, PUSH1, 0x00, RETURN,
+			},
+			expected: &runtime.ExecutionResult{
+				ReturnValue: []uint8{0x03},
+				GasLeft:     4976,
+			},
+		},
+		{
+			name:  "should fail and consume all gas by error",
+			value: big.NewInt(0),
+			gas:   5000,
+			// ADD will be failed by stack underflow
+			code: []byte{ADD},
+			expected: &runtime.ExecutionResult{
+				ReturnValue: nil,
+				GasLeft:     0,
+				Err:         errStackUnderflow,
+			},
+		},
+		{
+			name:  "should fail by REVERT and return remaining gas at that time",
+			value: big.NewInt(0),
+			gas:   5000,
+			// Stack size and offset for return value first
+			code: []byte{PUSH1, 0x00, PUSH1, 0x00, REVERT},
+			config: &chain.ForksInTime{
+				Byzantium: true,
+			},
+			expected: &runtime.ExecutionResult{
+				ReturnValue: nil,
+				// gas consumed for 2 push1 ops
+				GasLeft: 4994,
+				Err:     errRevert,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evm := NewEVM()
+			contract := newMockContract(tt.value, tt.gas, tt.code)
+			host := &mockHost{}
+			config := tt.config
+			if config == nil {
+				config = &chain.ForksInTime{}
+			}
+			res := evm.Run(contract, host, config)
+			assert.Equal(t, tt.expected, res)
+		})
+	}
+}

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -466,7 +466,7 @@ func opSload(c *state) {
 
 func opSStore(c *state) {
 	if c.inStaticCall() {
-		c.exit(errReadOnly)
+		c.exit(errWriteProtection)
 		return
 	}
 
@@ -866,7 +866,7 @@ func opGasLimit(c *state) {
 
 func opSelfDestruct(c *state) {
 	if c.inStaticCall() {
-		c.exit(errReadOnly)
+		c.exit(errWriteProtection)
 		return
 	}
 
@@ -963,7 +963,7 @@ func opLog(size int) instruction {
 	size = size - 1
 	return func(c *state) {
 		if c.inStaticCall() {
-			c.exit(errReadOnly)
+			c.exit(errWriteProtection)
 			return
 		}
 
@@ -1004,7 +1004,7 @@ func opStop(c *state) {
 func opCreate(op OpCode) instruction {
 	return func(c *state) {
 		if c.inStaticCall() {
-			c.exit(errReadOnly)
+			c.exit(errWriteProtection)
 			return
 		}
 
@@ -1058,7 +1058,7 @@ func opCall(op OpCode) instruction {
 
 		if op == CALL && c.inStaticCall() {
 			if val := c.peekAt(3); val != nil && val.BitLen() > 0 {
-				c.exit(errReadOnly)
+				c.exit(errWriteProtection)
 				return
 			}
 		}

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -793,12 +793,12 @@ func opReturnDataCopy(c *state) {
 
 	end := length.Add(dataOffset, length)
 	if !end.IsUint64() {
-		c.exit(errOutOfGas)
+		c.exit(errReturnDataOutOfBounds)
 		return
 	}
 	size = end.Uint64()
 	if uint64(len(c.returnData)) < size {
-		c.exit(errReturnBadSize)
+		c.exit(errReturnDataOutOfBounds)
 		return
 	}
 

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -101,8 +101,6 @@ type mockHostForCreate struct {
 	callxResult *runtime.ExecutionResult
 }
 
-var _ runtime.Host = (*mockHostForCreate)(nil)
-
 func (m *mockHostForCreate) GetNonce(types.Address) uint64 {
 	return m.nonce
 }
@@ -217,7 +215,7 @@ func TestCreate(t *testing.T) {
 			mockHost: &mockHostForCreate{},
 		},
 		{
-			name:     "should throw errOpCodeNotFound when op is CREATE2 and config.Constantinople is not disabled",
+			name:     "should throw errOpCodeNotFound when op is CREATE2 and config.Constantinople is disabled",
 			op:       CREATE2,
 			contract: &runtime.Contract{},
 			config: &chain.ForksInTime{

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -4,6 +4,10 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xPolygon/minimal/chain"
+	"github.com/0xPolygon/minimal/crypto"
+	"github.com/0xPolygon/minimal/state/runtime"
+	"github.com/0xPolygon/minimal/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -89,4 +93,248 @@ func TestMStore(t *testing.T) {
 	opMStore(s)
 
 	assert.Len(t, s.memory, 1024+32)
+}
+
+type mockHostForCreate struct {
+	mockHost
+	nonce       uint64
+	callxResult *runtime.ExecutionResult
+}
+
+var _ runtime.Host = (*mockHostForCreate)(nil)
+
+func (m *mockHostForCreate) GetNonce(types.Address) uint64 {
+	return m.nonce
+}
+
+func (m *mockHostForCreate) Callx(*runtime.Contract, runtime.Host) *runtime.ExecutionResult {
+	return m.callxResult
+}
+
+var (
+	addr1 = types.StringToAddress("1")
+)
+
+func TestCreate(t *testing.T) {
+	type state struct {
+		gas    uint64
+		sp     int
+		stack  []*big.Int
+		memory []byte
+		stop   bool
+		err    error
+	}
+
+	addressToBigInt := func(addr types.Address) *big.Int {
+		return new(big.Int).SetBytes(addr[:])
+	}
+
+	tests := []struct {
+		name        string
+		op          OpCode
+		contract    *runtime.Contract
+		config      *chain.ForksInTime
+		initState   *state
+		resultState *state
+		mockHost    *mockHostForCreate
+	}{
+		{
+			name: "should succeed",
+			op:   CREATE,
+			contract: &runtime.Contract{
+				Static:  false,
+				Address: addr1,
+			},
+			config: &chain.ForksInTime{},
+			initState: &state{
+				gas: 1000,
+				sp:  3,
+				stack: []*big.Int{
+					big.NewInt(0x01), // length
+					big.NewInt(0x00), // offset
+					big.NewInt(0x00), // value
+				},
+				memory: []byte{
+					byte(REVERT),
+				},
+			},
+			resultState: &state{
+				gas: 500,
+				sp:  1,
+				stack: []*big.Int{
+					addressToBigInt(crypto.CreateAddress(addr1, 0)), // contract address
+					big.NewInt(0x00),
+					big.NewInt(0x00),
+				},
+				memory: []byte{
+					byte(REVERT),
+				},
+			},
+			mockHost: &mockHostForCreate{
+				nonce: 0,
+				callxResult: &runtime.ExecutionResult{
+					GasLeft: 500,
+					GasUsed: 500,
+				},
+			},
+		},
+		{
+			name: "should throw errWriteProtection in case of static call",
+			op:   CREATE,
+			contract: &runtime.Contract{
+				Static: true,
+			},
+			config: &chain.ForksInTime{},
+			initState: &state{
+				gas: 1000,
+				sp:  3,
+				stack: []*big.Int{
+					big.NewInt(0x01), // length
+					big.NewInt(0x00), // offset
+					big.NewInt(0x00), // value
+				},
+				memory: []byte{
+					byte(REVERT),
+				},
+				stop: false,
+				err:  nil,
+			},
+			// shouldn't change any states except for stop and err
+			resultState: &state{
+				gas: 1000,
+				sp:  3,
+				stack: []*big.Int{
+					big.NewInt(0x01), // length
+					big.NewInt(0x00), // offset
+					big.NewInt(0x00), // value
+				},
+				memory: []byte{
+					byte(REVERT),
+				},
+				stop: true,
+				err:  errWriteProtection,
+			},
+			mockHost: &mockHostForCreate{},
+		},
+		{
+			name: "should set zero address if op is CREATE and contract call throws ErrCodeStoreOutOfGas",
+			op:   CREATE,
+			contract: &runtime.Contract{
+				Static:  false,
+				Address: addr1,
+			},
+			config: &chain.ForksInTime{
+				Homestead: true,
+			},
+			initState: &state{
+				gas: 1000,
+				sp:  3,
+				stack: []*big.Int{
+					big.NewInt(0x01), // length
+					big.NewInt(0x00), // offset
+					big.NewInt(0x00), // value
+				},
+				memory: []byte{
+					byte(REVERT),
+				},
+				stop: false,
+				err:  nil,
+			},
+			// shouldn't change any states except for stop and err
+			resultState: &state{
+				gas: 1000,
+				sp:  1,
+				stack: []*big.Int{
+					// need to init with 0x01 to add abs field in big.Int
+					big.NewInt(0x01).SetInt64(0x00),
+					big.NewInt(0x00),
+					big.NewInt(0x00),
+				},
+				memory: []byte{
+					byte(REVERT),
+				},
+				stop: false,
+				err:  nil,
+			},
+			mockHost: &mockHostForCreate{
+				nonce: 0,
+				callxResult: &runtime.ExecutionResult{
+					GasLeft: 1000,
+					Err:     runtime.ErrCodeStoreOutOfGas,
+				},
+			},
+		},
+		{
+			name: "should set zero address if contract call throws error except for ErrCodeStoreOutOfGas",
+			op:   CREATE,
+			contract: &runtime.Contract{
+				Static:  false,
+				Address: addr1,
+			},
+			config: &chain.ForksInTime{
+				Homestead: true,
+			},
+			initState: &state{
+				gas: 1000,
+				sp:  3,
+				stack: []*big.Int{
+					big.NewInt(0x01), // length
+					big.NewInt(0x00), // offset
+					big.NewInt(0x00), // value
+				},
+				memory: []byte{
+					byte(REVERT),
+				},
+				stop: false,
+				err:  nil,
+			},
+			// shouldn't change any states except for stop and err
+			resultState: &state{
+				gas: 1000,
+				sp:  1,
+				stack: []*big.Int{
+					// need to init with 0x01 to add abs field in big.Int
+					big.NewInt(0x01).SetInt64(0x00),
+					big.NewInt(0x00),
+					big.NewInt(0x00),
+				},
+				memory: []byte{
+					byte(REVERT),
+				},
+				stop: false,
+				err:  nil,
+			},
+			mockHost: &mockHostForCreate{
+				nonce: 0,
+				callxResult: &runtime.ExecutionResult{
+					GasLeft: 1000,
+					Err:     errRevert,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, close := getState()
+			defer close()
+
+			s.msg = tt.contract
+			s.gas = tt.initState.gas
+			s.sp = tt.initState.sp
+			s.stack = tt.initState.stack
+			s.memory = tt.initState.memory
+			s.config = tt.config
+			s.host = tt.mockHost
+
+			opCreate(tt.op)(s)
+
+			assert.Equal(t, tt.resultState.gas, s.gas, "gas in state after execution is not correct")
+			assert.Equal(t, tt.resultState.sp, s.sp, "sp in state after execution is not correct")
+			assert.Equal(t, tt.resultState.stack, s.stack, "stack in state after execution is not correct")
+			assert.Equal(t, tt.resultState.memory, s.memory, "memory in state after execution is not correct")
+			assert.Equal(t, tt.resultState.stop, s.stop, "stop in state after execution is not correct")
+			assert.Equal(t, tt.resultState.err, s.err, "err in state after execution is not correct")
+		})
+	}
 }

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -139,7 +139,7 @@ func TestCreate(t *testing.T) {
 		mockHost    *mockHostForCreate
 	}{
 		{
-			name: "should succeed",
+			name: "should succeed in case of CREATE",
 			op:   CREATE,
 			contract: &runtime.Contract{
 				Static:  false,
@@ -213,6 +213,44 @@ func TestCreate(t *testing.T) {
 				},
 				stop: true,
 				err:  errWriteProtection,
+			},
+			mockHost: &mockHostForCreate{},
+		},
+		{
+			name:     "should throw errOpCodeNotFound when op is CREATE2 and config.Constantinople is not disabled",
+			op:       CREATE2,
+			contract: &runtime.Contract{},
+			config: &chain.ForksInTime{
+				Constantinople: false,
+			},
+			initState: &state{
+				gas: 1000,
+				sp:  3,
+				stack: []*big.Int{
+					big.NewInt(0x01), // length
+					big.NewInt(0x00), // offset
+					big.NewInt(0x00), // value
+				},
+				memory: []byte{
+					byte(REVERT),
+				},
+				stop: false,
+				err:  nil,
+			},
+			// shouldn't change any states except for stop and err
+			resultState: &state{
+				gas: 1000,
+				sp:  3,
+				stack: []*big.Int{
+					big.NewInt(0x01), // length
+					big.NewInt(0x00), // offset
+					big.NewInt(0x00), // value
+				},
+				memory: []byte{
+					byte(REVERT),
+				},
+				stop: true,
+				err:  errOpCodeNotFound,
 			},
 			mockHost: &mockHostForCreate{},
 		},

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -35,6 +35,7 @@ var (
 	errOutOfGas        = fmt.Errorf("out of gas")
 	errStackUnderflow  = fmt.Errorf("stack underflow")
 	errStackOverflow   = fmt.Errorf("stack overflow")
+	errGasUintOverflow = errors.New("gas uint64 overflow")
 	errWriteProtection = errors.New("write protection")
 	errInvalidJump     = fmt.Errorf("invalid jump")
 	errOpCodeNotFound  = fmt.Errorf("opcode not found")
@@ -257,7 +258,7 @@ func (c *state) checkMemory(offset, size *big.Int) bool {
 	}
 
 	if !offset.IsUint64() || !size.IsUint64() {
-		c.exit(errOutOfGas)
+		c.exit(errGasUintOverflow)
 		return false
 	}
 
@@ -265,7 +266,7 @@ func (c *state) checkMemory(offset, size *big.Int) bool {
 	s := size.Uint64()
 
 	if o > 0xffffffffe0 || s > 0xffffffffe0 {
-		c.exit(errOutOfGas)
+		c.exit(errGasUintOverflow)
 		return false
 	}
 

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -2,7 +2,6 @@ package evm
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -33,13 +32,13 @@ const stackSize = 1024
 
 var (
 	errOutOfGas              = runtime.ErrOutOfGas
-	errStackUnderflow        = fmt.Errorf("stack underflow")
-	errStackOverflow         = fmt.Errorf("stack overflow")
+	errStackUnderflow        = runtime.ErrStackUnderflow
+	errStackOverflow         = runtime.ErrStackOverflow
+	errRevert                = runtime.ErrExecutionReverted
 	errGasUintOverflow       = errors.New("gas uint64 overflow")
 	errWriteProtection       = errors.New("write protection")
-	errInvalidJump           = fmt.Errorf("invalid jump")
-	errOpCodeNotFound        = fmt.Errorf("opcode not found")
-	errRevert                = runtime.ErrExecutionReverted
+	errInvalidJump           = errors.New("invalid jump destination")
+	errOpCodeNotFound        = errors.New("opcode not found")
 	errReturnDataOutOfBounds = errors.New("return data out of bounds")
 )
 

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -32,15 +32,15 @@ func releaseState(s *state) {
 const stackSize = 1024
 
 var (
-	errOutOfGas        = fmt.Errorf("out of gas")
-	errStackUnderflow  = fmt.Errorf("stack underflow")
-	errStackOverflow   = fmt.Errorf("stack overflow")
-	errGasUintOverflow = errors.New("gas uint64 overflow")
-	errWriteProtection = errors.New("write protection")
-	errInvalidJump     = fmt.Errorf("invalid jump")
-	errOpCodeNotFound  = fmt.Errorf("opcode not found")
-	errReturnBadSize   = fmt.Errorf("return bad size")
-	errRevert          = runtime.ErrExecutionReverted
+	errOutOfGas              = fmt.Errorf("out of gas")
+	errStackUnderflow        = fmt.Errorf("stack underflow")
+	errStackOverflow         = fmt.Errorf("stack overflow")
+	errGasUintOverflow       = errors.New("gas uint64 overflow")
+	errWriteProtection       = errors.New("write protection")
+	errInvalidJump           = fmt.Errorf("invalid jump")
+	errOpCodeNotFound        = fmt.Errorf("opcode not found")
+	errRevert                = runtime.ErrExecutionReverted
+	errReturnDataOutOfBounds = errors.New("return data out of bounds")
 )
 
 // Instructions is the code of instructions

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -1,6 +1,7 @@
 package evm
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -31,14 +32,14 @@ func releaseState(s *state) {
 const stackSize = 1024
 
 var (
-	errOutOfGas       = fmt.Errorf("out of gas")
-	errStackUnderflow = fmt.Errorf("stack underflow")
-	errStackOverflow  = fmt.Errorf("stack overflow")
-	errReadOnly       = fmt.Errorf("read only")
-	errInvalidJump    = fmt.Errorf("invalid jump")
-	errOpCodeNotFound = fmt.Errorf("opcode not found")
-	errReturnBadSize  = fmt.Errorf("return bad size")
-	errRevert         = runtime.ErrExecutionReverted
+	errOutOfGas        = fmt.Errorf("out of gas")
+	errStackUnderflow  = fmt.Errorf("stack underflow")
+	errStackOverflow   = fmt.Errorf("stack overflow")
+	errWriteProtection = errors.New("write protection")
+	errInvalidJump     = fmt.Errorf("invalid jump")
+	errOpCodeNotFound  = fmt.Errorf("opcode not found")
+	errReturnBadSize   = fmt.Errorf("return bad size")
+	errRevert          = runtime.ErrExecutionReverted
 )
 
 // Instructions is the code of instructions

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -32,7 +32,7 @@ func releaseState(s *state) {
 const stackSize = 1024
 
 var (
-	errOutOfGas              = fmt.Errorf("out of gas")
+	errOutOfGas              = runtime.ErrOutOfGas
 	errStackUnderflow        = fmt.Errorf("stack underflow")
 	errStackOverflow         = fmt.Errorf("stack overflow")
 	errGasUintOverflow       = errors.New("gas uint64 overflow")

--- a/state/runtime/precompiled/precompiled.go
+++ b/state/runtime/precompiled/precompiled.go
@@ -96,11 +96,11 @@ func (p *Precompiled) Run(c *runtime.Contract, _ runtime.Host, config *chain.For
 	contract := p.contracts[c.CodeAddress]
 	gasCost := contract.gas(c.Input, config)
 
-	// In the case of not enough gas for precompiled execution we return ErrGasOverflow as opposed to ErrGasConsumed
+	// In the case of not enough gas for precompiled execution we return ErrGasOverflow as opposed to ErrOutOfGas
 	if c.Gas < gasCost {
 		return &runtime.ExecutionResult{
 			GasLeft: 0,
-			Err:     runtime.ErrGasOverflow,
+			Err:     runtime.ErrOutOfGas,
 		}
 	}
 

--- a/state/runtime/precompiled/precompiled.go
+++ b/state/runtime/precompiled/precompiled.go
@@ -96,7 +96,7 @@ func (p *Precompiled) Run(c *runtime.Contract, _ runtime.Host, config *chain.For
 	contract := p.contracts[c.CodeAddress]
 	gasCost := contract.gas(c.Input, config)
 
-	// In the case of not enough gas for precompiled execution we return ErrGasOverflow as opposed to ErrOutOfGas
+	// In the case of not enough gas for precompiled execution we return ErrOutOfGas
 	if c.Gas < gasCost {
 		return &runtime.ExecutionResult{
 			GasLeft: 0,

--- a/state/runtime/runtime.go
+++ b/state/runtime/runtime.go
@@ -99,6 +99,7 @@ func (r *ExecutionResult) UpdateGasUsed(gasLimit uint64, refund uint64) {
 }
 
 var (
+	ErrOutOfGas                 = errors.New("out of gas")
 	ErrGasConsumed              = fmt.Errorf("gas has been consumed")
 	ErrGasOverflow              = fmt.Errorf("gas overflow")
 	ErrStackOverflow            = fmt.Errorf("stack overflow")

--- a/state/runtime/runtime.go
+++ b/state/runtime/runtime.go
@@ -106,6 +106,7 @@ var (
 	ErrJumpDestNotValid         = fmt.Errorf("jump destination is not valid")
 	ErrMemoryOverflow           = fmt.Errorf("error memory overflow")
 	ErrNotEnoughFunds           = fmt.Errorf("not enough funds")
+	ErrInsufficientBalance      = errors.New("insufficient balance for transfer")
 	ErrMaxCodeSizeExceeded      = errors.New("evm: max code size exceeded")
 	ErrContractAddressCollision = errors.New("contract address collision")
 	ErrDepth                    = errors.New("max call depth exceeded")

--- a/state/runtime/runtime.go
+++ b/state/runtime/runtime.go
@@ -2,7 +2,6 @@ package runtime
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 
 	"github.com/0xPolygon/minimal/chain"
@@ -100,20 +99,15 @@ func (r *ExecutionResult) UpdateGasUsed(gasLimit uint64, refund uint64) {
 
 var (
 	ErrOutOfGas                 = errors.New("out of gas")
-	ErrGasConsumed              = fmt.Errorf("gas has been consumed")
-	ErrGasOverflow              = fmt.Errorf("gas overflow")
-	ErrStackOverflow            = fmt.Errorf("stack overflow")
-	ErrStackUnderflow           = fmt.Errorf("stack underflow")
-	ErrJumpDestNotValid         = fmt.Errorf("jump destination is not valid")
-	ErrMemoryOverflow           = fmt.Errorf("error memory overflow")
-	ErrNotEnoughFunds           = fmt.Errorf("not enough funds")
+	ErrStackOverflow            = errors.New("stack overflow")
+	ErrStackUnderflow           = errors.New("stack underflow")
+	ErrNotEnoughFunds           = errors.New("not enough funds")
 	ErrInsufficientBalance      = errors.New("insufficient balance for transfer")
 	ErrMaxCodeSizeExceeded      = errors.New("evm: max code size exceeded")
 	ErrContractAddressCollision = errors.New("contract address collision")
 	ErrDepth                    = errors.New("max call depth exceeded")
-	ErrOpcodeNotFound           = errors.New("opcode not found")
 	ErrExecutionReverted        = errors.New("execution was reverted")
-	ErrCodeStoreOutOfGas        = fmt.Errorf("code storage out of gas")
+	ErrCodeStoreOutOfGas        = errors.New("contract creation code storage out of gas")
 )
 
 type CallType int

--- a/state/transition_test.go
+++ b/state/transition_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xPolygon/minimal/state/runtime"
 	"github.com/0xPolygon/minimal/types"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
@@ -34,7 +35,6 @@ func TestSubGasLimitPrice(t *testing.T) {
 				addr1: {
 					Nonce:   0,
 					Balance: 1000,
-					State:   map[types.Hash]types.Hash{},
 				},
 			},
 			from:        addr1,
@@ -77,6 +77,74 @@ func TestSubGasLimitPrice(t *testing.T) {
 				newBalance := transition.GetBalance(msg.From)
 				diff := new(big.Int).Sub(big.NewInt(int64(tt.preState[msg.From].Balance)), newBalance)
 				assert.Zero(t, diff.Cmp(reducedAmount))
+			}
+		})
+	}
+}
+
+func TestTransfer(t *testing.T) {
+	tests := []struct {
+		name        string
+		preState    map[types.Address]*PreState
+		from        types.Address
+		to          types.Address
+		amount      int64
+		expectedErr error
+	}{
+		{
+			name: "should succeed",
+			preState: map[types.Address]*PreState{
+				addr1: {
+					Nonce:   0,
+					Balance: 1000,
+				},
+				addr2: {
+					Nonce:   0,
+					Balance: 0,
+				},
+			},
+			from:        addr1,
+			to:          addr2,
+			amount:      100,
+			expectedErr: nil,
+		},
+		{
+			name: "should fail by ErrNotEnoughFunds",
+			preState: map[types.Address]*PreState{
+				addr1: {
+					Nonce:   0,
+					Balance: 10,
+					State:   map[types.Hash]types.Hash{},
+				},
+			},
+			from:   addr1,
+			to:     addr2,
+			amount: 100,
+			// should return ErrInsufficientBalance when state.transfer returns ErrNotEnoughFunds
+			expectedErr: runtime.ErrInsufficientBalance,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transition := newTestTransition(tt.preState)
+
+			amount := big.NewInt(tt.amount)
+			err := transition.transfer(tt.from, tt.to, amount)
+
+			assert.Equal(t, tt.expectedErr, err)
+			if err == nil {
+				// should move balance
+				oldBalanceForFrom := big.NewInt(int64(tt.preState[tt.from].Balance))
+				oldBalanceForTo := big.NewInt(int64(tt.preState[tt.to].Balance))
+				newBalanceForFrom := new(big.Int).Sub(oldBalanceForFrom, amount)
+				newBalanceForTo := new(big.Int).Add(oldBalanceForTo, amount)
+
+				diffForFrom := new(big.Int).Sub(newBalanceForFrom, oldBalanceForFrom)
+				diffForTo := new(big.Int).Sub(newBalanceForTo, oldBalanceForTo)
+
+				assert.Zero(t, diffForFrom.Cmp(new(big.Int).Mul(big.NewInt(-1), amount)))
+				assert.Zero(t, diffForTo.Cmp(amount))
 			}
 		})
 	}

--- a/state/transition_test.go
+++ b/state/transition_test.go
@@ -1,0 +1,71 @@
+package state
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/0xPolygon/minimal/types"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestTransition(preState map[types.Address]*PreState) *Transition {
+	if preState == nil {
+		preState = defaultPreState
+	}
+	return &Transition{
+		logger: hclog.NewNullLogger(),
+		state:  newTestTxn(preState),
+	}
+}
+
+func TestSubGasLimitPrice(t *testing.T) {
+	tests := []struct {
+		name        string
+		preState    map[types.Address]*PreState
+		msg         *types.Transaction
+		expectedErr error
+	}{
+		{
+			name: "should succeed and reduce cost for maximum gas from account balance",
+			preState: map[types.Address]*PreState{
+				addr1: {
+					Nonce:   0,
+					Balance: 1000,
+					State:   map[types.Hash]types.Hash{},
+				},
+			},
+			msg: &types.Transaction{
+				From:     addr1,
+				Gas:      10,
+				GasPrice: big.NewInt(10),
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "should fail by ErrNotEnoughFunds",
+			preState: map[types.Address]*PreState{
+				addr1: {
+					Nonce:   0,
+					Balance: 10,
+					State:   map[types.Hash]types.Hash{},
+				},
+			},
+			msg: &types.Transaction{
+				From:     addr1,
+				Gas:      10,
+				GasPrice: big.NewInt(10),
+			},
+			// should return ErrNotEnoughFundsForGas when state.SubBalance returns ErrNotEnoughFunds
+			expectedErr: ErrNotEnoughFundsForGas,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transition := newTestTransition(tt.preState)
+			err := transition.subGasLimitPrice(tt.msg)
+			assert.Equal(t, tt.expectedErr, err)
+		})
+	}
+}

--- a/state/transition_test.go
+++ b/state/transition_test.go
@@ -65,7 +65,15 @@ func TestSubGasLimitPrice(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			transition := newTestTransition(tt.preState)
 			err := transition.subGasLimitPrice(tt.msg)
+
 			assert.Equal(t, tt.expectedErr, err)
+			if err == nil {
+				// should reduce cost for gas from balance
+				reducedAmount := new(big.Int).Mul(tt.msg.GasPrice, big.NewInt(int64(tt.msg.Gas)))
+				newBalance := transition.GetBalance(tt.msg.From)
+				diff := new(big.Int).Sub(big.NewInt(int64(tt.preState[tt.msg.From].Balance)), newBalance)
+				assert.Zero(t, diff.Cmp(reducedAmount))
+			}
 		})
 	}
 }

--- a/state/transition_test.go
+++ b/state/transition_test.go
@@ -135,16 +135,15 @@ func TestTransfer(t *testing.T) {
 			assert.Equal(t, tt.expectedErr, err)
 			if err == nil {
 				// should move balance
-				oldBalanceForFrom := big.NewInt(int64(tt.preState[tt.from].Balance))
-				oldBalanceForTo := big.NewInt(int64(tt.preState[tt.to].Balance))
-				newBalanceForFrom := new(big.Int).Sub(oldBalanceForFrom, amount)
-				newBalanceForTo := new(big.Int).Add(oldBalanceForTo, amount)
+				oldBalanceOfFrom := big.NewInt(int64(tt.preState[tt.from].Balance))
+				oldBalanceOfTo := big.NewInt(int64(tt.preState[tt.to].Balance))
+				newBalanceOfFrom := transition.GetBalance(tt.from)
+				newBalanceOfTo := transition.GetBalance(tt.to)
+				diffOfFrom := new(big.Int).Sub(newBalanceOfFrom, oldBalanceOfFrom)
+				diffOfTo := new(big.Int).Sub(newBalanceOfTo, oldBalanceOfTo)
 
-				diffForFrom := new(big.Int).Sub(newBalanceForFrom, oldBalanceForFrom)
-				diffForTo := new(big.Int).Sub(newBalanceForTo, oldBalanceForTo)
-
-				assert.Zero(t, diffForFrom.Cmp(new(big.Int).Mul(big.NewInt(-1), amount)))
-				assert.Zero(t, diffForTo.Cmp(amount))
+				assert.Zero(t, diffOfFrom.Cmp(new(big.Int).Mul(big.NewInt(-1), amount)))
+				assert.Zero(t, diffOfTo.Cmp(amount))
 			}
 		})
 	}


### PR DESCRIPTION
# Description

This PR cleans up errors around transaction execution including evm
- [x] Changes `fmt.Errorf` call to `errors.New` in error definitions
- [x] Renames `errReadOnly` to `errWriteProtection`
- [x] Adds `ErrInsufficientBalance` for error of insufficient balance on transfer
- [x] Adds `errGasUintOverflow` for overflow error on gas calculation
- [x] Add tests of error handling for the errors to need to be handled.



# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
