### PR TITLE
Generate receipt for failed transactions

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -678,6 +678,7 @@ func (i *Ibft) writeTransactions(gasLimit uint64, transition transitionInterface
 			} else if appErr, ok := err.(*state.TransitionApplicationError); ok && appErr.IsRecoverable { // nolint:errorlint
 				i.txpool.Demote(tx)
 			} else {
+				failedTxCount++
 				i.txpool.Drop(tx)
 			}
 
@@ -692,8 +693,7 @@ func (i *Ibft) writeTransactions(gasLimit uint64, transition transitionInterface
 		transactions = append(transactions, tx)
 	}
 
-	//nolint:lll
-	i.logger.Info("picked out txns from pool", "numFailedTx ", failedTxCount, "numSuccessTx ", successTxCount, "remaining", i.txpool.Length())
+	i.logger.Info("executed txns", "failed ", failedTxCount, "successful", successTxCount, "remaining in pool", i.txpool.Length())
 
 	return transactions
 }

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -556,7 +556,7 @@ func TestWriteTransactions(t *testing.T) {
 			[]int{1},
 			5,
 			3,
-			2,
+			3,
 		},
 	}
 
@@ -735,6 +735,10 @@ type mockTransition struct {
 	gasLimitReachedTransaction *types.Transaction
 }
 
+func (t *mockTransition) WriteFailedReceipt(txn *types.Transaction) {
+	t.transactionsWritten = append(t.transactionsWritten, txn)
+}
+
 func (t *mockTransition) Write(txn *types.Transaction) error {
 	if txn == t.gasLimitReachedTransaction {
 		return state.NewGasLimitReachedTransitionApplicationError(nil)
@@ -755,6 +759,10 @@ func (t *mockTransition) Write(txn *types.Transaction) error {
 	t.transactionsWritten = append(t.transactionsWritten, txn)
 
 	return nil
+}
+
+func (t *mockTransition) WriteFa(txn *types.Transaction) {
+	t.transactionsWritten = append(t.transactionsWritten, txn)
 }
 
 type mockIbft struct {

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -761,10 +761,6 @@ func (t *mockTransition) Write(txn *types.Transaction) error {
 	return nil
 }
 
-func (t *mockTransition) WriteFa(txn *types.Transaction) {
-	t.transactionsWritten = append(t.transactionsWritten, txn)
-}
-
 type mockIbft struct {
 	t *testing.T
 	*Ibft

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -463,34 +463,39 @@ func TestTransition_RoundChangeState_MaxRound(t *testing.T) {
 }
 
 func TestWriteTransactions(t *testing.T) {
+	type testCaseParams struct {
+		txns                        []*types.Transaction
+		recoverableTxnsIndexes      []int
+		unrecoverableTxnsIndexes    []int
+		gasLimitReachedTxnIndex     int
+		expectedTxPoolLength        int
+		expectedIncludedTxnsCount   int
+		expectedFailReceiptsWritten int
+	}
+
 	type testCase struct {
-		description               string
-		txns                      []*types.Transaction
-		recoverableTxnsIndexes    []int
-		unrecoverableTxnsIndexes  []int
-		gasLimitReachedTxnIndex   int
-		expectedTxPoolLength      int
-		expectedIncludedTxnsCount int
+		description string
+		params      testCaseParams
 	}
 
 	setupMockTransition := func(test testCase, mockTxPool *mockTxPool) *mockTransition {
 		mockTransition := &mockTransition{}
-		for _, i := range test.recoverableTxnsIndexes {
+		for _, i := range test.params.recoverableTxnsIndexes {
 			mockTransition.recoverableTransactions = append(
 				mockTransition.recoverableTransactions,
 				mockTxPool.transactions[i],
 			)
 		}
 
-		for _, i := range test.unrecoverableTxnsIndexes {
+		for _, i := range test.params.unrecoverableTxnsIndexes {
 			mockTransition.unrecoverableTransactions = append(
 				mockTransition.unrecoverableTransactions,
 				mockTxPool.transactions[i],
 			)
 		}
 
-		if test.gasLimitReachedTxnIndex > 0 {
-			mockTransition.gasLimitReachedTransaction = mockTxPool.transactions[test.gasLimitReachedTxnIndex]
+		if test.params.gasLimitReachedTxnIndex > 0 {
+			mockTransition.gasLimitReachedTransaction = mockTxPool.transactions[test.params.gasLimitReachedTxnIndex]
 		}
 
 		return mockTransition
@@ -498,65 +503,83 @@ func TestWriteTransactions(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			"transaction whose gas exceeds block gas limit is discarded",
-			[]*types.Transaction{{Nonce: 1}},
-			nil,
-			nil,
-			-1,
-			0,
-			1,
+			"transaction whose gas exceeds block gas limit is included but with failedReceipt",
+			testCaseParams{
+				[]*types.Transaction{{Nonce: 1, Gas: 10000000000001}, {Nonce: 2, Gas: 10000000000002}, {Nonce: 1}},
+				nil,
+				nil,
+				-1,
+				0,
+				3,
+				2,
+			},
 		},
 		{
 			"valid transaction is included in transition",
-			[]*types.Transaction{{Nonce: 1}},
-			nil,
-			nil,
-			-1,
-			0,
-			1,
+			testCaseParams{
+				[]*types.Transaction{{Nonce: 1}},
+				nil,
+				nil,
+				-1,
+				0,
+				1,
+				0,
+			},
 		},
 		{
 			"recoverable transaction is returned to pool and not included in transition",
-			[]*types.Transaction{{Nonce: 1}},
-			[]int{0},
-			nil,
-			-1,
-			1,
-			0,
+			testCaseParams{
+				[]*types.Transaction{{Nonce: 1}},
+				[]int{0},
+				nil,
+				-1,
+				1,
+				0,
+				0,
+			},
 		},
 		{
 			"unrecoverable transaction is not returned to pool and not included in transition",
-			[]*types.Transaction{{Nonce: 1}},
-			nil,
-			[]int{0},
-			-1,
-			0,
-			0,
+			testCaseParams{
+				[]*types.Transaction{{Nonce: 1}},
+				nil,
+				[]int{0},
+				-1,
+				0,
+				0,
+				0,
+			},
 		},
 		{
 			"only valid transactions are ever included in transition",
-			[]*types.Transaction{{Nonce: 1}, {Nonce: 2}, {Nonce: 3}, {Nonce: 4}, {Nonce: 5}},
-			[]int{0},
-			[]int{3, 4},
-			-1,
-			1,
-			2,
+			testCaseParams{
+				[]*types.Transaction{{Nonce: 1}, {Nonce: 2}, {Nonce: 3}, {Nonce: 4}, {Nonce: 5}},
+				[]int{0},
+				[]int{3, 4},
+				-1,
+				1,
+				2,
+				0,
+			},
 		},
 		{
 			"write stops when next included transaction reaches block gas limit",
-			[]*types.Transaction{
-				{Nonce: 1},             // recoverable - returned to pool
-				{Nonce: 2},             // unrecoverable
-				{Nonce: 3},             // included
-				{Nonce: 4, Gas: 10001}, // exceeds block gas limit
-				{Nonce: 5},             // included
-				{Nonce: 6},             // reaches gas limit - returned to pool
-				{Nonce: 7}},            // not considered - stays in pool
-			[]int{0},
-			[]int{1},
-			5,
-			3,
-			3,
+			testCaseParams{
+				[]*types.Transaction{
+					{Nonce: 1},             // recoverable - returned to pool
+					{Nonce: 2},             // unrecoverable
+					{Nonce: 3},             // included
+					{Nonce: 4, Gas: 10001}, // exceeds block gas limit
+					{Nonce: 5},             // included
+					{Nonce: 6},             // reaches gas limit - returned to pool
+					{Nonce: 7}},            // not considered - stays in pool
+				[]int{0},
+				[]int{1},
+				5,
+				3,
+				3,
+				1,
+			},
 		},
 	}
 
@@ -564,14 +587,15 @@ func TestWriteTransactions(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			m := newMockIbft(t, []string{"A", "B", "C"}, "A")
 			mockTxPool := &mockTxPool{}
-			mockTxPool.transactions = append(mockTxPool.transactions, test.txns...)
+			mockTxPool.transactions = append(mockTxPool.transactions, test.params.txns...)
 			m.txpool = mockTxPool
 			mockTransition := setupMockTransition(test, mockTxPool)
 
 			included := m.writeTransactions(1000, mockTransition)
 
-			assert.Equal(t, uint64(test.expectedTxPoolLength), m.txpool.Length())
-			assert.Equal(t, test.expectedIncludedTxnsCount, len(included))
+			assert.Equal(t, uint64(test.params.expectedTxPoolLength), m.txpool.Length())
+			assert.Equal(t, test.params.expectedFailReceiptsWritten, len(mockTransition.failReceiptsWritten))
+			assert.Equal(t, test.params.expectedIncludedTxnsCount, len(included))
 			for _, recoverable := range mockTransition.recoverableTransactions {
 				assert.False(t, mockTxPool.nonceDecreased[recoverable])
 			}
@@ -729,14 +753,15 @@ func (p *mockTxPool) ResetWithHeaders(headers ...*types.Header) {
 }
 
 type mockTransition struct {
-	transactionsWritten        []*types.Transaction
+	failReceiptsWritten        []*types.Transaction
+	successReceiptsWritten     []*types.Transaction
 	recoverableTransactions    []*types.Transaction
 	unrecoverableTransactions  []*types.Transaction
 	gasLimitReachedTransaction *types.Transaction
 }
 
 func (t *mockTransition) WriteFailedReceipt(txn *types.Transaction) {
-	t.transactionsWritten = append(t.transactionsWritten, txn)
+	t.failReceiptsWritten = append(t.failReceiptsWritten, txn)
 }
 
 func (t *mockTransition) Write(txn *types.Transaction) error {
@@ -756,7 +781,7 @@ func (t *mockTransition) Write(txn *types.Transaction) error {
 		}
 	}
 
-	t.transactionsWritten = append(t.transactionsWritten, txn)
+	t.successReceiptsWritten = append(t.successReceiptsWritten, txn)
 
 	return nil
 }

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -463,7 +463,7 @@ func TestTransition_RoundChangeState_MaxRound(t *testing.T) {
 }
 
 func TestWriteTransactions(t *testing.T) {
-	type testCaseParams struct {
+	type testParams struct {
 		txns                        []*types.Transaction
 		recoverableTxnsIndexes      []int
 		unrecoverableTxnsIndexes    []int
@@ -475,7 +475,7 @@ func TestWriteTransactions(t *testing.T) {
 
 	type testCase struct {
 		description string
-		params      testCaseParams
+		params      testParams
 	}
 
 	setupMockTransition := func(test testCase, mockTxPool *mockTxPool) *mockTransition {
@@ -504,7 +504,7 @@ func TestWriteTransactions(t *testing.T) {
 	testCases := []testCase{
 		{
 			"transaction whose gas exceeds block gas limit is included but with failedReceipt",
-			testCaseParams{
+			testParams{
 				[]*types.Transaction{{Nonce: 1, Gas: 10000000000001}, {Nonce: 2, Gas: 10000000000002}, {Nonce: 1}},
 				nil,
 				nil,
@@ -516,7 +516,7 @@ func TestWriteTransactions(t *testing.T) {
 		},
 		{
 			"valid transaction is included in transition",
-			testCaseParams{
+			testParams{
 				[]*types.Transaction{{Nonce: 1}},
 				nil,
 				nil,
@@ -528,7 +528,7 @@ func TestWriteTransactions(t *testing.T) {
 		},
 		{
 			"recoverable transaction is returned to pool and not included in transition",
-			testCaseParams{
+			testParams{
 				[]*types.Transaction{{Nonce: 1}},
 				[]int{0},
 				nil,
@@ -540,7 +540,7 @@ func TestWriteTransactions(t *testing.T) {
 		},
 		{
 			"unrecoverable transaction is not returned to pool and not included in transition",
-			testCaseParams{
+			testParams{
 				[]*types.Transaction{{Nonce: 1}},
 				nil,
 				[]int{0},
@@ -552,7 +552,7 @@ func TestWriteTransactions(t *testing.T) {
 		},
 		{
 			"only valid transactions are ever included in transition",
-			testCaseParams{
+			testParams{
 				[]*types.Transaction{{Nonce: 1}, {Nonce: 2}, {Nonce: 3}, {Nonce: 4}, {Nonce: 5}},
 				[]int{0},
 				[]int{3, 4},
@@ -564,7 +564,7 @@ func TestWriteTransactions(t *testing.T) {
 		},
 		{
 			"write stops when next included transaction reaches block gas limit",
-			testCaseParams{
+			testParams{
 				[]*types.Transaction{
 					{Nonce: 1},             // recoverable - returned to pool
 					{Nonce: 2},             // unrecoverable

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -760,8 +760,10 @@ type mockTransition struct {
 	gasLimitReachedTransaction *types.Transaction
 }
 
-func (t *mockTransition) WriteFailedReceipt(txn *types.Transaction) {
+func (t *mockTransition) WriteFailedReceipt(txn *types.Transaction) error {
 	t.failReceiptsWritten = append(t.failReceiptsWritten, txn)
+
+	return nil
 }
 
 func (t *mockTransition) Write(txn *types.Transaction) error {

--- a/state/executor.go
+++ b/state/executor.go
@@ -214,13 +214,14 @@ var emptyFrom = types.Address{}
 func (t *Transition) WriteFailedReceipt(txn *types.Transaction) error {
 	signer := crypto.NewSigner(t.config, uint64(t.r.config.ChainID))
 
-	var err error
 	if txn.From == emptyFrom {
 		// Decrypt the from address
-		txn.From, err = signer.Sender(txn)
+		from, err := signer.Sender(txn)
 		if err != nil {
 			return NewTransitionApplicationError(err, false)
 		}
+
+		txn.From = from
 	}
 
 	receipt := &types.Receipt{

--- a/state/executor.go
+++ b/state/executor.go
@@ -210,13 +210,12 @@ func (t *Transition) Receipts() []*types.Receipt {
 var emptyFrom = types.Address{}
 
 func (t *Transition) WriteFailedReceipt(txn *types.Transaction) {
-	logs := t.state.Logs()
-
 	receipt := &types.Receipt{
 		CumulativeGasUsed: t.totalGas,
 		TxHash:            txn.Hash,
+		Logs:              t.state.Logs(),
 	}
-	receipt.Logs = logs
+
 	receipt.LogsBloom = types.CreateBloom([]*types.Receipt{receipt})
 	receipt.SetStatus(types.ReceiptFailed)
 	t.receipts = append(t.receipts, receipt)


### PR DESCRIPTION
# Description

This PR generates failed receipt if the transaction fails once it goes inside the pool.
This can happen because we do not have a default block gas limit, we dynamically calculate it when we create the block.
When we are validating a transaction before we put it in the pool we check for the gas limit but with the previous block.
In some specific edge-case, it can happen that when we are putting transaction in the pool to be valid (because the previous block gas limit is big enough) but when we are putting transaction in the block to be invalid.

Steps to test it:

Start IBFT network
Send transaction with gas limit 1000000000001
After transaction goes into block it will return ERROR receipt

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
