### PR TITLE
Total Difficulty in IBFT

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -290,16 +290,17 @@ func (b *Blockchain) writeCanonicalHeader(event *Event, h *types.Header) error {
 		return fmt.Errorf("parent difficulty not found")
 	}
 
-	diff := big.NewInt(1).Add(td, new(big.Int).SetUint64(h.Difficulty))
-	if err := b.db.WriteCanonicalHeader(h, diff); err != nil {
+	// calculate new TD (IBFT)
+	newTD := big.NewInt(0).Add(td, big.NewInt(1))
+	if err := b.db.WriteCanonicalHeader(h, newTD); err != nil {
 		return err
 	}
 
 	event.Type = EventHead
 	event.AddNewHeader(h)
-	event.SetDifficulty(diff)
+	event.SetDifficulty(newTD)
 
-	b.setCurrentHeader(h, diff)
+	b.setCurrentHeader(h, newTD)
 
 	return nil
 }

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -142,7 +142,7 @@ func TestInsertHeaders(t *testing.T) {
 						NewChain: []*header{
 							mock(0x2),
 						},
-						Diff: big.NewInt(2),
+						Diff: big.NewInt(3),
 					},
 				},
 			},
@@ -152,7 +152,7 @@ func TestInsertHeaders(t *testing.T) {
 				mock(0x1),
 				mock(0x2),
 			},
-			TD: 2,
+			TD: 0 + 1 + 2,
 		},
 		{
 			Name: "Keep block with higher difficulty",
@@ -170,20 +170,20 @@ func TestInsertHeaders(t *testing.T) {
 					},
 				},
 				{
-					header: mock(0x3).Parent(0x1).Diff(3),
+					header: mock(0x3).Parent(0x1).Diff(5),
 					event: &evnt{
 						NewChain: []*header{
-							mock(0x3).Parent(0x1).Diff(3),
+							mock(0x3).Parent(0x1).Diff(5),
 						},
-						Diff: big.NewInt(3),
+						Diff: big.NewInt(6),
 					},
 				},
 				{
 					// This block has lower difficulty than the current chain (fork)
-					header: mock(0x2).Parent(0x1).Diff(2),
+					header: mock(0x2).Parent(0x1).Diff(3),
 					event: &evnt{
 						OldChain: []*header{
-							mock(0x2).Parent(0x1).Diff(2),
+							mock(0x2).Parent(0x1).Diff(3),
 						},
 					},
 				},
@@ -193,9 +193,9 @@ func TestInsertHeaders(t *testing.T) {
 			Chain: []*header{
 				mock(0x0),
 				mock(0x1),
-				mock(0x3).Parent(0x1).Diff(3),
+				mock(0x3).Parent(0x1).Diff(5),
 			},
-			TD: 3,
+			TD: 0 + 1 + 5,
 		},
 		{
 			Name: "Reorg",
@@ -218,7 +218,7 @@ func TestInsertHeaders(t *testing.T) {
 						NewChain: []*header{
 							mock(0x2),
 						},
-						Diff: big.NewInt(2),
+						Diff: big.NewInt(1 + 2),
 					},
 				},
 				{
@@ -227,40 +227,40 @@ func TestInsertHeaders(t *testing.T) {
 						NewChain: []*header{
 							mock(0x3),
 						},
-						Diff: big.NewInt(3),
+						Diff: big.NewInt(1 + 2 + 3),
 					},
 				},
 				{
 					// First reorg
-					header: mock(0x4).Parent(0x1).Diff(4).Number(2),
+					header: mock(0x4).Parent(0x1).Diff(10).Number(2),
 					event: &evnt{
 						// add block 4
 						NewChain: []*header{
-							mock(0x4).Parent(0x1).Diff(4).Number(2),
+							mock(0x4).Parent(0x1).Diff(10).Number(2),
 						},
 						// remove block 2 and 3
 						OldChain: []*header{
 							mock(0x2),
 							mock(0x3),
 						},
-						Diff: big.NewInt(4),
+						Diff: big.NewInt(1 + 10),
 					},
 				},
 				{
-					header: mock(0x5).Parent(0x4).Diff(5).Number(3),
+					header: mock(0x5).Parent(0x4).Diff(11).Number(3),
 					event: &evnt{
 						NewChain: []*header{
-							mock(0x5).Parent(0x4).Diff(5).Number(3),
+							mock(0x5).Parent(0x4).Diff(11).Number(3),
 						},
-						Diff: big.NewInt(5),
+						Diff: big.NewInt(1 + 10 + 11),
 					},
 				},
 				{
-					header: mock(0x6).Parent(0x3).Number(4).Diff(4),
+					header: mock(0x6).Parent(0x3).Number(4),
 					event: &evnt{
 						// lower difficulty, its a fork
 						OldChain: []*header{
-							mock(0x6).Parent(0x3).Number(4).Diff(4),
+							mock(0x6).Parent(0x3).Number(4),
 						},
 					},
 				},
@@ -270,10 +270,10 @@ func TestInsertHeaders(t *testing.T) {
 			Chain: []*header{
 				mock(0x0),
 				mock(0x1),
-				mock(0x4).Parent(0x1).Diff(4).Number(2),
-				mock(0x5).Parent(0x4).Diff(5).Number(3),
+				mock(0x4).Parent(0x1).Diff(10).Number(2),
+				mock(0x5).Parent(0x4).Diff(11).Number(3),
 			},
-			TD: 5,
+			TD: 0 + 1 + 10 + 11,
 		},
 		{
 			Name: "Forks in reorgs",
@@ -296,7 +296,7 @@ func TestInsertHeaders(t *testing.T) {
 						NewChain: []*header{
 							mock(0x2),
 						},
-						Diff: big.NewInt(2),
+						Diff: big.NewInt(1 + 2),
 					},
 				},
 				{
@@ -305,7 +305,7 @@ func TestInsertHeaders(t *testing.T) {
 						NewChain: []*header{
 							mock(0x3),
 						},
-						Diff: big.NewInt(3),
+						Diff: big.NewInt(1 + 2 + 3),
 					},
 				},
 				{
@@ -318,7 +318,7 @@ func TestInsertHeaders(t *testing.T) {
 						OldChain: []*header{
 							mock(0x3),
 						},
-						Diff: big.NewInt(11),
+						Diff: big.NewInt(1 + 2 + 11),
 					},
 				},
 				{
@@ -348,7 +348,7 @@ func TestInsertHeaders(t *testing.T) {
 				mock(0x2),
 				mock(0x4).Parent(0x2).Diff(11),
 			},
-			TD: 11,
+			TD: 0 + 1 + 2 + 11,
 		},
 		{
 			Name: "Head from old long fork",
@@ -371,7 +371,7 @@ func TestInsertHeaders(t *testing.T) {
 						NewChain: []*header{
 							mock(0x2),
 						},
-						Diff: big.NewInt(2),
+						Diff: big.NewInt(1 + 2),
 					},
 				},
 				{
@@ -385,7 +385,7 @@ func TestInsertHeaders(t *testing.T) {
 							mock(0x1),
 							mock(0x2),
 						},
-						Diff: big.NewInt(5),
+						Diff: big.NewInt(0 + 5),
 					},
 				},
 				{
@@ -400,7 +400,7 @@ func TestInsertHeaders(t *testing.T) {
 						OldChain: []*header{
 							mock(0x3).Parent(0x0).Diff(5),
 						},
-						Diff: big.NewInt(10),
+						Diff: big.NewInt(1 + 2 + 10),
 					},
 				},
 			},
@@ -415,7 +415,7 @@ func TestInsertHeaders(t *testing.T) {
 				mock(0x2),
 				mock(0x4).Parent(0x2).Diff(10),
 			},
-			TD: 10,
+			TD: 0 + 1 + 2 + 10,
 		},
 	}
 

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -142,7 +142,7 @@ func TestInsertHeaders(t *testing.T) {
 						NewChain: []*header{
 							mock(0x2),
 						},
-						Diff: big.NewInt(3),
+						Diff: big.NewInt(2),
 					},
 				},
 			},
@@ -152,7 +152,7 @@ func TestInsertHeaders(t *testing.T) {
 				mock(0x1),
 				mock(0x2),
 			},
-			TD: 0 + 1 + 2,
+			TD: 2,
 		},
 		{
 			Name: "Keep block with higher difficulty",
@@ -170,20 +170,20 @@ func TestInsertHeaders(t *testing.T) {
 					},
 				},
 				{
-					header: mock(0x3).Parent(0x1).Diff(5),
+					header: mock(0x3).Parent(0x1).Diff(3),
 					event: &evnt{
 						NewChain: []*header{
-							mock(0x3).Parent(0x1).Diff(5),
+							mock(0x3).Parent(0x1).Diff(3),
 						},
-						Diff: big.NewInt(6),
+						Diff: big.NewInt(3),
 					},
 				},
 				{
 					// This block has lower difficulty than the current chain (fork)
-					header: mock(0x2).Parent(0x1).Diff(3),
+					header: mock(0x2).Parent(0x1).Diff(2),
 					event: &evnt{
 						OldChain: []*header{
-							mock(0x2).Parent(0x1).Diff(3),
+							mock(0x2).Parent(0x1).Diff(2),
 						},
 					},
 				},
@@ -193,9 +193,9 @@ func TestInsertHeaders(t *testing.T) {
 			Chain: []*header{
 				mock(0x0),
 				mock(0x1),
-				mock(0x3).Parent(0x1).Diff(5),
+				mock(0x3).Parent(0x1).Diff(3),
 			},
-			TD: 0 + 1 + 5,
+			TD: 3,
 		},
 		{
 			Name: "Reorg",
@@ -218,7 +218,7 @@ func TestInsertHeaders(t *testing.T) {
 						NewChain: []*header{
 							mock(0x2),
 						},
-						Diff: big.NewInt(1 + 2),
+						Diff: big.NewInt(2),
 					},
 				},
 				{
@@ -227,40 +227,40 @@ func TestInsertHeaders(t *testing.T) {
 						NewChain: []*header{
 							mock(0x3),
 						},
-						Diff: big.NewInt(1 + 2 + 3),
+						Diff: big.NewInt(3),
 					},
 				},
 				{
 					// First reorg
-					header: mock(0x4).Parent(0x1).Diff(10).Number(2),
+					header: mock(0x4).Parent(0x1).Diff(4).Number(2),
 					event: &evnt{
 						// add block 4
 						NewChain: []*header{
-							mock(0x4).Parent(0x1).Diff(10).Number(2),
+							mock(0x4).Parent(0x1).Diff(4).Number(2),
 						},
 						// remove block 2 and 3
 						OldChain: []*header{
 							mock(0x2),
 							mock(0x3),
 						},
-						Diff: big.NewInt(1 + 10),
+						Diff: big.NewInt(4),
 					},
 				},
 				{
-					header: mock(0x5).Parent(0x4).Diff(11).Number(3),
+					header: mock(0x5).Parent(0x4).Diff(5).Number(3),
 					event: &evnt{
 						NewChain: []*header{
-							mock(0x5).Parent(0x4).Diff(11).Number(3),
+							mock(0x5).Parent(0x4).Diff(5).Number(3),
 						},
-						Diff: big.NewInt(1 + 10 + 11),
+						Diff: big.NewInt(5),
 					},
 				},
 				{
-					header: mock(0x6).Parent(0x3).Number(4),
+					header: mock(0x6).Parent(0x3).Number(4).Diff(4),
 					event: &evnt{
 						// lower difficulty, its a fork
 						OldChain: []*header{
-							mock(0x6).Parent(0x3).Number(4),
+							mock(0x6).Parent(0x3).Number(4).Diff(4),
 						},
 					},
 				},
@@ -270,10 +270,10 @@ func TestInsertHeaders(t *testing.T) {
 			Chain: []*header{
 				mock(0x0),
 				mock(0x1),
-				mock(0x4).Parent(0x1).Diff(10).Number(2),
-				mock(0x5).Parent(0x4).Diff(11).Number(3),
+				mock(0x4).Parent(0x1).Diff(4).Number(2),
+				mock(0x5).Parent(0x4).Diff(5).Number(3),
 			},
-			TD: 0 + 1 + 10 + 11,
+			TD: 5,
 		},
 		{
 			Name: "Forks in reorgs",
@@ -296,7 +296,7 @@ func TestInsertHeaders(t *testing.T) {
 						NewChain: []*header{
 							mock(0x2),
 						},
-						Diff: big.NewInt(1 + 2),
+						Diff: big.NewInt(2),
 					},
 				},
 				{
@@ -305,7 +305,7 @@ func TestInsertHeaders(t *testing.T) {
 						NewChain: []*header{
 							mock(0x3),
 						},
-						Diff: big.NewInt(1 + 2 + 3),
+						Diff: big.NewInt(3),
 					},
 				},
 				{
@@ -318,7 +318,7 @@ func TestInsertHeaders(t *testing.T) {
 						OldChain: []*header{
 							mock(0x3),
 						},
-						Diff: big.NewInt(1 + 2 + 11),
+						Diff: big.NewInt(11),
 					},
 				},
 				{
@@ -348,7 +348,7 @@ func TestInsertHeaders(t *testing.T) {
 				mock(0x2),
 				mock(0x4).Parent(0x2).Diff(11),
 			},
-			TD: 0 + 1 + 2 + 11,
+			TD: 11,
 		},
 		{
 			Name: "Head from old long fork",
@@ -371,7 +371,7 @@ func TestInsertHeaders(t *testing.T) {
 						NewChain: []*header{
 							mock(0x2),
 						},
-						Diff: big.NewInt(1 + 2),
+						Diff: big.NewInt(2),
 					},
 				},
 				{
@@ -385,7 +385,7 @@ func TestInsertHeaders(t *testing.T) {
 							mock(0x1),
 							mock(0x2),
 						},
-						Diff: big.NewInt(0 + 5),
+						Diff: big.NewInt(5),
 					},
 				},
 				{
@@ -400,7 +400,7 @@ func TestInsertHeaders(t *testing.T) {
 						OldChain: []*header{
 							mock(0x3).Parent(0x0).Diff(5),
 						},
-						Diff: big.NewInt(1 + 2 + 10),
+						Diff: big.NewInt(10),
 					},
 				},
 			},
@@ -415,7 +415,7 @@ func TestInsertHeaders(t *testing.T) {
 				mock(0x2),
 				mock(0x4).Parent(0x2).Diff(10),
 			},
-			TD: 0 + 1 + 2 + 10,
+			TD: 10,
 		},
 	}
 

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -17,7 +17,7 @@ var (
 	GenesisGasLimit uint64 = 4712388
 
 	// GenesisDifficulty is the default difficulty of the Genesis block.
-	GenesisDifficulty = big.NewInt(131072)
+	GenesisDifficulty = big.NewInt(1)
 )
 
 // Chain is the blockchain chain configuration

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -350,7 +350,7 @@ func (i *Ibft) buildBlock(snap *Snapshot, parent *types.Header) (*types.Block, e
 		Miner:      types.Address{},
 		Nonce:      types.Nonce{},
 		MixHash:    IstanbulDigest,
-		Difficulty: parent.Number + 1,   // we need to do this because blockchain needs difficulty to organize blocks and forks
+		Difficulty: 1,
 		StateRoot:  types.EmptyRootHash, // this avoids needing state for now
 		Sha3Uncles: types.EmptyUncleHash,
 		GasLimit:   100000000, // placeholder for now
@@ -880,8 +880,8 @@ func (i *Ibft) verifyHeaderImpl(snap *Snapshot, parent, header *types.Header) er
 		return fmt.Errorf("invalid sha3 uncles")
 	}
 
-	// difficulty has to match number
-	if header.Difficulty != header.Number {
+	// difficulty has to be 1 (except for genesis block)
+	if header.Difficulty != 1 && header.Number != 0 {
 		return fmt.Errorf("wrong difficulty")
 	}
 

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -880,8 +880,8 @@ func (i *Ibft) verifyHeaderImpl(snap *Snapshot, parent, header *types.Header) er
 		return fmt.Errorf("invalid sha3 uncles")
 	}
 
-	// difficulty has to be 1 (except for genesis block)
-	if header.Difficulty != 1 && header.Number != 0 {
+	// difficulty has to be 1 for each block
+	if header.Difficulty != 1 {
 		return fmt.Errorf("wrong difficulty")
 	}
 

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -470,6 +470,7 @@ func (m *mockIbft) DummyBlock() *types.Block {
 			ExtraData:  parent.ExtraData,
 			MixHash:    IstanbulDigest,
 			Sha3Uncles: types.EmptyUncleHash,
+			Difficulty: 1,
 		},
 	}
 	return block

--- a/e2e/difficulty_test.go
+++ b/e2e/difficulty_test.go
@@ -1,0 +1,46 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/0xPolygon/polygon-sdk/e2e/framework"
+	"github.com/stretchr/testify/assert"
+	"github.com/umbracle/go-web3"
+)
+
+func TestBlockDifficulty(t *testing.T) {
+	ibftManager := framework.NewIBFTServersManager(t,
+		IBFTMinNodes,
+		IBFTDirPrefix,
+		func(i int, config *framework.TestServerConfig) {
+			config.SetSeal(true)
+		})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	ibftManager.StartServers(ctx)
+
+	srv := ibftManager.GetServer(0)
+	ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	err := srv.WaitForReady(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clt := srv.JSONRPC()
+	num, err := clt.Eth().BlockNumber()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blk, err := clt.Eth().GetBlockByNumber(web3.BlockNumber(num), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// verify that block difficulty is 1
+	assert.Equal(t, blk.Difficulty.Uint64(), uint64(1))
+}


### PR DESCRIPTION
# Description

Defining total difficulty in our IBFT implementation.
Addresses [#179](https://github.com/0xPolygon/polygon-sdk/issues/179)

Update:

Hardcoding `GenesisDifficulty` to 1 breaks backwards compatibility for existing chains due to new nodes having to generate the genesis block with difficulty 1.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

This PR is about coming to terms on what Total Difficulty means in IBFT.

In other consensuses, TD is what helps identify the correct chain (fork) based on the sum of all blocks' `difficulty` field (which varies from block to block). 
In IBFT, TD has nothing to do with the `difficulty` field, but serves the same purpose, in a sense that it decides what is the latest block (number) - hence this value should represent the block's `number` field.

In short (our IBFT impl):
```
Block's difficulty -> Block's number
Block's TD -> Sum of all previous block numbers (up to current)
Chain TD -> TD of the latest block in the chain
```

Related issues:
[https://github.com/0xPolygon/polygon-sdk/issues/179](#179)

This fix should provide the `Syncer` with the correct value (fetched with `CurrentTD()`) in order to resolve its best peer.