### PR TITLE
Fix txpool's GetNonce() to properly return nextnonce for addr within global pending txs

### DIFF
--- a/jsonrpc/blockchain.go
+++ b/jsonrpc/blockchain.go
@@ -44,7 +44,7 @@ type blockchainInterface interface {
 	AddTx(tx *types.Transaction) error
 
 	// Gets tx pool transactions currently pending for inclusion and currently queued for validation
-	GetTxs() (map[types.Address]map[uint64]*types.Transaction, map[types.Address]map[uint64]*types.Transaction)
+	GetTxs(inclQueued bool) (map[types.Address]map[uint64]*types.Transaction, map[types.Address]map[uint64]*types.Transaction)
 
 	// GetBlockByHash gets a block using the provided hash
 	GetBlockByHash(hash types.Hash, full bool) (*types.Block, bool)
@@ -96,7 +96,7 @@ func (b *nullBlockchainInterface) AddTx(tx *types.Transaction) error {
 	return nil
 }
 
-func (b *nullBlockchainInterface) GetTxs() (map[types.Address]map[uint64]*types.Transaction, map[types.Address]map[uint64]*types.Transaction) {
+func (b *nullBlockchainInterface) GetTxs(inclQueued bool) (map[types.Address]map[uint64]*types.Transaction, map[types.Address]map[uint64]*types.Transaction) {
 	return nil, nil
 }
 

--- a/jsonrpc/txpool_endpoint.go
+++ b/jsonrpc/txpool_endpoint.go
@@ -60,7 +60,7 @@ func toTxPoolTransaction(t *types.Transaction) *txpoolTransaction {
 // Create response for txpool_content request.
 // See https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_content.
 func (t *Txpool) Content() (interface{}, error) {
-	pendingTxs, queuedTxs := t.d.store.GetTxs()
+	pendingTxs, queuedTxs := t.d.store.GetTxs(true)
 	pendingRpcTxns := make(map[types.Address]map[uint64]*txpoolTransaction)
 	for address, nonces := range pendingTxs {
 		pendingRpcTxns[address] = make(map[uint64]*txpoolTransaction)
@@ -88,7 +88,7 @@ func (t *Txpool) Content() (interface{}, error) {
 // See https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_inspect.
 func (t *Txpool) Inspect() (interface{}, error) {
 
-	pendingTxs, queuedTxs := t.d.store.GetTxs()
+	pendingTxs, queuedTxs := t.d.store.GetTxs(true)
 	pendingRpcTxns := make(map[string]map[string]string)
 	for address, nonces := range pendingTxs {
 		pendingRpcTxns[address.String()] = make(map[string]string)
@@ -118,7 +118,7 @@ func (t *Txpool) Inspect() (interface{}, error) {
 // Create response for txpool_status request.
 // See https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_status.
 func (t *Txpool) Status() (interface{}, error) {
-	pendingTxs, queuedTxs := t.d.store.GetTxs()
+	pendingTxs, queuedTxs := t.d.store.GetTxs(true)
 	var pendingCount int
 	for _, t := range pendingTxs {
 		pendingCount += len(t)

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -382,8 +382,6 @@ func (t *TxPool) DecreaseAccountNonce(tx *types.Transaction) {
 // GetTxs gets pending and queued transactions
 func (t *TxPool) GetTxs(inclQueued bool) (map[types.Address]map[uint64]*types.Transaction, map[types.Address]map[uint64]*types.Transaction) {
 	t.pendingQueue.lock.Lock()
-	defer t.pendingQueue.lock.Unlock()
-
 	pendingTxs := make(map[types.Address]map[uint64]*types.Transaction)
 	sortedPricedTxs := t.pendingQueue.index
 	for _, sortedPricedTx := range sortedPricedTxs {
@@ -392,6 +390,7 @@ func (t *TxPool) GetTxs(inclQueued bool) (map[types.Address]map[uint64]*types.Tr
 		}
 		pendingTxs[sortedPricedTx.from][sortedPricedTx.tx.Nonce] = sortedPricedTx.tx
 	}
+	t.pendingQueue.lock.Unlock()
 	if !inclQueued {
 		return pendingTxs, nil
 	}

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -231,7 +231,7 @@ func (t *TxPool) GetNonce(addr types.Address) (uint64, bool) {
 		}
 	}
 
-	return accountTxs[highestNonce].Nonce + 1, true
+	return highestNonce + 1, true
 }
 
 // NumAccountTxs Returns the number of transactions in the account specific queue

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -381,6 +381,8 @@ func (t *TxPool) DecreaseAccountNonce(tx *types.Transaction) {
 
 // GetTxs gets pending and queued transactions
 func (t *TxPool) GetTxs(inclQueued bool) (map[types.Address]map[uint64]*types.Transaction, map[types.Address]map[uint64]*types.Transaction) {
+	t.pendingQueue.lock.Lock()
+	defer t.pendingQueue.lock.Unlock()
 
 	pendingTxs := make(map[types.Address]map[uint64]*types.Transaction)
 	sortedPricedTxs := t.pendingQueue.index

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -205,7 +205,7 @@ func TestGetPendingAndQueuedTransactions(t *testing.T) {
 	}
 	assert.NoError(t, pool.addImpl("", txn3))
 
-	pendingTxs, queuedTxs := pool.GetTxs()
+	pendingTxs, queuedTxs := pool.GetTxs(true)
 
 	assert.Len(t, pendingTxs, 1)
 	assert.Len(t, queuedTxs, 3)


### PR DESCRIPTION
# Description

Ethers.js and Metamask use `this.getTransactionCount("pending")` to obtain the nonce to use for subsequent txs. When testing with the SDK, it appears that `eth_getTransactionCount` was giving us inconsistent values when querying across different nodes. 

It turns out the GetNonce() function appeared to be returning the nextNonce for the given address for the node's accountQueue instead of the global pendingQueue.

This PR correctly obtains the nextNonce based on the highest nonce of the address within the global pendingTxs queue, similar to how matic does it (see https://github.com/maticnetwork/bor/blob/0a9bd7befd47f78f6ddd9104c5508ecdda726452/internal/ethapi/api.go).

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs
