### PR TITLE
Fix/bootnodes self connection

### DIFF
--- a/network/server.go
+++ b/network/server.go
@@ -149,6 +149,10 @@ func NewServer(logger hclog.Logger, config *Config) (*Server, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse bootnode %s: %v", raw, err)
 			}
+			if node.ID == srv.host.ID() {
+				srv.logger.Info("Omitting bootnode with same ID as host", node.ID)
+				continue
+			}
 			// add the bootnode to the peerstore
 			srv.host.Peerstore().AddAddr(node.ID, node.Addrs[0], peerstore.AddressTTL)
 			bootnodes = append(bootnodes, node)

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -223,6 +223,10 @@ func TestSelfConnection_WithBootNodes(t *testing.T) {
 	assert.NoError(t, err)
 	peerAddressInfo, err := StringToAddrInfo("/ip4/127.0.0.1/tcp/10001/p2p/16Uiu2HAmJxxH1tScDX2rLGSU9exnuvZKNM9SoK3v315azp68DLPW")
 	assert.NoError(t, err)
+	//remove the temporary directory
+	t.Cleanup(func() {
+		assert.NoError(t, os.RemoveAll(directoryName))
+	})
 	tests := []struct {
 		name         string
 		bootNodes    []string
@@ -255,6 +259,4 @@ func TestSelfConnection_WithBootNodes(t *testing.T) {
 		})
 	}
 
-	//remove the temporary directory
-	assert.NoError(t, os.RemoveAll(directoryName))
 }


### PR DESCRIPTION
# Description

This PR avoids node to self-connect, if specified as a boot node.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs


