### PR TITLE
Increased timeout of popBlock method to 20s and decreased log level t…

### DIFF
--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -513,9 +513,14 @@ func (s *Syncer) WatchSyncWithPeer(p *syncPeer, handler func(b *types.Block) boo
 			s.logger.Info("Connection to a peer has closed already", "id", p.peer)
 			break
 		}
+
 		b, err := p.popBlock(popTimeout)
 		if err != nil {
-			s.logger.Info("failed to pop block", "err", err)
+			if errors.Is(err, ErrPopTimeout) {
+				s.logger.Debug(fmt.Sprintf("failed to pop block within %ds", popTimeout))
+			} else {
+				s.logger.Info("failed to pop block", "err", err)
+			}
 			break
 		}
 		if err := s.blockchain.WriteBlocks([]*types.Block{b}); err != nil {

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	maxEnqueueSize = 50
-	popTimeout     = time.Second * 10
+	popTimeout     = 20 * time.Second
 )
 
 var (
@@ -515,7 +515,7 @@ func (s *Syncer) WatchSyncWithPeer(p *syncPeer, handler func(b *types.Block) boo
 		}
 		b, err := p.popBlock(popTimeout)
 		if err != nil {
-			s.logger.Error("failed to pop block", "err", err)
+			s.logger.Info("failed to pop block", "err", err)
 			break
 		}
 		if err := s.blockchain.WriteBlocks([]*types.Block{b}); err != nil {


### PR DESCRIPTION
…o INFO if error occurs

# Description

Purpose of this PR is to decrease the log level for the unnecessary ERROR logs for popBlock method timeout on the non-validator nodes. This occurs when not all of the validator nodes are up and running and the block production time can vary depending of the number of nodes down, causing the non-validator node to encounter a timeout while waiting for new block to arrive.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
