### PR TITLE
Adding configurable block time as server input parameter

### DIFF
--- a/command/helper/config.go
+++ b/command/helper/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	Join           string                 `json:"join_addr"`
 	Consensus      map[string]interface{} `json:"consensus"`
 	RestoreFile    string                 `json:"restore_file"`
+	BlockTime      uint64                 `json:"block_time"`
 }
 
 // Telemetry holds the config details for metric services.
@@ -76,6 +77,7 @@ func DefaultConfig() *Config {
 		Consensus:   map[string]interface{}{},
 		LogLevel:    "INFO",
 		RestoreFile: "",
+		BlockTime:   2,
 	}
 }
 
@@ -170,6 +172,11 @@ func (c *Config) BuildConfig() (*server.Config, error) {
 
 	if c.RestoreFile != "" {
 		conf.RestoreFile = &c.RestoreFile
+	}
+
+	// set block time if not default
+	if c.BlockTime != 2 {
+		conf.BlockTime = c.BlockTime
 	}
 
 	// if we are in dev mode, change the consensus protocol with 'dev'
@@ -296,6 +303,11 @@ func (c *Config) mergeConfigWith(otherConfig *Config) error {
 
 	if otherConfig.RestoreFile != "" {
 		c.RestoreFile = otherConfig.RestoreFile
+	}
+
+	// if block time not default, set to new value
+	if otherConfig.BlockTime != 2 {
+		c.BlockTime = otherConfig.BlockTime
 	}
 
 	if err := mergo.Merge(&c.Consensus, otherConfig.Consensus, mergo.WithOverride); err != nil {

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -469,6 +469,7 @@ func ReadConfig(baseCommand string, args []string) (*Config, error) {
 	flags.StringVar(&cliConfig.BlockGasTarget, "block-gas-target", strconv.FormatUint(0, 10), "")
 	flags.StringVar(&cliConfig.Secrets, "secrets-config", "", "")
 	flags.StringVar(&cliConfig.RestoreFile, "restore", "", "")
+	flags.Uint64Var(&cliConfig.BlockTime, "block-time", config.BlockTime, "")
 
 	if err := flags.Parse(args); err != nil {
 		return nil, err

--- a/command/server/server_command.go
+++ b/command/server/server_command.go
@@ -211,6 +211,14 @@ func (c *ServerCommand) DefineFlags() {
 		},
 		FlagOptional: true,
 	}
+
+	c.FlagMap["block-time"] = helper.FlagDescriptor{
+		Description: "Sets block time in seconds. Default: 2",
+		Arguments: []string{
+			"BLOCK_TIME",
+		},
+		FlagOptional: true,
+	}
 }
 
 // GetHelperText returns a simple description of the command

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -65,6 +65,7 @@ type ConsensusParams struct {
 	Logger         hclog.Logger
 	Metrics        *Metrics
 	SecretsManager secrets.SecretsManager
+	BlockTime      uint64
 }
 
 // Factory is the factory function to create a discovery backend

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -606,7 +606,7 @@ func (i *Ibft) buildBlock(snap *Snapshot, parent *types.Header) (*types.Block, e
 
 	// set the timestamp
 	parentTime := time.Unix(int64(parent.Timestamp), 0)
-	headerTime := parentTime.Add(time.Duration(i.blockTime) * time.Second)
+	headerTime := parentTime.Add(time.Duration(i.blockTime) * time.Millisecond)
 
 	if headerTime.Before(time.Now()) {
 		headerTime = time.Now()

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -96,6 +96,8 @@ type Ibft struct {
 	secretsManager secrets.SecretsManager
 
 	mechanism ConsensusMechanism // IBFT ConsensusMechanism used (PoA / PoS)
+
+	blockTime uint64 // Configurable consensus blocktime in seconds
 }
 
 // Define the type of the IBFT consensus
@@ -240,6 +242,7 @@ func Factory(
 		sealing:        params.Seal,
 		metrics:        params.Metrics,
 		secretsManager: params.SecretsManager,
+		blockTime:      params.BlockTime,
 	}
 
 	// Initialize the mechanism
@@ -571,8 +574,6 @@ func (i *Ibft) runSyncState() {
 	}
 }
 
-var defaultBlockPeriod = 2 * time.Second
-
 // buildBlock builds the block, based on the passed in snapshot and parent header
 func (i *Ibft) buildBlock(snap *Snapshot, parent *types.Header) (*types.Block, error) {
 	header := &types.Header{
@@ -605,7 +606,7 @@ func (i *Ibft) buildBlock(snap *Snapshot, parent *types.Header) (*types.Block, e
 
 	// set the timestamp
 	parentTime := time.Unix(int64(parent.Timestamp), 0)
-	headerTime := parentTime.Add(defaultBlockPeriod)
+	headerTime := parentTime.Add(time.Duration(i.blockTime))
 
 	if headerTime.Before(time.Now()) {
 		headerTime = time.Now()

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -606,7 +606,7 @@ func (i *Ibft) buildBlock(snap *Snapshot, parent *types.Header) (*types.Block, e
 
 	// set the timestamp
 	parentTime := time.Unix(int64(parent.Timestamp), 0)
-	headerTime := parentTime.Add(time.Duration(i.blockTime))
+	headerTime := parentTime.Add(time.Duration(i.blockTime) * time.Second)
 
 	if headerTime.Before(time.Now()) {
 		headerTime = time.Now()

--- a/server/config.go
+++ b/server/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	MaxSlots       uint64
 	SecretsManager *secrets.SecretsManagerConfig
 	RestoreFile    *string
+	BlockTime      uint64
 }
 
 // DefaultConfig returns the default config for JSON-RPC, GRPC (ports) and Networking
@@ -36,6 +37,7 @@ func DefaultConfig() *Config {
 		Network:        network.DefaultConfig(),
 		Telemetry:      &Telemetry{PrometheusAddr: nil},
 		SecretsManager: nil,
+		BlockTime:      2,
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -362,6 +362,7 @@ func (s *Server) setupConsensus() error {
 			Logger:         s.logger.Named("consensus"),
 			Metrics:        s.serverMetrics.consensus,
 			SecretsManager: s.secretsManager,
+			BlockTime:      s.config.BlockTime,
 		},
 	)
 


### PR DESCRIPTION
# Description

This PR implements the ability to customize the consensus block time.
Block time parameter can be set via ``` --block-time ``` parameter.
If this flag is omitted, the default value is 2 seconds.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs
