### PR TITLE
Solve syncer issue within BestPeer()

### DIFF
--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -300,6 +300,7 @@ func (s *Syncer) Broadcast(b *types.Block) {
 	if !ok {
 		// not supposed to happen
 		s.logger.Error("total difficulty not found", "block number", b.Number())
+		return
 	}
 
 	// broadcast the new block to all the peers

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -295,15 +295,19 @@ func (s *Syncer) updatePeerStatus(peerID peer.ID, status *Status) {
 
 // Broadcast broadcasts a block to all peers
 func (s *Syncer) Broadcast(b *types.Block) {
-	// diff is number in ibft
-	diff := new(big.Int).SetUint64(b.Header.Difficulty)
+	// Get the chain difficulty associated with block
+	td, ok := s.blockchain.GetTD(b.Hash())
+	if !ok {
+		// not supposed to happen
+		s.logger.Error("total difficulty not found", "block number", b.Number())
+	}
 
 	// broadcast the new block to all the peers
 	req := &proto.NotifyReq{
 		Status: &proto.V1Status{
 			Hash:       b.Hash().String(),
 			Number:     b.Number(),
-			Difficulty: diff.String(),
+			Difficulty: td.String(),
 		},
 		Raw: &any.Any{
 			Value: b.MarshalRLP(),
@@ -386,6 +390,7 @@ func (s *Syncer) BestPeer() *syncPeer {
 
 	curDiff := s.blockchain.CurrentTD()
 
+	println("BestPeer():", "(my TD)", curDiff.Uint64(), "-", bestTd.Uint64(), "(best peer TD)")
 	if bestTd.Cmp(curDiff) <= 0 {
 		return nil
 	}

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -389,8 +389,6 @@ func (s *Syncer) BestPeer() *syncPeer {
 	}
 
 	curDiff := s.blockchain.CurrentTD()
-
-	println("BestPeer():", "(my TD)", curDiff.Uint64(), "-", bestTd.Uint64(), "(best peer TD)")
 	if bestTd.Cmp(curDiff) <= 0 {
 		return nil
 	}

--- a/protocol/syncer_test.go
+++ b/protocol/syncer_test.go
@@ -114,8 +114,7 @@ func TestBroadcast(t *testing.T) {
 
 			newBlocks := GenerateNewBlocks(t, peerSyncer.blockchain, tt.numNewBlocks)
 
-			// See PR#208
-			assert.Nil(t, peerSyncer.blockchain.WriteBlocks(newBlocks))
+			assert.NoError(t, peerSyncer.blockchain.WriteBlocks(newBlocks))
 
 			for _, newBlock := range newBlocks {
 				peerSyncer.Broadcast(newBlock)
@@ -277,8 +276,7 @@ func TestWatchSyncWithPeer(t *testing.T) {
 
 			newBlocks := GenerateNewBlocks(t, peerChain, tt.numNewBlocks)
 
-			// See PR#208
-			assert.Nil(t, peerSyncer.blockchain.WriteBlocks(newBlocks))
+			assert.NoError(t, peerSyncer.blockchain.WriteBlocks(newBlocks))
 
 			for _, b := range newBlocks {
 				peerSyncer.Broadcast(b)

--- a/protocol/syncer_test.go
+++ b/protocol/syncer_test.go
@@ -93,25 +93,30 @@ func TestDeletePeer(t *testing.T) {
 
 func TestBroadcast(t *testing.T) {
 	tests := []struct {
-		name         string
-		chain        blockchainShim
-		peerChain    blockchainShim
-		numNewBlocks int
+		name          string
+		syncerHeaders []*types.Header
+		peerHeaders   []*types.Header
+		numNewBlocks  int
 	}{
 		{
-			name:         "syncer should receive new block in peer",
-			chain:        NewRandomChain(t, 5),
-			peerChain:    NewRandomChain(t, 10),
-			numNewBlocks: 5,
+			name:          "syncer should receive new block in peer",
+			syncerHeaders: blockchain.NewTestHeaderChainWithSeed(nil, 5, 0),
+			peerHeaders:   blockchain.NewTestHeaderChainWithSeed(nil, 10, 0),
+			numNewBlocks:  5,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			syncer, peerSyncers := SetupSyncerNetwork(t, tt.chain, []blockchainShim{tt.peerChain})
+			chain, peerChain := NewMockBlockchain(tt.syncerHeaders), NewMockBlockchain(tt.peerHeaders)
+			syncer, peerSyncers := SetupSyncerNetwork(t, chain, []blockchainShim{peerChain})
 			peerSyncer := peerSyncers[0]
 
 			newBlocks := GenerateNewBlocks(t, peerSyncer.blockchain, tt.numNewBlocks)
+
+			// See PR#208
+			assert.Nil(t, peerSyncer.blockchain.WriteBlocks(newBlocks))
+
 			for _, newBlock := range newBlocks {
 				peerSyncer.Broadcast(newBlock)
 			}
@@ -271,6 +276,10 @@ func TestWatchSyncWithPeer(t *testing.T) {
 			peerSyncer := peerSyncers[0]
 
 			newBlocks := GenerateNewBlocks(t, peerChain, tt.numNewBlocks)
+
+			// See PR#208
+			assert.Nil(t, peerSyncer.blockchain.WriteBlocks(newBlocks))
+
 			for _, b := range newBlocks {
 				peerSyncer.Broadcast(b)
 			}

--- a/protocol/testing.go
+++ b/protocol/testing.go
@@ -115,7 +115,7 @@ func SetupSyncerNetwork(t *testing.T, chain blockchainShim, peerChains []blockch
 		network.MultiJoin(t, syncer.server, peerSyncers[idx].server)
 	}
 	WaitUntilPeerConnected(t, syncer, len(peerChains), 10*time.Second)
-	return
+	return syncer, peerSyncers
 }
 
 // GenerateNewBlocks returns new blocks from latest block of given chain
@@ -166,10 +166,14 @@ func GetCurrentStatus(b blockchainShim) *Status {
 
 // HeaderToStatus converts given header to Status
 func HeaderToStatus(h *types.Header) *Status {
+	var td uint64 = 0
+	for i := uint64(1); i <= h.Difficulty; i++ {
+		td = td + i
+	}
 	return &Status{
 		Hash:       h.Hash,
 		Number:     h.Number,
-		Difficulty: big.NewInt(0).SetUint64(h.Difficulty),
+		Difficulty: big.NewInt(0).SetUint64(td),
 	}
 }
 
@@ -207,13 +211,18 @@ func (b *mockBlockchain) CurrentTD() *big.Int {
 	if current == nil {
 		return nil
 	}
-	return new(big.Int).SetUint64(current.Difficulty)
+
+	td, _ := b.GetTD(current.Hash)
+	return td
 }
 
 func (b *mockBlockchain) GetTD(hash types.Hash) (*big.Int, bool) {
+	var td uint64 = 0
 	for _, b := range b.blocks {
+		td = td + b.Header.Difficulty
+
 		if b.Header.Hash == hash {
-			return new(big.Int).SetUint64(b.Header.Difficulty), true
+			return big.NewInt(0).SetUint64(td), true
 		}
 	}
 	return nil, false
@@ -264,8 +273,10 @@ func NewMockSubscription() *mockSubscription {
 
 func (s *mockSubscription) AppendBlocks(blocks []*types.Block) {
 	for _, b := range blocks {
+		status := HeaderToStatus(b.Header)
 		s.eventCh <- &blockchain.Event{
-			Difficulty: new(big.Int).SetUint64(b.Header.Difficulty),
+			// Difficulty: new(big.Int).SetUint64(b.Header.Difficulty),
+			Difficulty: status.Difficulty,
 			NewChain:   []*types.Header{b.Header},
 		}
 	}

--- a/protocol/testing.go
+++ b/protocol/testing.go
@@ -275,7 +275,6 @@ func (s *mockSubscription) AppendBlocks(blocks []*types.Block) {
 	for _, b := range blocks {
 		status := HeaderToStatus(b.Header)
 		s.eventCh <- &blockchain.Event{
-			// Difficulty: new(big.Int).SetUint64(b.Header.Difficulty),
 			Difficulty: status.Difficulty,
 			NewChain:   []*types.Header{b.Header},
 		}


### PR DESCRIPTION
# Description

This fix provides the correct `bestTd` values from peers when a node is choosing the best candidate.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Explanation:

### Cause
Validator nodes always send the `blockNumber` as Difficulty (instead of TotalDifficulty) when building a new block. If this info is relayed to the non validator node before it resolves its best peer, the non validator will end up looping inside of `RunAcceptState()` (for quite some time), listening for new blocks, but not being able to write them.
As a consequence, reproducing the issue is a bit random, as the non validator will only sometimes be able to re-sync with the chain.

### In-depth

When a node's `Syncer` first starts it subscribes to the blockchain's stream of events (in the background) and handles incoming peer connections (disconnections). While the event stream is something mostly continuous, the peer conns/deconns are rather sporadic in nature. Nonetheless, both flows access the data structures crucial for the `Syncer` to work as intended.
In our particular case scenario (step 4.), when a node first connects to the network it starts to receive these initial handshakes with other peers, each containing the difficulty of the chain (totalDifficulty) that peer is seeing. Example (with custom prints):

![handshake](https://user-images.githubusercontent.com/58940501/140921145-6b97c548-81e4-43ac-bdc3-49d165acc7ec.png)

In the example above, the 4 validator nodes are up-and-running, while the last 2 non validators got stuck previously. The node being restarted is a non validator which also got stuck on `diff: 3742` . Let's see what it does next:

![best_peer](https://user-images.githubusercontent.com/58940501/140921522-cf94353f-4b96-4838-9f47-8088d0ab7997.png)

_What happened?_ 

Right after connecting to its peers, there was a window of opportunity for a race to happen. If before reaching the call to bestPeer() a new block was broadcasted from the validator set, the end result of that broadcast will update the difficulty the node has previously registered for that peer (during the initial handshake). The origin of the "lower" value comes from the fact that the validator, instead of sending total difficulty of the chain, actually sent the _last block's difficulty_ (which in IBFT is, at the time of writing this, equal to the block's number). 

At the time of discovery, the validator nodes were the only ones broadcasting blocks to the network, which is why their difficulty is growing in the next call to `bestPeer()` (as opposed to the stuck non validators).
Regardless, the node rejects these peers as candidates (believing they have yet to sync up with the chain) and repeats the process over again. 

Fortunately, all it takes to solve this bug is store the chain's difficulty (total difficulty) in the `Difficulty` field of `Status` instead of the last block's difficulty.
