### PR TITLE
Close trie storage when server closes

### DIFF
--- a/blockchain/storage/leveldb/leveldb_test.go
+++ b/blockchain/storage/leveldb/leveldb_test.go
@@ -19,6 +19,9 @@ func newStorage(t *testing.T) (storage.Storage, func()) {
 		t.Fatal(err)
 	}
 	close := func() {
+		if err := s.Close(); err != nil {
+			t.Fatal(err)
+		}
 		if err := os.RemoveAll(path); err != nil {
 			t.Fatal(err)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -33,9 +33,10 @@ import (
 
 // Minimal is the central manager of the blockchain client
 type Server struct {
-	logger hclog.Logger
-	config *Config
-	state  state.State
+	logger       hclog.Logger
+	config       *Config
+	state        state.State
+	stateStorage itrie.Storage
 
 	consensus consensus.Consensus
 
@@ -101,6 +102,7 @@ func NewServer(logger hclog.Logger, config *Config) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
+	m.stateStorage = stateStorage
 
 	st := itrie.NewState(stateStorage)
 	m.state = st
@@ -390,6 +392,11 @@ func (s *Server) Close() {
 	// Close the consensus layer
 	if err := s.consensus.Close(); err != nil {
 		s.logger.Error("failed to close consensus", "err", err.Error())
+	}
+
+	// Close the state storage
+	if err := s.stateStorage.Close(); err != nil {
+		s.logger.Error("failed to close storage for trie", "err", err.Error())
 	}
 }
 

--- a/state/immutable-trie/storage.go
+++ b/state/immutable-trie/storage.go
@@ -29,6 +29,8 @@ type Storage interface {
 	Batch() Batch
 	SetCode(hash types.Hash, code []byte)
 	GetCode(hash types.Hash) ([]byte, bool)
+
+	Close() error
 }
 
 // KVStorage is a k/v storage on memory using leveldb
@@ -78,6 +80,10 @@ func (kv *KVStorage) Get(k []byte) ([]byte, bool) {
 	return data, true
 }
 
+func (kv *KVStorage) Close() error {
+	return kv.db.Close()
+}
+
 func NewLevelDBStorage(path string, logger hclog.Logger) (Storage, error) {
 	db, err := leveldb.OpenFile(path, nil)
 	if err != nil {
@@ -125,6 +131,10 @@ func (m *memStorage) GetCode(hash types.Hash) ([]byte, bool) {
 
 func (m *memStorage) Batch() Batch {
 	return &memBatch{db: &m.db}
+}
+
+func (m *memStorage) Close() error {
+	return nil
 }
 
 func (m *memBatch) Put(p, v []byte) {


### PR DESCRIPTION
# Description

Relevant issue: https://github.com/0xPolygon/polygon-sdk/issues/170

The level DB to store trie data didn't close after server terminated. This causes some issues described in https://github.com/0xPolygon/polygon-sdk/issues/170.
This PR add closing process for this storage when server closes.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
