### PR TITLE
Discard transaction with invalid gas limit

### DIFF
--- a/txpool/mock_test.go
+++ b/txpool/mock_test.go
@@ -10,12 +10,25 @@ import (
 /* MOCK */
 
 type defaultMockStore struct {
+	DefaultHeader *types.Header
+}
+
+func NewDefaultMockStore(header *types.Header) defaultMockStore {
+	var defaultHeader = &types.Header{
+		GasLimit: 4712388,
+	}
+
+	if header != nil {
+		defaultHeader = header
+	}
+
+	return defaultMockStore{
+		defaultHeader,
+	}
 }
 
 func (m defaultMockStore) Header() *types.Header {
-	return &types.Header{
-		GasLimit: 4712388,
-	}
+	return m.DefaultHeader
 }
 
 func (m defaultMockStore) GetNonce(types.Hash, types.Address) uint64 {

--- a/txpool/mock_test.go
+++ b/txpool/mock_test.go
@@ -13,7 +13,9 @@ type defaultMockStore struct {
 }
 
 func (m defaultMockStore) Header() *types.Header {
-	return &types.Header{}
+	return &types.Header{
+		GasLimit: 4712388,
+	}
 }
 
 func (m defaultMockStore) GetNonce(types.Hash, types.Address) uint64 {

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -26,6 +26,7 @@ const (
 // errors
 var (
 	ErrIntrinsicGas        = errors.New("intrinsic gas too low")
+	ErrBlockLimitExceeded  = errors.New("transaction's gas limit exceeds block gas limit")
 	ErrNegativeValue       = errors.New("negative value")
 	ErrNonEncryptedTx      = errors.New("non-encrypted transaction")
 	ErrInvalidSender       = errors.New("invalid sender")
@@ -534,6 +535,13 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 
 	if tx.Gas < intrinsicGas {
 		return ErrIntrinsicGas
+	}
+
+	// Grab the block gas limit for the latest block
+	latestBlockGasLimit := p.store.Header().GasLimit
+
+	if tx.Gas > latestBlockGasLimit {
+		return ErrBlockLimitExceeded
 	}
 
 	return nil

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -26,7 +26,7 @@ const (
 // errors
 var (
 	ErrIntrinsicGas        = errors.New("intrinsic gas too low")
-	ErrBlockLimitExceeded  = errors.New("transaction's gas limit exceeds block gas limit")
+	ErrBlockLimitExceeded  = errors.New("exceeds block gas limit")
 	ErrNegativeValue       = errors.New("negative value")
 	ErrNonEncryptedTx      = errors.New("non-encrypted transaction")
 	ErrInvalidSender       = errors.New("invalid sender")

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -19,7 +19,8 @@ import (
 const (
 	defaultPriceLimit uint64 = 1
 	defaultMaxSlots   uint64 = 4096
-	validGasLimit     uint64 = 10000000
+	validGasLimit     uint64 = 4712350
+	invalidGasLimit   uint64 = 10000000000001
 )
 
 var (
@@ -108,6 +109,19 @@ func TestAddTxErrors(t *testing.T) {
 
 		return pool
 	}
+
+	t.Run("ErrBlockLimitExceeded", func(t *testing.T) {
+		pool := setupPool()
+
+		tx := newTx(addr1, 0, 1)
+		tx.Value = big.NewInt(1)
+		tx.Gas = invalidGasLimit
+
+		assert.ErrorIs(t,
+			pool.addTx(local, tx),
+			ErrBlockLimitExceeded,
+		)
+	})
 
 	t.Run("ErrNegativeValue", func(t *testing.T) {
 		pool := setupPool()


### PR DESCRIPTION
# Description

If a transaction has gasLimit bigger than the latest blockGasLimit it is considered invalid.
There is no way to know for sure what will be gas limit of the block where the transaction will be placed, so we have another check when we are creating a block.

Different error cases

Transaction has gasLimit > latestBlockGasLimit (it will not go into pool and it will be rejected as invalid)
Transaction has gasLimit < latestBlockGasLimit but when we create a block gasLimit > newBlockGasLimit (we will generate failed transaction receipt)
Testing:

Try to add a transaction with gasLimit 10000000001.


# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
