### PR TITLE
Change signature r,s,v values to bigInt

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -548,7 +548,7 @@ func TestBlockchainWriteBody(t *testing.T) {
 		Transactions: []*types.Transaction{
 			{
 				Value: big.NewInt(10),
-				V:     *big.NewInt(1),
+				V:     big.NewInt(1),
 			},
 		},
 	}

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -548,7 +548,7 @@ func TestBlockchainWriteBody(t *testing.T) {
 		Transactions: []*types.Transaction{
 			{
 				Value: big.NewInt(10),
-				V:     []byte{1},
+				V:     *big.NewInt(1),
 			},
 		},
 	}

--- a/blockchain/storage/testing.go
+++ b/blockchain/storage/testing.go
@@ -251,7 +251,7 @@ func testBody(t *testing.T, m MockStorage) {
 		Gas:      11,
 		GasPrice: big.NewInt(11),
 		Input:    []byte{1, 2},
-		V:        *big.NewInt(1),
+		V:        big.NewInt(1),
 	}
 	t0.ComputeHash()
 
@@ -263,7 +263,7 @@ func testBody(t *testing.T, m MockStorage) {
 		Gas:      22,
 		GasPrice: big.NewInt(11),
 		Input:    []byte{4, 5},
-		V:        *big.NewInt(2),
+		V:        big.NewInt(2),
 	}
 	t1.ComputeHash()
 
@@ -309,7 +309,7 @@ func testReceipts(t *testing.T, m MockStorage) {
 		Nonce:    1000,
 		Gas:      50,
 		GasPrice: new(big.Int).SetUint64(100),
-		V:        *big.NewInt(11),
+		V:        big.NewInt(11),
 	}
 	body := &types.Body{
 		Transactions: []*types.Transaction{txn},

--- a/blockchain/storage/testing.go
+++ b/blockchain/storage/testing.go
@@ -251,7 +251,7 @@ func testBody(t *testing.T, m MockStorage) {
 		Gas:      11,
 		GasPrice: big.NewInt(11),
 		Input:    []byte{1, 2},
-		V:        []byte{1},
+		V:        *big.NewInt(1),
 	}
 	t0.ComputeHash()
 
@@ -263,7 +263,7 @@ func testBody(t *testing.T, m MockStorage) {
 		Gas:      22,
 		GasPrice: big.NewInt(11),
 		Input:    []byte{4, 5},
-		V:        []byte{2},
+		V:        *big.NewInt(2),
 	}
 	t1.ComputeHash()
 
@@ -309,7 +309,7 @@ func testReceipts(t *testing.T, m MockStorage) {
 		Nonce:    1000,
 		Gas:      50,
 		GasPrice: new(big.Int).SetUint64(100),
-		V:        []byte{11},
+		V:        *big.NewInt(11),
 	}
 	body := &types.Body{
 		Transactions: []*types.Transaction{txn},

--- a/blockchain/testing.go
+++ b/blockchain/testing.go
@@ -111,7 +111,7 @@ func NewTestBodyChain(n int) ([]*types.Header, []*types.Block, [][]*types.Receip
 			Gas:      0,
 			GasPrice: big.NewInt(0),
 			Input:    header.Hash.Bytes(),
-			V:        *big.NewInt(27),
+			V:        big.NewInt(27),
 		}
 		t0.ComputeHash()
 

--- a/blockchain/testing.go
+++ b/blockchain/testing.go
@@ -111,7 +111,7 @@ func NewTestBodyChain(n int) ([]*types.Header, []*types.Block, [][]*types.Receip
 			Gas:      0,
 			GasPrice: big.NewInt(0),
 			Input:    header.Hash.Bytes(),
-			V:        []byte{0x27},
+			V:        *big.NewInt(27),
 		}
 		t0.ComputeHash()
 

--- a/command/loadbot/execution.go
+++ b/command/loadbot/execution.go
@@ -87,7 +87,7 @@ func (c *Configuration) createTransactionObjects() ([]*types.Transaction, error)
 			Value:    c.Value,
 			GasPrice: c.GasPrice,
 			Nonce:    nonce,
-			V:        *big.NewInt(1), // it is necessary to encode in rlp
+			V:        big.NewInt(1), // it is necessary to encode in rlp
 		}, privateKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to sign transaction: %v", err)

--- a/command/loadbot/execution.go
+++ b/command/loadbot/execution.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
+	"math/big"
+	"os"
+	"sync"
+	"time"
+
 	"github.com/0xPolygon/polygon-sdk/crypto"
 	"github.com/0xPolygon/polygon-sdk/helper/tests"
 	txpoolOp "github.com/0xPolygon/polygon-sdk/txpool/proto"
@@ -11,10 +16,6 @@ import (
 	"github.com/umbracle/go-web3"
 	"github.com/umbracle/go-web3/jsonrpc"
 	"google.golang.org/grpc"
-	"math/big"
-	"os"
-	"sync"
-	"time"
 )
 
 // Configuration represents the loadbot run configuration
@@ -86,7 +87,7 @@ func (c *Configuration) createTransactionObjects() ([]*types.Transaction, error)
 			Value:    c.Value,
 			GasPrice: c.GasPrice,
 			Nonce:    nonce,
-			V:        []byte{1}, // it is necessary to encode in rlp
+			V:        *big.NewInt(1), // it is necessary to encode in rlp
 		}, privateKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to sign transaction: %v", err)

