### PR TITLE
Fix multiple addresses issue with same libp2p id

### DIFF
--- a/network/dial_queue.go
+++ b/network/dial_queue.go
@@ -68,7 +68,9 @@ func (d *dialQueue) del(peer peer.ID) {
 
 	item, ok := d.items[peer]
 	if ok {
-		heap.Remove(&d.heap, item.index)
+		if item.index >= 0 {
+			heap.Remove(&d.heap, item.index)
+		}
 		delete(d.items, peer)
 	}
 }

--- a/network/dial_queue.go
+++ b/network/dial_queue.go
@@ -68,6 +68,7 @@ func (d *dialQueue) del(peer peer.ID) {
 
 	item, ok := d.items[peer]
 	if ok {
+		// negative index for popped element
 		if item.index >= 0 {
 			heap.Remove(&d.heap, item.index)
 		}

--- a/network/dial_queue_test.go
+++ b/network/dial_queue_test.go
@@ -15,14 +15,18 @@ func TestDialQueue(t *testing.T) {
 		ID: peer.ID("a"),
 	}
 	q.add(info0, 1)
+	assert.Equal(t, 1, q.heap.Len())
 
 	info1 := &peer.AddrInfo{
 		ID: peer.ID("b"),
 	}
 	q.add(info1, 1)
+	assert.Equal(t, 2, q.heap.Len())
 
 	assert.Equal(t, q.popImpl().addr.ID, peer.ID("a"))
 	assert.Equal(t, q.popImpl().addr.ID, peer.ID("b"))
+	assert.Equal(t, 0, q.heap.Len())
+
 	assert.Nil(t, q.popImpl())
 
 	done := make(chan struct{})
@@ -44,5 +48,113 @@ func TestDialQueue(t *testing.T) {
 	case <-done:
 	case <-time.After(1 * time.Second):
 		t.Fatal("timeout")
+	}
+}
+
+func TestDel(t *testing.T) {
+	type task struct {
+		id     string
+		action string // "add"/"delete"/"pop"
+	}
+
+	tests := []struct {
+		name        string
+		tasks       []task
+		expectedLen int
+	}{
+		{
+			name: "should be able to push element",
+			tasks: []task{
+				{
+					id:     "a",
+					action: "add",
+				},
+			},
+			expectedLen: 1,
+		},
+		{
+			name: "should be able to delete",
+			tasks: []task{
+				{
+					id:     "a",
+					action: "add",
+				},
+				{
+					id:     "a",
+					action: "delete",
+				},
+			},
+			expectedLen: 0,
+		},
+		{
+			name: "should succeed on removing non-exist data",
+			tasks: []task{
+				{
+					id:     "a",
+					action: "add",
+				},
+				{
+					id:     "b",
+					action: "delete",
+				},
+			},
+			expectedLen: 1,
+		},
+		{
+			name: "should be able to pop",
+			tasks: []task{
+				{
+					id:     "a",
+					action: "add",
+				},
+				{
+					id:     "a",
+					action: "pop",
+				},
+			},
+			expectedLen: 0,
+		},
+		{
+			name: "should be able to delete popped data",
+			tasks: []task{
+				{
+					id:     "a",
+					action: "add",
+				},
+				{
+					id:     "a",
+					action: "pop",
+				},
+				{
+					id:     "a",
+					action: "delete",
+				},
+			},
+			expectedLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := newDialQueue()
+			for _, task := range tt.tasks {
+				id := peer.ID(task.id)
+
+				switch task.action {
+				case "add":
+					q.add(&peer.AddrInfo{
+						ID: id,
+					}, 1)
+				case "delete":
+					q.del(id)
+				case "pop":
+					d := q.pop()
+					assert.Equal(t, id, d.addr.ID)
+				default:
+					t.Errorf("unsupported action: %s", task.action)
+				}
+			}
+			assert.Equal(t, tt.expectedLen, q.heap.Len())
+		})
 	}
 }

--- a/network/dial_queue_test.go
+++ b/network/dial_queue_test.go
@@ -52,9 +52,16 @@ func TestDialQueue(t *testing.T) {
 }
 
 func TestDel(t *testing.T) {
+	type Action string
+	const (
+		ActionAdd    Action = "add"
+		ActionDelete Action = "delete"
+		ActionPop    Action = "pop"
+	)
+
 	type task struct {
 		id     string
-		action string // "add"/"delete"/"pop"
+		action Action
 	}
 
 	tests := []struct {
@@ -67,7 +74,7 @@ func TestDel(t *testing.T) {
 			tasks: []task{
 				{
 					id:     "a",
-					action: "add",
+					action: ActionAdd,
 				},
 			},
 			expectedLen: 1,
@@ -77,11 +84,11 @@ func TestDel(t *testing.T) {
 			tasks: []task{
 				{
 					id:     "a",
-					action: "add",
+					action: ActionAdd,
 				},
 				{
 					id:     "a",
-					action: "delete",
+					action: ActionDelete,
 				},
 			},
 			expectedLen: 0,
@@ -91,11 +98,11 @@ func TestDel(t *testing.T) {
 			tasks: []task{
 				{
 					id:     "a",
-					action: "add",
+					action: ActionAdd,
 				},
 				{
 					id:     "b",
-					action: "delete",
+					action: ActionDelete,
 				},
 			},
 			expectedLen: 1,
@@ -105,11 +112,11 @@ func TestDel(t *testing.T) {
 			tasks: []task{
 				{
 					id:     "a",
-					action: "add",
+					action: ActionAdd,
 				},
 				{
 					id:     "a",
-					action: "pop",
+					action: ActionPop,
 				},
 			},
 			expectedLen: 0,
@@ -119,15 +126,15 @@ func TestDel(t *testing.T) {
 			tasks: []task{
 				{
 					id:     "a",
-					action: "add",
+					action: ActionAdd,
 				},
 				{
 					id:     "a",
-					action: "pop",
+					action: ActionPop,
 				},
 				{
 					id:     "a",
-					action: "delete",
+					action: ActionDelete,
 				},
 			},
 			expectedLen: 0,
@@ -141,13 +148,13 @@ func TestDel(t *testing.T) {
 				id := peer.ID(task.id)
 
 				switch task.action {
-				case "add":
+				case ActionAdd:
 					q.add(&peer.AddrInfo{
 						ID: id,
 					}, 1)
-				case "delete":
+				case ActionDelete:
 					q.del(id)
-				case "pop":
+				case ActionPop:
 					d := q.pop()
 					assert.Equal(t, id, d.addr.ID)
 				default:

--- a/network/discovery.go
+++ b/network/discovery.go
@@ -119,6 +119,7 @@ func (d *discovery) setup() error {
 			})
 			d.peersLock.Unlock()
 		case PeerEventDisconnected:
+			d.routingTable.RemovePeer(peerID)
 			d.peersLock.Lock()
 			d.peers.delete(peerID)
 			d.peersLock.Unlock()

--- a/network/discovery.go
+++ b/network/discovery.go
@@ -119,7 +119,6 @@ func (d *discovery) setup() error {
 			})
 			d.peersLock.Unlock()
 		case PeerEventDisconnected:
-			d.routingTable.RemovePeer(peerID)
 			d.peersLock.Lock()
 			d.peers.delete(peerID)
 			d.peersLock.Unlock()

--- a/network/server.go
+++ b/network/server.go
@@ -302,6 +302,7 @@ func (s *Server) delPeer(id peer.ID) {
 	defer s.peersLock.Unlock()
 
 	delete(s.peers, id)
+	s.host.Network().ClosePeer(id)
 
 	s.emitEvent(&PeerEvent{
 		PeerID: id,

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -14,6 +14,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func generateTestKey(t *testing.T) (crypto.PrivKey, string) {
+	t.Helper()
+
+	dir, err := ioutil.TempDir(os.TempDir(), "")
+	assert.NoError(t, err)
+	key, err := ReadLibp2pKey(dir)
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		// remove directory after test is done
+		assert.NoError(t, os.RemoveAll(dir))
+	})
+
+	return key, dir
+}
+
 func TestConnLimit_Inbound(t *testing.T) {
 	// we should not receive more inbound connections if we are already connected to max peers
 	conf := func(c *Config) {
@@ -212,21 +227,68 @@ func TestNat(t *testing.T) {
 	})
 }
 
+func TestConnectionWithNewIP(t *testing.T) {
+	natIP := "127.0.0.1"
+	natPort := 1500
+
+	_, dir0 := generateTestKey(t)
+	_, dir1 := generateTestKey(t)
+
+	defaultConfig := func(c *Config) {
+		c.NoDiscover = true
+	}
+
+	srv0 := CreateServer(t, func(c *Config) {
+		defaultConfig(c)
+		c.DataDir = dir0
+	})
+	srv1 := CreateServer(t, func(c *Config) {
+		defaultConfig(c)
+		c.DataDir = dir1
+	})
+	// same ID to but diffrent IP from srv1
+	srv2 := CreateServer(t, func(c *Config) {
+		defaultConfig(c)
+		c.DataDir = dir1
+		c.NatAddr = net.ParseIP(natIP)
+		c.Addr.Port = natPort
+	})
+	t.Cleanup(func() {
+		srv0.Close()
+		srv1.Close()
+		srv2.Close()
+	})
+
+	// srv0 connects to srv1
+	connectedCh := asyncWaitForEvent(srv1, 5*time.Second, connectedPeerHandler(srv0.AddrInfo().ID))
+	assert.NoError(t, srv0.Join(srv1.AddrInfo(), DefaultJoinTimeout))
+	assert.True(t, <-connectedCh)
+	assert.Len(t, srv0.peers, 1)
+	assert.Len(t, srv1.peers, 1)
+
+	// srv0 disconnect from srv1
+	disconnectedCh := asyncWaitForEvent(srv0, 5*time.Second, disconnectedPeerHandler(srv1.AddrInfo().ID))
+	srv0.Disconnect(srv1.host.ID(), "bye")
+	assert.True(t, <-disconnectedCh)
+	assert.Len(t, srv0.peers, 0)
+
+	// srv0 connects to srv2
+	connectedCh = asyncWaitForEvent(srv2, 5*time.Second, connectedPeerHandler(srv0.AddrInfo().ID))
+	assert.NoError(t, srv0.Join(srv2.AddrInfo(), DefaultJoinTimeout))
+	assert.True(t, <-connectedCh)
+	assert.Len(t, srv0.peers, 1)
+	assert.Len(t, srv2.peers, 1)
+}
+
 func TestSelfConnection_WithBootNodes(t *testing.T) {
 
 	//Create a temporary directory for storing the key file
-	directoryName, err := ioutil.TempDir(os.TempDir(), "")
-	assert.NoError(t, err)
-	key, err := ReadLibp2pKey(directoryName)
-	assert.NoError(t, err)
+	key, directoryName := generateTestKey(t)
 	peerId, err := peer.IDFromPrivateKey(key)
 	assert.NoError(t, err)
 	peerAddressInfo, err := StringToAddrInfo("/ip4/127.0.0.1/tcp/10001/p2p/16Uiu2HAmJxxH1tScDX2rLGSU9exnuvZKNM9SoK3v315azp68DLPW")
 	assert.NoError(t, err)
-	//remove the temporary directory
-	t.Cleanup(func() {
-		assert.NoError(t, os.RemoveAll(directoryName))
-	})
+
 	tests := []struct {
 		name         string
 		bootNodes    []string


### PR DESCRIPTION
# Description

This PR fixes the issue that node throws panic if peer reconnect with same ID but different IP.
This issue happens after following steps:
(1) node disconnects from peer
(2) the peer change IP and reconnect to the node
(3) the node throw panic

PolygonSDK currently doesn't support multiple addresses and node keep an address after disconnected. So there will be multiple addresses per one ID when peer change IP (e.g. using NAT feature) and connect to node again.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
