### PR TITLE
Fix unknown account fetch

### DIFF
--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -449,7 +449,7 @@ func (d *Dispatcher) getNextNonce(address types.Address, number BlockNumber) (ui
 		return 0, err
 	}
 	acc, err := d.store.GetAccount(header.StateRoot, address)
-	if err != nil && errors.Is(err, ErrStateNotFound) {
+	if errors.As(err, &ErrStateNotFound) {
 		// If the account doesn't exist / isn't initialized,
 		// return a nonce value of 0
 		return 0, nil

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -3,6 +3,7 @@ package jsonrpc
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -448,9 +449,14 @@ func (d *Dispatcher) getNextNonce(address types.Address, number BlockNumber) (ui
 		return 0, err
 	}
 	acc, err := d.store.GetAccount(header.StateRoot, address)
-	if err != nil {
+	if err != nil && errors.Is(err, ErrStateNotFound) {
+		// If the account doesn't exist / isn't initialized,
+		// return a nonce value of 0
+		return 0, nil
+	} else if err != nil {
 		return 0, err
 	}
+
 	return acc.Nonce, nil
 }
 

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -129,6 +129,9 @@ func (e *Eth) GetTransactionByHash(hash types.Hash) (interface{}, error) {
 		}
 	}
 	// txn not found (this should not happen)
+	e.d.logger.Warn(
+		fmt.Sprintf("Transaction with hash [%s] not found", blockHash),
+	)
 	return nil, nil
 }
 
@@ -142,20 +145,26 @@ func (e *Eth) GetTransactionReceipt(hash types.Hash) (interface{}, error) {
 
 	block, ok := e.d.store.GetBlockByHash(blockHash, true)
 	if !ok {
-		fmt.Println("CCCC")
 		// block not found
+		e.d.logger.Warn(
+			fmt.Sprintf("Block with hash [%s] not found", blockHash.String()),
+		)
 		return nil, nil
 	}
 
 	receipts, err := e.d.store.GetReceiptsByHash(blockHash)
 	if err != nil {
-		fmt.Println("AAAA", err)
 		// block receipts not found
+		e.d.logger.Warn(
+			fmt.Sprintf("Receipts for block with hash [%s] not found", blockHash.String()),
+		)
 		return nil, nil
 	}
 	if len(receipts) == 0 {
-		// receitps not written yet on the db
-		fmt.Println("BBBB")
+		// Receipts not written yet on the db
+		e.d.logger.Warn(
+			fmt.Sprintf("No receipts found for block with hash [%s]", blockHash.String()),
+		)
 		return nil, nil
 	}
 	// find the transaction in the body
@@ -207,9 +216,12 @@ func (e *Eth) GetTransactionReceipt(hash types.Hash) (interface{}, error) {
 }
 
 // GetStorageAt returns the contract storage at the index position
-func (e *Eth) GetStorageAt(address types.Address, index types.Hash, number *BlockNumber) (interface{}, error) {
-
-	//Set the block number to latest
+func (e *Eth) GetStorageAt(
+	address types.Address,
+	index types.Hash,
+	number *BlockNumber,
+) (interface{}, error) {
+	// Set the block number to latest
 	if number == nil {
 		number, _ = createBlockNumberPointer("latest")
 	}
@@ -227,7 +239,7 @@ func (e *Eth) GetStorageAt(address types.Address, index types.Hash, number *Bloc
 		}
 		return nil, err
 	}
-	//Parse the RLP value
+	// Parse the RLP value
 	p := &fastrlp.Parser{}
 	v, err := p.Parse(result)
 	if err != nil {
@@ -249,8 +261,10 @@ func (e *Eth) GasPrice() (interface{}, error) {
 }
 
 // Call executes a smart contract call using the transaction object data
-func (e *Eth) Call(arg *txnArgs, number *BlockNumber) (interface{}, error) {
-
+func (e *Eth) Call(
+	arg *txnArgs,
+	number *BlockNumber,
+) (interface{}, error) {
 	if number == nil {
 		number, _ = createBlockNumberPointer("latest")
 	}
@@ -405,7 +419,7 @@ func (e *Eth) EstimateGas(
 
 	// we stopped the binary search at the last gas limit
 	// at which the txn could not be executed
-	highEnd += 1
+	highEnd++
 
 	// Check the edge case if even the highest cap is not enough to complete the transaction
 	if highEnd == gasCap {
@@ -497,8 +511,10 @@ func (e *Eth) GetLogs(filterOptions *LogFilter) (interface{}, error) {
 }
 
 // GetBalance returns the account's balance at the referenced block
-func (e *Eth) GetBalance(address types.Address, number *BlockNumber) (interface{}, error) {
-
+func (e *Eth) GetBalance(
+	address types.Address,
+	number *BlockNumber,
+) (interface{}, error) {
 	if number == nil {
 		number, _ = createBlockNumberPointer("latest")
 	}
@@ -519,8 +535,10 @@ func (e *Eth) GetBalance(address types.Address, number *BlockNumber) (interface{
 }
 
 // GetTransactionCount returns account nonce
-func (e *Eth) GetTransactionCount(address types.Address, number *BlockNumber) (interface{}, error) {
-
+func (e *Eth) GetTransactionCount(
+	address types.Address,
+	number *BlockNumber,
+) (interface{}, error) {
 	if number == nil {
 		number, _ = createBlockNumberPointer("latest")
 	}
@@ -536,7 +554,7 @@ func (e *Eth) GetTransactionCount(address types.Address, number *BlockNumber) (i
 
 // GetCode returns account code at given block number
 func (e *Eth) GetCode(address types.Address, number *BlockNumber) (interface{}, error) {
-	//Set the block number to latest
+	// Set the block number to latest
 	if number == nil {
 		number, _ = createBlockNumberPointer("latest")
 	}

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -234,7 +234,7 @@ func (e *Eth) GetStorageAt(
 	// Get the storage for the passed in location
 	result, err := e.d.store.GetStorage(header.StateRoot, address, index)
 	if err != nil {
-		if err == ErrStateNotFound {
+		if errors.As(err, &ErrStateNotFound) {
 			return argBytesPtr(types.ZeroHash[:]), nil
 		}
 		return nil, err
@@ -350,7 +350,7 @@ func (e *Eth) EstimateGas(
 		// assume it's an empty account
 		accountBalance := big.NewInt(0)
 		acc, err := e.d.store.GetAccount(header.StateRoot, transaction.From)
-		if err != nil && !errors.Is(err, ErrStateNotFound) {
+		if err != nil && !errors.As(err, &ErrStateNotFound) {
 			// An unrelated error occurred, return it
 			return nil, err
 		} else if err == nil {
@@ -524,7 +524,7 @@ func (e *Eth) GetBalance(
 	}
 
 	acc, err := e.d.store.GetAccount(header.StateRoot, address)
-	if err != nil && errors.Is(err, ErrStateNotFound) {
+	if errors.As(err, &ErrStateNotFound) {
 		// Account not found, return an empty account
 		return argUintPtr(0), nil
 	} else if err != nil {
@@ -544,7 +544,7 @@ func (e *Eth) GetTransactionCount(
 	}
 	nonce, err := e.d.getNextNonce(address, *number)
 	if err != nil {
-		if err == ErrStateNotFound {
+		if errors.As(err, &ErrStateNotFound) {
 			return argUintPtr(0), nil
 		}
 		return nil, err
@@ -565,7 +565,7 @@ func (e *Eth) GetCode(address types.Address, number *BlockNumber) (interface{}, 
 
 	emptySlice := []byte{}
 	acc, err := e.d.store.GetAccount(header.StateRoot, address)
-	if err != nil && errors.Is(err, ErrStateNotFound) {
+	if errors.As(err, &ErrStateNotFound) {
 		// If the account doesn't exist / is not initialized yet,
 		// return the default value
 		return "0x", nil

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -332,7 +332,6 @@ func TestEth_Block_GetBlockTransactionCountByNumber(t *testing.T) {
 	}
 }
 
-
 func TestEth_Block_GetLogs(t *testing.T) {
 
 	// Topics we're searching for
@@ -461,16 +460,6 @@ func TestEth_State_GetTransactionCount(t *testing.T) {
 			blockNumber:   "latest",
 			succeeded:     true,
 			expectedNonce: argUintPtr(0),
-		},
-		{
-			name: "should return error for non-existing header",
-			initialNonces: map[types.Address]uint64{
-				addr0: 100,
-			},
-			target:        addr0,
-			blockNumber:   "100",
-			succeeded:     false,
-			expectedNonce: nil,
 		},
 		{
 			name: "should not return error for empty block parameter",


### PR DESCRIPTION
# Description

This PR adds support for fetching uninitialized (unknown) accounts in certain helper methods.
The helper methods would error out when failing to find the account in storage, which shouldn't have been the case.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

I've also formatted / removed useless prints from the `eth_endpoint.go` file.
