### PR TITLE
Update validator set in every epoch

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -649,8 +649,12 @@ func (i *Ibft) insertBlock(block *types.Block) error {
 		return err
 	}
 
-	if err := i.updateValidators(header.Number); err != nil {
-		return err
+	if i.IsLastOfEpoch(header.Number) {
+		if err := i.updateValidators(header.Number); err != nil {
+			return err
+		}
+	} else {
+		fmt.Printf("\n\nskip updateing validators\n\n")
 	}
 
 	i.logger.Info(

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -653,8 +653,6 @@ func (i *Ibft) insertBlock(block *types.Block) error {
 		if err := i.updateValidators(header.Number); err != nil {
 			return err
 		}
-	} else {
-		fmt.Printf("\n\nskip updateing validators\n\n")
 	}
 
 	i.logger.Info(


### PR DESCRIPTION
# Description

This PR change updating validator set from staking contract. Lets consensus fetch validators from contract and update validator set in IBFT only when block number is in the end of epoch.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
