### PR TITLE
Fix/get storage at response

### DIFF
--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -295,7 +295,7 @@ func (d *Dispatcher) handleReq(req Request) ([]byte, Error) {
 	output := fd.fv.Call(inArgs)
 	if err := getError(output[1]); err != nil {
 		d.logInternalError(req.Method, err)
-		return nil, NewInternalError("Internal error")
+		return nil, NewInvalidRequestError(err.Error())
 	}
 
 	var data []byte

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/0xPolygon/polygon-sdk/helper/hex"
 	"github.com/0xPolygon/polygon-sdk/types"
+	"github.com/umbracle/fastrlp"
 )
 
 // Eth is the eth jsonrpc endpoint
@@ -202,8 +203,17 @@ func (e *Eth) GetStorageAt(address types.Address, index types.Hash, number Block
 		}
 		return nil, err
 	}
-
-	return argBytesPtr(result), nil
+	//Parse the RLP value
+	p := &fastrlp.Parser{}
+	v, err := p.Parse(result)
+	if err != nil {
+		return argBytesPtr(types.ZeroHash[:]), nil
+	}
+	data, err := v.Bytes()
+	if err != nil {
+		return argBytesPtr(types.ZeroHash[:]), nil
+	}
+	return argBytesPtr(data), nil
 }
 
 // GasPrice returns the average gas price based on the last x blocks

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
+	"github.com/umbracle/fastrlp"
 
 	"github.com/0xPolygon/polygon-sdk/helper/hex"
 	"github.com/0xPolygon/polygon-sdk/state"
@@ -19,10 +20,10 @@ type mockAccount2 struct {
 	address types.Address
 	code    []byte
 	account *state.Account
-	storage map[types.Hash]types.Hash
+	storage map[types.Hash][]byte
 }
 
-func (m *mockAccount2) Storage(k, v types.Hash) {
+func (m *mockAccount2) Storage(k types.Hash, v []byte) {
 	m.storage[k] = v
 }
 
@@ -53,7 +54,7 @@ func (m *mockAccountStore) AddAccount(addr types.Address) *mockAccount2 {
 		store:   m,
 		address: addr,
 		account: &state.Account{},
-		storage: map[types.Hash]types.Hash{},
+		storage: make(map[types.Hash][]byte),
 	}
 	m.accounts[addr] = acct
 	return acct
@@ -89,7 +90,7 @@ func (m *mockAccountStore) GetStorage(root types.Hash, addr types.Address, slot 
 	if !ok {
 		return nil, ErrStateNotFound
 	}
-	return val.Bytes(), nil
+	return val, nil
 }
 
 type mockBlockStore2 struct {
@@ -495,7 +496,10 @@ func TestEth_State_GetStorageAt(t *testing.T) {
 			for addr, storage := range tt.initialStorage {
 				account := store.AddAccount(addr)
 				for index, data := range storage {
-					account.Storage(index, data)
+					a := &fastrlp.Arena{}
+					value := a.NewBytes(data.Bytes())
+					newData := value.MarshalTo(nil)
+					account.Storage(index, newData)
 				}
 			}
 			dispatcher := newTestDispatcher(hclog.NewNullLogger(), store)


### PR DESCRIPTION
# Description

 Modified `getStorageAt` RPC method to return the RLP decode value.  

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments
 `TestEth_State_GetStorageAt` is also modified to test the new response


