### PR TITLE
Fix/bootnode reconnection

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -25,7 +25,7 @@ type Chain struct {
 	Name      string   `json:"name"`
 	Genesis   *Genesis `json:"genesis"`
 	Params    *Params  `json:"params"`
-	Bootnodes []string `json:"bootnodes"`
+	Bootnodes []string `json:"bootnodes,omitempty"`
 }
 
 // Genesis specifies the header fields, state of a genesis block

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -146,7 +146,7 @@ func (c *GenesisCommand) Run(args []string) int {
 	var baseDir string
 	var premine helperFlags.ArrayFlags
 	var chainID uint64
-	var bootnodes = helperFlags.BootnodeFlags{IsSet: false, Addrs: make([]string, 0)}
+	var bootnodes = helperFlags.BootnodeFlags{AreSet: false, Addrs: make([]string, 0)}
 	var name string
 	var consensus string
 
@@ -209,7 +209,7 @@ func (c *GenesisCommand) Run(args []string) int {
 		extraData = ibftExtra.MarshalRLPTo(extraData)
 	}
 
-	if bootnodes.IsSet && len(bootnodes.Addrs) < 2 {
+	if bootnodes.AreSet && len(bootnodes.Addrs) < 2 {
 		c.UI.Error("Minimum two bootnodes are required")
 		return 1
 	}

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -146,7 +146,7 @@ func (c *GenesisCommand) Run(args []string) int {
 	var baseDir string
 	var premine helperFlags.ArrayFlags
 	var chainID uint64
-	var bootnodes = make(helperFlags.BootnodeFlags, 0)
+	var bootnodes = helperFlags.BootnodeFlags{IsSet: false, Addrs: make([]string, 0)}
 	var name string
 	var consensus string
 
@@ -209,6 +209,11 @@ func (c *GenesisCommand) Run(args []string) int {
 		extraData = ibftExtra.MarshalRLPTo(extraData)
 	}
 
+	if bootnodes.IsSet && len(bootnodes.Addrs) < 2 {
+		c.UI.Error("Minimum two bootnodes are required")
+		return 1
+	}
+
 	cc := &chain.Chain{
 		Name: name,
 		Genesis: &chain.Genesis{
@@ -225,7 +230,7 @@ func (c *GenesisCommand) Run(args []string) int {
 				consensus: map[string]interface{}{},
 			},
 		},
-		Bootnodes: bootnodes,
+		Bootnodes: bootnodes.Addrs,
 	}
 
 	if err = helper.FillPremineMap(cc.Genesis.Alloc, premine); err != nil {

--- a/helper/flags/flags.go
+++ b/helper/flags/flags.go
@@ -24,17 +24,21 @@ func (i *ArrayFlags) Set(value string) error {
 	return nil
 }
 
-type BootnodeFlags []string
+type BootnodeFlags struct {
+	IsSet bool
+	Addrs []string
+}
 
 func (i *BootnodeFlags) String() string {
-	return formatArrayForOutput(*i)
+	return formatArrayForOutput(i.Addrs)
 }
 
 func (i *BootnodeFlags) Set(value string) error {
+	i.IsSet = true
 	if _, err := multiaddr.NewMultiaddr(value); err != nil {
 		return err
 	}
-	*i = append(*i, value)
+	i.Addrs = append(i.Addrs, value)
 	return nil
 }
 

--- a/helper/flags/flags.go
+++ b/helper/flags/flags.go
@@ -25,8 +25,8 @@ func (i *ArrayFlags) Set(value string) error {
 }
 
 type BootnodeFlags struct {
-	IsSet bool
-	Addrs []string
+	AreSet bool
+	Addrs  []string
 }
 
 func (i *BootnodeFlags) String() string {
@@ -34,7 +34,7 @@ func (i *BootnodeFlags) String() string {
 }
 
 func (i *BootnodeFlags) Set(value string) error {
-	i.IsSet = true
+	i.AreSet = true
 	if _, err := multiaddr.NewMultiaddr(value); err != nil {
 		return err
 	}

--- a/network/server.go
+++ b/network/server.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -181,6 +182,11 @@ func NewServer(logger hclog.Logger, config *Config) (*Server, error) {
 	logger.Info("LibP2P server running", "addr", AddrInfoToString(srv.AddrInfo()))
 
 	if !config.NoDiscover {
+
+		if config.Chain.Bootnodes != nil && len(config.Chain.Bootnodes) < 2 {
+			return nil, errors.New("Minimum two bootnodes are required")
+		}
+
 		// start discovery
 		srv.discovery = &discovery{srv: srv}
 		srv.discovery.setup()

--- a/network/server.go
+++ b/network/server.go
@@ -30,6 +30,9 @@ const DefaultLibp2pPort int = 1478
 
 const MinimumPeerConnections int64 = 1
 
+// MinimumBootNodes Count is set to 2 so that, a bootnode can reconnect to the network using other bootnode after restarting.
+const MinimumBootNodes int = 2
+
 type Config struct {
 	NoDiscover     bool
 	Addr           *net.TCPAddr
@@ -183,7 +186,7 @@ func NewServer(logger hclog.Logger, config *Config) (*Server, error) {
 
 	if !config.NoDiscover {
 
-		if config.Chain.Bootnodes != nil && len(config.Chain.Bootnodes) < 2 {
+		if config.Chain.Bootnodes != nil && len(config.Chain.Bootnodes) < MinimumBootNodes {
 			return nil, errors.New("Minimum two bootnodes are required")
 		}
 

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -394,13 +394,13 @@ func TestPeerReconnection(t *testing.T) {
 	disconnectedCh1 := asyncWaitForEvent(srv1, 15*time.Second, disconnectedPeerHandler(bootNode.AddrInfo().ID))
 	srv1.Disconnect(bootNode.AddrInfo().ID, "Bye")
 
-	assert.True(t, <-disconnectedCh1, "Failed to recieve peer disconnected event")
+	assert.True(t, <-disconnectedCh1, "Failed to receive peer disconnected event")
 
 	//disconnect from the second boot node
 	disconnectedCh2 := asyncWaitForEvent(srv1, 15*time.Second, disconnectedPeerHandler(bootNode2.AddrInfo().ID))
 	srv1.Disconnect(bootNode2.AddrInfo().ID, "Bye")
 
-	assert.True(t, <-disconnectedCh2, "Failed to recieve peer disconnected event")
+	assert.True(t, <-disconnectedCh2, "Failed to receive peer disconnected event")
 
 	//disconnect from the third second node
 	disconnectedCh3 := asyncWaitForEvent(srv1, 15*time.Second, disconnectedPeerHandler(srv2.AddrInfo().ID))
@@ -502,24 +502,24 @@ func TestSelfConnection_WithBootNodes(t *testing.T) {
 
 func TestMinimumBootNodeCount(t *testing.T) {
 	tests := []struct {
-		name      string
-		bootNodes []string
-		isError   bool
+		name       string
+		bootNodes  []string
+		shouldFail bool
 	}{
 		{
-			name:      "Server config with empty bootnodes",
-			bootNodes: []string{},
-			isError:   true,
+			name:       "Server config with empty bootnodes",
+			bootNodes:  []string{},
+			shouldFail: true,
 		},
 		{
-			name:      "Server config with less than two bootnodes",
-			bootNodes: []string{"/ip4/127.0.0.1/tcp/10001/p2p/16Uiu2HAmJxxH1tScDX2rLGSU9exnuvZKNM9SoK3v315azp68DLPW"},
-			isError:   true,
+			name:       "Server config with less than two bootnodes",
+			bootNodes:  []string{"/ip4/127.0.0.1/tcp/10001/p2p/16Uiu2HAmJxxH1tScDX2rLGSU9exnuvZKNM9SoK3v315azp68DLPW"},
+			shouldFail: true,
 		},
 		{
-			name:      "Server config with more than two bootnodes",
-			bootNodes: []string{"/ip4/127.0.0.1/tcp/10001/p2p/16Uiu2HAmJxxH1tScDX2rLGSU9exnuvZKNM9SoK3v315azp68DLPW", "/ip4/127.0.0.1/tcp/10001/p2p/16Uiu2HAmKGVgzogc2dWU1tpzNnYyJPLN81nzkpAsMCvh3hpt3sC2"},
-			isError:   false,
+			name:       "Server config with more than two bootnodes",
+			bootNodes:  []string{"/ip4/127.0.0.1/tcp/10001/p2p/16Uiu2HAmJxxH1tScDX2rLGSU9exnuvZKNM9SoK3v315azp68DLPW", "/ip4/127.0.0.1/tcp/10001/p2p/16Uiu2HAmKGVgzogc2dWU1tpzNnYyJPLN81nzkpAsMCvh3hpt3sC2"},
+			shouldFail: false,
 		},
 	}
 	for _, tt := range tests {
@@ -530,7 +530,7 @@ func TestMinimumBootNodeCount(t *testing.T) {
 			})
 
 			_, err := NewServer(hclog.NewNullLogger(), cfg)
-			if tt.isError {
+			if tt.shouldFail {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -3,61 +3,17 @@ package network
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/0xPolygon/polygon-sdk/helper/common"
 	"github.com/0xPolygon/polygon-sdk/helper/tests"
-	"github.com/0xPolygon/polygon-sdk/secrets"
-	"github.com/0xPolygon/polygon-sdk/secrets/local"
 	"github.com/hashicorp/go-hclog"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/assert"
 )
-
-func GenerateTestLibp2pKey(t *testing.T) (crypto.PrivKey, string) {
-	t.Helper()
-
-	dir, err := ioutil.TempDir(os.TempDir(), "")
-	assert.NoError(t, err)
-
-	// Instantiate the correct folder structure
-	setupErr := common.SetupDataDir(dir, []string{"libp2p"})
-	if setupErr != nil {
-		t.Fatalf("unable to generate libp2p folder structure, %v", setupErr)
-	}
-
-	localSecretsManager, factoryErr := local.SecretsManagerFactory(
-		nil,
-		&secrets.SecretsManagerParams{
-			Logger: hclog.NewNullLogger(),
-			Extra: map[string]interface{}{
-				secrets.Path: dir,
-			},
-		})
-	assert.NoError(t, factoryErr)
-
-	libp2pKey, libp2pKeyEncoded, keyErr := GenerateAndEncodeLibp2pKey()
-	if keyErr != nil {
-		t.Fatalf("unable to generate libp2p key, %v", keyErr)
-	}
-
-	if setErr := localSecretsManager.SetSecret(secrets.NetworkKey, libp2pKeyEncoded); setErr != nil {
-		t.Fatalf("unable to save libp2p key, %v", setErr)
-	}
-
-	t.Cleanup(func() {
-		// remove directory after test is done
-		assert.NoError(t, os.RemoveAll(dir))
-	})
-
-	return libp2pKey, dir
-}
 
 func TestConnLimit_Inbound(t *testing.T) {
 	// we should not receive more inbound connections if we are already connected to max peers
@@ -470,7 +426,8 @@ func TestSelfConnection_WithBootNodes(t *testing.T) {
 	key, directoryName := GenerateTestLibp2pKey(t)
 	peerId, err := peer.IDFromPrivateKey(key)
 	assert.NoError(t, err)
-	peerAddressInfo, err := StringToAddrInfo("/ip4/127.0.0.1/tcp/10001/p2p/16Uiu2HAmJxxH1tScDX2rLGSU9exnuvZKNM9SoK3v315azp68DLPW")
+	testMultiAddr := GenerateTestMultiAddr(t).String()
+	peerAddressInfo, err := StringToAddrInfo(testMultiAddr)
 	assert.NoError(t, err)
 
 	tests := []struct {
@@ -481,7 +438,7 @@ func TestSelfConnection_WithBootNodes(t *testing.T) {
 
 		{
 			name:         "Should return an non empty bootnodes list",
-			bootNodes:    []string{"/ip4/127.0.0.1/tcp/10001/p2p/" + peerId.Pretty(), "/ip4/127.0.0.1/tcp/10001/p2p/16Uiu2HAmJxxH1tScDX2rLGSU9exnuvZKNM9SoK3v315azp68DLPW"},
+			bootNodes:    []string{"/ip4/127.0.0.1/tcp/10001/p2p/" + peerId.Pretty(), testMultiAddr},
 			expectedList: []*peer.AddrInfo{peerAddressInfo},
 		},
 	}
@@ -513,12 +470,12 @@ func TestMinimumBootNodeCount(t *testing.T) {
 		},
 		{
 			name:       "Server config with less than two bootnodes",
-			bootNodes:  []string{"/ip4/127.0.0.1/tcp/10001/p2p/16Uiu2HAmJxxH1tScDX2rLGSU9exnuvZKNM9SoK3v315azp68DLPW"},
+			bootNodes:  []string{GenerateTestMultiAddr(t).String()},
 			shouldFail: true,
 		},
 		{
 			name:       "Server config with more than two bootnodes",
-			bootNodes:  []string{"/ip4/127.0.0.1/tcp/10001/p2p/16Uiu2HAmJxxH1tScDX2rLGSU9exnuvZKNM9SoK3v315azp68DLPW", "/ip4/127.0.0.1/tcp/10001/p2p/16Uiu2HAmKGVgzogc2dWU1tpzNnYyJPLN81nzkpAsMCvh3hpt3sC2"},
+			bootNodes:  []string{GenerateTestMultiAddr(t).String(), GenerateTestMultiAddr(t).String()},
 			shouldFail: false,
 		},
 	}

--- a/network/testing.go
+++ b/network/testing.go
@@ -1,14 +1,22 @@
 package network
 
 import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/0xPolygon/polygon-sdk/chain"
+	"github.com/0xPolygon/polygon-sdk/helper/common"
 	"github.com/0xPolygon/polygon-sdk/secrets"
 	"github.com/0xPolygon/polygon-sdk/secrets/local"
 	"github.com/hashicorp/go-hclog"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -108,4 +116,55 @@ func getTestConfig(callback func(c *Config)) *Config {
 	cfg.SecretsManager = secretsManager
 
 	return cfg
+}
+func GenerateTestMultiAddr(t *testing.T) multiaddr.Multiaddr {
+	libp2pKey, _, keyErr := GenerateAndEncodeLibp2pKey()
+	if keyErr != nil {
+		t.Fatalf("unable to generate libp2p key, %v", keyErr)
+	}
+	nodeId, err := peer.IDFromPrivateKey(libp2pKey)
+	assert.NoError(t, err)
+	rand.Seed(time.Now().Unix())
+	randomPort := rand.Intn(10) + 10010
+	addr, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d/p2p/%s", randomPort, nodeId))
+	assert.NoError(t, err)
+	return addr
+}
+func GenerateTestLibp2pKey(t *testing.T) (crypto.PrivKey, string) {
+	t.Helper()
+
+	dir, err := ioutil.TempDir(os.TempDir(), "")
+	assert.NoError(t, err)
+
+	// Instantiate the correct folder structure
+	setupErr := common.SetupDataDir(dir, []string{"libp2p"})
+	if setupErr != nil {
+		t.Fatalf("unable to generate libp2p folder structure, %v", setupErr)
+	}
+
+	localSecretsManager, factoryErr := local.SecretsManagerFactory(
+		nil,
+		&secrets.SecretsManagerParams{
+			Logger: hclog.NewNullLogger(),
+			Extra: map[string]interface{}{
+				secrets.Path: dir,
+			},
+		})
+	assert.NoError(t, factoryErr)
+
+	libp2pKey, libp2pKeyEncoded, keyErr := GenerateAndEncodeLibp2pKey()
+	if keyErr != nil {
+		t.Fatalf("unable to generate libp2p key, %v", keyErr)
+	}
+
+	if setErr := localSecretsManager.SetSecret(secrets.NetworkKey, libp2pKeyEncoded); setErr != nil {
+		t.Fatalf("unable to save libp2p key, %v", setErr)
+	}
+
+	t.Cleanup(func() {
+		// remove directory after test is done
+		assert.NoError(t, os.RemoveAll(dir))
+	})
+
+	return libp2pKey, dir
 }

--- a/network/testing.go
+++ b/network/testing.go
@@ -79,3 +79,33 @@ func MultiJoin(t *testing.T, srvs ...*Server) {
 		}
 	}
 }
+
+func getTestConfig(callback func(c *Config)) *Config {
+	cfg := DefaultConfig()
+	cfg.Addr.Port = int(atomic.AddUint64(&initialPort, 1))
+	cfg.Chain = &chain.Chain{
+		Params: &chain.Params{
+			ChainID: 1,
+		},
+	}
+
+	logger := hclog.NewNullLogger()
+
+	if callback != nil {
+		callback(cfg)
+	}
+
+	secretsManager, _ := local.SecretsManagerFactory(
+		nil,
+		&secrets.SecretsManagerParams{
+			Logger: logger,
+			Extra: map[string]interface{}{
+				secrets.Path: cfg.DataDir,
+			},
+		},
+	)
+
+	cfg.SecretsManager = secretsManager
+
+	return cfg
+}


### PR DESCRIPTION
# Description

This PR enforces PSDK users to specify at-least 2 bootnodes during the genesis configuration.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking Change

As part of this PR, we have added a new constraint to specify at-least two bootnodes while setting up the genesis condition and while starting the server. Due to this change PSDK network can't be started with a single bootnode.

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

