### PR TITLE
Remove earliest from JSON-RPC block filter

### DIFF
--- a/jsonrpc/codec.go
+++ b/jsonrpc/codec.go
@@ -94,9 +94,8 @@ func (e *ObjectError) Error() string {
 }
 
 const (
-	PendingBlockNumber  = BlockNumber(-3)
-	LatestBlockNumber   = BlockNumber(-2)
-	EarliestBlockNumber = BlockNumber(-1)
+	PendingBlockNumber = BlockNumber(-3)
+	LatestBlockNumber  = BlockNumber(-2)
 )
 
 type BlockNumber int64
@@ -109,10 +108,10 @@ type BlockNumberOrHash struct {
 // UnmarshalJSON will try to extract the filter's data.
 // Here are the possible input formats :
 //
-// 1 - "latest", "pending" or "earliest"	- self-explaining keywords
-// 2 - "0x2"								- block number #2 (EIP-1898 backward compatible)
-// 3 - {blockNumber:	"0x2"}				- EIP-1898 compliant block number #2
-// 4 - {blockHash:		"0xe0e..."}			- EIP-1898 compliant block hash 0xe0e...
+// 1 - "latest" or "pending"			- self-explaining keywords
+// 2 - "0x2"							- block number #2 (EIP-1898 backward compatible)
+// 3 - {blockNumber:	"0x2"}			- EIP-1898 compliant block number #2
+// 4 - {blockHash:		"0xe0e..."}		- EIP-1898 compliant block hash 0xe0e...
 func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 	type bnhCopy BlockNumberOrHash
 
@@ -152,8 +151,6 @@ func stringToBlockNumber(str string) (BlockNumber, error) {
 		return PendingBlockNumber, nil
 	case "latest":
 		return LatestBlockNumber, nil
-	case "earliest":
-		return EarliestBlockNumber, nil
 	}
 
 	n, err := types.ParseUint64orHex(&str)

--- a/jsonrpc/codec.go
+++ b/jsonrpc/codec.go
@@ -109,8 +109,11 @@ type BlockNumberOrHash struct {
 // Here are the possible input formats :
 //
 // 1 - "latest" or "pending"			- self-explaining keywords
+//
 // 2 - "0x2"							- block number #2 (EIP-1898 backward compatible)
+//
 // 3 - {blockNumber:	"0x2"}			- EIP-1898 compliant block number #2
+//
 // 4 - {blockHash:		"0xe0e..."}		- EIP-1898 compliant block hash 0xe0e...
 func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 	type bnhCopy BlockNumberOrHash

--- a/jsonrpc/codec_test.go
+++ b/jsonrpc/codec_test.go
@@ -79,6 +79,12 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 				BlockHash: &blockHash,
 			},
 		},
+		{
+			"should not unmarshal earliest block number",
+			`earliest`,
+			true,
+			BlockNumberOrHash{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -455,9 +455,6 @@ func (d *Dispatcher) getBlockHeaderImpl(number BlockNumber) (*types.Header, erro
 	case LatestBlockNumber:
 		return d.store.Header(), nil
 
-	case EarliestBlockNumber:
-		return nil, fmt.Errorf("fetching the earliest header is not supported")
-
 	case PendingBlockNumber:
 		return nil, fmt.Errorf("fetching the pending header is not supported")
 

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -222,11 +222,6 @@ func TestDispatcherFuncDecode(t *testing.T) {
 	}{
 		{
 			"block",
-			`["earliest"]`,
-			EarliestBlockNumber,
-		},
-		{
-			"block",
 			`["latest"]`,
 			LatestBlockNumber,
 		},
@@ -249,11 +244,6 @@ func TestDispatcherFuncDecode(t *testing.T) {
 			"blockPtr",
 			`["a", "latest"]`,
 			LatestBlockNumber,
-		},
-		{
-			"filter",
-			`[{"fromBlock": "pending", "toBlock": "earliest"}]`,
-			LogFilter{fromBlock: PendingBlockNumber, toBlock: EarliestBlockNumber},
 		},
 	}
 	for _, c := range cases {

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -62,9 +62,6 @@ func GetNumericBlockNumber(number BlockNumber, e *Eth) (uint64, error) {
 	case LatestBlockNumber:
 		return e.d.store.Header().Number, nil
 
-	case EarliestBlockNumber:
-		return 0, fmt.Errorf("fetching the earliest header is not supported")
-
 	case PendingBlockNumber:
 		return 0, fmt.Errorf("fetching the pending header is not supported")
 
@@ -605,11 +602,7 @@ func (e *Eth) GetLogs(filterOptions *LogFilter) (interface{}, error) {
 	head := e.d.store.Header().Number
 
 	resolveNum := func(num BlockNumber) uint64 {
-		if num == PendingBlockNumber || num == EarliestBlockNumber {
-			num = LatestBlockNumber
-		}
-
-		if num == LatestBlockNumber {
+		if num == LatestBlockNumber || num == PendingBlockNumber {
 			return head
 		}
 

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -183,7 +183,6 @@ func TestEth_Block_GetBlockByNumber(t *testing.T) {
 		err      bool
 	}{
 		{LatestBlockNumber, true, false},
-		{EarliestBlockNumber, false, true},
 		{BlockNumber(-50), false, true},
 		{BlockNumber(0), true, false},
 		{BlockNumber(2), true, false},
@@ -259,7 +258,6 @@ func TestEth_Block_GetBlockTransactionCountByNumber(t *testing.T) {
 		err      bool
 	}{
 		{LatestBlockNumber, true, false},
-		{EarliestBlockNumber, false, true},
 		{BlockNumber(-50), false, true},
 		{BlockNumber(0), true, false},
 		{BlockNumber(2), true, false},

--- a/jsonrpc/query_test.go
+++ b/jsonrpc/query_test.go
@@ -100,16 +100,6 @@ func TestFilterDecode(t *testing.T) {
 		},
 		{
 			`{
-				"fromBlock": "pending",
-				"toBlock": "earliest"
-			}`,
-			&LogFilter{
-				fromBlock: PendingBlockNumber,
-				toBlock:   EarliestBlockNumber,
-			},
-		},
-		{
-			`{
 				"blockHash": "` + hash1.String() + `"
 			}`,
 			&LogFilter{


### PR DESCRIPTION
# Description

This PR removes the `earliest` block filter from the JSON-RPC module, as it is not supported.

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [X] I have tested this code
- [X] I have updated the README and other relevant documents (guides...)
- [X] I have added sufficient documentation both in code, as well as in the READMEs