### PR TITLE
Resolve deadlock in promotedTxnCleanup

### DIFF
--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -583,28 +583,32 @@ func (t *TxPool) promotedTxnCleanup(
 	t.pendingQueue.lock.Lock()
 
 	// Find the txns that correspond to this account
-	droppedPendingTxs := 0
+	droppedPendingTxs := make([]*types.Transaction, 0)
 	for _, pendingQueueTxn := range t.pendingQueue.index {
 		// Check if the txn in the promoted queue matches the search criteria
 		if pendingQueueTxn.from == address && // The sender of this txn is the account we're looking for
 			pendingQueueTxn.tx.Nonce < stateNonce { // The nonce on this promoted txn is invalid
 			// Transaction found, drop it from the pending queue
 			if dropped := t.pendingQueue.dropTx(pendingQueueTxn.tx); dropped {
-				// Update the log data
-				droppedPendingTxs++
-				t.logger.Debug(
-					fmt.Sprintf(
-						"Dropping promoted txn [%s]",
-						pendingQueueTxn.tx.Hash.String(),
-					),
-				)
-
-				cleanupCallback(pendingQueueTxn.tx)
+				// Save the transaction as dropped
+				droppedPendingTxs = append(droppedPendingTxs, pendingQueueTxn.tx)
 			}
 		}
 	}
 
 	t.pendingQueue.lock.Unlock()
+
+	for _, droppedPendingTx := range droppedPendingTxs {
+		// Update the log
+		t.logger.Debug(
+			fmt.Sprintf(
+				"Dropping promoted txn [%s]",
+				droppedPendingTx.Hash.String(),
+			),
+		)
+
+		cleanupCallback(droppedPendingTx)
+	}
 
 	// Print out the number of dropped pending txns
 	t.logger.Debug(

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -614,7 +614,7 @@ func (t *TxPool) promotedTxnCleanup(
 	t.logger.Debug(
 		fmt.Sprintf(
 			"Dropped %d promoted txns for account [%s]",
-			droppedPendingTxs,
+			len(droppedPendingTxs),
 			address.String(),
 		),
 	)


### PR DESCRIPTION
# Description

This PR resolves a deadlock situation that can occur inside `promotedTxnCleanup`.

Scenario:
* Thread A enters `promotedTxnCleanup` and grabs the promoted queue lock
* Thread A still hasn't grabbed the gauge lock in the callback method when pruning the txn
* Thread B enters `processSlots`, grabs the gauge lock since it's free
* Thread A executes the callback method inside `promotedTxnCleanup`, which attempts to grab the lock for the gauge, but blocks since Thread B has it
* Thread B attempts to grab the lock for the pending queue when dropping a txn in `processSlots`, but fails since Thread A is holding it

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

This deadlock occurs on highly concurrent environments, found using @mrwillis and @dankostiuk's tool:
https://github.com/mrwillis/eth-txn-spam
