### PR TITLE
Removing leading 0 in marshaled transaction object V, R, S fields

### DIFF
--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -21,9 +21,9 @@ type transaction struct {
 	To          *types.Address `json:"to"`
 	Value       argBig         `json:"value"`
 	Input       argBytes       `json:"input"`
-	V           argBytes       `json:"v"`
-	R           argBytes       `json:"r"`
-	S           argBytes       `json:"s"`
+	V           argBig         `json:"v"`
+	R           argBig         `json:"r"`
+	S           argBig         `json:"s"`
 	Hash        types.Hash     `json:"hash"`
 	From        types.Address  `json:"from"`
 	BlockHash   types.Hash     `json:"blockHash"`
@@ -43,16 +43,20 @@ func (h transactionHash) MarshalText() ([]byte, error) {
 }
 
 func toTransaction(t *types.Transaction, b *types.Block, txIndex int) *transaction {
+	v := new(big.Int).SetBytes(t.V)
+	r := new(big.Int).SetBytes(t.R)
+	s := new(big.Int).SetBytes(t.S)
+
 	return &transaction{
 		Nonce:       argUint64(t.Nonce),
 		GasPrice:    argBig(*t.GasPrice),
 		Gas:         argUint64(t.Gas),
 		To:          t.To,
 		Value:       argBig(*t.Value),
-		Input:       argBytes(t.Input),
-		V:           argBytes(t.V),
-		R:           argBytes(t.R),
-		S:           argBytes(t.S),
+		Input:       t.Input,
+		V:           argBig(*v),
+		R:           argBig(*r),
+		S:           argBig(*s),
 		Hash:        t.Hash,
 		From:        t.From,
 		BlockHash:   b.Hash(),

--- a/jsonrpc/types_test.go
+++ b/jsonrpc/types_test.go
@@ -3,6 +3,7 @@ package jsonrpc
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/0xPolygon/polygon-sdk/helper/hex"
 	"math/big"
 	"reflect"
 	"strings"
@@ -91,4 +92,38 @@ func TestDecode_TxnArgs(t *testing.T) {
 			t.Fatal("bad")
 		}
 	}
+}
+
+func TestToTransaction_Returns_V_R_S_ValuesWithoutLeading0(t *testing.T) {
+	hexWithLeading0 := "0x0ba93811466694b3b3cb8853cb8227b7c9f49db10bf6e7db59d20ac904961565"
+	hexWithoutLeading0 := "0xba93811466694b3b3cb8853cb8227b7c9f49db10bf6e7db59d20ac904961565"
+	v, _ := hex.DecodeHex(hexWithLeading0)
+	r, _ := hex.DecodeHex(hexWithLeading0)
+	s, _ := hex.DecodeHex(hexWithLeading0)
+	txn := types.Transaction{
+		Nonce:    0,
+		GasPrice: big.NewInt(0),
+		Gas:      0,
+		To:       nil,
+		Value:    big.NewInt(0),
+		Input:    nil,
+		V:        v,
+		R:        r,
+		S:        s,
+		Hash:     types.Hash{},
+		From:     types.Address{},
+	}
+	block := types.Block{
+		Transactions: []*types.Transaction{&txn},
+		Header:       &types.Header{},
+	}
+
+	jsonTx := toTransaction(&txn, &block, 0)
+
+	jsonV, _ := jsonTx.V.MarshalText()
+	jsonR, _ := jsonTx.V.MarshalText()
+	jsonS, _ := jsonTx.V.MarshalText()
+	assert.Equal(t, hexWithoutLeading0, string(jsonV))
+	assert.Equal(t, hexWithoutLeading0, string(jsonR))
+	assert.Equal(t, hexWithoutLeading0, string(jsonS))
 }


### PR DESCRIPTION
# Description

This PR solves issue with unmarshaling Block.transactions in situation where V, R, S fields of the transaction object were heaving leading 0, for example 0x0ba93811466694b3b3cb8853cb8227b7c9f49db10bf6e7db59d20ac904961565

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs
