### PR TITLE
Remove type casting for the transition error

### DIFF
--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -144,7 +144,7 @@ func (d *Dev) writeNewBlock(parent *types.Header) error {
 		} else {
 			// Execute the state transition
 			if err := transition.Write(txn); err != nil {
-				if err.IsRecoverable {
+				if err.(*state.TransitionApplicationError).IsRecoverable {
 					retFn()
 				} else {
 					d.txpool.DecreaseAccountNonce(txn)

--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -144,7 +144,7 @@ func (d *Dev) writeNewBlock(parent *types.Header) error {
 		} else {
 			// Execute the state transition
 			if err := transition.Write(txn); err != nil {
-				if err.(*state.TransitionApplicationError).IsRecoverable {
+				if appErr, ok := err.(*state.TransitionApplicationError); ok && appErr.IsRecoverable {
 					retFn()
 				} else {
 					d.txpool.DecreaseAccountNonce(txn)

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -393,7 +393,7 @@ func (i *Ibft) buildBlock(snap *Snapshot, parent *types.Header) (*types.Block, e
 			i.txpool.DecreaseAccountNonce(txn)
 		} else {
 			if err := transition.Write(txn); err != nil {
-				if err.IsRecoverable {
+				if err.(*state.TransitionApplicationError).IsRecoverable {
 					retFn()
 				} else {
 					i.txpool.DecreaseAccountNonce(txn)

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -393,7 +393,7 @@ func (i *Ibft) buildBlock(snap *Snapshot, parent *types.Header) (*types.Block, e
 			i.txpool.DecreaseAccountNonce(txn)
 		} else {
 			if err := transition.Write(txn); err != nil {
-				if err.(*state.TransitionApplicationError).IsRecoverable {
+				if appErr, ok := err.(*state.TransitionApplicationError); ok && appErr.IsRecoverable {
 					retFn()
 				} else {
 					i.txpool.DecreaseAccountNonce(txn)

--- a/e2e/syncer_test.go
+++ b/e2e/syncer_test.go
@@ -19,7 +19,6 @@ func TestSyncer(t *testing.T) {
 	// Start IBFT cluster (4 Validator + 2 Non-Validator)
 	ibftManager := framework.NewIBFTServersManager(t, IBFTMinNodes+numNonValidators, IBFTDirPrefix, func(i int, config *framework.TestServerConfig) {
 		config.SetSeal(i < IBFTMinNodes)
-		config.SetShowsLog(i == IBFTMinNodes+numNonValidators-1)
 	})
 	ctx1, cancel1 := context.WithTimeout(context.Background(), time.Minute)
 	t.Cleanup(func() {

--- a/state/executor.go
+++ b/state/executor.go
@@ -184,7 +184,7 @@ func (t *Transition) Receipts() []*types.Receipt {
 var emptyFrom = types.Address{}
 
 // Write writes another transaction to the executor
-func (t *Transition) Write(txn *types.Transaction) *TransitionApplicationError {
+func (t *Transition) Write(txn *types.Transaction) error {
 	signer := crypto.NewSigner(t.config, uint64(t.r.config.ChainID))
 
 	var err error
@@ -278,9 +278,9 @@ func (t *Transition) GetTxnHash() types.Hash {
 }
 
 // Apply applies a new transaction
-func (t *Transition) Apply(msg *types.Transaction) (result *runtime.ExecutionResult, err *TransitionApplicationError) {
+func (t *Transition) Apply(msg *types.Transaction) (*runtime.ExecutionResult, error) {
 	s := t.state.Snapshot()
-	result, err = t.apply(msg)
+	result, err := t.apply(msg)
 	if err != nil {
 		t.state.RevertToSnapshot(s)
 	}
@@ -289,7 +289,7 @@ func (t *Transition) Apply(msg *types.Transaction) (result *runtime.ExecutionRes
 		t.r.PostHook(t)
 	}
 
-	return
+	return result, nil
 }
 
 // ContextPtr returns reference of context


### PR DESCRIPTION
# Description

This PR introduces a hot-fix for error casting when applying transactions.
Even though no error would occur, because of type casting where a non-empty object is created, a condition check if an error has occurred would fail, causing unexpected behavior.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs
