### PR TITLE
Printing the execution result error message in the eth_call response.

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -330,7 +330,7 @@ func (e *Eth) Call(
 	}
 
 	if result.Failed() {
-		return nil, fmt.Errorf("unable to execute call")
+		return nil, fmt.Errorf("unable to execute call: %s", result.Err.Error())
 	}
 	return argBytesPtr(result.ReturnValue), nil
 }


### PR DESCRIPTION
# Description

Printing the cause of the execution result error in the JSON-RPC response to the `eth_call`.
Users confronted with this error will first think there is something wrong with the Polygon-SDK.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

