### PR TITLE
Skip ipv4, ipv6 loopback addresses in peer dialing

### DIFF
--- a/network/server.go
+++ b/network/server.go
@@ -603,21 +603,26 @@ var (
 
 // AddrInfoToString converts an AddrInfo into a string representation that can be dialed from another node
 func AddrInfoToString(addr *peer.AddrInfo) string {
-	dialAddress := ""
+	// Safety check
+	if len(addr.Addrs) == 0 {
+		panic("No dial addresses found")
+	}
 
-	// Find an address that's not a loopback address
-	for _, address := range addr.Addrs {
-		if !loopbackRegex.MatchString(address.String()) {
-			// Not a loopback address, dial address found
-			dialAddress = address.String()
-			break
+	dialAddress := addr.Addrs[0].String()
+
+	// Try to see if a non loopback address is present in the list
+	if len(addr.Addrs) > 1 && loopbackRegex.MatchString(dialAddress) {
+		// Find an address that's not a loopback address
+		for _, address := range addr.Addrs {
+			if !loopbackRegex.MatchString(address.String()) {
+				// Not a loopback address, dial address found
+				dialAddress = address.String()
+				break
+			}
 		}
 	}
 
-	if dialAddress == "" {
-		panic("Unable to find appropriate dial address")
-	}
-
+	// Format output and return
 	return dialAddress + "/p2p/" + addr.ID.String()
 }
 

--- a/network/server.go
+++ b/network/server.go
@@ -589,18 +589,20 @@ func StringToAddrInfo(addr string) (*peer.AddrInfo, error) {
 	return addr1, nil
 }
 
-// AddrInfoToString converts an AddrInfo into a string representation that can be dialed from another node
-func AddrInfoToString(addr *peer.AddrInfo) string {
+var (
 	// Regex used for matching loopback addresses (IPv4 and IPv6)
 	// This regex will match:
 	// /ip4/localhost/tcp/<port>
 	// /ip4/127.0.0.1/tcp/<port>
 	// /ip4/<any other loopback>/tcp/<port>
 	// /ip6/<any loopback>/tcp/<port>
-	loopbackRegex := regexp.MustCompile(
+	loopbackRegex = regexp.MustCompile(
 		`/^\\/ip4\\/127(?:\\.[0-9]+){0,2}\\.[0-9]+\\/tcp\\/\\d+$|^\\/ip4\\/localhost\\/tcp\\/\\d+$|^\\/ip6\\/(?:0*\\:)*?:?0*1\\/tcp\\/\\d+$/gm`,
 	)
+)
 
+// AddrInfoToString converts an AddrInfo into a string representation that can be dialed from another node
+func AddrInfoToString(addr *peer.AddrInfo) string {
 	dialAddress := ""
 
 	// Find an address that's not a loopback address

--- a/network/server.go
+++ b/network/server.go
@@ -610,6 +610,7 @@ func AddrInfoToString(addr *peer.AddrInfo) string {
 		if !loopbackRegex.MatchString(address.String()) {
 			// Not a loopback address, dial address found
 			dialAddress = address.String()
+			break
 		}
 	}
 

--- a/network/server.go
+++ b/network/server.go
@@ -598,7 +598,7 @@ func AddrInfoToString(addr *peer.AddrInfo) string {
 	// /ip4/<any other loopback>/tcp/<port>
 	// /ip6/<any loopback>/tcp/<port>
 	loopbackRegex := regexp.MustCompile(
-		"/^\\/ip4\\/127(?:\\.[0-9]+){0,2}\\.[0-9]+\\/tcp\\/\\d+$|^\\/ip4\\/localhost\\/tcp\\/\\d+$|^\\/ip6\\/(?:0*\\:)*?:?0*1\\/tcp\\/\\d+$/gm",
+		`/^\\/ip4\\/127(?:\\.[0-9]+){0,2}\\.[0-9]+\\/tcp\\/\\d+$|^\\/ip4\\/localhost\\/tcp\\/\\d+$|^\\/ip6\\/(?:0*\\:)*?:?0*1\\/tcp\\/\\d+$/gm`,
 	)
 
 	dialAddress := ""

--- a/network/server.go
+++ b/network/server.go
@@ -597,7 +597,7 @@ var (
 	// /ip4/<any other loopback>/tcp/<port>
 	// /ip6/<any loopback>/tcp/<port>
 	loopbackRegex = regexp.MustCompile(
-		`/^\\/ip4\\/127(?:\\.[0-9]+){0,2}\\.[0-9]+\\/tcp\\/\\d+$|^\\/ip4\\/localhost\\/tcp\\/\\d+$|^\\/ip6\\/(?:0*\\:)*?:?0*1\\/tcp\\/\\d+$/gm`,
+		`^\/ip4\/127(?:\.[0-9]+){0,2}\.[0-9]+\/tcp\/\d+$|^\/ip4\/localhost\/tcp\/\d+$|^\/ip6\/(?:0*\:)*?:?0*1\/tcp\/\d+$`,
 	)
 )
 


### PR DESCRIPTION
# Description

This PR fixes issue #160.

It adds support for skipping loopback ipv4 and ipv6 loopback addresses when dialing.
All permutations of the loopback addresses are covered.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs
