### PR TITLE
Allow longer domain suffix for server --dns value.

### DIFF
--- a/helper/flags/flags.go
+++ b/helper/flags/flags.go
@@ -52,7 +52,7 @@ func MultiAddrFromDNS(addr string, port int) (multiaddr.Multiaddr, error) {
 	var domain string
 
 	match, err := regexp.MatchString(
-		"^/?(dns)(4|6)?/[^-|^/][A-Za-z0-9-]([^-|^/]?)+([\\-\\.]{1}[a-z0-9]+)*\\.[A-Za-z]{2,6}(/?)$",
+		"^/?(dns)(4|6)?/[^-|^/][A-Za-z0-9-]([^-|^/]?)+([\\-\\.]{1}[a-z0-9]+)*\\.[A-Za-z]{2,}(/?)$",
 		addr,
 	)
 	if err != nil || !match {

--- a/helper/flags/flags_test.go
+++ b/helper/flags/flags_test.go
@@ -91,6 +91,13 @@ func TestMultiAddrFromDns(t *testing.T) {
 			err:        true,
 			outcome:    "",
 		},
+		{
+			name:       "valid long domain suffix",
+			dnsAddress: "dns/validator-1.foo.technology",
+			port:       12345,
+			err:        false,
+			outcome:    "/dns/validator-1.foo.technology/tcp/12345",
+		},
 	}
 
 	for _, tt := range tests {

--- a/helper/flags/flags_test.go
+++ b/helper/flags/flags_test.go
@@ -1,12 +1,15 @@
 package flags
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMultiAddrFromDns(t *testing.T) {
+	port := 12345
+
 	tests := []struct {
 		name       string
 		dnsAddress string
@@ -17,30 +20,30 @@ func TestMultiAddrFromDns(t *testing.T) {
 		{
 			name:       "Invalid DNS Version",
 			dnsAddress: "/dns8/example.io/",
-			port:       12345,
+			port:       port,
 			err:        true,
 			outcome:    "",
 		},
 		{
 			name:       "Invalid DNS String",
 			dnsAddress: "dns4rahul.io",
-			port:       12345,
+			port:       port,
 			err:        true,
 			outcome:    "",
 		},
 		{
 			name:       "Valid DNS Address with `/` ",
 			dnsAddress: "/dns4/rahul.io/",
-			port:       12345,
+			port:       port,
 			err:        false,
-			outcome:    "/dns4/rahul.io/tcp/12345",
+			outcome:    fmt.Sprintf("/dns4/rahul.io/tcp/%d", port),
 		},
 		{
 			name:       "Valid DNS Address without `/`",
 			dnsAddress: "dns6/example.io",
-			port:       12345,
+			port:       port,
 			err:        false,
-			outcome:    "/dns6/example.io/tcp/12345",
+			outcome:    fmt.Sprintf("/dns6/example.io/tcp/%d", port),
 		},
 		{
 			name:       "Invalid Port Number",
@@ -52,14 +55,14 @@ func TestMultiAddrFromDns(t *testing.T) {
 		{
 			name:       "Invalid Host name starting with `-` ",
 			dnsAddress: "dns6/-example.io",
-			port:       12345,
+			port:       port,
 			err:        true,
 			outcome:    "",
 		},
 		{
 			name:       "Invalid Host name starting with `/` ",
 			dnsAddress: "dns6//example.io",
-			port:       12345,
+			port:       port,
 			err:        true,
 			outcome:    "",
 		},
@@ -73,30 +76,30 @@ func TestMultiAddrFromDns(t *testing.T) {
 		{
 			name:       "Invalid Host name  with `-` ",
 			dnsAddress: "dns6/example-.io",
-			port:       12345,
+			port:       port,
 			err:        true,
 			outcome:    "",
 		},
 		{
 			name:       "Missing DNS version",
 			dnsAddress: "example.io",
-			port:       12345,
+			port:       port,
 			err:        true,
 			outcome:    "",
 		},
 		{
 			name:       "Invalid DNS version",
 			dnsAddress: "/dns8/example.io",
-			port:       12345,
+			port:       port,
 			err:        true,
 			outcome:    "",
 		},
 		{
 			name:       "valid long domain suffix",
 			dnsAddress: "dns/validator-1.foo.technology",
-			port:       12345,
+			port:       port,
 			err:        false,
-			outcome:    "/dns/validator-1.foo.technology/tcp/12345",
+			outcome:    fmt.Sprintf("/dns/validator-1.foo.technology/tcp/%d", port),
 		},
 	}
 


### PR DESCRIPTION
# Description

When testing with valid DNS suffixes longer than 6 chars (for E.g `.technology`) the server was throwing an error `Invalid DNS ` due to the regex restricting dns suffix between 2-6 chars. 

This PR still enforces min length of 2 chars and uncaps the max length.



# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have tested this code
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs
