### PR TITLE
Enable txPool to accept sped up transactions

### DIFF
--- a/command/helper/config.go
+++ b/command/helper/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Dev         bool
 	DevInterval uint64
 	Join        string
+	SpeedUp     uint64
 }
 
 // Network defines the network configuration params
@@ -66,6 +67,7 @@ func (c *Config) BuildConfig() (*server.Config, error) {
 	conf.Chain = cc
 	conf.Seal = c.Seal
 	conf.DataDir = c.DataDir
+	conf.SpeedUp = c.SpeedUp
 
 	// JSON RPC + GRPC
 	if c.GRPCAddr != "" {
@@ -169,6 +171,10 @@ func (c *Config) mergeConfigWith(otherConfig *Config) error {
 
 	if otherConfig.Join != "" {
 		c.Join = otherConfig.Join
+	}
+
+	if otherConfig.SpeedUp != 0 {
+		c.SpeedUp = otherConfig.SpeedUp
 	}
 
 	{

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -409,6 +409,7 @@ func ReadConfig(baseCommand string, args []string) (*Config, error) {
 	flags.Uint64Var(&cliConfig.Network.MaxPeers, "max-peers", 0, "")
 	flags.BoolVar(&cliConfig.Dev, "dev", false, "")
 	flags.Uint64Var(&cliConfig.DevInterval, "dev-interval", 0, "")
+	flags.Uint64Var(&cliConfig.SpeedUp, "speed-up", 0, "")
 
 	if err := flags.Parse(args); err != nil {
 		return nil, err

--- a/command/server/server_command.go
+++ b/command/server/server_command.go
@@ -140,6 +140,14 @@ func (c *ServerCommand) DefineFlags() {
 		},
 		FlagOptional: true,
 	}
+
+	c.flagMap["speed-up"] = helper.FlagDescriptor{
+		Description: "TODO",
+		Arguments: []string{
+			"SPEED_UP",
+		},
+		FlagOptional: true,
+	}
 }
 
 // GetHelperText returns a simple description of the command

--- a/server/config.go
+++ b/server/config.go
@@ -20,6 +20,7 @@ type Config struct {
 
 	Network *network.Config
 	DataDir string
+	SpeedUp uint64
 	Seal    bool
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -129,7 +129,14 @@ func NewServer(logger hclog.Logger, config *Config) (*Server, error) {
 			Blockchain: m.blockchain,
 		}
 		// start transaction pool
-		m.txpool, err = txpool.NewTxPool(logger, m.config.Seal, m.chain.Params.Forks.At(0), hub, m.grpcServer, m.network)
+		m.txpool, err = txpool.NewTxPool(logger,
+			m.config.Seal,
+			m.chain.Params.Forks.At(0),
+			hub,
+			m.grpcServer,
+			m.network,
+			m.config.SpeedUp,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -410,6 +410,7 @@ func (t *TxPool) speedUpTx(tx *types.Transaction) error {
 	if t.pendingQueue.Contains(oldTx) {
 		t.pendingQueue.Delete(oldTx)
 		t.pendingQueue.Push(tx)
+		t.accountQueues[tx.From].lastPromoted = tx
 	} else {
 		// Otherwise, the old tx is in the acc specific queue
 		// waiting to be promoted


### PR DESCRIPTION
# Description

Extend client functionality with the `--speed-up` flag indicating the minimum amount of additional gas price a new transaction is supposed to have in order to overwrite the previous one (same nonce).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

