### PR TITLE
[Hotfix] Fix build script for protocol buffer in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ bindata:
 
 .PHONY: protoc
 protoc:
-	protoc --go_out=. --go-grpc_out=. ./minimal/proto/*.proto
+	protoc --go_out=. --go-grpc_out=. ./server/proto/*.proto
 	protoc --go_out=. --go-grpc_out=. ./protocol/proto/*.proto
-	protoc --go_out=. --go-grpc_out=. ./network/proto/test/*.proto
 	protoc --go_out=. --go-grpc_out=. ./network/proto/*.proto
 	protoc --go_out=. --go-grpc_out=. ./txpool/proto/*.proto
-	protoc --go_out=. --go-grpc_out=. ./consensus/ibft/proto/*.proto
+	protoc --go_out=. --go-grpc_out=. ./consensus/ibft/**/*.proto
+
 
 .PHONY: lint
 lint:

--- a/server/proto/system.proto
+++ b/server/proto/system.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package v1;
 
-option go_package = "/minimal/proto";
+option go_package = "/server/proto";
 
 import "google/protobuf/empty.proto";
 
@@ -35,13 +35,13 @@ message BlockchainEvent {
 
 message ServerStatus {
     int64 network = 1;
-    
+
     string genesis = 2;
 
     Block current = 3;
 
     string p2pAddr = 4;
-    
+
     message Block {
         int64 number = 1;
         string hash = 2;


### PR DESCRIPTION
# Description

This PR fixes the following problems around build protocol buffer in Makefile
- Remove `protoc --go_out=. --go-grpc_out=. ./minimal/proto/*.proto` from `make protoc` because the file doesn't exist currently
- Fix go package path of server/proto/system.proto

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
