### PR TITLE
Fix prometheus txpool_pending_transactions Gauge

### DIFF
--- a/txpool/metrics.go
+++ b/txpool/metrics.go
@@ -25,7 +25,7 @@ func GetPrometheusMetrics(namespace string, labelsWithValues ...string) *Metrics
 		PendingTxs: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: "txpool",
-			Name:      "pending_txs",
+			Name:      "pending_transactions",
 			Help:      "Pending transactions in the pool",
 		}, labels).With(labelsWithValues...),
 	}

--- a/txpool/metrics.go
+++ b/txpool/metrics.go
@@ -25,7 +25,7 @@ func GetPrometheusMetrics(namespace string, labelsWithValues ...string) *Metrics
 		PendingTxs: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: "txpool",
-			Name:      "pendingTxs",
+			Name:      "pending_txs",
 			Help:      "Pending transactions in the pool",
 		}, labels).With(labelsWithValues...),
 	}

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -223,6 +223,9 @@ func NewTxPool(
 // On each request received, the appropriate handler
 // is invoked in a separate goroutine.
 func (p *TxPool) Start() {
+	// set default value of txpool pending transactions gauge
+	p.metrics.PendingTxs.Set(0)
+	
 	go func() {
 		for {
 			select {

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -225,7 +225,7 @@ func NewTxPool(
 func (p *TxPool) Start() {
 	// set default value of txpool pending transactions gauge
 	p.metrics.PendingTxs.Set(0)
-	
+
 	go func() {
 		for {
 			select {


### PR DESCRIPTION
# Description

This PR fixes txpool_pending_transactions Prometheus metric.

It fixes the name of the metric to conform to public docs and it sets the metric default value to 0.
Currently it is not working as the default value is not set.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs
