### PR TITLE
Fix invalid reference values

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -248,6 +248,9 @@ func (b *Blockchain) writeGenesisImpl(header *types.Header) error {
 		return err
 	}
 
+	// Update the average gas price to take into account the genesis block
+	b.UpdateGasPriceAvg(new(big.Int).SetUint64(header.GasUsed))
+
 	// Advance the head
 	if _, err := b.advanceHead(header); err != nil {
 		return err

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -200,10 +200,11 @@ func (c *GenesisCommand) Run(args []string) int {
 	cc := &chain.Chain{
 		Name: name,
 		Genesis: &chain.Genesis{
-			GasLimit:   5000,
+			GasLimit:   helper.GenesisGasLimit,
 			Difficulty: 1,
 			Alloc:      map[types.Address]*chain.GenesisAccount{},
 			ExtraData:  extraData,
+			GasUsed:    helper.GenesisGasUsed,
 		},
 		Params: &chain.Params{
 			ChainID: int(chainID),

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -28,7 +28,8 @@ const (
 	DefaultChainID        = 100
 	DefaultPremineBalance = "0x3635C9ADC5DEA00000" // 1000 ETH
 	DefaultConsensus      = "pow"
-	DefaultGasLimit       = 5000
+	GenesisGasUsed        = 458752  // 0x70000
+	GenesisGasLimit       = 5242880 // 0x500000
 )
 
 // FlagDescriptor contains the description elements for a command flag
@@ -317,6 +318,7 @@ func generateDevGenesis(params devGenesisParams) error {
 			Difficulty: 1,
 			Alloc:      map[types.Address]*chain.GenesisAccount{},
 			ExtraData:  []byte{},
+			GasUsed:    GenesisGasUsed,
 		},
 		Params: &chain.Params{
 			ChainID: int(params.chainID),
@@ -358,7 +360,7 @@ func BootstrapDevCommand(baseCommand string, args []string) (*Config, error) {
 
 	flags.StringVar(&cliConfig.LogLevel, "log-level", DefaultConfig().LogLevel, "")
 	flags.Var(&premine, "premine", "")
-	flags.Uint64Var(&gaslimit, "gas-limit", DefaultGasLimit, "")
+	flags.Uint64Var(&gaslimit, "gas-limit", GenesisGasLimit, "")
 	flags.Uint64Var(&cliConfig.DevInterval, "dev-interval", 0, "")
 	flags.Uint64Var(&chainID, "chainid", DefaultChainID, "")
 

--- a/e2e/transaction_test.go
+++ b/e2e/transaction_test.go
@@ -167,13 +167,8 @@ func TestEthTransfer(t *testing.T) {
 	srv := srvs[0]
 
 	rpcClient := srv.JSONRPC()
-	for indx, testCase := range testTable {
+	for _, testCase := range testTable {
 		t.Run(testCase.name, func(t *testing.T) {
-			// TODO @Vuksan Please remove this skip statement when JSON-RPC Error wrapping is added
-			if indx == 1 {
-				t.Skip()
-			}
-
 			// Fetch the balances before sending
 			balanceSender, err := rpcClient.Eth().GetBalance(
 				web3.Address(testCase.sender),
@@ -205,7 +200,12 @@ func TestEthTransfer(t *testing.T) {
 
 			// Do the transfer
 			txnHash, err := rpcClient.Eth().SendTransaction(txnObject)
-			assert.NoError(t, err)
+			if testCase.shouldSucceed {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+
 			assert.IsTypef(t, web3.Hash{}, txnHash, "Return type mismatch")
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/jsonrpc/blockchain.go
+++ b/jsonrpc/blockchain.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/0xPolygon/polygon-sdk/blockchain"
+	"github.com/0xPolygon/polygon-sdk/chain"
 	"github.com/0xPolygon/polygon-sdk/state"
 	"github.com/0xPolygon/polygon-sdk/state/runtime"
 	"github.com/0xPolygon/polygon-sdk/types"
@@ -15,6 +16,7 @@ type stateHelperInterface interface {
 	GetAccount(root types.Hash, addr types.Address) (*state.Account, error)
 	GetStorage(root types.Hash, addr types.Address, slot types.Hash) ([]byte, error)
 	GetCode(hash types.Hash) ([]byte, error)
+	GetForksInTime(blockNumber uint64) chain.ForksInTime
 }
 
 // blockchain is the interface with the blockchain required

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -211,7 +211,6 @@ func (e *Eth) GetStorageAt(address types.Address, index types.Hash, number *Bloc
 
 // GasPrice returns the average gas price based on the last x blocks
 func (e *Eth) GasPrice() (interface{}, error) {
-
 	// Grab the average gas price and convert it to a hex value
 	avgGasPrice := hex.EncodeBig(e.d.store.GetAvgGasPrice())
 
@@ -471,7 +470,7 @@ func (e *Eth) GetTransactionCount(address types.Address, number *BlockNumber) (i
 	if number == nil {
 		return nil, fmt.Errorf("block parameter is required")
 	}
- 	nonce, err := e.d.getNextNonce(address, *number)
+	nonce, err := e.d.getNextNonce(address, *number)
 	if err != nil {
 		if err == ErrStateNotFound {
 			return argUintPtr(0), nil

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xPolygon/polygon-sdk/chain"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
 
@@ -43,6 +44,10 @@ func (m *mockAccount2) Balance(n uint64) {
 type mockAccountStore struct {
 	nullBlockchainInterface
 	accounts map[types.Address]*mockAccount2
+}
+
+func (m *mockAccountStore) GetForksInTime(blockNumber uint64) chain.ForksInTime {
+	panic("implement me")
 }
 
 func (m *mockAccountStore) AddAccount(addr types.Address) *mockAccount2 {
@@ -95,6 +100,10 @@ func (m *mockAccountStore) GetStorage(root types.Hash, addr types.Address, slot 
 type mockBlockStore2 struct {
 	nullBlockchainInterface
 	blocks []*types.Block
+}
+
+func (m *mockBlockStore2) GetForksInTime(blockNumber uint64) chain.ForksInTime {
+	panic("implement me")
 }
 
 func (m *mockBlockStore2) add(blocks ...*types.Block) {
@@ -553,6 +562,10 @@ type mockStoreTxn struct {
 	nullBlockchainInterface
 
 	txn *types.Transaction
+}
+
+func (m *mockStoreTxn) GetForksInTime(blockNumber uint64) chain.ForksInTime {
+	panic("implement me")
 }
 
 func (m *mockStoreTxn) AddTx(tx *types.Transaction) error {

--- a/jsonrpc/filter_manager_test.go
+++ b/jsonrpc/filter_manager_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0xPolygon/polygon-sdk/chain"
 	"github.com/0xPolygon/polygon-sdk/state/runtime"
 
 	"github.com/0xPolygon/polygon-sdk/blockchain"
@@ -215,6 +216,10 @@ type mockStore struct {
 	subscription *blockchain.MockSubscription
 	receiptsLock sync.Mutex
 	receipts     map[types.Hash][]*types.Receipt
+}
+
+func (m *mockStore) GetForksInTime(blockNumber uint64) chain.ForksInTime {
+	panic("implement me")
 }
 
 func (m *mockStore) ApplyTxn(header *types.Header, txn *types.Transaction) (*runtime.ExecutionResult, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -272,6 +272,11 @@ func (j *jsonRPCHub) GetAccount(root types.Hash, addr types.Address) (*state.Acc
 	return &account, nil
 }
 
+// GetForksInTime returns the active forks at the given block height
+func (j *jsonRPCHub) GetForksInTime(blockNumber uint64) chain.ForksInTime {
+	return j.Executor.GetForksInTime(blockNumber)
+}
+
 func (j *jsonRPCHub) GetStorage(root types.Hash, addr types.Address, slot types.Hash) ([]byte, error) {
 	account, err := j.GetAccount(root, addr)
 

--- a/state/executor.go
+++ b/state/executor.go
@@ -112,6 +112,11 @@ func (e *Executor) StateAt(root types.Hash) (Snapshot, error) {
 	return e.state.NewSnapshotAt(root)
 }
 
+// GetForksInTime returns the active forks at the given block height
+func (e *Executor) GetForksInTime(blockNumber uint64) chain.ForksInTime {
+	return e.config.Forks.At(blockNumber)
+}
+
 func (e *Executor) BeginTxn(parentRoot types.Hash, header *types.Header, coinbaseReceiver types.Address) (*Transition, error) {
 	config := e.config.Forks.At(header.Number)
 


### PR DESCRIPTION
# Description

This PR fixes issue #150.

## Problem with `eth_gasPrice`
Within the Polygon SDK, we keep track of an average gas price for transactions, using a rolling average method.
This rolling average method previously didn't take into account the genesis block, so the initial value was set to `0`, causing any `eth_gasPrice` call to return a `0` value if no transactions have been previously executed (the chain has just been started, for example)

## Problem with `eth_estimateGas`
The `eth_estimateGas` issue is indirectly linked to the `eth_gasPrice` issue mentioned before.
The Polygon SDK estimates the gas for a certain transaction by running the transaction multiple times, while keeping the gas within certain bounds. Then, it tried to determine what is the minimum gas amount required for the transaction to go through.

If the transaction had a defined `Gas` field, `eth_estimateGas` would take this value as the high end for its bounding.

The `Gas` field in the transaction is usually a result of a previous `eth_gasPrice` call, and if the value returned from that call is faulty, than the `eth_estimateGas` call would be faulty, as well.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs