### PR TITLE
Enable non-validator to broadcast block + Fix blocking issue in syncer

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -326,6 +326,7 @@ func (i *Ibft) runSyncState() {
 		// start watch mode
 		var isValidator bool
 		i.syncer.WatchSyncWithPeer(p, func(b *types.Block) bool {
+			i.syncer.Broadcast(b)
 			isValidator = i.isValidSnapshot()
 
 			return !isValidator

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -139,6 +139,24 @@ func WaitUntilTxPoolFilled(ctx context.Context, srv *TestServer, requiredNum uin
 	return res.(*txpoolProto.TxnPoolStatusResp), nil
 }
 
+// WaitUntilBlockMined waits until server mined block with bigger height than given height
+// otherwise returns timeout
+func WaitUntilBlockMined(ctx context.Context, srv *TestServer, desiredHeight uint64) (uint64, error) {
+	clt := srv.JSONRPC().Eth()
+	res, err := RetryUntilTimeout(ctx, func() (interface{}, bool) {
+		height, err := clt.BlockNumber()
+		if err == nil && height >= desiredHeight {
+			return height, false
+		}
+		return nil, true
+	})
+
+	if err != nil {
+		return 0, err
+	}
+	return res.(uint64), nil
+}
+
 func RetryUntilTimeout(ctx context.Context, f func() (interface{}, bool)) (interface{}, error) {
 	type result struct {
 		data interface{}

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -125,6 +125,10 @@ func (t *TestServer) Stop() {
 	}
 }
 
+func (t *TestServer) GetLatestBlockHeight() (uint64, error) {
+	return t.JSONRPC().Eth().BlockNumber()
+}
+
 type InitIBFTResult struct {
 	Address string
 	NodeID  string
@@ -377,9 +381,8 @@ func (t *TestServer) WaitForReceipt(ctx context.Context, hash web3.Hash) (*web3.
 }
 
 func (t *TestServer) WaitForReady(ctx context.Context) error {
-	client := t.JSONRPC()
 	_, err := tests.RetryUntilTimeout(ctx, func() (interface{}, bool) {
-		num, err := client.Eth().BlockNumber()
+		num, err := t.GetLatestBlockHeight()
 		if err != nil {
 			return nil, true
 		}

--- a/e2e/syncer_test.go
+++ b/e2e/syncer_test.go
@@ -1,0 +1,46 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/0xPolygon/polygon-sdk/e2e/framework"
+	"github.com/stretchr/testify/assert"
+	"github.com/umbracle/go-web3"
+)
+
+func TestSyncer(t *testing.T) {
+	const (
+		numNonValidators = 2
+		desiredHeight    = 10
+	)
+
+	// Start IBFT cluster (4 Validator + 2 Non-Validator)
+	ibftManager := framework.NewIBFTServersManager(t, IBFTMinNodes+numNonValidators, IBFTDirPrefix, func(i int, config *framework.TestServerConfig) {
+		config.SetSeal(i < IBFTMinNodes)
+		config.SetShowsLog(i == IBFTMinNodes+numNonValidators-1)
+	})
+	ctx1, cancel1 := context.WithTimeout(context.Background(), time.Minute)
+	t.Cleanup(func() {
+		cancel1()
+	})
+	ibftManager.StartServers(ctx1)
+
+	// Wait until some blocks are mined
+	ctx2, cancel2 := context.WithTimeout(context.Background(), time.Minute)
+	t.Cleanup(func() {
+		cancel2()
+	})
+	_, err := framework.WaitUntilBlockMined(ctx2, ibftManager.GetServer(0), desiredHeight)
+	assert.NoError(t, err)
+
+	// Get latest block height
+	latestBlockHeight, err := ibftManager.GetServer(0).JSONRPC().Eth().BlockNumber()
+	assert.NoError(t, err)
+
+	// Test if non-validator has latest block
+	nonValidatorBlock, err := ibftManager.GetServer(IBFTMinNodes+numNonValidators-1).JSONRPC().Eth().GetBlockByNumber(web3.BlockNumber(latestBlockHeight), false)
+	assert.NoError(t, err)
+	assert.NotNil(t, nonValidatorBlock)
+}

--- a/e2e/syncer_test.go
+++ b/e2e/syncer_test.go
@@ -36,7 +36,7 @@ func TestSyncer(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Get latest block height
-	latestBlockHeight, err := ibftManager.GetServer(0).JSONRPC().Eth().BlockNumber()
+	latestBlockHeight, err := ibftManager.GetServer(0).GetLatestBlockHeight()
 	assert.NoError(t, err)
 
 	// Test if non-validator has latest block

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -79,8 +79,6 @@ func (s *syncPeer) purgeBlocks(lastSeen types.Hash) {
 	}
 }
 
-// ErrPopTimeout
-
 // popBlock pops a block from the block queue [BLOCKING]
 func (s *syncPeer) popBlock(timeout time.Duration) (b *types.Block, err error) {
 	timeoutCh := time.After(timeout)

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"math/big"
 	"sync"
+	"time"
 
 	"github.com/0xPolygon/polygon-sdk/blockchain"
 	"github.com/0xPolygon/polygon-sdk/network"
@@ -21,7 +22,18 @@ import (
 	empty "google.golang.org/protobuf/types/known/emptypb"
 )
 
-const maxEnqueueSize = 50
+const (
+	maxEnqueueSize = 50
+	popTimeout     = time.Second * 10
+)
+
+var (
+	ErrLoadLocalGenesisFailed = errors.New("failed to read local genesis")
+	ErrMismatchGenesis        = errors.New("genesis does not match?")
+	ErrCommonAncestorNotFound = errors.New("header is nil")
+	ErrForkNotFound           = errors.New("fork not found")
+	ErrPopTimeout             = errors.New("timeout")
+)
 
 // syncPeer is a representation of the peer the node is syncing with
 type syncPeer struct {
@@ -67,8 +79,11 @@ func (s *syncPeer) purgeBlocks(lastSeen types.Hash) {
 	}
 }
 
+// ErrPopTimeout
+
 // popBlock pops a block from the block queue [BLOCKING]
-func (s *syncPeer) popBlock() (b *types.Block) {
+func (s *syncPeer) popBlock(timeout time.Duration) (b *types.Block, err error) {
+	timeoutCh := time.After(timeout)
 	for {
 		s.enqueueLock.Lock()
 		if len(s.enqueue) != 0 {
@@ -76,9 +91,13 @@ func (s *syncPeer) popBlock() (b *types.Block) {
 			s.enqueueLock.Unlock()
 			return
 		}
-
 		s.enqueueLock.Unlock()
-		<-s.enqueueCh
+
+		select {
+		case <-s.enqueueCh:
+		case <-timeoutCh:
+			return nil, ErrPopTimeout
+		}
 	}
 }
 
@@ -404,7 +423,7 @@ func (s *Syncer) findCommonAncestor(clt proto.V1Client, status *Status) (*types.
 			// our common ancestor is the genesis
 			genesis, ok := s.blockchain.GetHeaderByNumber(0)
 			if !ok {
-				return nil, nil, fmt.Errorf("failed to read local genesis")
+				return nil, nil, ErrLoadLocalGenesisFailed
 			}
 			header = genesis
 			break
@@ -427,7 +446,7 @@ func (s *Syncer) findCommonAncestor(clt proto.V1Client, status *Status) (*types.
 				min = m + 1
 			} else {
 				if m == 0 {
-					return nil, nil, errors.New("genesis does not match?")
+					return nil, nil, ErrMismatchGenesis
 				}
 				max = m - 1
 			}
@@ -435,7 +454,7 @@ func (s *Syncer) findCommonAncestor(clt proto.V1Client, status *Status) (*types.
 	}
 
 	if header == nil {
-		return nil, nil, errors.New("header is nil")
+		return nil, nil, ErrCommonAncestorNotFound
 	}
 
 	// get the block fork
@@ -445,7 +464,7 @@ func (s *Syncer) findCommonAncestor(clt proto.V1Client, status *Status) (*types.
 		return nil, nil, fmt.Errorf("failed to get fork at num %d", header.Number)
 	}
 	if fork == nil {
-		return nil, nil, errors.New("fork not found")
+		return nil, nil, ErrForkNotFound
 	}
 
 	return header, fork, nil
@@ -463,7 +482,11 @@ func (s *Syncer) WatchSyncWithPeer(p *syncPeer, handler func(b *types.Block) boo
 			break
 		}
 
-		b := p.popBlock()
+		b, err := p.popBlock(popTimeout)
+		if err != nil {
+			s.logger.Error("failed to pop block", "err", err)
+			break
+		}
 		if err := s.blockchain.WriteBlocks([]*types.Block{b}); err != nil {
 			s.logger.Error("failed to write block", "err", err)
 			break


### PR DESCRIPTION
# Description

This PR fixes 2 issues:
- Fix issue that non-validator wasn't working as syncer
- Fix blocking issue when non-validator chooses another non-validator which isn't advancing block as sync peer

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
