### PR TITLE
Implement --speed-up tx feature

### DIFF
--- a/command/helper/config.go
+++ b/command/helper/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	Dev            bool
 	DevInterval    uint64
 	Join           string
+	SpeedUpMin     uint64
 }
 
 // Network defines the network configuration params
@@ -84,6 +85,7 @@ func (c *Config) BuildConfig() (*server.Config, error) {
 	conf.Chain = cc
 	conf.Seal = c.Seal
 	conf.DataDir = c.DataDir
+	conf.SpeedUpMin = c.SpeedUpMin
 
 	// JSON RPC + GRPC
 	if c.GRPCAddr != "" {
@@ -225,6 +227,10 @@ func (c *Config) mergeConfigWith(otherConfig *Config) error {
 
 	if otherConfig.Join != "" {
 		c.Join = otherConfig.Join
+	}
+
+	if otherConfig.SpeedUpMin != 0 {
+		c.SpeedUpMin = otherConfig.SpeedUpMin
 	}
 
 	{

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -425,6 +425,7 @@ func ReadConfig(baseCommand string, args []string) (*Config, error) {
 	flags.BoolVar(&cliConfig.Dev, "dev", false, "")
 	flags.Uint64Var(&cliConfig.DevInterval, "dev-interval", 0, "")
 	flags.StringVar(&cliConfig.BlockGasTarget, "block-gas-target", strconv.FormatUint(0, 10), "")
+	flags.Uint64Var(&cliConfig.SpeedUpMin, "speed-up", 0, "")
 
 	if err := flags.Parse(args); err != nil {
 		return nil, err

--- a/command/server/server_command.go
+++ b/command/server/server_command.go
@@ -189,6 +189,14 @@ func (c *ServerCommand) DefineFlags() {
 		},
 		FlagOptional: true,
 	}
+
+	c.flagMap["speed-up"] = helper.FlagDescriptor{
+		Description: "Minimum amount of additional gas fee required to accelerate a same-nonce transaction",
+		Arguments: []string{
+			"SPEED_UP",
+		},
+		FlagOptional: true,
+	}
 }
 
 // GetHelperText returns a simple description of the command

--- a/e2e/framework/config.go
+++ b/e2e/framework/config.go
@@ -39,6 +39,7 @@ type TestServerConfig struct {
 	BlockGasLimit  uint64        // Block gas limit
 	BlockGasTarget uint64        // Gas target for new blocks
 	ShowsLog       bool
+	SpeedUpMin     uint64
 }
 
 // CALLBACKS //
@@ -111,4 +112,9 @@ func (t *TestServerConfig) SetBlockLimit(limit uint64) {
 // SetShowsLog sets flag for logging
 func (t *TestServerConfig) SetShowsLog(f bool) {
 	t.ShowsLog = f
+}
+
+// SetSpeedUpMin sets the minimum additonal gas fee required to speed up a tx
+func (t *TestServerConfig) SetSpeedUpMin(amount uint64) {
+	t.SpeedUpMin = amount
 }

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -272,6 +272,10 @@ func (t *TestServer) Start(ctx context.Context) error {
 		args = append(args, "--block-gas-target", *types.EncodeUint64(t.Config.BlockGasTarget))
 	}
 
+	if t.Config.SpeedUpMin != 0 {
+		args = append(args, "--speed-up", *types.EncodeUint64(t.Config.SpeedUpMin))
+	}
+
 	t.ReleaseReservedPorts()
 
 	// Start the server

--- a/server/config.go
+++ b/server/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	NoLocals   bool
 	PriceLimit uint64
 	MaxSlots   uint64
+	SpeedUpMin uint64
 }
 
 // DefaultConfig returns the default config for JSON-RPC, GRPC (ports) and Networking

--- a/server/server.go
+++ b/server/server.go
@@ -129,7 +129,18 @@ func NewServer(logger hclog.Logger, config *Config) (*Server, error) {
 			Blockchain: m.blockchain,
 		}
 		// start transaction pool
-		m.txpool, err = txpool.NewTxPool(logger, m.config.Seal, m.config.Locals, m.config.NoLocals, m.config.PriceLimit, m.config.MaxSlots, m.chain.Params.Forks.At(0), hub, m.grpcServer, m.network)
+		m.txpool, err = txpool.NewTxPool(
+			logger,
+			m.config.Seal,
+			m.config.Locals,
+			m.config.NoLocals,
+			m.config.PriceLimit,
+			m.config.MaxSlots,
+			m.config.SpeedUpMin,
+			m.chain.Params.Forks.At(0),
+			hub,
+			m.grpcServer,
+			m.network)
 		if err != nil {
 			return nil, err
 		}

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -602,7 +602,6 @@ func (t *TxPool) decreaseSlots(slots uint64) {
 func (t *TxPool) isSpeedUp(tx *types.Transaction) (*types.Transaction, bool) {
 	nextNonce, ok := t.GetNonce(tx.From)
 	if !ok {
-		println("No previous txs for this acc")
 		return nil, false
 	}
 

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -760,21 +760,6 @@ func (t *txHeapWrapper) Peek() *types.Transaction {
 
 // Push adds a transaction to the account based heap
 func (t *txHeapWrapper) Push(tx *types.Transaction) {
-	// Check if the current transaction has a higher or equal nonce
-	// than all the current transactions in the account based heap
-	i := sort.Search(len(t.txs), func(i int) bool {
-		return t.txs[0].Nonce >= tx.Nonce
-	})
-
-	// If sort.Search found something, it will return the index
-	// of the first found element for which func(i int) was true
-	if i < len(t.txs) && t.txs[i].Nonce == tx.Nonce {
-		// i is an index corresponding to an element in the
-		// account based heap, and the nonces match up, so this tx is discarded
-		return
-	}
-
-	// All checks have passed, add the tx to the account based heap
 	heap.Push(&t.txs, tx)
 }
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -27,6 +27,7 @@ var forks = &chain.Forks{
 const (
 	defaultPriceLimit uint64 = 1
 	defaultMaxSlots   uint64 = 4096
+	defaultSpeedUpMin uint64 = 0
 )
 
 var (
@@ -91,7 +92,7 @@ func TestAddingTransaction(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, false, defaultPriceLimit, defaultMaxSlots, forks.At(0), &mockStore{}, nil, nil)
+			pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, false, defaultPriceLimit, defaultMaxSlots, defaultSpeedUpMin, forks.At(0), &mockStore{}, nil, nil)
 			if err != nil {
 				t.Fatal("Failed to initialize transaction pool:", err)
 			}
@@ -125,7 +126,7 @@ func TestAddingTransaction(t *testing.T) {
 
 func TestMultipleTransactions(t *testing.T) {
 	// if we add the same transaction it should only be included once
-	pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, true, defaultPriceLimit, defaultMaxSlots, forks.At(0), &mockStore{}, nil, nil)
+	pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, true, defaultPriceLimit, defaultMaxSlots, defaultSpeedUpMin, forks.At(0), &mockStore{}, nil, nil)
 	assert.NoError(t, err)
 	pool.EnableDev()
 	pool.AddSigner(&mockSigner{})
@@ -160,7 +161,7 @@ func TestMultipleTransactions(t *testing.T) {
 }
 
 func TestGetPendingAndQueuedTransactions(t *testing.T) {
-	pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, false, defaultPriceLimit, defaultMaxSlots, forks.At(0), &mockStore{}, nil, nil)
+	pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, false, defaultPriceLimit, defaultMaxSlots, defaultSpeedUpMin, forks.At(0), &mockStore{}, nil, nil)
 	assert.NoError(t, err)
 	pool.EnableDev()
 	pool.AddSigner(&mockSigner{})
@@ -224,7 +225,7 @@ func TestBroadcast(t *testing.T) {
 
 	createPool := func() (*TxPool, *network.Server) {
 		server := network.CreateServer(t, nil)
-		pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, true, defaultPriceLimit, defaultMaxSlots, forks.At(0), &mockStore{}, nil, server)
+		pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, true, defaultPriceLimit, defaultMaxSlots, defaultSpeedUpMin, forks.At(0), &mockStore{}, nil, server)
 		assert.NoError(t, err)
 		pool.AddSigner(signer)
 		return pool, server
@@ -250,7 +251,7 @@ func TestBroadcast(t *testing.T) {
 }
 
 func TestTxnQueue_Promotion(t *testing.T) {
-	pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, true, defaultPriceLimit, defaultMaxSlots, forks.At(0), &mockStore{}, nil, nil)
+	pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, true, defaultPriceLimit, defaultMaxSlots, defaultSpeedUpMin, forks.At(0), &mockStore{}, nil, nil)
 	assert.NoError(t, err)
 	pool.EnableDev()
 	pool.AddSigner(&mockSigner{})
@@ -291,7 +292,7 @@ func TestTxnQueue_Heap(t *testing.T) {
 	}
 
 	test := func(t *testing.T, testTable []TestCase) {
-		pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, false, defaultPriceLimit, defaultMaxSlots, forks.At(0), &mockStore{}, nil, nil)
+		pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, false, defaultPriceLimit, defaultMaxSlots, defaultSpeedUpMin, forks.At(0), &mockStore{}, nil, nil)
 		assert.NoError(t, err)
 		pool.EnableDev()
 		pool.AddSigner(&mockSigner{})
@@ -365,7 +366,7 @@ func TestTxnQueue_Heap(t *testing.T) {
 	})
 
 	t.Run("make sure that heap is not functioning as a FIFO", func(t *testing.T) {
-		pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, true, defaultPriceLimit, defaultMaxSlots, forks.At(0), &mockStore{}, nil, nil)
+		pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, true, defaultPriceLimit, defaultMaxSlots, defaultSpeedUpMin, forks.At(0), &mockStore{}, nil, nil)
 		assert.NoError(t, err)
 		pool.EnableDev()
 		pool.AddSigner(&mockSigner{})
@@ -486,7 +487,7 @@ func TestTxPool_ErrorCodes(t *testing.T) {
 
 	for _, testCase := range testTable {
 		t.Run(testCase.name, func(t *testing.T) {
-			pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, true, defaultPriceLimit, defaultMaxSlots, forks.At(0), testCase.mockStore, nil, nil)
+			pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, true, defaultPriceLimit, defaultMaxSlots, defaultSpeedUpMin, forks.At(0), testCase.mockStore, nil, nil)
 			assert.NoError(t, err)
 			if testCase.devMode {
 				pool.EnableDev()
@@ -505,7 +506,7 @@ func TestTxPool_ErrorCodes(t *testing.T) {
 	}
 }
 func TestTx_MaxSize(t *testing.T) {
-	pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, false, defaultPriceLimit, defaultMaxSlots, forks.At(0), &mockStore{}, nil, nil)
+	pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, false, defaultPriceLimit, defaultMaxSlots, defaultSpeedUpMin, forks.At(0), &mockStore{}, nil, nil)
 	pool.EnableDev()
 	pool.AddSigner(&mockSigner{})
 	assert.NoError(t, err)
@@ -550,7 +551,7 @@ func TestTx_MaxSize(t *testing.T) {
 
 }
 func TestTxnOperatorAddNilRaw(t *testing.T) {
-	pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, true, defaultPriceLimit, defaultMaxSlots, forks.At(0), &mockStore{}, nil, nil)
+	pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, true, defaultPriceLimit, defaultMaxSlots, defaultSpeedUpMin, forks.At(0), &mockStore{}, nil, nil)
 	assert.NoError(t, err)
 
 	txnReq := new(proto.AddTxnReq)
@@ -653,7 +654,7 @@ func TestPriceLimit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pool, err := NewTxPool(hclog.NewNullLogger(), false, tt.locals, tt.noLocals, tt.priceLimit, defaultMaxSlots, forks.At(0), &mockStore{}, nil, nil)
+			pool, err := NewTxPool(hclog.NewNullLogger(), false, tt.locals, tt.noLocals, tt.priceLimit, defaultMaxSlots, defaultSpeedUpMin, forks.At(0), &mockStore{}, nil, nil)
 			assert.NoError(t, err)
 			pool.AddSigner(signer)
 
@@ -843,7 +844,7 @@ func TestSizeLimit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, false, defaultPriceLimit, tt.maxSlot, forks.At(0), &mockStore{}, nil, nil)
+			pool, err := NewTxPool(hclog.NewNullLogger(), false, nil, false, defaultPriceLimit, tt.maxSlot, defaultSpeedUpMin, forks.At(0), &mockStore{}, nil, nil)
 			assert.NoError(t, err)
 			pool.AddSigner(signer)
 


### PR DESCRIPTION
# Description

Extend client functionality with the --speed-up flag indicating the minimum amount of additional gas fee a new transaction is supposed to have in order to overwrite the previous one (same nonce).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs
