### PR TITLE
Set closed to true before closing channel

### DIFF
--- a/network/server.go
+++ b/network/server.go
@@ -682,6 +682,9 @@ func (s *Server) SubscribeCh() (<-chan *PeerEvent, error) {
 		}
 	})
 	if err != nil {
+		mutex.Lock()
+		closed = true
+		mutex.Unlock()
 		close(ch)
 
 		return nil, err

--- a/network/server.go
+++ b/network/server.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"regexp"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/0xPolygon/polygon-sdk/chain"
@@ -665,26 +666,15 @@ func (s *Server) SubscribeFn(handler func(evnt *PeerEvent)) error {
 func (s *Server) SubscribeCh() (<-chan *PeerEvent, error) {
 	ch := make(chan *PeerEvent)
 
-	var closed bool
-
-	var mutex sync.Mutex
-
-	isClosed := func() bool {
-		mutex.Lock()
-		defer mutex.Unlock()
-
-		return closed
-	}
+	var isClosed int32 = 0
 
 	err := s.SubscribeFn(func(evnt *PeerEvent) {
-		if !isClosed() {
+		if atomic.LoadInt32(&isClosed) == 0 {
 			ch <- evnt
 		}
 	})
 	if err != nil {
-		mutex.Lock()
-		closed = true
-		mutex.Unlock()
+		atomic.StoreInt32(&isClosed, 1)
 		close(ch)
 
 		return nil, err
@@ -692,9 +682,7 @@ func (s *Server) SubscribeCh() (<-chan *PeerEvent, error) {
 
 	go func() {
 		<-s.closeCh
-		mutex.Lock()
-		closed = true
-		mutex.Unlock()
+		atomic.StoreInt32(&isClosed, 1)
 		close(ch)
 	}()
 


### PR DESCRIPTION
# Description

This issue is really tricky to reproduce. We know that it happened only 2 times, once 2 months ago and last week on one of the in-progress (really unstable) branch.

Two catches gave us exact line where panic happens:
https://github.com/0xPolygon/polygon-edge/blob/81e632e80e4d45560d74ea7cfa1fb9821c8d1f14/network/server.go#L681
And the error is: `panic: send on closed channel`


What could go wrong
https://github.com/0xPolygon/polygon-edge/blob/81e632e80e4d45560d74ea7cfa1fb9821c8d1f14/network/server.go#L641-L702

Watching the code I have conclude 2 things:

1. Before we write in the channel we check _isClosed()_, where we return _closed_ flag
2. This callback is called from _SubscribeFn()_ routine, where the program is listening channel for `evnt`, and then trigger the callback.

We are closing the channel in only 2 places 
1. When we get _<-s.closeCh_ signal
2. If some error happens in 'SubscribeFn()' call.

When an error occurs we do not set flag _closed_ to true. In some edge case, there is the possibility that the channel could close because of the error,  callback goroutine would continue it would check _isClosed()_ which would be false because the flag is not correct and our code will try to write in the closed channel.

 Without reproducing this bug one more time I can not be 100% that this solves our problem. If this bug happens ever again we need to save the log and check if _[ERROR] failed to subscribe_ happened which would prove my theory.


# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
