### PR TITLE
No transactions at the end of epoch

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -655,8 +655,6 @@ func (i *Ibft) insertBlock(block *types.Block) error {
 		if err := i.updateValidators(header.Number); err != nil {
 			return err
 		}
-	} else {
-		fmt.Printf("\n\nskip updateing validators\n\n")
 	}
 
 	i.logger.Info(

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -649,8 +649,12 @@ func (i *Ibft) insertBlock(block *types.Block) error {
 		return err
 	}
 
-	if err := i.updateValidators(header.Number); err != nil {
-		return err
+	if i.IsLastOfEpoch(header.Number) {
+		if err := i.updateValidators(header.Number); err != nil {
+			return err
+		}
+	} else {
+		fmt.Printf("\n\nskip updateing validators\n\n")
 	}
 
 	i.logger.Info(

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -549,13 +549,18 @@ func (i *Ibft) runAcceptState() { // start new round
 			if err := i.verifyHeaderImpl(snap, parent, block.Header); err != nil {
 				i.logger.Error("block verification failed", "err", err)
 				i.handleStateErr(errBlockVerificationFailed)
-			} else {
-				i.state.block = block
-
-				// send prepare message and wait for validations
-				i.sendPrepareMsg()
-				i.setState(ValidateState)
+				continue
 			}
+			if i.IsLastOfEpoch(block.Number()) && len(block.Transactions) > 0 {
+				i.logger.Error("block verification failed, block at the end of epoch has transactions")
+				i.handleStateErr(errBlockVerificationFailed)
+				continue
+			}
+
+			i.state.block = block
+			// send prepare message and wait for validations
+			i.sendPrepareMsg()
+			i.setState(ValidateState)
 		}
 	}
 }


### PR DESCRIPTION
# Description

This PR change IBFT consensus behaviour for IBFT-PoS so that not let IBFT take any transactions into block when number is at the end of epoch.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have tested this code
- [x] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
