### PR TITLE
Fix up the block timestamp to be read in seconds

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -646,7 +646,7 @@ func (b *Blockchain) WriteBlock(block *types.Block) error {
 
 	if prevHeader, ok := b.GetHeaderByNumber(header.Number - 1); ok {
 		diff := header.Timestamp - prevHeader.Timestamp
-		logArgs = append(logArgs, "generation_time_in_miliseconds", diff)
+		logArgs = append(logArgs, "generation_time_in_seconds", diff)
 	}
 
 	b.logger.Info("new block", logArgs...)

--- a/command/helper/config.go
+++ b/command/helper/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	Join           string                 `json:"join_addr"`
 	Consensus      map[string]interface{} `json:"consensus"`
 	RestoreFile    string                 `json:"restore_file"`
-	BlockTime      uint64                 `json:"block_time_ms"` // block time im miliseconds
+	BlockTime      uint64                 `json:"block_time_s"`
 }
 
 // Telemetry holds the config details for metric services.
@@ -60,8 +60,8 @@ type TxPool struct {
 	MaxSlots   uint64 `json:"max_slots"`
 }
 
-// variable defining default BlockTime parameter in miliseconds
-const defaultBlockTime uint64 = 2000
+// minimum block generation time in seconds
+const defaultBlockTime uint64 = 2
 
 // DefaultConfig returns the default server configuration
 func DefaultConfig() *Config {
@@ -84,7 +84,7 @@ func DefaultConfig() *Config {
 		Consensus:   map[string]interface{}{},
 		LogLevel:    "INFO",
 		RestoreFile: "",
-		BlockTime:   defaultBlockTime, // default block time in miliseconds
+		BlockTime:   defaultBlockTime,
 	}
 }
 

--- a/command/server/server_command.go
+++ b/command/server/server_command.go
@@ -232,7 +232,7 @@ func (c *ServerCommand) DefineFlags() {
 	}
 
 	c.FlagMap["block-time"] = helper.FlagDescriptor{
-		Description: fmt.Sprintf("Sets block time in miliseconds. Default: %d", helper.DefaultConfig().BlockTime),
+		Description: fmt.Sprintf("Sets block time in seconds. Default: %ds", helper.DefaultConfig().BlockTime),
 		Arguments: []string{
 			"BLOCK_TIME",
 		},

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -65,7 +65,7 @@ type ConsensusParams struct {
 	Logger         hclog.Logger
 	Metrics        *Metrics
 	SecretsManager secrets.SecretsManager
-	BlockTime      uint64 // block time im miliseconds
+	BlockTime      uint64
 }
 
 // Factory is the factory function to create a discovery backend

--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -52,7 +52,7 @@ func GetPrometheusMetrics(namespace string, labelsWithValues ...string) *Metrics
 			Namespace: namespace,
 			Subsystem: "consensus",
 			Name:      "block_interval",
-			Help:      "Time between current block and the previous block in miliseconds.",
+			Help:      "Time between current block and the previous block in seconds.",
 		}, labels).With(labelsWithValues...),
 	}
 }

--- a/consensus/utils.go
+++ b/consensus/utils.go
@@ -1,8 +1,6 @@
 package consensus
 
 import (
-	"time"
-
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/0xPolygon/polygon-edge/types/buildroot"
 )
@@ -39,14 +37,4 @@ func BuildBlock(params BuildBlockParams) *types.Block {
 		Header:       header,
 		Transactions: txs,
 	}
-}
-
-// MilliToUnix returns the local Time corresponding to the given Unix time m milliseconds since January 1, 1970 UTC.
-func MilliToUnix(m uint64) time.Time {
-	return time.Unix(0, int64(m)*1e6)
-}
-
-// UnixToMilli returns uint64 value for miliseconds
-func UnixToMilli(t time.Time) uint64 {
-	return uint64(t.UnixNano() / 1e6)
 }

--- a/server/config.go
+++ b/server/config.go
@@ -10,7 +10,7 @@ import (
 
 const DefaultGRPCPort int = 9632
 const DefaultJSONRPCPort int = 8545
-const DefaultBlockTime = 2000 // in milliseconds
+const DefaultBlockTime = 2 // in seconds
 
 // Config is used to parametrize the minimal client
 type Config struct {
@@ -38,7 +38,7 @@ func DefaultConfig() *Config {
 		Network:        network.DefaultConfig(),
 		Telemetry:      &Telemetry{PrometheusAddr: nil},
 		SecretsManager: nil,
-		BlockTime:      DefaultBlockTime, // default block time in milliseconds
+		BlockTime:      DefaultBlockTime,
 	}
 }
 


### PR DESCRIPTION
# Description

Fixes EDGE-380

This PR patches a bug that treats the block timestamp in milliseconds instead of seconds

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Relevant docs PR:
https://github.com/0xPolygon/polygon-edge-docs/pull/64
