### PR TITLE
Ensure eth_logs handles case where fromBlock == toBlock

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -425,7 +425,7 @@ func (e *Eth) GetLogs(filterOptions *LogFilter) (interface{}, error) {
 	if to < from {
 		return nil, fmt.Errorf("incorrect range")
 	}
-	for i := from; i < to; i++ {
+	for i := from; i <= to; i++ {
 		header, ok := e.d.store.GetHeaderByNumber(i)
 		if !ok {
 			break

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/big"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
@@ -105,6 +106,77 @@ func (m *mockBlockStore2) add(blocks ...*types.Block) {
 }
 
 func (m *mockBlockStore2) GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error) {
+	switch hash {
+	case types.StringToHash(strconv.Itoa(1)):
+		return []*types.Receipt{
+			{
+				Logs: []*types.Log{
+					{
+						Topics: []types.Hash{
+							hash1,
+						},
+					},
+					{
+						Topics: []types.Hash{
+							types.StringToHash("4"), types.StringToHash("5"), types.StringToHash("6"),
+						},
+					},
+				},
+			},
+		}, nil
+	case types.StringToHash(strconv.Itoa(2)):
+		return []*types.Receipt{
+			{
+				Logs: []*types.Log{
+					{
+						Topics: []types.Hash{
+							hash1, hash2, hash3,
+						},
+					},
+				},
+			},
+			{
+				Logs: []*types.Log{
+					{
+						Topics: []types.Hash{
+							types.StringToHash("4"), types.StringToHash("5"), types.StringToHash("6"),
+						},
+					},
+				},
+			},
+		}, nil
+	case types.StringToHash(strconv.Itoa(3)):
+		return []*types.Receipt{
+			{
+				Logs: []*types.Log{
+					{
+						Topics: []types.Hash{
+							types.StringToHash("4"), types.StringToHash("5"), types.StringToHash("6"),
+						},
+					},
+				},
+			},
+			{
+				Logs: []*types.Log{
+					{
+						Topics: []types.Hash{
+							hash1, hash2, hash3,
+						},
+					},
+				},
+			},
+			{
+				Logs: []*types.Log{
+					{
+						Topics: []types.Hash{
+							hash1, hash2, hash3,
+						},
+					},
+				},
+			},
+		}, nil
+	}
+
 	return nil, nil
 }
 
@@ -214,104 +286,77 @@ func TestEth_Block_BlockNumber(t *testing.T) {
 
 func TestEth_Block_GetLogs(t *testing.T) {
 
-	/*
-		// Topics we're searching for
-		var topics = [][]types.Hash{
-			{types.StringToHash("topic 4")},
-			{types.StringToHash("topic 5")},
-			{types.StringToHash("topic 6")},
-		}
+	// Topics we're searching for
+	var topics = [][]types.Hash{
+		{types.StringToHash("4")},
+		{types.StringToHash("5")},
+		{types.StringToHash("6")},
+	}
 
-		testTable := []struct {
-			name          string
-			filterOptions *LogFilter
-			shouldFail    bool
-		}{
-			{"Found matching logs",
-				&LogFilter{
-					fromBlock: 1,
-					toBlock:   4,
-					Topics:    topics,
-				},
-				false},
-			{"Invalid block range", &LogFilter{
-				fromBlock: 10,
-				toBlock:   5,
+	testTable := []struct {
+		name          string
+		filterOptions *LogFilter
+		shouldFail    bool
+	}{
+		{"Found matching logs, fromBlock < toBlock",
+			&LogFilter{
+				fromBlock: 1,
+				toBlock:   3,
 				Topics:    topics,
-			}, true},
-			{"Reference blocks not found", &LogFilter{
-				fromBlock: 10,
-				toBlock:   20,
+			},
+			false},
+		{"Found matching logs, fromBlock == toBlock",
+			&LogFilter{
+				fromBlock: 2,
+				toBlock:   2,
 				Topics:    topics,
-			}, true},
-		}
+			},
+			false},
+		{"No logs found", &LogFilter{
+			fromBlock: 4,
+			toBlock:   5,
+			Topics:    topics,
+		}, false},
+		{"Invalid block range", &LogFilter{
+			fromBlock: 10,
+			toBlock:   5,
+			Topics:    topics,
+		}, true},
+	}
 
-		// Setup //
-		store := newMockBlockStore()
+	// setup test
+	store := &mockBlockStore2{}
+	for i := 0; i < 4; i++ {
+		store.add(&types.Block{
+			Header: &types.Header{
+				Number: uint64(i),
+				Hash:   types.StringToHash(strconv.Itoa(i)),
+			},
+		})
+	}
+	dispatcher := newTestDispatcher(hclog.NewNullLogger(), store)
 
-		dispatcher := newTestDispatcher(hclog.NewNullLogger(), store)
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			foundLogs, logError := dispatcher.endpoints.Eth.GetLogs(
+				testCase.filterOptions,
+			)
 
-		store.getHeaderByNumberCallback = func(blockNumber uint64) (*types.Header, bool) {
-			return &types.Header{
-				Number:       blockNumber,
-				ReceiptsRoot: types.StringToHash(strconv.FormatUint(blockNumber, 10)),
-			}, true
-		}
-
-		store.getReceiptsByHashCallback = func(hash types.Hash) ([]*types.Receipt, error) {
-
-			switch hash {
-			case types.StringToHash(strconv.FormatUint(1, 10)):
-				return store.generateReceipts(
-					generateReceiptsParams{
-						numReceipts: 1,
-						numTopics:   1,
-						numLogs:     2,
-					},
-				), nil
-			case types.StringToHash(strconv.FormatUint(2, 10)):
-				return store.generateReceipts(
-					generateReceiptsParams{
-						numReceipts: 2,
-						numTopics:   5,
-						numLogs:     1,
-					},
-				), nil
-			case types.StringToHash(strconv.FormatUint(3, 10)):
-				return store.generateReceipts(
-					generateReceiptsParams{
-						numReceipts: 3,
-						numTopics:   10,
-						numLogs:     5,
-					},
-				), nil
-			}
-
-			return nil, nil
-		}
-
-		for index, testCase := range testTable {
-
-			if index == 2 {
-				store.getHeaderByNumberCallback = func(blockNumber uint64) (*types.Header, bool) {
-					return nil, false
+			if logError != nil && !testCase.shouldFail {
+				// If there is an error and test isn't expected to fail
+				t.Fatalf("Error: %v", logError)
+			} else if !testCase.shouldFail {
+				switch testCase.name {
+				case "Found matching logs, fromBlock < toBlock":
+					assert.Lenf(t, foundLogs, 3, "Invalid number of logs found")
+				case "Found matching logs, toBlock == fromBlock":
+					assert.Lenf(t, foundLogs, 1, "Invalid number of logs found")
+				case "No logs found":
+					assert.Lenf(t, foundLogs, 0, "Invalid number of logs found")
 				}
 			}
-
-			t.Run(testCase.name, func(t *testing.T) {
-				foundLogs, logError := dispatcher.endpoints.Eth.GetLogs(
-					testCase.filterOptions,
-				)
-
-				if logError != nil && !testCase.shouldFail {
-					// If there is an error, and the test shouldn't fail
-					t.Fatalf("Error: %v", logError)
-				} else if !testCase.shouldFail {
-					assert.Lenf(t, foundLogs, 17, "Invalid number of logs found")
-				}
-			})
-		}
-	*/
+		})
+	}
 }
 
 var (

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -349,7 +349,7 @@ func TestEth_Block_GetLogs(t *testing.T) {
 				switch testCase.name {
 				case "Found matching logs, fromBlock < toBlock":
 					assert.Lenf(t, foundLogs, 3, "Invalid number of logs found")
-				case "Found matching logs, toBlock == fromBlock":
+				case "Found matching logs, fromBlock == toBlock":
 					assert.Lenf(t, foundLogs, 1, "Invalid number of logs found")
 				case "No logs found":
 					assert.Lenf(t, foundLogs, 0, "Invalid number of logs found")

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -342,14 +342,7 @@ func TestEth_Block_GetLogs(t *testing.T) {
 				// If there is an error and test isn't expected to fail
 				t.Fatalf("Error: %v", logError)
 			} else if !testCase.shouldFail {
-				switch testCase.name {
-				case "Found matching logs, fromBlock < toBlock":
-					assert.Lenf(t, foundLogs, testCase.expectedLength, "Invalid number of logs found")
-				case "Found matching logs, fromBlock == toBlock":
-					assert.Lenf(t, foundLogs, testCase.expectedLength, "Invalid number of logs found")
-				case "No logs found":
-					assert.Lenf(t, foundLogs, testCase.expectedLength, "Invalid number of logs found")
-				}
+				assert.Lenf(t, foundLogs, testCase.expectedLength, "Invalid number of logs found")
 			}
 		})
 	}


### PR DESCRIPTION
# Description

While attempting to integrate a bridge with nodes running the SDK, json-rpc calls going out to `eth_logs` which had the same value for the `fromBlock` and `toBlock` fields within the request were returning empty.

For example:
```
{"jsonrpc":"2.0","id":3061,"method":"eth_getLogs","params":[{"address":["0x2da3dcaa07453dfdb69ce7a4ce3674e4084a2234"],"fromBlock":"0x21b7","toBlock":"0x21b7","topics":[["0xdbb69440df8433824a026ef190652f29929eb64b4d1d5d2a69be8afe3e6eaed8"]]}]}
```

would previously return a response body such as:
```
{
    "id": 3061,
    "jsonrpc": "2.0",
    "result": null
}
```

I adjusted the for-loop comparator so that queries with identical `fromBlock` and `toBlock` values return logs for that single block.

I also brought back some commented out tests I saw and added the case where `fromBlock == toBlock`.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs