### PR TITLE
Add PriceLimit setting in TxPool

### DIFF
--- a/command/dev/dev_command.go
+++ b/command/dev/dev_command.go
@@ -48,6 +48,30 @@ func (d *DevCommand) DefineFlags() {
 		FlagOptional: true,
 	}
 
+	d.FlagMap["locals"] = helper.FlagDescriptor{
+		Description: "Sets comma separated accounts whose transactions are treated as locals",
+		Arguments: []string{
+			"LOCALS",
+		},
+		FlagOptional: true,
+	}
+
+	d.FlagMap["nolocals"] = helper.FlagDescriptor{
+		Description: "Sets flag to disable price exemptions for locally submitted transactions",
+		Arguments: []string{
+			"NOLOCALS",
+		},
+		FlagOptional: true,
+	}
+
+	d.FlagMap["price-limit"] = helper.FlagDescriptor{
+		Description: fmt.Sprintf("Sets minimum gas price limit to enforce for acceptance into the pool. Default: %d", helper.DefaultConfig().TxPool.PriceLimit),
+		Arguments: []string{
+			"PRICE_LIMIT",
+		},
+		FlagOptional: true,
+	}
+
 	d.FlagMap["gas-limit"] = helper.FlagDescriptor{
 		Description: "Sets the gas limit of each block. Default: 5000",
 		Arguments: []string{

--- a/command/helper/config.go
+++ b/command/helper/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	JSONRPCAddr string                 `json:"jsonrpc_addr"`
 	Network     *Network               `json:"network"`
 	Seal        bool                   `json:"seal"`
+	TxPool      *TxPool                `json:"tx_pool"`
 	LogLevel    string                 `json:"log_level"`
 	Consensus   map[string]interface{} `json:"consensus"`
 	Dev         bool
@@ -37,6 +38,11 @@ type Network struct {
 	MaxPeers   uint64 `json:"max_peers"`
 }
 
+// TxPool defines the TxPool configuration params
+type TxPool struct {
+	PriceLimit uint64 `json:"price_limit"`
+}
+
 // DefaultConfig returns the default server configuration
 func DefaultConfig() *Config {
 	return &Config{
@@ -46,7 +52,10 @@ func DefaultConfig() *Config {
 			NoDiscover: false,
 			MaxPeers:   20,
 		},
-		Seal:      false,
+		Seal: false,
+		TxPool: &TxPool{
+			PriceLimit: 1,
+		},
 		LogLevel:  "INFO",
 		Consensus: map[string]interface{}{},
 	}
@@ -65,6 +74,7 @@ func (c *Config) BuildConfig() (*server.Config, error) {
 
 	conf.Chain = cc
 	conf.Seal = c.Seal
+	conf.PriceLimit = c.TxPool.PriceLimit
 	conf.DataDir = c.DataDir
 
 	// JSON RPC + GRPC
@@ -186,6 +196,8 @@ func (c *Config) mergeConfigWith(otherConfig *Config) error {
 			c.Network.NoDiscover = true
 		}
 	}
+
+	c.TxPool.PriceLimit = otherConfig.TxPool.PriceLimit
 
 	if err := mergo.Merge(&c.Consensus, otherConfig.Consensus, mergo.WithOverride); err != nil {
 		return err

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -29,6 +29,7 @@ const (
 	DefaultPremineBalance = "0x3635C9ADC5DEA00000" // 1000 ETH
 	DefaultConsensus      = "pow"
 	DefaultGasLimit       = 5000
+	DefaultPriceLimit     = 1
 )
 
 // FlagDescriptor contains the description elements for a command flag
@@ -344,6 +345,9 @@ func BootstrapDevCommand(baseCommand string, args []string) (*Config, error) {
 			NoDiscover: true,
 			MaxPeers:   0,
 		},
+		TxPool: &TxPool{
+			PriceLimit: 0,
+		},
 	}
 	cliConfig.Seal = true
 	cliConfig.Dev = true
@@ -387,6 +391,7 @@ func ReadConfig(baseCommand string, args []string) (*Config, error) {
 
 	cliConfig := &Config{
 		Network: &Network{},
+		TxPool:  &TxPool{},
 	}
 
 	flags := flag.NewFlagSet(baseCommand, flag.ContinueOnError)
@@ -405,6 +410,7 @@ func ReadConfig(baseCommand string, args []string) (*Config, error) {
 	flags.StringVar(&cliConfig.Network.NatAddr, "nat", "", "the external IP address without port, as can be seen by peers")
 	flags.BoolVar(&cliConfig.Network.NoDiscover, "no-discover", false, "")
 	flags.Uint64Var(&cliConfig.Network.MaxPeers, "max-peers", 0, "")
+	flags.Uint64Var(&cliConfig.TxPool.PriceLimit, "price-limit", DefaultPriceLimit, "")
 	flags.BoolVar(&cliConfig.Dev, "dev", false, "")
 	flags.Uint64Var(&cliConfig.DevInterval, "dev-interval", 0, "")
 

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -345,9 +345,7 @@ func BootstrapDevCommand(baseCommand string, args []string) (*Config, error) {
 			NoDiscover: true,
 			MaxPeers:   0,
 		},
-		TxPool: &TxPool{
-			PriceLimit: 0,
-		},
+		TxPool: &TxPool{},
 	}
 	cliConfig.Seal = true
 	cliConfig.Dev = true
@@ -363,6 +361,9 @@ func BootstrapDevCommand(baseCommand string, args []string) (*Config, error) {
 	flags.StringVar(&cliConfig.LogLevel, "log-level", DefaultConfig().LogLevel, "")
 	flags.Var(&premine, "premine", "")
 	flags.Uint64Var(&gaslimit, "gas-limit", DefaultGasLimit, "")
+	flags.StringVar(&cliConfig.TxPool.Locals, "locals", "", "")
+	flags.BoolVar(&cliConfig.TxPool.NoLocals, "nolocals", false, "")
+	flags.Uint64Var(&cliConfig.TxPool.PriceLimit, "price-limit", DefaultPriceLimit, "")
 	flags.Uint64Var(&cliConfig.DevInterval, "dev-interval", 0, "")
 	flags.Uint64Var(&chainID, "chainid", DefaultChainID, "")
 

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -410,6 +410,8 @@ func ReadConfig(baseCommand string, args []string) (*Config, error) {
 	flags.StringVar(&cliConfig.Network.NatAddr, "nat", "", "the external IP address without port, as can be seen by peers")
 	flags.BoolVar(&cliConfig.Network.NoDiscover, "no-discover", false, "")
 	flags.Uint64Var(&cliConfig.Network.MaxPeers, "max-peers", 0, "")
+	flags.StringVar(&cliConfig.TxPool.Locals, "locals", "", "")
+	flags.BoolVar(&cliConfig.TxPool.NoLocals, "nolocals", false, "")
 	flags.Uint64Var(&cliConfig.TxPool.PriceLimit, "price-limit", DefaultPriceLimit, "")
 	flags.BoolVar(&cliConfig.Dev, "dev", false, "")
 	flags.Uint64Var(&cliConfig.DevInterval, "dev-interval", 0, "")

--- a/command/server/server_command.go
+++ b/command/server/server_command.go
@@ -125,6 +125,22 @@ func (c *ServerCommand) DefineFlags() {
 		FlagOptional: true,
 	}
 
+	c.flagMap["locals"] = helper.FlagDescriptor{
+		Description: "Sets comma separated accounts whose transactions are treated as locals",
+		Arguments: []string{
+			"LOCALS",
+		},
+		FlagOptional: true,
+	}
+
+	c.flagMap["nolocals"] = helper.FlagDescriptor{
+		Description: "Sets flag to disable price exemptions for locally submitted transactions",
+		Arguments: []string{
+			"NOLOCALS",
+		},
+		FlagOptional: true,
+	}
+
 	c.flagMap["price-limit"] = helper.FlagDescriptor{
 		Description: fmt.Sprintf("Sets minimum gas price limit to enforce for acceptance into the pool. Default: %d", helper.DefaultConfig().TxPool.PriceLimit),
 		Arguments: []string{
@@ -179,6 +195,7 @@ func (c *ServerCommand) Run(args []string) int {
 
 		return 1
 	}
+	fmt.Printf("\n\nconf %+v\n\n", conf.TxPool)
 
 	config, err := conf.BuildConfig()
 	if err != nil {
@@ -186,6 +203,8 @@ func (c *ServerCommand) Run(args []string) int {
 
 		return 1
 	}
+
+	fmt.Printf("\n\nconfig %+v\n\n", config)
 
 	logger := hclog.New(&hclog.LoggerOptions{
 		Name:  "polygon",

--- a/command/server/server_command.go
+++ b/command/server/server_command.go
@@ -125,6 +125,14 @@ func (c *ServerCommand) DefineFlags() {
 		FlagOptional: true,
 	}
 
+	c.flagMap["price-limit"] = helper.FlagDescriptor{
+		Description: fmt.Sprintf("Sets minimum gas price limit to enforce for acceptance into the pool. Default: %d", helper.DefaultConfig().TxPool.PriceLimit),
+		Arguments: []string{
+			"PRICE_LIMIT",
+		},
+		FlagOptional: true,
+	}
+
 	c.flagMap["dev"] = helper.FlagDescriptor{
 		Description: "Sets the client to dev mode. Default: false",
 		Arguments: []string{

--- a/command/server/server_command.go
+++ b/command/server/server_command.go
@@ -195,7 +195,6 @@ func (c *ServerCommand) Run(args []string) int {
 
 		return 1
 	}
-	fmt.Printf("\n\nconf %+v\n\n", conf.TxPool)
 
 	config, err := conf.BuildConfig()
 	if err != nil {
@@ -203,8 +202,6 @@ func (c *ServerCommand) Run(args []string) int {
 
 		return 1
 	}
-
-	fmt.Printf("\n\nconfig %+v\n\n", config)
 
 	logger := hclog.New(&hclog.LoggerOptions{
 		Name:  "polygon",

--- a/e2e/framework/config.go
+++ b/e2e/framework/config.go
@@ -32,6 +32,9 @@ type TestServerConfig struct {
 	PremineAccts  []*SrvAccount // Accounts with existing balances (genesis accounts)
 	Consensus     ConsensusType // Consensus Type
 	Bootnodes     []string      // Bootnode Addresses
+	Locals        []string      // Accounts whose transactions are treated as locals
+	NoLocals      bool          // Flag to disable price exemptions for locally transactions
+	PriceLimit    *uint64       // Minimum gas price limit to enforce for acceptance into the pool
 	DevInterval   int           // Dev consensus update interval [s]
 	ShowsLog      bool
 }
@@ -76,6 +79,21 @@ func (t *TestServerConfig) SetSeal(state bool) {
 // SetBootnodes sets bootnodes
 func (t *TestServerConfig) SetBootnodes(bootnodes []string) {
 	t.Bootnodes = bootnodes
+}
+
+// SetLocals sets locals
+func (t *TestServerConfig) SetLocals(locals []string) {
+	t.Locals = locals
+}
+
+// SetLocals sets NoLocals flag
+func (t *TestServerConfig) SetNoLocals(noLocals bool) {
+	t.NoLocals = noLocals
+}
+
+// SetLocals sets PriceLimit
+func (t *TestServerConfig) SetPriceLimit(priceLimit *uint64) {
+	t.PriceLimit = priceLimit
 }
 
 // SetShowsLog sets flag for logging

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -241,6 +241,18 @@ func (t *TestServer) Start(ctx context.Context) error {
 		args = append(args, "--seal")
 	}
 
+	if len(t.Config.Locals) > 0 {
+		args = append(args, "--locals", strings.Join(t.Config.Locals, ","))
+	}
+
+	if t.Config.NoLocals {
+		args = append(args, "--nolocals")
+	}
+
+	if t.Config.PriceLimit != nil {
+		args = append(args, "--price-limit", strconv.FormatUint(*t.Config.PriceLimit, 10))
+	}
+
 	if t.Config.ShowsLog {
 		args = append(args, "--log-level", "debug")
 	}

--- a/e2e/ibft_test.go
+++ b/e2e/ibft_test.go
@@ -95,7 +95,7 @@ func TestIbft_TransactionFeeRecipient(t *testing.T) {
 				// Deploy contract
 				deployTx := &framework.PreparedTransaction{
 					From:     senderAddr,
-					GasPrice: big.NewInt(0),
+					GasPrice: big.NewInt(10),
 					Gas:      1000000,
 					Value:    big.NewInt(0),
 					Input:    framework.MethodSig("setA1"),

--- a/e2e/txpool_test.go
+++ b/e2e/txpool_test.go
@@ -279,7 +279,7 @@ func TestTxPool_TransactionCoalescing(t *testing.T) {
 	)
 }
 
-func TestGasLimit(t *testing.T) {
+func TestPriceLimit(t *testing.T) {
 	signer := &crypto.FrontierSigner{}
 	senderKey, senderAddr := tests.GenerateKeyAndAddr(t)
 	_, receiverAddr := tests.GenerateKeyAndAddr(t)

--- a/e2e/txpool_test.go
+++ b/e2e/txpool_test.go
@@ -298,17 +298,17 @@ func TestPriceLimit(t *testing.T) {
 	}{
 		{
 			name:             "tx should propagate",
-			numNodes:         5,
+			numNodes:         3,
 			locals:           nil,
 			noLocals:         false,
 			priceLimit:       10,
 			gasPrice:         100,
 			err:              nil,
-			numReceivedNodes: 5,
+			numReceivedNodes: 3,
 		},
 		{
 			name:             "tx should be rejected due to low gas price",
-			numNodes:         5,
+			numNodes:         3,
 			locals:           nil,
 			noLocals:         true,
 			priceLimit:       10,
@@ -318,7 +318,7 @@ func TestPriceLimit(t *testing.T) {
 		},
 		{
 			name:             "tx should not propagate",
-			numNodes:         5,
+			numNodes:         3,
 			locals:           nil,
 			noLocals:         false,
 			priceLimit:       10,
@@ -328,13 +328,13 @@ func TestPriceLimit(t *testing.T) {
 		},
 		{
 			name:             "tx should propagate because sender address is treated as local transaction",
-			numNodes:         5,
+			numNodes:         3,
 			locals:           []string{senderAddr.String()},
 			noLocals:         true,
 			priceLimit:       10,
 			gasPrice:         0,
 			err:              nil,
-			numReceivedNodes: 5, // only first node receive
+			numReceivedNodes: 3,
 		},
 	}
 

--- a/server/config.go
+++ b/server/config.go
@@ -18,9 +18,10 @@ type Config struct {
 	GRPCAddr    *net.TCPAddr
 	LibP2PAddr  *net.TCPAddr
 
-	Network *network.Config
-	DataDir string
-	Seal    bool
+	Network    *network.Config
+	DataDir    string
+	Seal       bool
+	PriceLimit uint64
 }
 
 // DefaultConfig returns the default config for JSON-RPC, GRPC (ports) and Networking

--- a/server/config.go
+++ b/server/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/0xPolygon/polygon-sdk/chain"
 	"github.com/0xPolygon/polygon-sdk/network"
+	"github.com/0xPolygon/polygon-sdk/types"
 )
 
 const DefaultGRPCPort int = 9632
@@ -21,6 +22,8 @@ type Config struct {
 	Network    *network.Config
 	DataDir    string
 	Seal       bool
+	Locals     []types.Address
+	NoLocals   bool
 	PriceLimit uint64
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -127,7 +127,7 @@ func NewServer(logger hclog.Logger, config *Config) (*Server, error) {
 			Blockchain: m.blockchain,
 		}
 		// start transaction pool
-		m.txpool, err = txpool.NewTxPool(logger, m.config.Seal, m.chain.Params.Forks.At(0), hub, m.grpcServer, m.network)
+		m.txpool, err = txpool.NewTxPool(logger, m.config.Seal, m.config.PriceLimit, m.chain.Params.Forks.At(0), hub, m.grpcServer, m.network)
 		if err != nil {
 			return nil, err
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -127,7 +127,7 @@ func NewServer(logger hclog.Logger, config *Config) (*Server, error) {
 			Blockchain: m.blockchain,
 		}
 		// start transaction pool
-		m.txpool, err = txpool.NewTxPool(logger, m.config.Seal, m.config.PriceLimit, m.chain.Params.Forks.At(0), hub, m.grpcServer, m.network)
+		m.txpool, err = txpool.NewTxPool(logger, m.config.Seal, m.config.Locals, m.config.NoLocals, m.config.PriceLimit, m.chain.Params.Forks.At(0), hub, m.grpcServer, m.network)
 		if err != nil {
 			return nil, err
 		}

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -208,7 +208,7 @@ func (t *TxPool) AddTx(tx *types.Transaction) error {
 
 // addImpl validates the tx and adds it to the appropriate account transaction queue.
 // Additionally, it updates the global valid transactions queue
-func (t *TxPool) addImpl(ctx TxOrigin, tx *types.Transaction) error {
+func (t *TxPool) addImpl(origin TxOrigin, tx *types.Transaction) error {
 	// Since this is a single point of inclusion for new transactions both
 	// to the promoted queue and pending queue we use this point to calculate the hash
 	tx.ComputeHash()
@@ -216,14 +216,14 @@ func (t *TxPool) addImpl(ctx TxOrigin, tx *types.Transaction) error {
 	// should treat as local in the following cases
 	// (1) noLocals is false and Tx is local transaction
 	// (2) from in tx is in locals addresses
-	isLocal := (!t.noLocals && ctx == OriginAddTxn) || t.locals.containsTxSender(t.signer, tx)
+	isLocal := (!t.noLocals && origin == OriginAddTxn) || t.locals.containsTxSender(t.signer, tx)
 	err := t.validateTx(tx, isLocal)
 	if err != nil {
 		t.logger.Error("Discarding invalid transaction", "hash", tx.Hash, "err", err)
 		return err
 	}
 
-	t.logger.Debug("add txn", "ctx", ctx, "hash", tx.Hash, "from", tx.From)
+	t.logger.Debug("add txn", "ctx", origin, "hash", tx.Hash, "from", tx.From)
 
 	txnsQueue, ok := t.accountQueues[tx.From]
 	if !ok {

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -236,7 +236,7 @@ func (t *TxPool) addImpl(ctx TxOrigin, tx *types.Transaction) error {
 	}
 	txnsQueue.Add(tx)
 
-	// Ignore check of GasPrice in the future transactions created by same address when TxPool receives transaction by Gossip or Reorg
+	// Skip check of GasPrice in the future transactions created by same address when TxPool receives transaction by Gossip or Reorg
 	if isLocal && !t.locals.containsAddr(tx.From) {
 		t.locals.addAddr(tx.From)
 	}
@@ -367,7 +367,7 @@ func (t *TxPool) validateTx(tx *types.Transaction, isLocal bool) error {
 		}
 	}
 
-	// Ignore non-local transactions under priceLimit
+	// Reject non-local transactions whose Gas Price is under priceLimit
 	if !isLocal && tx.GasPrice.Cmp(big.NewInt(int64(t.priceLimit))) < 0 {
 		return ErrUnderpriced
 	}


### PR DESCRIPTION
# Description

This PR adds PriceLimit check in TxPool so that TxPool reject incoming transactions with low GasPrice.
This change contains following new command line options for the setting:
* --price-limit [PRICE_LIMIT]
  + Sets PriceLimit which is the threshold of Tx GasPrice for acceptable transaction in TxPool
  + This limitation is applied to only remote transactions (txs via Gossip or Reorg) when only this option is given.
* --nolocals
  + Enable check of GasPrice for local transaction just like remote transaction.
* --locals [COMMA_SEPARATED_ADDRESSES]
  + Skip GasPrice check for the transactions sent from given addresses

Doc PR: 0xPolygon/polygon-sdk-docs#17

## How to check if it works

### Case 1, Test gas price checking for remote transaction with low gas price
(1) Run first IBFT node without `--seal` and remaining IBFT nodes with `--seal` and `--price-limit [PRICE_LIMIT]`
(2) Send transaction with lower gas price than `PRICE_LIMIT` to node1 by JSON-RPC
(3) Transaction shouldn't be processed because first node won't build block and remaining node won't take the transaction because gas price is too low.

### Case 2, Test gas price checking for remote transaction with high gas price
(1) Start nodes as in the Case 1
(2) Send transaction with larger gas price than `PRICE_LIMIT` to node1 by JSON-RPC
(3) Transaction should be processed because the Node 2-4 will take the tx into TxPool and one of them will process it.

### Case3, Test skipping GasPrice checking for local transaction
(1) Run all IBFT nodes with just `--seal`
(2) Send transaction with lower gas price than `PRICE_LIMIT` to node1 by JSON-RPC
(3) Transaction should be processed because first node can take the tx into txpool and process it.

### Case4, Test gas price checking for local transaction when `NoLocals` is enabled
(1) Run all IBFT nodes with `--seal` and `--nolocals`
(2) Send transaction with lower gas price than `PRICE_LIMIT` to node1 by JSON-RPC
(3) Server should return error because failed to validate tx due to low gas price in node1

### Case5, Test gas price checking for local transaction when `NoLocals` is enabled
(1) Run first IBFT nodes with `--seal`, `--nolocals`, `--locals [ADDRESS]` and run remaining nodes with `--seal`, `--nolocals`
(2) Send transaction with lower gas price than `PRICE_LIMIT` to node1 by JSON-RPC
(3) Transaction should be processed because first node can take the tx into txpool and process it. (From in Tx is registered in local address list)

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
