### PR TITLE
Add support for the eth_syncing endpoint

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"context"
+	"github.com/0xPolygon/polygon-sdk/protocol"
 	"log"
 
 	"github.com/0xPolygon/polygon-sdk/blockchain"
@@ -23,6 +24,9 @@ type Consensus interface {
 
 	// GetBlockCreator retrieves the block creator (or signer) given the block header
 	GetBlockCreator(header *types.Header) (types.Address, error)
+
+	// GetSyncProgression retrieves the current sync progression, if any
+	GetSyncProgression() *protocol.Progression
 
 	// Start starts the consensus
 	Start() error
@@ -56,7 +60,7 @@ type ConsensusParams struct {
 	Executor       *state.Executor
 	Grpc           *grpc.Server
 	Logger         hclog.Logger
-  Metrics        *Metrics
+	Metrics        *Metrics
 	SecretsManager secrets.SecretsManager
 }
 

--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -3,6 +3,7 @@ package dev
 import (
 	"context"
 	"fmt"
+	"github.com/0xPolygon/polygon-sdk/protocol"
 	"time"
 
 	"github.com/0xPolygon/polygon-sdk/blockchain"
@@ -209,6 +210,10 @@ func (d *Dev) VerifyHeader(parent *types.Header, header *types.Header) error {
 
 func (d *Dev) GetBlockCreator(header *types.Header) (types.Address, error) {
 	return header.Miner, nil
+}
+
+func (d *Dev) GetSyncProgression() *protocol.Progression {
+	return nil
 }
 
 func (d *Dev) Prepare(header *types.Header) error {

--- a/consensus/dummy/dummy.go
+++ b/consensus/dummy/dummy.go
@@ -3,6 +3,7 @@ package dummy
 import (
 	"github.com/0xPolygon/polygon-sdk/blockchain"
 	"github.com/0xPolygon/polygon-sdk/consensus"
+	"github.com/0xPolygon/polygon-sdk/protocol"
 	"github.com/0xPolygon/polygon-sdk/state"
 	"github.com/0xPolygon/polygon-sdk/txpool"
 	"github.com/0xPolygon/polygon-sdk/types"
@@ -49,6 +50,10 @@ func (d *Dummy) VerifyHeader(parent *types.Header, header *types.Header) error {
 
 func (d *Dummy) GetBlockCreator(header *types.Header) (types.Address, error) {
 	return header.Miner, nil
+}
+
+func (d *Dummy) GetSyncProgression() *protocol.Progression {
+	return nil
 }
 
 func (d *Dummy) Close() error {

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -42,6 +42,7 @@ type syncerInterface interface {
 	BestPeer() *protocol.SyncPeer
 	BulkSyncWithPeer(p *protocol.SyncPeer) error
 	WatchSyncWithPeer(p *protocol.SyncPeer, handler func(b *types.Block) bool)
+	GetSyncProgression() *protocol.Progression
 	Broadcast(b *types.Block)
 }
 
@@ -68,8 +69,7 @@ type Ibft struct {
 	msgQueue *msgQueue     // Structure containing different message queues
 	updateCh chan struct{} // Update channel
 
-	syncer       syncerInterface // Reference to the sync protocol
-	syncNotifyCh chan bool       // Sync protocol notification channel
+	syncer syncerInterface // Reference to the sync protocol
 
 	network   *network.Server // Reference to the networking layer
 	transport transport       // Reference to the transport protocol
@@ -98,7 +98,6 @@ func Factory(
 		state:          &currentState{},
 		network:        params.Network,
 		epochSize:      DefaultEpochSize,
-		syncNotifyCh:   make(chan bool),
 		sealing:        params.Seal,
 		metrics:        params.Metrics,
 		secretsManager: params.SecretsManager,
@@ -142,6 +141,11 @@ func (i *Ibft) Start() error {
 	go i.start()
 
 	return nil
+}
+
+// GetSyncProgression gets the latest sync progression, if any
+func (i *Ibft) GetSyncProgression() *protocol.Progression {
+	return i.syncer.GetSyncProgression()
 }
 
 type transport interface {

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -537,7 +537,7 @@ func TestWriteTransactions(t *testing.T) {
 				{Nonce: 4, Gas: 10001}, // exceeds block gas limit
 				{Nonce: 5},             // included
 				{Nonce: 6},             // reaches gas limit - returned to pool
-				{Nonce: 7}}, // not considered - stays in pool
+				{Nonce: 7}},            // not considered - stays in pool
 			[]int{0},
 			[]int{1},
 			5,
@@ -611,6 +611,10 @@ func (s *mockSyncer) BulkSyncWithPeer(p *protocol.SyncPeer) error {
 
 func (s *mockSyncer) WatchSyncWithPeer(p *protocol.SyncPeer, handler func(b *types.Block) bool) {
 	handler(s.receivedNewHeadFromPeer)
+}
+
+func (s *mockSyncer) GetSyncProgression() *protocol.Progression {
+	return nil
 }
 
 func (s *mockSyncer) Broadcast(b *types.Block) {

--- a/jsonrpc/blockchain.go
+++ b/jsonrpc/blockchain.go
@@ -1,6 +1,7 @@
 package jsonrpc
 
 import (
+	"github.com/0xPolygon/polygon-sdk/protocol"
 	"math/big"
 
 	"github.com/0xPolygon/polygon-sdk/blockchain"
@@ -57,6 +58,9 @@ type blockchainInterface interface {
 
 	// ApplyTxn applies a transaction object to the blockchain
 	ApplyTxn(header *types.Header, txn *types.Transaction) (*runtime.ExecutionResult, error)
+
+	// GetSyncProgression retrieves the current sync progression, if any
+	GetSyncProgression() *protocol.Progression
 
 	// GetNonce returns the next nonce for this address
 	GetNonce(addr types.Address) uint64
@@ -144,4 +148,8 @@ func (b *nullBlockchainInterface) GetCapacity() (uint64, uint64) {
 
 func (b *nullBlockchainInterface) GetPendingTx(txHash types.Hash) (*types.Transaction, bool) {
 	return nil, false
+}
+
+func (b *nullBlockchainInterface) GetSyncProgression() *protocol.Progression {
+	return nil
 }

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -21,6 +21,20 @@ func (e *Eth) ChainId() (interface{}, error) {
 	return argUintPtr(e.d.chainID), nil
 }
 
+func (e *Eth) Syncing() (interface{}, error) {
+	if syncProgression := e.d.store.GetSyncProgression(); syncProgression != nil {
+		// Node is bulk syncing, return the status
+		return progression{
+			startingBlock: hex.EncodeUint64(syncProgression.StartingBlock),
+			currentBlock:  hex.EncodeUint64(syncProgression.CurrentBlock),
+			highestBlock:  hex.EncodeUint64(syncProgression.HighestBlock),
+		}, nil
+	}
+
+	// Node is not bulk syncing
+	return false, nil
+}
+
 func GetNumericBlockNumber(number BlockNumber, e *Eth) (uint64, error) {
 	switch number {
 	case LatestBlockNumber:

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -25,9 +25,9 @@ func (e *Eth) Syncing() (interface{}, error) {
 	if syncProgression := e.d.store.GetSyncProgression(); syncProgression != nil {
 		// Node is bulk syncing, return the status
 		return progression{
-			startingBlock: hex.EncodeUint64(syncProgression.StartingBlock),
-			currentBlock:  hex.EncodeUint64(syncProgression.CurrentBlock),
-			highestBlock:  hex.EncodeUint64(syncProgression.HighestBlock),
+			StartingBlock: hex.EncodeUint64(syncProgression.StartingBlock),
+			CurrentBlock:  hex.EncodeUint64(syncProgression.CurrentBlock),
+			HighestBlock:  hex.EncodeUint64(syncProgression.HighestBlock),
 		}, nil
 	}
 

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -288,7 +288,7 @@ type txnArgs struct {
 }
 
 type progression struct {
-	startingBlock string `json:"startingBlock"`
-	currentBlock  string `json:"currentBlock"`
-	highestBlock  string `json:"highestBlock"`
+	StartingBlock string `json:"startingBlock"`
+	CurrentBlock  string `json:"currentBlock"`
+	HighestBlock  string `json:"highestBlock"`
 }

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -286,3 +286,9 @@ type txnArgs struct {
 	Data     *argBytes
 	Nonce    *argUint64
 }
+
+type progression struct {
+	startingBlock string `json:"startingBlock"`
+	currentBlock  string `json:"currentBlock"`
+	highestBlock  string `json:"highestBlock"`
+}

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -29,7 +29,7 @@ const (
 
 var (
 	ErrLoadLocalGenesisFailed = errors.New("failed to read local genesis")
-	ErrMismatchGenesis        = errors.New("genesis does not match?")
+	ErrMismatchGenesis        = errors.New("genesis does not match")
 	ErrCommonAncestorNotFound = errors.New("header is nil")
 	ErrForkNotFound           = errors.New("fork not found")
 	ErrPopTimeout             = errors.New("timeout")
@@ -190,6 +190,101 @@ func statusFromProto(p *proto.V1Status) (*Status, error) {
 	return s, nil
 }
 
+type progressionWrapper struct {
+	// progression is a reference to the ongoing batch sync.
+	// Nil if no batch sync is currently in progress
+	progression *Progression
+
+	// stopCh is the channel for receiving stop signals
+	// in progression tracking
+	stopCh chan struct{}
+
+	lock sync.RWMutex
+}
+
+// startProgression initializes the progression tracking
+func (pw *progressionWrapper) startProgression(
+	startingBlock uint64,
+	eventCh chan *blockchain.Event,
+) {
+	pw.lock.Lock()
+	defer pw.lock.Unlock()
+
+	pw.progression = &Progression{
+		StartingBlock: startingBlock,
+	}
+
+	go pw.runUpdateLoop(eventCh)
+}
+
+// runUpdateLoop starts the blockchain event monitoring loop and
+// updates the currently written block in the batch sync
+func (pw *progressionWrapper) runUpdateLoop(eventCh chan *blockchain.Event) {
+	for {
+		select {
+		case event := <-eventCh:
+			if event.Type == blockchain.EventFork {
+				continue
+			}
+
+			if len(event.NewChain) == 0 {
+				continue
+			}
+
+			pw.updateCurrentProgression(event.NewChain[0].Number)
+		case <-pw.stopCh:
+			return
+		}
+	}
+}
+
+// stopProgression stops the progression tracking
+func (pw *progressionWrapper) stopProgression() {
+	pw.lock.Lock()
+	defer pw.lock.Unlock()
+
+	pw.stopCh <- struct{}{}
+	pw.progression = nil
+}
+
+// updateCurrentProgression sets the currently written block in the bulk sync
+func (pw *progressionWrapper) updateCurrentProgression(currentBlock uint64) {
+	pw.lock.Lock()
+	defer pw.lock.Unlock()
+
+	pw.progression.CurrentBlock = currentBlock
+}
+
+// updateHighestProgression sets the highest-known target block in the bulk sync
+func (pw *progressionWrapper) updateHighestProgression(highestBlock uint64) {
+	pw.lock.Lock()
+	defer pw.lock.Unlock()
+
+	pw.progression.HighestBlock = highestBlock
+}
+
+// getProgression returns the latest sync progression
+func (pw *progressionWrapper) getProgression() *Progression {
+	pw.lock.RLock()
+	defer pw.lock.RUnlock()
+
+	return pw.progression
+}
+
+// Progression defines the status of the sync
+// progression of the node
+type Progression struct {
+	// StartingBlock is the initial block that the node is starting
+	// the sync from. It is reset after every sync batch
+	StartingBlock uint64
+
+	// CurrentBlock is the last written block from the sync batch
+	CurrentBlock uint64
+
+	// HighestBlock is the target block in the sync batch
+	HighestBlock uint64
+}
+
 // Syncer is a sync protocol
 type Syncer struct {
 	logger     hclog.Logger
@@ -204,6 +299,8 @@ type Syncer struct {
 	statusLock sync.Mutex
 
 	server *network.Server
+
+	syncProgression *progressionWrapper
 }
 
 // NewSyncer creates a new Syncer instance
@@ -213,9 +310,17 @@ func NewSyncer(logger hclog.Logger, server *network.Server, blockchain blockchai
 		stopCh:     make(chan struct{}),
 		blockchain: blockchain,
 		server:     server,
+		syncProgression: &progressionWrapper{
+			progression: nil,
+		},
 	}
 
 	return s
+}
+
+// GetSyncProgression returns the latest sync progression, if any
+func (s *Syncer) GetSyncProgression() *Progression {
+	return s.syncProgression.getProgression()
 }
 
 // syncCurrentStatus taps into the blockchain event steam and updates the Syncer.status field
@@ -552,10 +657,18 @@ func (s *Syncer) BulkSyncWithPeer(p *SyncPeer) error {
 
 	var lastTarget uint64
 
+	// Create a blockchain subscription for the sync progression and start tracking
+	eventCh := s.blockchain.SubscribeEvents().GetEventCh()
+	s.syncProgression.startProgression(startBlock.Number, eventCh)
+
+	// Stop monitoring the sync progression upon exit
+	defer s.syncProgression.stopProgression()
+
 	// sync up to the current known header
 	for {
 		// update target
 		target := p.status.Number
+		s.syncProgression.updateHighestProgression(target)
 		if target == lastTarget {
 			// there are no more changes to pull for now
 			break
@@ -596,6 +709,7 @@ func (s *Syncer) BulkSyncWithPeer(p *SyncPeer) error {
 
 		lastTarget = target
 	}
+
 	return nil
 }
 

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -328,16 +328,6 @@ func (s *Syncer) GetSyncProgression() *Progression {
 
 // syncCurrentStatus taps into the blockchain event steam and updates the Syncer.status field
 func (s *Syncer) syncCurrentStatus() {
-	// Get the current status of the syncer
-	currentHeader := s.blockchain.Header()
-	diff, _ := s.blockchain.GetTD(currentHeader.Hash)
-
-	s.status = &Status{
-		Hash:       currentHeader.Hash,
-		Number:     currentHeader.Number,
-		Difficulty: diff,
-	}
-
 	sub := s.blockchain.SubscribeEvents()
 	eventCh := sub.GetEventCh()
 
@@ -435,6 +425,16 @@ func (s *Syncer) Broadcast(b *types.Block) {
 // Start starts the syncer protocol
 func (s *Syncer) Start() {
 	s.serviceV1 = &serviceV1{syncer: s, logger: hclog.NewNullLogger(), store: s.blockchain}
+
+	// Get the current status of the syncer
+	currentHeader := s.blockchain.Header()
+	diff, _ := s.blockchain.GetTD(currentHeader.Hash)
+
+	s.status = &Status{
+		Hash:       currentHeader.Hash,
+		Number:     currentHeader.Number,
+		Difficulty: diff,
+	}
 
 	// Run the blockchain event listener loop
 	go s.syncCurrentStatus()

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -312,6 +312,7 @@ func NewSyncer(logger hclog.Logger, server *network.Server, blockchain blockchai
 		server:     server,
 		syncProgression: &progressionWrapper{
 			progression: nil,
+			stopCh:      make(chan struct{}),
 		},
 	}
 

--- a/protocol/syncer_test.go
+++ b/protocol/syncer_test.go
@@ -108,7 +108,7 @@ func TestBroadcast(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			chain, peerChain := NewMockBlockchain(tt.syncerHeaders), NewMockBlockchain(tt.peerHeaders)
+			chain, peerChain := NewMockBlockchain(tt.syncerHeaders, 2), NewMockBlockchain(tt.peerHeaders, 2)
 			syncer, peerSyncers := SetupSyncerNetwork(t, chain, []blockchainShim{peerChain})
 			peerSyncer := peerSyncers[0]
 
@@ -242,6 +242,9 @@ func TestFindCommonAncestor(t *testing.T) {
 }
 
 func TestWatchSyncWithPeer(t *testing.T) {
+	// TODO remove
+	t.SkipNow()
+
 	tests := []struct {
 		name           string
 		headers        []*types.Header
@@ -270,7 +273,8 @@ func TestWatchSyncWithPeer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			chain, peerChain := NewMockBlockchain(tt.headers), NewMockBlockchain(tt.peerHeaders)
+			chain, peerChain := NewMockBlockchain(tt.headers, 2), NewMockBlockchain(tt.peerHeaders, 2)
+
 			syncer, peerSyncers := SetupSyncerNetwork(t, chain, []blockchainShim{peerChain})
 			peerSyncer := peerSyncers[0]
 
@@ -312,6 +316,9 @@ func TestWatchSyncWithPeer(t *testing.T) {
 }
 
 func TestBulkSyncWithPeer(t *testing.T) {
+	// TODO remove
+	t.SkipNow()
+
 	tests := []struct {
 		name        string
 		headers     []*types.Header
@@ -338,7 +345,7 @@ func TestBulkSyncWithPeer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			chain, peerChain := NewMockBlockchain(tt.headers), NewMockBlockchain(tt.peerHeaders)
+			chain, peerChain := NewMockBlockchain(tt.headers, 2), NewMockBlockchain(tt.peerHeaders, 2)
 			syncer, peerSyncers := SetupSyncerNetwork(t, chain, []blockchainShim{peerChain})
 			peerSyncer := peerSyncers[0]
 
@@ -356,6 +363,35 @@ func TestBulkSyncWithPeer(t *testing.T) {
 			assert.Equal(t, expectedStatus, syncer.status)
 		})
 	}
+}
+
+func TestSyncer_GetSyncProgression(t *testing.T) {
+	initialChainSize := 10
+	targetChainSize := 1000
+
+	existingChain := blockchain.NewTestHeaderChainWithSeed(nil, initialChainSize, 0)
+	syncerChain := NewMockBlockchain(existingChain, 0)
+	syncer := CreateSyncer(t, syncerChain, nil)
+
+	syncHeaders := blockchain.NewTestHeaderChainWithSeed(nil, targetChainSize, 0)
+	syncBlocks := blockchain.HeadersToBlocks(syncHeaders)
+
+	syncer.syncProgression.startProgression(uint64(initialChainSize), syncerChain.SubscribeEvents())
+	if syncer.GetSyncProgression() == nil {
+		t.Fatalf("Unable to start progression")
+	}
+	assert.Equal(t, uint64(initialChainSize), syncer.syncProgression.getProgression().StartingBlock)
+
+	syncer.syncProgression.updateHighestProgression(uint64(targetChainSize))
+	assert.Equal(t, uint64(targetChainSize), syncer.syncProgression.getProgression().HighestBlock)
+
+	writeErr := syncerChain.WriteBlocks(syncBlocks[initialChainSize+1:])
+	assert.NoError(t, writeErr)
+
+	WaitUntilProgressionUpdated(t, syncer, 15*time.Second, uint64(targetChainSize-1))
+	assert.Equal(t, uint64(targetChainSize-1), syncer.syncProgression.getProgression().CurrentBlock)
+
+	syncer.syncProgression.stopProgression()
 }
 
 type mockBlockStore struct {

--- a/protocol/syncer_test.go
+++ b/protocol/syncer_test.go
@@ -108,7 +108,7 @@ func TestBroadcast(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			chain, peerChain := NewMockBlockchain(tt.syncerHeaders, 2), NewMockBlockchain(tt.peerHeaders, 2)
+			chain, peerChain := NewMockBlockchain(tt.syncerHeaders), NewMockBlockchain(tt.peerHeaders)
 			syncer, peerSyncers := SetupSyncerNetwork(t, chain, []blockchainShim{peerChain})
 			peerSyncer := peerSyncers[0]
 
@@ -242,9 +242,6 @@ func TestFindCommonAncestor(t *testing.T) {
 }
 
 func TestWatchSyncWithPeer(t *testing.T) {
-	// TODO remove
-	t.SkipNow()
-
 	tests := []struct {
 		name           string
 		headers        []*types.Header
@@ -273,7 +270,7 @@ func TestWatchSyncWithPeer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			chain, peerChain := NewMockBlockchain(tt.headers, 2), NewMockBlockchain(tt.peerHeaders, 2)
+			chain, peerChain := NewMockBlockchain(tt.headers), NewMockBlockchain(tt.peerHeaders)
 
 			syncer, peerSyncers := SetupSyncerNetwork(t, chain, []blockchainShim{peerChain})
 			peerSyncer := peerSyncers[0]
@@ -316,9 +313,6 @@ func TestWatchSyncWithPeer(t *testing.T) {
 }
 
 func TestBulkSyncWithPeer(t *testing.T) {
-	// TODO remove
-	t.SkipNow()
-
 	tests := []struct {
 		name        string
 		headers     []*types.Header
@@ -345,7 +339,7 @@ func TestBulkSyncWithPeer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			chain, peerChain := NewMockBlockchain(tt.headers, 2), NewMockBlockchain(tt.peerHeaders, 2)
+			chain, peerChain := NewMockBlockchain(tt.headers), NewMockBlockchain(tt.peerHeaders)
 			syncer, peerSyncers := SetupSyncerNetwork(t, chain, []blockchainShim{peerChain})
 			peerSyncer := peerSyncers[0]
 
@@ -370,7 +364,7 @@ func TestSyncer_GetSyncProgression(t *testing.T) {
 	targetChainSize := 1000
 
 	existingChain := blockchain.NewTestHeaderChainWithSeed(nil, initialChainSize, 0)
-	syncerChain := NewMockBlockchain(existingChain, 0)
+	syncerChain := NewMockBlockchain(existingChain)
 	syncer := CreateSyncer(t, syncerChain, nil)
 
 	syncHeaders := blockchain.NewTestHeaderChainWithSeed(nil, targetChainSize, 0)

--- a/protocol/testing.go
+++ b/protocol/testing.go
@@ -196,23 +196,21 @@ func HeaderToStatus(h *types.Header) *Status {
 type mockBlockchain struct {
 	blocks        []*types.Block
 	subscriptions []*mockSubscription
-	channelSize   int
 }
 
 func (b *mockBlockchain) CalculateGasLimit(number uint64) (uint64, error) {
 	panic("implement me")
 }
 
-func NewMockBlockchain(headers []*types.Header, channelSize int) *mockBlockchain {
+func NewMockBlockchain(headers []*types.Header) *mockBlockchain {
 	return &mockBlockchain{
 		blocks:        blockchain.HeadersToBlocks(headers),
 		subscriptions: make([]*mockSubscription, 0),
-		channelSize:   channelSize,
 	}
 }
 
 func (b *mockBlockchain) SubscribeEvents() blockchain.Subscription {
-	subscription := NewMockSubscription(b.channelSize)
+	subscription := NewMockSubscription()
 	b.subscriptions = append(b.subscriptions, subscription)
 	return subscription
 }
@@ -286,9 +284,9 @@ type mockSubscription struct {
 	eventCh chan *blockchain.Event
 }
 
-func NewMockSubscription(channelSize int) *mockSubscription {
+func NewMockSubscription() *mockSubscription {
 	return &mockSubscription{
-		eventCh: make(chan *blockchain.Event, channelSize),
+		eventCh: make(chan *blockchain.Event),
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -416,7 +416,7 @@ func (j *jsonRPCHub) ApplyTxn(header *types.Header, txn *types.Transaction) (res
 }
 
 func (j *jsonRPCHub) GetSyncProgression() *protocol.Progression {
-	return j.GetSyncProgression()
+	return j.Consensus.GetSyncProgression()
 }
 
 // SETUP //

--- a/server/server.go
+++ b/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"github.com/0xPolygon/polygon-sdk/protocol"
 	"math/big"
 	"net"
 	"net/http"
@@ -334,6 +335,7 @@ type jsonRPCHub struct {
 	*blockchain.Blockchain
 	*txpool.TxPool
 	*state.Executor
+	consensus.Consensus
 }
 
 // HELPER + WRAPPER METHODS //
@@ -413,6 +415,10 @@ func (j *jsonRPCHub) ApplyTxn(header *types.Header, txn *types.Transaction) (res
 	return
 }
 
+func (j *jsonRPCHub) GetSyncProgression() *protocol.Progression {
+	return j.GetSyncProgression()
+}
+
 // SETUP //
 
 // setupJSONRCP sets up the JSONRPC server, using the set configuration
@@ -422,6 +428,7 @@ func (s *Server) setupJSONRPC() error {
 		Blockchain: s.blockchain,
 		TxPool:     s.txpool,
 		Executor:   s.executor,
+		Consensus:  s.consensus,
 	}
 
 	conf := &jsonrpc.Config{


### PR DESCRIPTION
# Description

This PR adds support for querying the bulk sync status of a node using the `eth_syncing` endpoint.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs
