### PR TITLE
[TxPool] Return capacity in InspectResponse

### DIFF
--- a/jsonrpc/blockchain.go
+++ b/jsonrpc/blockchain.go
@@ -58,6 +58,9 @@ type blockchainInterface interface {
 	// GetNonce returns the next nonce for this address
 	GetNonce(addr types.Address) (uint64, bool)
 
+	// GetCapacity returs the current and max capacity of the pool
+	GetCapacity() (uint64, uint64)
+
 	stateHelperInterface
 }
 
@@ -130,4 +133,8 @@ func (b *nullBlockchainInterface) GetStorage(root types.Hash, addr types.Address
 
 func (b *nullBlockchainInterface) GetAccount(root types.Hash, addr types.Address) (*state.Account, error) {
 	return nil, nil
+}
+
+func (m *nullBlockchainInterface) GetCapacity() (uint64, uint64) {
+	panic("implement me")
 }

--- a/jsonrpc/blockchain.go
+++ b/jsonrpc/blockchain.go
@@ -58,7 +58,7 @@ type blockchainInterface interface {
 	// GetNonce returns the next nonce for this address
 	GetNonce(addr types.Address) (uint64, bool)
 
-	// GetCapacity returs the current and max capacity of the pool
+	// GetCapacity returns the current and max capacity of the pool
 	GetCapacity() (uint64, uint64)
 
 	stateHelperInterface

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -52,6 +52,10 @@ func (m *mockAccountStore) GetForksInTime(blockNumber uint64) chain.ForksInTime 
 	panic("implement me")
 }
 
+func (m *mockAccountStore) GetCapacity() (uint64, uint64) {
+	panic("implement me")
+}
+
 func (m *mockAccountStore) AddAccount(addr types.Address) *mockAccount2 {
 	if m.accounts == nil {
 		m.accounts = map[types.Address]*mockAccount2{}
@@ -106,6 +110,10 @@ type mockBlockStore2 struct {
 }
 
 func (m *mockBlockStore2) GetForksInTime(blockNumber uint64) chain.ForksInTime {
+	panic("implement me")
+}
+
+func (m *mockBlockStore2) GetCapacity() (uint64, uint64) {
 	panic("implement me")
 }
 

--- a/jsonrpc/filter_manager_test.go
+++ b/jsonrpc/filter_manager_test.go
@@ -247,6 +247,10 @@ func (m *mockStore) SetAccount(addr types.Address, account *state.Account) {
 	m.accounts[addr] = account
 }
 
+func (m *mockStore) GetCapacity() (uint64, uint64) {
+	return 0, 0
+}
+
 func newMockStore() *mockStore {
 	return &mockStore{
 		header:       &types.Header{Number: 0},

--- a/jsonrpc/txpool_endpoint.go
+++ b/jsonrpc/txpool_endpoint.go
@@ -18,8 +18,10 @@ type ContentResponse struct {
 }
 
 type InspectResponse struct {
-	Pending map[string]map[string]string `json:"pending"`
-	Queued  map[string]map[string]string `json:"queued"`
+	Pending         map[string]map[string]string `json:"pending"`
+	Queued          map[string]map[string]string `json:"queued"`
+	CurrentCapacity uint64                       `json:"currentCapacity"`
+	MaxCapacity     uint64                       `json:"maxCapacity"`
 }
 
 type StatusResponse struct {
@@ -107,9 +109,14 @@ func (t *Txpool) Inspect() (interface{}, error) {
 		}
 	}
 
+	// get capacity of the TxPool
+	current, max := t.d.store.GetCapacity()
+
 	resp := InspectResponse{
-		Pending: pendingRpcTxns,
-		Queued:  queuedRpcTxns,
+		Pending:         pendingRpcTxns,
+		Queued:          queuedRpcTxns,
+		CurrentCapacity: current,
+		MaxCapacity:     max,
 	}
 
 	return resp, nil

--- a/jsonrpc/txpool_endpoint_test.go
+++ b/jsonrpc/txpool_endpoint_test.go
@@ -37,6 +37,8 @@ func TestInspectEndpoint(t *testing.T) {
 	assert.NoError(t, expectJSONResult(resp, &res))
 	assert.Len(t, res.Pending, 0)
 	assert.Len(t, res.Queued, 0)
+	assert.Equal(t, res.CurrentCapacity, uint64(0))
+	assert.Equal(t, res.MaxCapacity, uint64(0))
 }
 
 func TestStatusEndpoint(t *testing.T) {

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -265,6 +265,11 @@ func (t *TxPool) GetNonce(addr types.Address) (uint64, bool) {
 	return highestNonce + 1, true
 }
 
+// GetCapacity returns the current state of the gauge
+func (t *TxPool) GetCapacity() (uint64, uint64) {
+	return t.gauge.getHeight(), t.gauge.limit
+}
+
 // NumAccountTxs Returns the number of transactions in the account specific queue
 func (t *TxPool) NumAccountTxs(address types.Address) int {
 	mux := t.lockAccountQueue(address, false)

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -265,7 +265,7 @@ func (t *TxPool) GetNonce(addr types.Address) (uint64, bool) {
 	return highestNonce + 1, true
 }
 
-// GetCapacity returns the current state of the gauge
+// GetCapacity returns the current number of slots occupied and the max slot limit
 func (t *TxPool) GetCapacity() (uint64, uint64) {
 	return t.gauge.getHeight(), t.gauge.limit
 }


### PR DESCRIPTION
# Description

Return the status of pool capacity when inspecting the TxPool with `txpool_inspect`.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs