### PR TITLE
Split up data directories into keystore and data. Add READ_ONLY flag.

### DIFF
--- a/command/helper/config.go
+++ b/command/helper/config.go
@@ -27,6 +27,8 @@ type Config struct {
 	Dev         bool
 	DevInterval uint64
 	Join        string
+	KeyDir      string
+	ReadOnly    bool
 }
 
 // Network defines the network configuration params
@@ -41,11 +43,13 @@ type Network struct {
 func DefaultConfig() *Config {
 	return &Config{
 		Chain:   "test",
-		DataDir: "./test-chain",
+		DataDir: "./test-chain-data",
+		KeyDir:  "./test-chain-keys",
 		Network: &Network{
 			NoDiscover: false,
 			MaxPeers:   20,
 		},
+		ReadOnly:  false,
 		Seal:      false,
 		LogLevel:  "INFO",
 		Consensus: map[string]interface{}{},
@@ -66,6 +70,8 @@ func (c *Config) BuildConfig() (*server.Config, error) {
 	conf.Chain = cc
 	conf.Seal = c.Seal
 	conf.DataDir = c.DataDir
+	conf.KeyDir = c.KeyDir
+	conf.ReadOnly = c.ReadOnly
 
 	// JSON RPC + GRPC
 	if c.GRPCAddr != "" {
@@ -139,6 +145,10 @@ func (c *Config) mergeConfigWith(otherConfig *Config) error {
 		c.DataDir = otherConfig.DataDir
 	}
 
+	if otherConfig.KeyDir != "" {
+		c.KeyDir = otherConfig.KeyDir
+	}
+
 	if otherConfig.Chain != "" {
 		c.Chain = otherConfig.Chain
 	}
@@ -153,6 +163,10 @@ func (c *Config) mergeConfigWith(otherConfig *Config) error {
 
 	if otherConfig.Seal {
 		c.Seal = true
+	}
+
+	if otherConfig.ReadOnly {
+		c.ReadOnly = true
 	}
 
 	if otherConfig.LogLevel != "" {

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -400,6 +400,8 @@ func ReadConfig(baseCommand string, args []string) (*Config, error) {
 	flags.StringVar(&configFile, "config", "", "")
 	flags.StringVar(&cliConfig.Chain, "chain", "", "")
 	flags.StringVar(&cliConfig.DataDir, "data-dir", "", "")
+	flags.StringVar(&cliConfig.KeyDir, "key-dir", "", "")
+	flags.BoolVar(&cliConfig.ReadOnly, "read-only", false, "")
 	flags.StringVar(&cliConfig.GRPCAddr, "grpc", "", "")
 	flags.StringVar(&cliConfig.JSONRPCAddr, "jsonrpc", "", "")
 	flags.StringVar(&cliConfig.Join, "join", "", "")

--- a/command/server/server_command.go
+++ b/command/server/server_command.go
@@ -69,6 +69,14 @@ func (c *ServerCommand) DefineFlags() {
 		FlagOptional: true,
 	}
 
+	c.flagMap["key-dir"] = helper.FlagDescriptor{
+		Description: fmt.Sprintf("Specifics the data directory used for storing the libp2p key and validator key. Default: %s", helper.DefaultConfig().KeyDir),
+		Arguments: []string{
+			"KEY_DIRECTORY",
+		},
+		FlagOptional: true,
+	}
+
 	c.flagMap["grpc"] = helper.FlagDescriptor{
 		Description: fmt.Sprintf("Sets the address and port for the gRPC service (address:port). Default: address: 127.0.0.1:%d", server.DefaultGRPCPort),
 		Arguments: []string{
@@ -113,6 +121,13 @@ func (c *ServerCommand) DefineFlags() {
 		Description: "Prevents the client from discovering other peers. Default: false",
 		Arguments: []string{
 			"NO_DISCOVER",
+		},
+		FlagOptional: true,
+	}
+	c.flagMap["read-only"] = helper.FlagDescriptor{
+		Description: "Prevents the client from participating in consensus and writing to disk. Default: false",
+		Arguments: []string{
+			"READ_ONLY",
 		},
 		FlagOptional: true,
 	}

--- a/network/keystore.go
+++ b/network/keystore.go
@@ -17,8 +17,8 @@ var Libp2pKeyName = "libp2p.key"
 // The key must be named 'libp2p.key'
 //
 // If no key is found, it is generated and returned
-func ReadLibp2pKey(dataDir string) (crypto.PrivKey, error) {
-	if dataDir == "" {
+func ReadLibp2pKey(keyDir string) (crypto.PrivKey, error) {
+	if keyDir == "" {
 		// use an in-memory key
 		priv, _, err := crypto.GenerateKeyPair(crypto.Secp256k1, 256)
 		if err != nil {
@@ -28,7 +28,7 @@ func ReadLibp2pKey(dataDir string) (crypto.PrivKey, error) {
 		return priv, nil
 	}
 
-	path := filepath.Join(dataDir, Libp2pKeyName)
+	path := filepath.Join(keyDir, Libp2pKeyName)
 	_, err := os.Stat(path)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("failed to stat (%s): %v", path, err)

--- a/network/server.go
+++ b/network/server.go
@@ -27,7 +27,8 @@ type Config struct {
 	NoDiscover bool
 	Addr       *net.TCPAddr
 	NatAddr    net.IP
-	DataDir    string
+	KeyDir     string
+	ReadOnly bool
 	MaxPeers   uint64
 	Chain      *chain.Chain
 }
@@ -78,7 +79,7 @@ type Peer struct {
 func NewServer(logger hclog.Logger, config *Config) (*Server, error) {
 	logger = logger.Named("network")
 
-	key, err := ReadLibp2pKey(config.DataDir)
+	key, err := ReadLibp2pKey(config.KeyDir)
 	if err != nil {
 		return nil, err
 	}

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -249,7 +249,7 @@ func TestSelfConnection_WithBootNodes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			conf := func(c *Config) {
 				c.NoDiscover = false
-				c.DataDir = directoryName
+				c.KeyDir = directoryName
 				c.Chain.Bootnodes = tt.bootNodes
 			}
 			srv0 := CreateServer(t, conf)

--- a/server/config.go
+++ b/server/config.go
@@ -20,6 +20,8 @@ type Config struct {
 
 	Network *network.Config
 	DataDir string
+	KeyDir string
+	ReadOnly bool
 	Seal    bool
 }
 


### PR DESCRIPTION
# Description

I split up the data directories so that not all the data is under ./chain for example. Now it is split between `--data-dir` and `--key-dir` which seemed like a more reasonable way of going about it, especially given the fact that you might transfer "the whole chain" to another system or back it up.

The second rationale for this and for the READ_ONLY flag is to allow clients to share state and not participate in consensus. The reasoning for this is to create a sort of "light client" that doesn't validate blocks and only serves to gossip new txns. I dug a bit and realized that I think the only thing that writes to disk is in the IBFT consensus on block writes.

This allows for easy horizontal scaling from a JSON-RPC point of view as there is no longer the requirement for each polygon-sdk node to store the whole chain, but can read from a shared volume instead. 

The idea is kind of like a master write, slave read idea. The primary node would have READ_ONLY=false while the slaves would have READ_ONLY=true.


# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

There is a new required flag called `--key-dir` which is mandatory and stores the `consensus` and `libp2p` sub directories previously in the data dir. 

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
