### PR TITLE
Fix wrong response when account doesn't exist in jsonrpc endpoint

### DIFF
--- a/jsonrpc/errors.go
+++ b/jsonrpc/errors.go
@@ -1,0 +1,7 @@
+package jsonrpc
+
+import "errors"
+
+var (
+	ErrStateNotFound = errors.New("given root and slot not found in storage")
+)

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -198,7 +198,7 @@ func (e *Eth) GetStorageAt(address types.Address, index types.Hash, number Block
 	result, err := e.d.store.GetStorage(header.StateRoot, address, index)
 	if err != nil {
 		if err == ErrStateNotFound {
-			return types.ZeroHash, nil
+			return argBytesPtr(types.ZeroHash[:]), nil
 		}
 		return nil, err
 	}

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -66,7 +66,7 @@ func (m *mockAccountStore) Header() *types.Header {
 func (m *mockAccountStore) GetAccount(root types.Hash, addr types.Address) (*state.Account, error) {
 	acct, ok := m.accounts[addr]
 	if !ok {
-		return nil, fmt.Errorf("not found")
+		return nil, ErrStateNotFound
 	}
 	return acct.account, nil
 }
@@ -83,11 +83,11 @@ func (m *mockAccountStore) GetCode(hash types.Hash) ([]byte, error) {
 func (m *mockAccountStore) GetStorage(root types.Hash, addr types.Address, slot types.Hash) ([]byte, error) {
 	acct, ok := m.accounts[addr]
 	if !ok {
-		return nil, fmt.Errorf("not found")
+		return nil, ErrStateNotFound
 	}
 	val, ok := acct.storage[slot]
 	if !ok {
-		return nil, fmt.Errorf("not found")
+		return nil, ErrStateNotFound
 	}
 	return val.Bytes(), nil
 }
@@ -338,20 +338,66 @@ func TestEth_State_GetBalance(t *testing.T) {
 }
 
 func TestEth_State_GetTransactionCount(t *testing.T) {
-	store := &mockAccountStore{}
+	tests := []struct {
+		name          string
+		initialNonces map[types.Address]uint64
+		target        types.Address
+		blockNumber   BlockNumber
+		succeeded     bool
+		expectedNonce *argUint64
+	}{
+		{
+			name: "should return nonce for existing account",
+			initialNonces: map[types.Address]uint64{
+				addr0: 100,
+			},
+			target:        addr0,
+			blockNumber:   LatestBlockNumber,
+			succeeded:     true,
+			expectedNonce: argUintPtr(100),
+		},
+		{
+			name: "should return zero for non-existing account",
+			initialNonces: map[types.Address]uint64{
+				addr0: 100,
+			},
+			target:        addr1,
+			blockNumber:   LatestBlockNumber,
+			succeeded:     true,
+			expectedNonce: argUintPtr(0),
+		},
+		{
+			name: "should return error for non-existing header",
+			initialNonces: map[types.Address]uint64{
+				addr0: 100,
+			},
+			target:        addr0,
+			blockNumber:   100,
+			succeeded:     false,
+			expectedNonce: nil,
+		},
+	}
 
-	acct0 := store.AddAccount(addr0)
-	acct0.Nonce(100)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &mockAccountStore{}
 
-	dispatcher := newTestDispatcher(hclog.NewNullLogger(), store)
+			for addr, nonce := range tt.initialNonces {
+				account := store.AddAccount(addr)
+				account.Nonce(nonce)
+			}
+			dispatcher := newTestDispatcher(hclog.NewNullLogger(), store)
 
-	balance, err := dispatcher.endpoints.Eth.GetTransactionCount(addr0, LatestBlockNumber)
-	assert.NoError(t, err)
-	assert.Equal(t, balance, argUintPtr(100))
-
-	// address not found
-	_, err = dispatcher.endpoints.Eth.GetTransactionCount(addr1, LatestBlockNumber)
-	assert.Error(t, err)
+			nonce, err := dispatcher.endpoints.Eth.GetTransactionCount(tt.target, tt.blockNumber)
+			if tt.succeeded {
+				assert.NoError(t, err)
+				assert.NotNil(t, nonce)
+				assert.Equal(t, tt.expectedNonce, nonce)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
 }
 
 var (
@@ -380,19 +426,89 @@ func TestEth_State_GetCode(t *testing.T) {
 }
 
 func TestEth_State_GetStorageAt(t *testing.T) {
-	store := &mockAccountStore{}
+	tests := []struct {
+		name           string
+		initialStorage map[types.Address]map[types.Hash]types.Hash
+		address        types.Address
+		index          types.Hash
+		blockNumber    BlockNumber
+		succeeded      bool
+		expectedData   *argBytes
+	}{
+		{
+			name: "should return data for existing slot",
+			initialStorage: map[types.Address]map[types.Hash]types.Hash{
+				addr0: {
+					hash1: hash1,
+				},
+			},
+			address:      addr0,
+			index:        hash1,
+			blockNumber:  LatestBlockNumber,
+			succeeded:    true,
+			expectedData: argBytesPtr([]byte(hash1[:])),
+		},
+		{
+			name: "should return 32 bytes filled with zero for undefined slot",
+			initialStorage: map[types.Address]map[types.Hash]types.Hash{
+				addr0: {
+					hash1: hash1,
+				},
+			},
+			address:      addr0,
+			index:        hash2,
+			blockNumber:  LatestBlockNumber,
+			succeeded:    true,
+			expectedData: argBytesPtr(types.ZeroHash[:]),
+		},
+		{
+			name: "should return 32 bytes filled with zero for non-existing account",
+			initialStorage: map[types.Address]map[types.Hash]types.Hash{
+				addr0: {
+					hash1: hash1,
+				},
+			},
+			address:      addr0,
+			index:        hash2,
+			blockNumber:  LatestBlockNumber,
+			succeeded:    true,
+			expectedData: argBytesPtr(types.ZeroHash[:]),
+		},
+		{
+			name: "should return error for non-existing header",
+			initialStorage: map[types.Address]map[types.Hash]types.Hash{
+				addr0: {
+					hash1: hash1,
+				},
+			},
+			address:      addr0,
+			index:        hash2,
+			blockNumber:  100,
+			succeeded:    false,
+			expectedData: nil,
+		},
+	}
 
-	acct0 := store.AddAccount(addr0)
-	acct0.Storage(hash1, hash1)
-
-	dispatcher := newTestDispatcher(hclog.NewNullLogger(), store)
-	res, err := dispatcher.endpoints.Eth.GetStorageAt(acct0.address, hash1, LatestBlockNumber)
-	assert.NoError(t, err)
-	assert.Equal(t, res, argBytesPtr(hash1.Bytes()))
-
-	// slot not found
-	_, err = dispatcher.endpoints.Eth.GetStorageAt(acct0.address, hash2, LatestBlockNumber)
-	assert.Error(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &mockAccountStore{}
+			for addr, storage := range tt.initialStorage {
+				account := store.AddAccount(addr)
+				for index, data := range storage {
+					account.Storage(index, data)
+				}
+			}
+			dispatcher := newTestDispatcher(hclog.NewNullLogger(), store)
+			res, err := dispatcher.endpoints.Eth.GetStorageAt(tt.address, tt.index, tt.blockNumber)
+			if tt.succeeded {
+				assert.NoError(t, err)
+				assert.NotNil(t, res)
+				assert.Equal(t, tt.expectedData, res)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
 }
 
 type mockStoreTxn struct {

--- a/minimal/server.go
+++ b/minimal/server.go
@@ -2,7 +2,6 @@ package minimal
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -256,7 +255,7 @@ func (j *jsonRPCHub) getState(root types.Hash, slot []byte) ([]byte, error) {
 	}
 	result, ok := snap.Get(key)
 	if !ok {
-		return nil, errors.New("given root and slot not found in storage")
+		return nil, jsonrpc.ErrStateNotFound
 	}
 	return result, nil
 }


### PR DESCRIPTION
# Description

Related issue: https://github.com/0xPolygon/polygon-sdk/issues/131

This PR fixes wrong response in some endpoints of jsonrpc

1. `eth_getStorageAt(address, index, block number)`, `eth_getTransactionCount(address, block number)`
     These endpoint returned error in both cases of (1) the header with given number doesn't exist and (2) data for the account doesn't exist in storage. But they should return zero value in case of (2). So this PR adds new special error and return zero value when account doesn't exist in storage.

2. `GetLogs(options)`
     This returned null when there are no logs to return. But expect to return empty array. So this PR lets this function return empty array in this case.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
