### PR TITLE
Add support for earliest block number in JSON-RPC module

### DIFF
--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -456,7 +456,7 @@ func (d *Dispatcher) getBlockHeaderImpl(number BlockNumber) (*types.Header, erro
 		return d.store.Header(), nil
 
 	case EarliestBlockNumber:
-		header, ok := d.store.GetHeaderByNumber(uint64(number))
+		header, ok := d.store.GetHeaderByNumber(uint64(0))
 		if !ok {
 			return nil, fmt.Errorf("error fetching genesis block header")
 		}

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -456,7 +456,12 @@ func (d *Dispatcher) getBlockHeaderImpl(number BlockNumber) (*types.Header, erro
 		return d.store.Header(), nil
 
 	case EarliestBlockNumber:
-		return nil, fmt.Errorf("fetching the earliest header is not supported")
+		header, ok := d.store.GetHeaderByNumber(uint64(number))
+		if !ok {
+			return nil, fmt.Errorf("error fetching genesis block header")
+		}
+
+		return header, nil
 
 	case PendingBlockNumber:
 		return nil, fmt.Errorf("fetching the pending header is not supported")

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -64,7 +64,7 @@ func GetNumericBlockNumber(number BlockNumber, e *Eth) (uint64, error) {
 		return e.d.store.Header().Number, nil
 
 	case EarliestBlockNumber:
-		return 0, fmt.Errorf("fetching the earliest header is not supported")
+		return 0, nil
 
 	case PendingBlockNumber:
 		return 0, fmt.Errorf("fetching the pending header is not supported")

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -606,8 +606,12 @@ func (e *Eth) GetLogs(filterOptions *LogFilter) (interface{}, error) {
 	head := e.d.store.Header().Number
 
 	resolveNum := func(num BlockNumber) uint64 {
-		if num == PendingBlockNumber || num == EarliestBlockNumber {
+		if num == PendingBlockNumber {
 			num = LatestBlockNumber
+		}
+
+		if num == EarliestBlockNumber {
+			num = 0
 		}
 
 		if num == LatestBlockNumber {

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -183,7 +183,7 @@ func TestEth_Block_GetBlockByNumber(t *testing.T) {
 		err      bool
 	}{
 		{LatestBlockNumber, true, false},
-		{EarliestBlockNumber, false, true},
+		{EarliestBlockNumber, true, false},
 		{BlockNumber(-50), false, true},
 		{BlockNumber(0), true, false},
 		{BlockNumber(2), true, false},

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -259,7 +259,7 @@ func TestEth_Block_GetBlockTransactionCountByNumber(t *testing.T) {
 		err      bool
 	}{
 		{LatestBlockNumber, true, false},
-		{EarliestBlockNumber, false, true},
+		{EarliestBlockNumber, true, false},
 		{BlockNumber(-50), false, true},
 		{BlockNumber(0), true, false},
 		{BlockNumber(2), true, false},
@@ -467,6 +467,7 @@ func TestEth_State_GetBalance(t *testing.T) {
 	}
 
 	dispatcher := newTestDispatcher(hclog.NewNullLogger(), store)
+	blockNumberEarliest := EarliestBlockNumber
 	blockNumberLatest := LatestBlockNumber
 	blockNumberZero := BlockNumber(0x0)
 	blockNumberInvalid := BlockNumber(0x1)
@@ -479,6 +480,14 @@ func TestEth_State_GetBalance(t *testing.T) {
 		blockHash       *types.Hash
 		expectedBalance int64
 	}{
+		{
+			"should return the balance based on the earliest block",
+			addr0,
+			false,
+			&blockNumberEarliest,
+			nil,
+			100,
+		},
 		{
 			"valid implicit latest block number",
 			addr0,
@@ -581,6 +590,7 @@ func TestEth_State_GetTransactionCount(t *testing.T) {
 	}
 
 	dispatcher := newTestDispatcher(hclog.NewNullLogger(), store)
+	blockNumberEarliest := EarliestBlockNumber
 	blockNumberLatest := LatestBlockNumber
 	blockNumberZero := BlockNumber(0x0)
 	blockNumberInvalid := BlockNumber(0x1)
@@ -593,6 +603,14 @@ func TestEth_State_GetTransactionCount(t *testing.T) {
 		shouldFail    bool
 		expectedNonce uint64
 	}{
+		{
+			"should return valid nonce using earliest block number",
+			addr0,
+			&blockNumberEarliest,
+			nil,
+			false,
+			100,
+		},
 		{
 			"should return valid nonce for implicit block number",
 			addr0,
@@ -695,6 +713,7 @@ func TestEth_State_GetCode(t *testing.T) {
 	}
 
 	dispatcher := newTestDispatcher(hclog.NewNullLogger(), store)
+	blockNumberEarliest := EarliestBlockNumber
 	blockNumberLatest := LatestBlockNumber
 	blockNumberZero := BlockNumber(0x0)
 	blockNumberInvalid := BlockNumber(0x1)
@@ -709,6 +728,14 @@ func TestEth_State_GetCode(t *testing.T) {
 		shouldFail   bool
 		expectedCode []byte
 	}{
+		{
+			"should return a valid code using earliest block number",
+			addr0,
+			&blockNumberEarliest,
+			nil,
+			false,
+			code0,
+		},
 		{
 			"should return a valid code for implicit block number",
 			addr0,
@@ -810,6 +837,7 @@ func TestEth_State_GetStorageAt(t *testing.T) {
 	}
 
 	dispatcher := newTestDispatcher(hclog.NewNullLogger(), store)
+	blockNumberEarliest := EarliestBlockNumber
 	blockNumberLatest := LatestBlockNumber
 	blockNumberZero := BlockNumber(0x0)
 	blockNumberInvalid := BlockNumber(0x1)
@@ -920,6 +948,20 @@ func TestEth_State_GetStorageAt(t *testing.T) {
 			blockHash:    &hash1,
 			succeeded:    false,
 			expectedData: nil,
+		},
+		{
+			name: "should return data using earliest block number",
+			initialStorage: map[types.Address]map[types.Hash]types.Hash{
+				addr0: {
+					hash1: hash1,
+				},
+			},
+			address:      addr0,
+			index:        hash1,
+			blockNumber:  &blockNumberEarliest,
+			blockHash:    nil,
+			succeeded:    true,
+			expectedData: argBytesPtr(hash1[:]),
 		},
 	}
 


### PR DESCRIPTION
# Description

This PR adds support for `earliest` keywork in the JSON-RPC module, allowing to make queries on the genesis block.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [X] I have tested this code
- [X] I have updated the README and other relevant documents (guides...)
- [X] I have added sufficient documentation both in code, as well as in the READMEs
