### PR TITLE
Fix structure of result for eth_getBlockByNumber and eth_getBlockByHash

### DIFF
--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -233,7 +233,7 @@ func TestDispatcherBatchRequest(t *testing.T) {
 	// test with leading whitespace ("  \t\n\n\r")
 	leftBytes := []byte{0x20, 0x20, 0x09, 0x0A, 0x0A, 0x0D}
 	resp, err := s.Handle(append(leftBytes, []byte(`[
-    {"id":1,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x1", true]},
+    {"id":1,"jsonrpc":"2.0","method":"eth_getBalance","params":["0x1", true]},
     {"id":2,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x2", true]},
     {"id":3,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x3", true]},
 		{"id":4,"jsonrpc":"2.0","method": "web3_sha3","params": ["0x68656c6c6f20776f726c64"]}
@@ -243,6 +243,6 @@ func TestDispatcherBatchRequest(t *testing.T) {
 	var res []Response
 	assert.NoError(t, expectBatchJSONResult(resp, &res))
 	assert.Len(t, res, 4)
-	assert.Equal(t, res[0].Error, internalError)
+	assert.Equal(t, internalError, res[0].Error)
 	assert.Nil(t, res[3].Error)
 }

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -19,7 +19,7 @@ func (e *Eth) ChainId() (interface{}, error) {
 }
 
 // GetBlockByNumber returns information about a block by block number
-func (e *Eth) GetBlockByNumber(number BlockNumber, full bool) (interface{}, error) {
+func (e *Eth) GetBlockByNumber(number BlockNumber, fullTx bool) (interface{}, error) {
 	var num uint64
 	switch number {
 	case LatestBlockNumber:
@@ -35,20 +35,20 @@ func (e *Eth) GetBlockByNumber(number BlockNumber, full bool) (interface{}, erro
 		num = uint64(number)
 	}
 
-	block, ok := e.d.store.GetBlockByNumber(num, full)
+	block, ok := e.d.store.GetBlockByNumber(num, true)
 	if !ok {
 		return nil, fmt.Errorf("unable to get block by num %v", num)
 	}
-	return toBlock(block), nil
+	return toBlock(block, fullTx), nil
 }
 
 // GetBlockByHash returns information about a block by hash
-func (e *Eth) GetBlockByHash(hash types.Hash, full bool) (interface{}, error) {
-	block, ok := e.d.store.GetBlockByHash(hash, full)
+func (e *Eth) GetBlockByHash(hash types.Hash, fullTx bool) (interface{}, error) {
+	block, ok := e.d.store.GetBlockByHash(hash, true)
 	if !ok {
 		return nil, fmt.Errorf("unable to get block by hash %v", hash)
 	}
-	return toBlock(block), nil
+	return toBlock(block, fullTx), nil
 }
 
 // BlockNumber returns current block number

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -37,7 +37,7 @@ func (e *Eth) GetBlockByNumber(number BlockNumber, fullTx bool) (interface{}, er
 
 	block, ok := e.d.store.GetBlockByNumber(num, true)
 	if !ok {
-		return nil, fmt.Errorf("unable to get block by num %v", num)
+		return nil, nil
 	}
 	return toBlock(block, fullTx), nil
 }
@@ -46,7 +46,7 @@ func (e *Eth) GetBlockByNumber(number BlockNumber, fullTx bool) (interface{}, er
 func (e *Eth) GetBlockByHash(hash types.Hash, fullTx bool) (interface{}, error) {
 	block, ok := e.d.store.GetBlockByHash(hash, true)
 	if !ok {
-		return nil, fmt.Errorf("unable to get block by hash %v", hash)
+		return nil, nil
 	}
 	return toBlock(block, fullTx), nil
 }

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -32,6 +32,9 @@ func (e *Eth) GetBlockByNumber(number BlockNumber, fullTx bool) (interface{}, er
 		return nil, fmt.Errorf("fetching the pending header is not supported")
 
 	default:
+		if number < 0 {
+			return nil, fmt.Errorf("invalid argument 0: block number larger than int64")
+		}
 		num = uint64(number)
 	}
 

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -152,22 +152,28 @@ func TestEth_Block_GetBlockByNumber(t *testing.T) {
 
 	cases := []struct {
 		blockNum BlockNumber
+		isNotNil bool
 		err      bool
 	}{
-		{LatestBlockNumber, false},
-		{EarliestBlockNumber, true},
-		{BlockNumber(-50), true},
-		{BlockNumber(0), false},
-		{BlockNumber(2), false},
-		{BlockNumber(50), true},
+		{LatestBlockNumber, true, false},
+		{EarliestBlockNumber, false, true},
+		{BlockNumber(0), true, false},
+		{BlockNumber(2), true, false},
+		{BlockNumber(50), false, false},
 	}
 	for _, c := range cases {
-		_, err := dispatcher.endpoints.Eth.GetBlockByNumber(c.blockNum, false)
-		if err != nil && !c.err {
-			t.Fatal(err)
+		res, err := dispatcher.endpoints.Eth.GetBlockByNumber(c.blockNum, false)
+
+		if c.isNotNil {
+			assert.NotNil(t, res, "expected to return block, but got nil")
+		} else {
+			assert.Nil(t, res, "expected to return nil, but got data")
 		}
-		if err == nil && c.err {
-			t.Fatal("bad")
+
+		if c.err {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
 		}
 	}
 }
@@ -182,11 +188,13 @@ func TestEth_Block_GetBlockByHash(t *testing.T) {
 
 	dispatcher := newTestDispatcher(hclog.NewNullLogger(), store)
 
-	_, err := dispatcher.endpoints.Eth.GetBlockByHash(hash1, false)
+	res, err := dispatcher.endpoints.Eth.GetBlockByHash(hash1, false)
 	assert.NoError(t, err)
+	assert.NotNil(t, res)
 
-	_, err = dispatcher.endpoints.Eth.GetBlockByHash(hash2, false)
-	assert.Error(t, err)
+	res, err = dispatcher.endpoints.Eth.GetBlockByHash(hash2, false)
+	assert.NoError(t, err)
+	assert.Nil(t, res)
 }
 
 func TestEth_Block_BlockNumber(t *testing.T) {

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -157,6 +157,7 @@ func TestEth_Block_GetBlockByNumber(t *testing.T) {
 	}{
 		{LatestBlockNumber, true, false},
 		{EarliestBlockNumber, false, true},
+		{BlockNumber(-50), false, true},
 		{BlockNumber(0), true, false},
 		{BlockNumber(2), true, false},
 		{BlockNumber(50), false, false},

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -100,9 +100,9 @@ var wsUpgrader = websocket.Upgrader{
 
 // wsWrapper is a wrapping object for the web socket connection and logger
 type wsWrapper struct {
-	ws     *websocket.Conn // the actual WS connection
-	logger hclog.Logger    // module logger
-	writeLock sync.Mutex // writer lock
+	ws        *websocket.Conn // the actual WS connection
+	logger    hclog.Logger    // module logger
+	writeLock sync.Mutex      // writer lock
 }
 
 // WriteMessage writes out the message to the WS peer
@@ -190,6 +190,7 @@ func (j *JSONRPC) handleWs(w http.ResponseWriter, req *http.Request) {
 }
 
 func (j *JSONRPC) handle(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
 	w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -96,7 +96,7 @@ func toBlock(b *types.Block, fullTx bool) *block {
 		LogsBloom:       h.LogsBloom,
 		Difficulty:      argUint64(h.Difficulty),
 		TotalDifficulty: argUint64(h.Difficulty), // not needed for POS
-		Size:            argUint64(0),            // should derive actual size
+		Size:            argUint64(b.Size()),
 		Number:          argUint64(h.Number),
 		GasLimit:        argUint64(h.GasLimit),
 		GasUsed:         argUint64(h.GasUsed),

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -9,6 +9,11 @@ import (
 	"github.com/0xPolygon/minimal/types"
 )
 
+// For union type of transaction and types.Hash
+type transactionOrHash interface {
+	getHash() types.Hash
+}
+
 type transaction struct {
 	Nonce       argUint64      `json:"nonce"`
 	GasPrice    argBig         `json:"gasPrice"`
@@ -24,6 +29,17 @@ type transaction struct {
 	BlockHash   types.Hash     `json:"blockHash"`
 	BlockNumber argUint64      `json:"blockNumber"`
 	TxIndex     argUint64      `json:"transactionIndex"`
+}
+
+func (t transaction) getHash() types.Hash { return t.Hash }
+
+// Redefine to implement getHash() of transactionOrHash
+type transactionHash types.Hash
+
+func (h transactionHash) getHash() types.Hash { return types.Hash(h) }
+
+func (h transactionHash) MarshalText() ([]byte, error) {
+	return []byte(types.Hash(h).String()), nil
 }
 
 func toTransaction(t *types.Transaction, b *types.Block, txIndex int) *transaction {
@@ -45,68 +61,62 @@ func toTransaction(t *types.Transaction, b *types.Block, txIndex int) *transacti
 	}
 }
 
-type uncle struct {
-	ParentHash      types.Hash    `json:"parentHash"`
-	Sha3Uncles      types.Hash    `json:"sha3Uncles"`
-	Miner           types.Address `json:"miner"`
-	StateRoot       types.Hash    `json:"stateRoot"`
-	TxRoot          types.Hash    `json:"transactionsRoot"`
-	ReceiptsRoot    types.Hash    `json:"receiptsRoot"`
-	LogsBloom       types.Bloom   `json:"logsBloom"`
-	Difficulty      argUint64     `json:"difficulty"`
-	TotalDifficulty argUint64     `json:"totalDifficulty"`
-	Size            argUint64     `json:"size"`
-	Number          argUint64     `json:"number"`
-	GasLimit        argUint64     `json:"gasLimit"`
-	GasUsed         argUint64     `json:"gasUsed"`
-	Timestamp       argUint64     `json:"timestamp"`
-	ExtraData       argBytes      `json:"extraData"`
-	MixHash         types.Hash    `json:"mixHash"`
-	Nonce           types.Nonce   `json:"nonce"`
-	Hash            types.Hash    `json:"hash"`
-}
-
-func toUncle(u *types.Header) *uncle {
-	return &uncle{
-		ParentHash:      u.ParentHash,
-		Sha3Uncles:      u.Sha3Uncles,
-		Miner:           u.Miner,
-		StateRoot:       u.StateRoot,
-		TxRoot:          u.TxRoot,
-		ReceiptsRoot:    u.ReceiptsRoot,
-		LogsBloom:       u.LogsBloom,
-		Difficulty:      argUint64(u.Difficulty),
-		TotalDifficulty: argUint64(u.Difficulty), // not needed for POS
-		Size:            argUint64(0),            // should derive actual size
-		Number:          argUint64(u.Number),
-		GasLimit:        argUint64(u.GasLimit),
-		GasUsed:         argUint64(u.GasUsed),
-		Timestamp:       argUint64(u.Timestamp),
-		ExtraData:       argBytes(u.ExtraData),
-		MixHash:         u.MixHash,
-		Nonce:           u.Nonce,
-		Hash:            u.Hash,
-	}
-}
-
 type block struct {
-	uncle
-	Transactions []*transaction `json:"transactions"`
-	Uncles       []*uncle       `json:"uncles"`
+	ParentHash      types.Hash          `json:"parentHash"`
+	Sha3Uncles      types.Hash          `json:"sha3Uncles"`
+	Miner           types.Address       `json:"miner"`
+	StateRoot       types.Hash          `json:"stateRoot"`
+	TxRoot          types.Hash          `json:"transactionsRoot"`
+	ReceiptsRoot    types.Hash          `json:"receiptsRoot"`
+	LogsBloom       types.Bloom         `json:"logsBloom"`
+	Difficulty      argUint64           `json:"difficulty"`
+	TotalDifficulty argUint64           `json:"totalDifficulty"`
+	Size            argUint64           `json:"size"`
+	Number          argUint64           `json:"number"`
+	GasLimit        argUint64           `json:"gasLimit"`
+	GasUsed         argUint64           `json:"gasUsed"`
+	Timestamp       argUint64           `json:"timestamp"`
+	ExtraData       argBytes            `json:"extraData"`
+	MixHash         types.Hash          `json:"mixHash"`
+	Nonce           types.Nonce         `json:"nonce"`
+	Hash            types.Hash          `json:"hash"`
+	Transactions    []transactionOrHash `json:"transactions"`
+	Uncles          []types.Hash        `json:"uncles"`
 }
 
-func toBlock(b *types.Block) *block {
+func toBlock(b *types.Block, fullTx bool) *block {
 	h := b.Header
 	res := &block{
-		uncle:        *toUncle(h),
-		Transactions: []*transaction{},
-		Uncles:       []*uncle{},
+		ParentHash:      h.ParentHash,
+		Sha3Uncles:      h.Sha3Uncles,
+		Miner:           h.Miner,
+		StateRoot:       h.StateRoot,
+		TxRoot:          h.TxRoot,
+		ReceiptsRoot:    h.ReceiptsRoot,
+		LogsBloom:       h.LogsBloom,
+		Difficulty:      argUint64(h.Difficulty),
+		TotalDifficulty: argUint64(h.Difficulty), // not needed for POS
+		Size:            argUint64(0),            // should derive actual size
+		Number:          argUint64(h.Number),
+		GasLimit:        argUint64(h.GasLimit),
+		GasUsed:         argUint64(h.GasUsed),
+		Timestamp:       argUint64(h.Timestamp),
+		ExtraData:       argBytes(h.ExtraData),
+		MixHash:         h.MixHash,
+		Nonce:           h.Nonce,
+		Hash:            h.Hash,
+		Transactions:    []transactionOrHash{},
+		Uncles:          []types.Hash{},
 	}
 	for idx, txn := range b.Transactions {
-		res.Transactions = append(res.Transactions, toTransaction(txn, b, idx))
+		if fullTx {
+			res.Transactions = append(res.Transactions, toTransaction(txn, b, idx))
+		} else {
+			res.Transactions = append(res.Transactions, transactionHash(txn.Hash))
+		}
 	}
 	for _, uncle := range b.Uncles {
-		res.Uncles = append(res.Uncles, toUncle(uncle))
+		res.Uncles = append(res.Uncles, uncle.Hash)
 	}
 	return res
 }


### PR DESCRIPTION
# Description

This PR fixes result of `eth_getBlockByNumber` and `eth_getBlockByHash`
+ Sets proper value to `size` field in block
+ Lets it return array of transactions when second arg is `true`, but return array of tx hash if second args is `false`
+ Lets it return array of uncle hash in `uncles` field
  - Note it'll be empty array if you use `dev` or `ibft` consensus because fork doesn't appear
+ Lets it return `null` if block doesn't exist, not error

Please check the spec for details: https://eth.wiki/json-rpc/API#eth_getblockbyhash

In addition,
+ Adds Content-Type to JSONRPC response header

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