--- a/command/txpool/txpool_add.go
+++ b/command/txpool/txpool_add.go
@@ -3,6 +3,7 @@ package txpool
 import (
 	"context"
 	"fmt"
+	"math/big"
 
 	"github.com/0xPolygon/polygon-sdk/command/helper"
 	"github.com/0xPolygon/polygon-sdk/txpool/proto"
@@ -159,7 +160,7 @@ func (p *TxPoolAdd) Run(args []string) int {
 		Value:    value,
 		GasPrice: gasPrice,
 		Nonce:    nonce,
-		V:        []byte{1}, // it is necessary to encode in rlp
+		V:        *big.NewInt(1), // it is necessary to encode in rlp
 	}
 
 	msg := &proto.AddTxnReq{

--- a/command/txpool/txpool_add.go
+++ b/command/txpool/txpool_add.go
@@ -160,7 +160,7 @@ func (p *TxPoolAdd) Run(args []string) int {
 		Value:    value,
 		GasPrice: gasPrice,
 		Nonce:    nonce,
-		V:        *big.NewInt(1), // it is necessary to encode in rlp
+		V:        big.NewInt(1), // it is necessary to encode in rlp
 	}
 
 	msg := &proto.AddTxnReq{

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -42,19 +42,26 @@ func trimLeftZeros(b []byte) []byte {
 }
 
 // ValidateSignatureValues checks if the signature values are correct
-func ValidateSignatureValues(v byte, r, s []byte) bool {
+func ValidateSignatureValues(v byte, r, s *big.Int) bool {
 	// TODO: ECDSA malleability
+
+	if r == nil || s == nil {
+		return false
+	}
+
 	if v > 1 {
 		return false
 	}
 
-	r = trimLeftZeros(r)
-	if bytes.Compare(r, secp256k1N) >= 0 || bytes.Compare(r, one) < 0 {
+	rr := r.Bytes()
+	rr = trimLeftZeros(rr)
+	if bytes.Compare(rr, secp256k1N) >= 0 || bytes.Compare(rr, one) < 0 {
 		return false
 	}
 
-	s = trimLeftZeros(s)
-	if bytes.Compare(s, secp256k1N) >= 0 || bytes.Compare(s, one) < 0 {
+	ss := s.Bytes()
+	ss = trimLeftZeros(ss)
+	if bytes.Compare(ss, secp256k1N) >= 0 || bytes.Compare(ss, one) < 0 {
 		return false
 	}
 	return true

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -112,19 +112,18 @@ func TestCreate2(t *testing.T) {
 }
 
 func TestValidateSignatureValues(t *testing.T) {
-	one := big.NewInt(1).Bytes()
-	zero := big.NewInt(0).Bytes()
-
+	one := big.NewInt(1)
+	zero := big.NewInt(0)
 	secp256k1N, _ := new(big.Int).SetString("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141", 16)
 
-	limit := secp256k1N.Bytes()
-	limitMinus1 := new(big.Int).Sub(secp256k1N, big1).Bytes()
+	limit := secp256k1N
+	limitMinus1 := new(big.Int).Sub(secp256k1N, big1)
 
 	cases := []struct {
 		homestead bool
 		v         byte
-		r         []byte
-		s         []byte
+		r         *big.Int
+		s         *big.Int
 		res       bool
 	}{
 		// correct v, r, s
@@ -157,12 +156,6 @@ func TestValidateSignatureValues(t *testing.T) {
 		found := ValidateSignatureValues(c.v, c.r, c.s)
 		assert.Equal(t, found, c.res)
 	}
-}
-
-func TestVV(t *testing.T) {
-
-	ValidateSignatureValues(0, []byte{0x0, 0x1, 0x2, 0x3}, []byte{0x1, 0x2, 0x3})
-
 }
 
 func getAddressFromKey(key crypto.PrivateKey, t *testing.T) types.Address {

--- a/crypto/txsigner.go
+++ b/crypto/txsigner.go
@@ -86,7 +86,8 @@ var (
 
 // Sender decodes the signature and returns the sender of the transaction
 func (f *FrontierSigner) Sender(tx *types.Transaction) (types.Address, error) {
-	refV := big.NewInt(0).SetBytes(tx.V)
+	refV := big.NewInt(0).SetBytes(tx.V.Bytes())
+
 	refV.Sub(refV, big27)
 
 	sig, err := encodeSignature(tx.R, tx.S, byte(refV.Int64()))
@@ -118,9 +119,9 @@ func (f *FrontierSigner) SignTx(
 		return nil, err
 	}
 
-	tx.R = sig[:32]
-	tx.S = sig[32:64]
-	tx.V = f.CalculateV(sig[64])
+	tx.R = *new(big.Int).SetBytes(sig[:32])
+	tx.S = *new(big.Int).SetBytes(sig[32:64])
+	tx.V = *new(big.Int).SetBytes(f.CalculateV(sig[64]))
 
 	return tx, nil
 }
@@ -152,7 +153,7 @@ func (e *EIP155Signer) Sender(tx *types.Transaction) (types.Address, error) {
 	protected := true
 
 	// Check if v value conforms to an earlier standard (before EIP155)
-	bigV := big.NewInt(0).SetBytes(tx.V)
+	bigV := big.NewInt(0).SetBytes(tx.V.Bytes())
 	if vv := bigV.Uint64(); bits.Len(uint(vv)) <= 8 {
 		protected = vv != 27 && vv != 28
 	}
@@ -196,9 +197,9 @@ func (e *EIP155Signer) SignTx(
 		return nil, err
 	}
 
-	tx.R = sig[:32]
-	tx.S = sig[32:64]
-	tx.V = e.CalculateV(sig[64])
+	tx.R = *new(big.Int).SetBytes(sig[:32])
+	tx.S = *new(big.Int).SetBytes(sig[32:64])
+	tx.V = *new(big.Int).SetBytes(e.CalculateV(sig[64]))
 
 	return tx, nil
 }
@@ -215,14 +216,15 @@ func (e *EIP155Signer) CalculateV(parity byte) []byte {
 }
 
 // encodeSignature generates a signature value based on the R, S and V value
-func encodeSignature(R, S []byte, V byte) ([]byte, error) {
-	if !ValidateSignatureValues(V, R, S) {
+func encodeSignature(R, S big.Int, V byte) ([]byte, error) {
+
+	if !ValidateSignatureValues(V, R.Bytes(), S.Bytes()) {
 		return nil, fmt.Errorf("invalid txn signature")
 	}
 
 	sig := make([]byte, 65)
-	copy(sig[32-len(R):32], R)
-	copy(sig[64-len(S):64], S)
+	copy(sig[32-len(R.Bytes()):32], R.Bytes())
+	copy(sig[64-len(S.Bytes()):64], S.Bytes())
 	sig[64] = V
 
 	return sig, nil

--- a/crypto/txsigner.go
+++ b/crypto/txsigner.go
@@ -86,8 +86,10 @@ var (
 
 // Sender decodes the signature and returns the sender of the transaction
 func (f *FrontierSigner) Sender(tx *types.Transaction) (types.Address, error) {
-	refV := big.NewInt(0).SetBytes(tx.V.Bytes())
-
+	refV := big.NewInt(0)
+	if tx.V != nil {
+		refV.SetBytes(tx.V.Bytes())
+	}
 	refV.Sub(refV, big27)
 
 	sig, err := encodeSignature(tx.R, tx.S, byte(refV.Int64()))
@@ -119,9 +121,9 @@ func (f *FrontierSigner) SignTx(
 		return nil, err
 	}
 
-	tx.R = *new(big.Int).SetBytes(sig[:32])
-	tx.S = *new(big.Int).SetBytes(sig[32:64])
-	tx.V = *new(big.Int).SetBytes(f.CalculateV(sig[64]))
+	tx.R = new(big.Int).SetBytes(sig[:32])
+	tx.S = new(big.Int).SetBytes(sig[32:64])
+	tx.V = new(big.Int).SetBytes(f.CalculateV(sig[64]))
 
 	return tx, nil
 }
@@ -153,7 +155,10 @@ func (e *EIP155Signer) Sender(tx *types.Transaction) (types.Address, error) {
 	protected := true
 
 	// Check if v value conforms to an earlier standard (before EIP155)
-	bigV := big.NewInt(0).SetBytes(tx.V.Bytes())
+	bigV := big.NewInt(0)
+	if tx.V != nil {
+		bigV.SetBytes(tx.V.Bytes())
+	}
 	if vv := bigV.Uint64(); bits.Len(uint(vv)) <= 8 {
 		protected = vv != 27 && vv != 28
 	}
@@ -197,9 +202,9 @@ func (e *EIP155Signer) SignTx(
 		return nil, err
 	}
 
-	tx.R = *new(big.Int).SetBytes(sig[:32])
-	tx.S = *new(big.Int).SetBytes(sig[32:64])
-	tx.V = *new(big.Int).SetBytes(e.CalculateV(sig[64]))
+	tx.R = new(big.Int).SetBytes(sig[:32])
+	tx.S = new(big.Int).SetBytes(sig[32:64])
+	tx.V = new(big.Int).SetBytes(e.CalculateV(sig[64]))
 
 	return tx, nil
 }
@@ -216,9 +221,8 @@ func (e *EIP155Signer) CalculateV(parity byte) []byte {
 }
 
 // encodeSignature generates a signature value based on the R, S and V value
-func encodeSignature(R, S big.Int, V byte) ([]byte, error) {
-
-	if !ValidateSignatureValues(V, R.Bytes(), S.Bytes()) {
+func encodeSignature(R, S *big.Int, V byte) ([]byte, error) {
+	if !ValidateSignatureValues(V, R, S) {
 		return nil, fmt.Errorf("invalid txn signature")
 	}
 

--- a/e2e/genesis_test.go
+++ b/e2e/genesis_test.go
@@ -89,7 +89,7 @@ func TestCustomBlockGasLimitPropagation(t *testing.T) {
 			Gas:      blockGasLimit,
 			To:       &receiverAddress,
 			Value:    framework.EthToWei(1),
-			V:        *big.NewInt(1),
+			V:        big.NewInt(1),
 			From:     senderAddress,
 		}, senderKey)
 		if err != nil {

--- a/e2e/genesis_test.go
+++ b/e2e/genesis_test.go
@@ -89,7 +89,7 @@ func TestCustomBlockGasLimitPropagation(t *testing.T) {
 			Gas:      blockGasLimit,
 			To:       &receiverAddress,
 			Value:    framework.EthToWei(1),
-			V:        []byte{1},
+			V:        *big.NewInt(1),
 			From:     senderAddress,
 		}, senderKey)
 		if err != nil {

--- a/e2e/transaction_test.go
+++ b/e2e/transaction_test.go
@@ -442,7 +442,7 @@ func generateStressTestTx(
 		GasPrice: bigGasPrice,
 		Gas:      framework.DefaultGasLimit,
 		Value:    big.NewInt(0),
-		V:        []byte{1}, // it is necessary to encode in rlp,
+		V:        *big.NewInt(1), // it is necessary to encode in rlp,
 		Input:    append(setNameMethod.ID(), encodedInput...),
 	}, senderKey)
 

--- a/e2e/transaction_test.go
+++ b/e2e/transaction_test.go
@@ -442,7 +442,7 @@ func generateStressTestTx(
 		GasPrice: bigGasPrice,
 		Gas:      framework.DefaultGasLimit,
 		Value:    big.NewInt(0),
-		V:        *big.NewInt(1), // it is necessary to encode in rlp,
+		V:        big.NewInt(1), // it is necessary to encode in rlp,
 		Input:    append(setNameMethod.ID(), encodedInput...),
 	}, senderKey)
 

--- a/e2e/txpool_test.go
+++ b/e2e/txpool_test.go
@@ -72,7 +72,7 @@ func generateTx(params generateTxReqParams) *types.Transaction {
 		GasPrice: params.gasPrice,
 		Gas:      1000000,
 		Value:    params.value,
-		V:        []byte{1}, // it is necessary to encode in rlp
+		V:        *big.NewInt(27), // it is necessary to encode in rlp
 	}, params.referenceKey)
 
 	if signErr != nil {
@@ -217,7 +217,7 @@ func TestTxPool_TransactionCoalescing(t *testing.T) {
 			GasPrice: gasPrice,
 			Gas:      1000000,
 			Value:    oneEth,
-			V:        []byte{1}, // it is necessary to encode in rlp
+			V:        *big.NewInt(1), // it is necessary to encode in rlp
 		}, referenceKey)
 
 		if signErr != nil {
@@ -344,7 +344,7 @@ func TestTxPool_StressAddition(t *testing.T) {
 			GasPrice: big.NewInt(10),
 			Gas:      framework.DefaultGasLimit,
 			Value:    defaultValue,
-			V:        []byte{1}, // it is necessary to encode in rlp
+			V:        *big.NewInt(27), // it is necessary to encode in rlp
 		}, account.key)
 
 		if signErr != nil {
@@ -572,7 +572,7 @@ func TestInvalidTransactionRecover(t *testing.T) {
 				Gas:      testCase.submittedGasLimit,
 				To:       &testCase.receiver,
 				Value:    testCase.value,
-				V:        []byte{1},
+				V:        *big.NewInt(1),
 				From:     testCase.sender,
 			}, senderKey)
 			assert.NoError(t, err, "failed to sign transaction")
@@ -673,7 +673,7 @@ func TestTxPool_RecoverableError(t *testing.T) {
 				Gas:      testCase.gas,
 				To:       &testCase.receiver,
 				Value:    testCase.value,
-				V:        []byte{1},
+				V:        *big.NewInt(27),
 				From:     testCase.sender,
 			}, testCase.senderKey)
 			assert.NoError(t, err, "failed to sign transaction")
@@ -739,7 +739,7 @@ func TestTxPool_ZeroPriceDev(t *testing.T) {
 			Gas:      framework.DefaultGasLimit - 1,
 			To:       &receiverAddress,
 			Value:    oneEth,
-			V:        []byte{1},
+			V:        *big.NewInt(27),
 			From:     types.ZeroAddress,
 		}, senderKey)
 		assert.NoError(t, err, "failed to sign transaction")

--- a/e2e/txpool_test.go
+++ b/e2e/txpool_test.go
@@ -72,7 +72,7 @@ func generateTx(params generateTxReqParams) *types.Transaction {
 		GasPrice: params.gasPrice,
 		Gas:      1000000,
 		Value:    params.value,
-		V:        *big.NewInt(27), // it is necessary to encode in rlp
+		V:        big.NewInt(27), // it is necessary to encode in rlp
 	}, params.referenceKey)
 
 	if signErr != nil {
@@ -217,7 +217,7 @@ func TestTxPool_TransactionCoalescing(t *testing.T) {
 			GasPrice: gasPrice,
 			Gas:      1000000,
 			Value:    oneEth,
-			V:        *big.NewInt(1), // it is necessary to encode in rlp
+			V:        big.NewInt(1), // it is necessary to encode in rlp
 		}, referenceKey)
 
 		if signErr != nil {
@@ -344,7 +344,7 @@ func TestTxPool_StressAddition(t *testing.T) {
 			GasPrice: big.NewInt(10),
 			Gas:      framework.DefaultGasLimit,
 			Value:    defaultValue,
-			V:        *big.NewInt(27), // it is necessary to encode in rlp
+			V:        big.NewInt(27), // it is necessary to encode in rlp
 		}, account.key)
 
 		if signErr != nil {
@@ -572,7 +572,7 @@ func TestInvalidTransactionRecover(t *testing.T) {
 				Gas:      testCase.submittedGasLimit,
 				To:       &testCase.receiver,
 				Value:    testCase.value,
-				V:        *big.NewInt(1),
+				V:        big.NewInt(1),
 				From:     testCase.sender,
 			}, senderKey)
 			assert.NoError(t, err, "failed to sign transaction")
@@ -673,7 +673,7 @@ func TestTxPool_RecoverableError(t *testing.T) {
 				Gas:      testCase.gas,
 				To:       &testCase.receiver,
 				Value:    testCase.value,
-				V:        *big.NewInt(27),
+				V:        big.NewInt(27),
 				From:     testCase.sender,
 			}, testCase.senderKey)
 			assert.NoError(t, err, "failed to sign transaction")
@@ -739,7 +739,7 @@ func TestTxPool_ZeroPriceDev(t *testing.T) {
 			Gas:      framework.DefaultGasLimit - 1,
 			To:       &receiverAddress,
 			Value:    oneEth,
-			V:        *big.NewInt(27),
+			V:        big.NewInt(27),
 			From:     types.ZeroAddress,
 		}, senderKey)
 		assert.NoError(t, err, "failed to sign transaction")
@@ -807,7 +807,7 @@ func TestTxPool_GetPendingTx(t *testing.T) {
 		Gas:      framework.DefaultGasLimit - 1,
 		To:       &receiverAddress,
 		Value:    oneEth,
-		V:        []byte{1},
+		V:        big.NewInt(1),
 		From:     types.ZeroAddress,
 	}, senderKey)
 	assert.NoError(t, err, "failed to sign transaction")

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -689,7 +689,7 @@ func TestEth_TxnPool_SendRawTransaction(t *testing.T) {
 
 	txn := &types.Transaction{
 		From: addr0,
-		V:    []byte{1},
+		V:    *big.NewInt(1),
 	}
 	txn.ComputeHash()
 

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -689,7 +689,7 @@ func TestEth_TxnPool_SendRawTransaction(t *testing.T) {
 
 	txn := &types.Transaction{
 		From: addr0,
-		V:    *big.NewInt(1),
+		V:    big.NewInt(1),
 	}
 	txn.ComputeHash()
 

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -52,9 +52,6 @@ func toTransaction(
 	blockHash *types.Hash,
 	txIndex *int,
 ) *transaction {
-	v := new(big.Int).SetBytes(t.V)
-	r := new(big.Int).SetBytes(t.R)
-	s := new(big.Int).SetBytes(t.S)
 
 	res := &transaction{
 		Nonce:    argUint64(t.Nonce),
@@ -63,9 +60,9 @@ func toTransaction(
 		To:       t.To,
 		Value:    argBig(*t.Value),
 		Input:    t.Input,
-		V:        argBig(*v),
-		R:        argBig(*r),
-		S:        argBig(*s),
+		V:        argBig(t.V),
+		R:        argBig(t.R),
+		S:        argBig(t.S),
 		Hash:     t.Hash,
 		From:     t.From,
 	}

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -60,9 +60,9 @@ func toTransaction(
 		To:       t.To,
 		Value:    argBig(*t.Value),
 		Input:    t.Input,
-		V:        argBig(t.V),
-		R:        argBig(t.R),
-		S:        argBig(t.S),
+		V:        argBig(*t.V),
+		R:        argBig(*t.R),
+		S:        argBig(*t.S),
 		Hash:     t.Hash,
 		From:     t.From,
 	}

--- a/jsonrpc/types_test.go
+++ b/jsonrpc/types_test.go
@@ -108,9 +108,9 @@ func TestToTransaction_Returns_V_R_S_ValuesWithoutLeading0(t *testing.T) {
 		To:       nil,
 		Value:    big.NewInt(0),
 		Input:    nil,
-		V:        *new(big.Int).SetBytes(v),
-		R:        *new(big.Int).SetBytes(r),
-		S:        *new(big.Int).SetBytes(s),
+		V:        new(big.Int).SetBytes(v),
+		R:        new(big.Int).SetBytes(r),
+		S:        new(big.Int).SetBytes(s),
 		Hash:     types.Hash{},
 		From:     types.Address{},
 	}

--- a/jsonrpc/types_test.go
+++ b/jsonrpc/types_test.go
@@ -3,12 +3,13 @@ package jsonrpc
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/0xPolygon/polygon-sdk/helper/hex"
 	"math/big"
 	"reflect"
 	"strings"
 	"testing"
 	"text/template"
+
+	"github.com/0xPolygon/polygon-sdk/helper/hex"
 
 	"github.com/0xPolygon/polygon-sdk/types"
 	"github.com/stretchr/testify/assert"
@@ -107,9 +108,9 @@ func TestToTransaction_Returns_V_R_S_ValuesWithoutLeading0(t *testing.T) {
 		To:       nil,
 		Value:    big.NewInt(0),
 		Input:    nil,
-		V:        v,
-		R:        r,
-		S:        s,
+		V:        *new(big.Int).SetBytes(v),
+		R:        *new(big.Int).SetBytes(r),
+		S:        *new(big.Int).SetBytes(s),
 		Hash:     types.Hash{},
 		From:     types.Address{},
 	}
@@ -117,8 +118,8 @@ func TestToTransaction_Returns_V_R_S_ValuesWithoutLeading0(t *testing.T) {
 	jsonTx := toTransaction(&txn, nil, nil, nil)
 
 	jsonV, _ := jsonTx.V.MarshalText()
-	jsonR, _ := jsonTx.V.MarshalText()
-	jsonS, _ := jsonTx.V.MarshalText()
+	jsonR, _ := jsonTx.R.MarshalText()
+	jsonS, _ := jsonTx.S.MarshalText()
 	assert.Equal(t, hexWithoutLeading0, string(jsonV))
 	assert.Equal(t, hexWithoutLeading0, string(jsonR))
 	assert.Equal(t, hexWithoutLeading0, string(jsonS))

--- a/state/runtime/precompiled/base.go
+++ b/state/runtime/precompiled/base.go
@@ -2,6 +2,7 @@ package precompiled
 
 import (
 	"crypto/sha256"
+	"math/big"
 
 	"golang.org/x/crypto/ripemd160" //nolint:staticcheck
 
@@ -28,7 +29,9 @@ func (e *ecrecover) run(input []byte) ([]byte, error) {
 		}
 	}
 	v := input[63] - 27
-	if !crypto.ValidateSignatureValues(v, input[64:96], input[96:128]) {
+	r := big.NewInt(0).SetBytes(input[64:96])
+	s := big.NewInt(0).SetBytes(input[96:128])
+	if !crypto.ValidateSignatureValues(v, r, s) {
 		return nil, nil
 	}
 

--- a/types/rlp_encoding_test.go
+++ b/types/rlp_encoding_test.go
@@ -42,9 +42,9 @@ func TestRLPMarshall_And_Unmarshall_Transaction(t *testing.T) {
 		To:       &addrTo,
 		Value:    big.NewInt(1),
 		Input:    []byte{1, 2},
-		V:        *big.NewInt(25),
-		S:        *big.NewInt(26),
-		R:        *big.NewInt(27),
+		V:        big.NewInt(25),
+		S:        big.NewInt(26),
+		R:        big.NewInt(27),
 	}
 	unmarshalledTxn := new(Transaction)
 	marshaledRlp := txn.MarshalRLP()

--- a/types/rlp_encoding_test.go
+++ b/types/rlp_encoding_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"math/big"
 	"reflect"
 	"testing"
 
@@ -27,8 +28,34 @@ func TestRLPEncoding(t *testing.T) {
 
 		buf2 := c.MarshalRLPTo(nil)
 		if !reflect.DeepEqual(buf, buf2) {
-			t.Fatal("bad")
+			t.Fatal("[ERROR] Buffers not equal")
 		}
+	}
+}
+
+func TestRLPMarshall_And_Unmarshall_Transaction(t *testing.T) {
+	addrTo := StringToAddress("11")
+	txn := &Transaction{
+		Nonce:    0,
+		GasPrice: big.NewInt(11),
+		Gas:      11,
+		To:       &addrTo,
+		Value:    big.NewInt(1),
+		Input:    []byte{1, 2},
+		V:        *big.NewInt(25),
+		S:        *big.NewInt(26),
+		R:        *big.NewInt(27),
+	}
+	unmarshalledTxn := new(Transaction)
+	marshaledRlp := txn.MarshalRLP()
+	if err := unmarshalledTxn.UnmarshalRLP(marshaledRlp); err != nil {
+		t.Fatal(err)
+	}
+	unmarshalledTxn.ComputeHash()
+
+	txn.Hash = unmarshalledTxn.Hash
+	if !reflect.DeepEqual(txn, unmarshalledTxn) {
+		t.Fatal("[ERROR] Unmarshalled transaction not equal to base transaction")
 	}
 }
 

--- a/types/rlp_marshal.go
+++ b/types/rlp_marshal.go
@@ -172,9 +172,9 @@ func (t *Transaction) MarshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 	vv.Set(arena.NewCopyBytes(t.Input))
 
 	// signature values
-	vv.Set(arena.NewCopyBytes(t.V))
-	vv.Set(arena.NewCopyBytes(t.R))
-	vv.Set(arena.NewCopyBytes(t.S))
+	vv.Set(arena.NewBigInt(&t.V))
+	vv.Set(arena.NewBigInt(&t.R))
+	vv.Set(arena.NewBigInt(&t.S))
 
 	return vv
 }

--- a/types/rlp_marshal.go
+++ b/types/rlp_marshal.go
@@ -172,9 +172,9 @@ func (t *Transaction) MarshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 	vv.Set(arena.NewCopyBytes(t.Input))
 
 	// signature values
-	vv.Set(arena.NewBigInt(&t.V))
-	vv.Set(arena.NewBigInt(&t.R))
-	vv.Set(arena.NewBigInt(&t.S))
+	vv.Set(arena.NewBigInt(t.V))
+	vv.Set(arena.NewBigInt(t.R))
+	vv.Set(arena.NewBigInt(t.S))
 
 	return vv
 }

--- a/types/rlp_unmarshal.go
+++ b/types/rlp_unmarshal.go
@@ -313,16 +313,19 @@ func (t *Transaction) UnmarshalRLPFrom(p *fastrlp.Parser, v *fastrlp.Value) erro
 	}
 
 	// V
-	if err = elems[6].GetBigInt(&t.V); err != nil {
+	t.V = new(big.Int)
+	if err = elems[6].GetBigInt(t.V); err != nil {
 		return err
 	}
 
 	// R
-	if err = elems[7].GetBigInt(&t.R); err != nil {
+	t.R = new(big.Int)
+	if err = elems[7].GetBigInt(t.R); err != nil {
 		return err
 	}
 	// S
-	if err = elems[8].GetBigInt(&t.S); err != nil {
+	t.S = new(big.Int)
+	if err = elems[8].GetBigInt(t.S); err != nil {
 		return err
 	}
 	return nil

--- a/types/rlp_unmarshal.go
+++ b/types/rlp_unmarshal.go
@@ -313,16 +313,16 @@ func (t *Transaction) UnmarshalRLPFrom(p *fastrlp.Parser, v *fastrlp.Value) erro
 	}
 
 	// V
-	if t.V, err = elems[6].GetBytes(t.V[:0]); err != nil {
+	if err = elems[6].GetBigInt(&t.V); err != nil {
 		return err
 	}
 
 	// R
-	if t.R, err = elems[7].GetBytes(t.R[:0]); err != nil {
+	if err = elems[7].GetBigInt(&t.R); err != nil {
 		return err
 	}
 	// S
-	if t.S, err = elems[8].GetBytes(t.S[:0]); err != nil {
+	if err = elems[8].GetBigInt(&t.S); err != nil {
 		return err
 	}
 	return nil

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -14,9 +14,9 @@ type Transaction struct {
 	To       *Address
 	Value    *big.Int
 	Input    []byte
-	V        []byte
-	R        []byte
-	S        []byte
+	V        big.Int
+	R        big.Int
+	S        big.Int
 	Hash     Hash
 	From     Address
 
@@ -51,10 +51,8 @@ func (t *Transaction) Copy() *Transaction {
 	tt.Value = new(big.Int)
 	tt.Value.Set(t.Value)
 
-	tt.R = make([]byte, len(t.R))
-	copy(tt.R[:], t.R[:])
-	tt.S = make([]byte, len(t.S))
-	copy(tt.S[:], t.S[:])
+	tt.R = *big.NewInt(0).SetBits(t.R.Bits())
+	tt.S = *big.NewInt(0).SetBits(t.S.Bits())
 
 	tt.Input = make([]byte, len(t.Input))
 	copy(tt.Input[:], t.Input[:])

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -14,9 +14,9 @@ type Transaction struct {
 	To       *Address
 	Value    *big.Int
 	Input    []byte
-	V        big.Int
-	R        big.Int
-	S        big.Int
+	V        *big.Int
+	R        *big.Int
+	S        *big.Int
 	Hash     Hash
 	From     Address
 
@@ -51,8 +51,15 @@ func (t *Transaction) Copy() *Transaction {
 	tt.Value = new(big.Int)
 	tt.Value.Set(t.Value)
 
-	tt.R = *big.NewInt(0).SetBits(t.R.Bits())
-	tt.S = *big.NewInt(0).SetBits(t.S.Bits())
+	if t.R != nil {
+		tt.R = new(big.Int)
+		tt.R = big.NewInt(0).SetBits(t.R.Bits())
+	}
+
+	if t.S != nil {
+		tt.S = new(big.Int)
+		tt.S = big.NewInt(0).SetBits(t.S.Bits())
+	}
 
 	tt.Input = make([]byte, len(t.Input))
 	copy(tt.Input[:], t.Input[:])

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,4 +58,24 @@ func TestEIP55(t *testing.T) {
 			assert.Equal(t, c.expected, addr.String())
 		})
 	}
+}
+
+func TestTransactionCopy(t *testing.T) {
+	addrTo := StringToAddress("11")
+	txn := &Transaction{
+		Nonce:    0,
+		GasPrice: big.NewInt(11),
+		Gas:      11,
+		To:       &addrTo,
+		Value:    big.NewInt(1),
+		Input:    []byte{1, 2},
+		V:        *big.NewInt(25),
+		S:        *big.NewInt(26),
+		R:        *big.NewInt(27),
+	}
+	newTxn := txn.Copy()
+	if !reflect.DeepEqual(txn, newTxn) {
+		t.Fatal("[ERROR] Copied transaction not equal base transaction")
+	}
+
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -69,9 +69,9 @@ func TestTransactionCopy(t *testing.T) {
 		To:       &addrTo,
 		Value:    big.NewInt(1),
 		Input:    []byte{1, 2},
-		V:        *big.NewInt(25),
-		S:        *big.NewInt(26),
-		R:        *big.NewInt(27),
+		V:        big.NewInt(25),
+		S:        big.NewInt(26),
+		R:        big.NewInt(27),
 	}
 	newTxn := txn.Copy()
 	if !reflect.DeepEqual(txn, newTxn) {


### PR DESCRIPTION
# Description

The Transaction object wrongly has []byte instead of big.Int for the v,r,s values.
The reason why that is wrong is because a byte slice is completely valid to start with a leading 0 when encoded to hex, but that's not the case with any numbers, e.g. big.Int.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs
