### PR TITLE
Fix eth call default values

### DIFF
--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -475,6 +475,10 @@ func (d *Dispatcher) getNextNonce(address types.Address, number BlockNumber) (ui
 }
 
 func (d *Dispatcher) decodeTxn(arg *txnArgs) (*types.Transaction, error) {
+	if arg.Data != nil && arg.Input != nil {
+		return nil, fmt.Errorf("both input and data cannot be set")
+	}
+
 	// set default values
 	if arg.From == nil {
 		arg.From = &types.ZeroAddress
@@ -486,10 +490,6 @@ func (d *Dispatcher) decodeTxn(arg *txnArgs) (*types.Transaction, error) {
 			return nil, err
 		}
 		arg.Nonce = argUintPtr(nonce)
-	}
-
-	if arg.Data != nil && arg.Input != nil {
-		return nil, fmt.Errorf("both input and data cannot be set")
 	}
 	if arg.Value == nil {
 		arg.Value = argBytesPtr([]byte{})

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -495,8 +495,7 @@ func (d *Dispatcher) decodeTxn(arg *txnArgs) (*types.Transaction, error) {
 		arg.Value = argBytesPtr([]byte{})
 	}
 	if arg.GasPrice == nil {
-		// use the suggested gas price
-		arg.GasPrice = argBytesPtr(d.store.GetAvgGasPrice().Bytes())
+		arg.GasPrice = argBytesPtr([]byte{})
 	}
 
 	var input []byte

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -478,17 +478,18 @@ func (d *Dispatcher) decodeTxn(arg *txnArgs) (*types.Transaction, error) {
 	// set default values
 	if arg.From == nil {
 		arg.From = &types.ZeroAddress
-	}
-	if arg.Data != nil && arg.Input != nil {
-		return nil, fmt.Errorf("both input and data cannot be set")
-	}
-	if arg.Nonce == nil {
+		arg.Nonce = argUintPtr(0)
+	} else if arg.Nonce == nil {
 		// get nonce from the pool
 		nonce, err := d.getNextNonce(*arg.From, LatestBlockNumber)
 		if err != nil {
 			return nil, err
 		}
 		arg.Nonce = argUintPtr(nonce)
+	}
+
+	if arg.Data != nil && arg.Input != nil {
+		return nil, fmt.Errorf("both input and data cannot be set")
 	}
 	if arg.Value == nil {
 		arg.Value = argBytesPtr([]byte{})


### PR DESCRIPTION
# Description

Fixing the issue reported in: https://github.com/0xPolygon/polygon-sdk/issues/123

After more research, it doesn't make sense that we are fetching the average gas price when it wasn't explicitly provided as a part of the message for `eth_call`, `eth_sendTransaction` or `eth_estimateGas`, this will only cause the call to fail when not specifying the from address.

Also, when the from is not specified, we will no longer try to fetch the nonce.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the README
