### PR TITLE
Fix/max peers limit

### DIFF
--- a/command/helper/config.go
+++ b/command/helper/config.go
@@ -66,7 +66,7 @@ func DefaultConfig() *Config {
 		BlockGasTarget: "0x0", // Special value signaling the parent gas limit should be applied
 		Network: &Network{
 			NoDiscover: false,
-			MaxPeers:   20,
+			MaxPeers:   30,
 		},
 		Telemetry: &Telemetry{},
 		Seal:      false,

--- a/command/helper/config.go
+++ b/command/helper/config.go
@@ -66,7 +66,7 @@ func DefaultConfig() *Config {
 		BlockGasTarget: "0x0", // Special value signaling the parent gas limit should be applied
 		Network: &Network{
 			NoDiscover: false,
-			MaxPeers:   30,
+			MaxPeers:   50,
 		},
 		Telemetry: &Telemetry{},
 		Seal:      false,

--- a/network/discovery.go
+++ b/network/discovery.go
@@ -200,6 +200,11 @@ func (d *discovery) findPeersCall(peerID peer.ID) ([]*peer.AddrInfo, error) {
 	return addrInfo, nil
 }
 
+func (d *discovery) peersCount() int {
+	d.peersLock.Lock()
+	defer d.peersLock.Unlock()
+	return len(d.peers)
+}
 func (d *discovery) run() {
 	for {
 		select {
@@ -222,8 +227,8 @@ func (d *discovery) handleDiscovery() {
 		}
 	} else {
 		// take a random peer and find peers
-		if len(d.peers) > 0 {
-			target := d.peers[rand.Intn(len(d.peers))]
+		if d.peersCount() > 0 {
+			target := d.peers[rand.Intn(d.peersCount())]
 			if err := d.call(target.id); err != nil {
 				d.srv.logger.Error("failed to dial bootnode", "err", err)
 			}

--- a/network/identity.go
+++ b/network/identity.go
@@ -64,19 +64,16 @@ func (i *identity) setup() {
 			peerID := conn.RemotePeer()
 			i.srv.logger.Trace("Conn", "peer", peerID, "direction", conn.Stat().Direction)
 
-			// limit by MaxPeers on incomming requests since we already limit
-			// the outgoing requests
-			if conn.Stat().Direction == network.DirInbound {
-				if i.isPending(peerID) {
-					// handshake has already started
-					return
-				}
-				if i.srv.numOpenSlots() == 0 {
-					i.srv.Disconnect(peerID, "no available slots")
-					return
-				}
+			// limit by MaxPeers on incomming/outgoing requests
+			if i.isPending(peerID) {
+				// handshake has already started
+				return
 			}
 
+			if i.srv.numOpenSlots() == 0 {
+				i.srv.Disconnect(peerID, "no available slots")
+				return
+			}
 			// pending of handshake
 			i.setPending(peerID)
 

--- a/network/server.go
+++ b/network/server.go
@@ -280,12 +280,11 @@ func (s *Server) runDial() {
 	}
 
 	for {
-		slots := s.numOpenSlots()
 
 		// TODO: Right now the dial task are done sequentially because Connect
 		// is a blocking request. In the future we should try to make up to
 		// maxDials requests concurrently.
-		for i := int64(0); i < slots; i++ {
+		for i := int64(0); i < s.numOpenSlots(); i++ {
 			tt := s.dialQueue.pop()
 			if tt == nil {
 				// dial closed

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -380,7 +380,7 @@ func TestPeerReconnection(t *testing.T) {
 
 	assert.True(t, <-disconnectedCh2, "Failed to receive peer disconnected event")
 
-	//disconnect from the third second node
+	//disconnect from the third  node
 	disconnectedCh3 := asyncWaitForEvent(srv1, 15*time.Second, disconnectedPeerHandler(srv2.AddrInfo().ID))
 	assert.NoError(t, srv2.Close())
 	assert.True(t, <-disconnectedCh3)


### PR DESCRIPTION
# Description

This PR will  fix an issue in identity exchange routine which checks the maxPeer count only on inbound connection(Ideally it should check on both inbound/outbound connections). This PR also increases the default `MaxPeers` count to `50` nodes 

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs


