### PR TITLE
Add namespace capability to HashiCorp Vault Secrets Manager

### DIFF
--- a/command/secrets/secrets_generate.go
+++ b/command/secrets/secrets_generate.go
@@ -16,6 +16,7 @@ type SecretsGenerate struct {
 const (
 	defaultNodeName       = "polygon-sdk-node"
 	defaultConfigFileName = "./secretsManagerConfig.json"
+	defaultNamespace = "admin"
 )
 
 func (s *SecretsGenerate) DefineFlags() {
@@ -60,6 +61,15 @@ func (s *SecretsGenerate) DefineFlags() {
 		FlagOptional:      false,
 	}
 
+	s.FlagMap["namespace"] = helper.FlagDescriptor{
+		Description: "Specifics the namespace for the service",
+		Arguments: []string{
+			"NAMESPACE",
+		},
+		ArgumentsOptional: false,
+		FlagOptional: false,
+	}
+
 	s.FlagMap["name"] = helper.FlagDescriptor{
 		Description: fmt.Sprintf("Specifies the name of the node for on-service record keeping. Default: %s", defaultNodeName),
 		Arguments: []string{
@@ -99,12 +109,14 @@ func (s *SecretsGenerate) Run(args []string) int {
 	var serverURL string
 	var serviceType string
 	var name string
+	var namespace string
 
 	flags.StringVar(&path, "dir", defaultConfigFileName, "")
 	flags.StringVar(&token, "token", "", "")
 	flags.StringVar(&serverURL, "server-url", "", "")
 	flags.StringVar(&serviceType, "type", string(secrets.HashicorpVault), "")
 	flags.StringVar(&name, "name", defaultNodeName, "")
+	flags.StringVar(&namespace, "namespace", defaultNamespace, "")
 
 	if err := flags.Parse(args); err != nil {
 		s.UI.Error(err.Error())
@@ -143,6 +155,7 @@ func (s *SecretsGenerate) Run(args []string) int {
 		ServerURL: serverURL,
 		Type:      secrets.SecretsManagerType(serviceType),
 		Name:      name,
+		Namespace: namespace,
 		Extra:     nil,
 	}
 
@@ -159,6 +172,7 @@ func (s *SecretsGenerate) Run(args []string) int {
 		fmt.Sprintf("Server URL|%s", serverURL),
 		fmt.Sprintf("Access Token|%s", token),
 		fmt.Sprintf("Node Name|%s", name),
+		fmt.Sprintf("Namespace|%s", namespace),
 	})
 
 	output += "\n\nCONFIGURATION GENERATED"

--- a/secrets/config.go
+++ b/secrets/config.go
@@ -12,6 +12,7 @@ type SecretsManagerConfig struct {
 	ServerURL string                 `json:"server_url"` // The URL of the running server
 	Type      SecretsManagerType     `json:"type"`       // The type of SecretsManager
 	Name      string                 `json:"name"`       // The name of the current node
+	Namespace string                 `json:"namespace"`  // The namespace of the service
 	Extra     map[string]interface{} `json:"extra"`      // Any kind of arbitrary data
 }
 

--- a/secrets/hashicorpvault/hashicorp_vault.go
+++ b/secrets/hashicorpvault/hashicorp_vault.go
@@ -29,6 +29,9 @@ type VaultSecretsManager struct {
 
 	// The HTTP client used for interacting with the Vault server
 	client *vault.Client
+
+	// The namespace under which the secrets are stored 
+	namespace string
 }
 
 // SecretsManagerFactory implements the factory method
@@ -65,6 +68,9 @@ func SecretsManagerFactory(
 	// Grab the node name from the config
 	vaultManager.name = config.Name
 
+	// Grab the namespace from the config
+	vaultManager.namespace = config.Namespace
+
 	// Set the base path to store the secrets in the KV-2 Vault storage
 	vaultManager.basePath = fmt.Sprintf("secret/data/%s", vaultManager.name)
 
@@ -87,6 +93,9 @@ func (v *VaultSecretsManager) Setup() error {
 
 	// Set the access token
 	client.SetToken(v.token)
+
+	// Set the namespace 
+	client.SetNamespace(v.namespace)
 
 	v.client = client
 


### PR DESCRIPTION
# Add namespace capability to Vault Secrets Manager

In the hosted hashicorp and enterprise version, namespaces are used by default, and the default is "admin". This was not set in the current code causing a lot of head-scratching (access denied, etc). 

It looks like the namespaces are supported in the OS version as well, so this is not a breaking change. 

This PR adds support for the namespace field and sets it on the vault client. 

If this looks okay, I can update the docs as well. 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have tested this code
- [x] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

