### PR TITLE
[TxPool] Skip empty accounts in allTxs

### DIFF
--- a/txpool/account.go
+++ b/txpool/account.go
@@ -101,13 +101,17 @@ func (m *accountsMap) allTxs(includeEnqueued bool) (
 		account.promoted.lock(false)
 		defer account.promoted.unlock()
 
-		allPromoted[addr] = account.promoted.queue
+		if account.promoted.length() != 0 {
+			allPromoted[addr] = account.promoted.queue
+		}
 
 		if includeEnqueued {
 			account.enqueued.lock(false)
 			defer account.enqueued.unlock()
 
-			allEnqueued[addr] = account.enqueued.queue
+			if account.enqueued.length() != 0 {
+				allEnqueued[addr] = account.enqueued.queue
+			}
 		}
 
 		return true


### PR DESCRIPTION
# Description

This PR addresses the issue of txpool's `content` operator command including empty queues in result.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs
