### PR TITLE
Whitelist restriction smartcontract deployment

### DIFF
--- a/chain/params.go
+++ b/chain/params.go
@@ -7,6 +7,7 @@ import (
 // Params are all the set of params for the chain
 type Params struct {
 	Forks          *Forks                 `json:"forks"`
+	Features       *Features              `json:"features"`
 	ChainID        int                    `json:"chainID"`
 	Engine         map[string]interface{} `json:"engine"`
 	BlockGasTarget uint64                 `json:"blockGasTarget"`
@@ -19,6 +20,15 @@ func (p *Params) GetEngine() string {
 	}
 
 	return ""
+}
+
+// Forks specifies when each fork is activated
+type Features struct {
+	ContractDeployment *ContractDeployment `json:"contractDeployment"`
+}
+
+type ContractDeployment struct {
+	WhiteList []string `json:"contractDeploymentWhiteList"`
 }
 
 // Forks specifies when each fork is activated
@@ -118,4 +128,10 @@ var AllForksEnabled = &Forks{
 	Constantinople: NewFork(0),
 	Petersburg:     NewFork(0),
 	Istanbul:       NewFork(0),
+}
+
+var AllDefaultFeatures = &Features{
+	ContractDeployment: &ContractDeployment{
+		WhiteList: make([]string, 0),
+	},
 }

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -296,8 +296,9 @@ func (c *GenesisCommand) Run(args []string) int {
 			GasUsed:    helper.GenesisGasUsed,
 		},
 		Params: &chain.Params{
-			ChainID: int(chainID),
-			Forks:   chain.AllForksEnabled,
+			ChainID:  int(chainID),
+			Forks:    chain.AllForksEnabled,
+			Features: chain.AllDefaultFeatures,
 			Engine: map[string]interface{}{
 				consensus: constructEngineConfig(),
 			},

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -344,8 +344,9 @@ func generateDevGenesis(params devGenesisParams) error {
 			GasUsed:    GenesisGasUsed,
 		},
 		Params: &chain.Params{
-			ChainID: int(params.chainID),
-			Forks:   chain.AllForksEnabled,
+			ChainID:  int(params.chainID),
+			Forks:    chain.AllForksEnabled,
+			Features: chain.AllDefaultFeatures,
 			Engine: map[string]interface{}{
 				"dev": map[string]interface{}{},
 			},

--- a/command/ibft/ibft_contract_restriction.go
+++ b/command/ibft/ibft_contract_restriction.go
@@ -1,0 +1,107 @@
+package ibft
+
+import (
+	"errors"
+	"fmt"
+	"github.com/0xPolygon/polygon-edge/chain"
+	"os"
+
+	"github.com/0xPolygon/polygon-edge/command/helper"
+)
+
+// IbftContractRestriction is the command to query the snapshot
+type IbftContractRestriction struct {
+	helper.Base
+	Formatter *helper.FormatterFlag
+	GRPC      *helper.GRPCFlag
+}
+
+func (p *IbftContractRestriction) DefineFlags() {
+	p.Base.DefineFlags(p.Formatter, p.GRPC)
+
+	p.FlagMap["accounts"] = helper.FlagDescriptor{
+		Description: "Accounts that whill go into whitelist",
+		Arguments: []string{
+			"WHITE_LIST_ACCOUNT",
+		},
+		ArgumentsOptional: false,
+		FlagOptional:      true,
+	}
+}
+
+// GetHelperText returns a simple description of the command
+func (p *IbftContractRestriction) GetHelperText() string {
+	return "Sets a list of accounts to go into whitelist"
+}
+
+func (p *IbftContractRestriction) GetBaseCommand() string {
+	return "ibft contract_whitelist"
+}
+
+// Help implements the cli.IbftSnapshot interface
+func (p *IbftContractRestriction) Help() string {
+	p.DefineFlags()
+
+	return helper.GenerateHelp(p.Synopsis(), helper.GenerateUsage(p.GetBaseCommand(), p.FlagMap), p.FlagMap)
+}
+
+// Synopsis implements the cli.IbftSnapshot interface
+func (p *IbftContractRestriction) Synopsis() string {
+	return p.GetHelperText()
+}
+
+func (p *IbftContractRestriction) Run(args []string) int {
+
+	flags := p.Base.NewFlagSet(p.GetBaseCommand(), p.Formatter, p.GRPC)
+
+	// query a specific snapshot
+	var account, genesisPath string
+
+	flags.StringVar(&account, "addAccount", "", "")
+	flags.StringVar(&genesisPath, "chain", "genesis.json", "")
+	if err := flags.Parse(args); err != nil {
+		p.Formatter.OutputError(err)
+
+		return 1
+	}
+	if account == "" {
+		p.Formatter.OutputError(errors.New("Adddress not specified"))
+
+		return 1
+	}
+
+	cc, err := chain.Import(genesisPath)
+	if err != nil {
+		p.Formatter.OutputError(fmt.Errorf("failed to load chain config from %s: %w", genesisPath, err))
+
+		return 1
+	}
+
+	if err := appendIBFTForks(cc, account); err != nil {
+		p.Formatter.OutputError(err)
+
+		return 1
+	}
+
+	// Remove current genesis
+	if err := os.Remove("genesis.json"); err != nil {
+		p.Formatter.OutputError(err)
+
+		return 1
+	}
+
+	// Save new genesis
+	if err = helper.WriteGenesisToDisk(cc, "genesis.json"); err != nil {
+		p.UI.Error(err.Error())
+
+		return 1
+	}
+
+	return 0
+}
+
+func appendIBFTForks(cc *chain.Chain, account string) error {
+	cc.Params.Features.ContractDeployment.WhiteList = append(cc.Params.Features.ContractDeployment.WhiteList, account)
+
+	return nil
+}

--- a/command/util/commands.go
+++ b/command/util/commands.go
@@ -46,6 +46,7 @@ func Commands() map[string]cli.CommandFactory {
 	ibftProposeCmd := ibft.IbftPropose{Base: base, Formatter: formatter, GRPC: grpc}
 	ibftSnapshotCmd := ibft.IbftSnapshot{Base: base, Formatter: formatter, GRPC: grpc}
 	ibftStatusCmd := ibft.IbftStatus{Base: base, Formatter: formatter, GRPC: grpc}
+	ibftContractCmd := ibft.IbftContractRestriction{Base: base, Formatter: formatter, GRPC: grpc}
 
 	peersCmd := peers.PeersCommand{}
 	peersAddCmd := peers.PeersAdd{Base: base, Formatter: formatter, GRPC: grpc}
@@ -108,6 +109,9 @@ func Commands() map[string]cli.CommandFactory {
 		},
 		ibftStatusCmd.GetBaseCommand(): func() (cli.Command, error) {
 			return &ibftStatusCmd, nil
+		},
+		ibftContractCmd.GetBaseCommand(): func() (cli.Command, error) {
+			return &ibftContractCmd, nil
 		},
 
 		// TXPOOL COMMANDS //

--- a/server/server.go
+++ b/server/server.go
@@ -161,6 +161,7 @@ func NewServer(logger hclog.Logger, config *Config) (*Server, error) {
 		m.txpool, err = txpool.NewTxPool(
 			logger,
 			m.chain.Params.Forks.At(0),
+			m.chain.Params.Features,
 			hub,
 			m.grpcServer,
 			m.network,

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -25,18 +25,19 @@ const (
 
 // errors
 var (
-	ErrIntrinsicGas        = errors.New("intrinsic gas too low")
-	ErrBlockLimitExceeded  = errors.New("exceeds block gas limit")
-	ErrNegativeValue       = errors.New("negative value")
-	ErrNonEncryptedTx      = errors.New("non-encrypted transaction")
-	ErrInvalidSender       = errors.New("invalid sender")
-	ErrTxPoolOverflow      = errors.New("txpool is full")
-	ErrUnderpriced         = errors.New("transaction underpriced")
-	ErrNonceTooLow         = errors.New("nonce too low")
-	ErrInsufficientFunds   = errors.New("insufficient funds for gas * price + value")
-	ErrInvalidAccountState = errors.New("invalid account state")
-	ErrAlreadyKnown        = errors.New("already known")
-	ErrOversizedData       = errors.New("oversized data")
+	ErrIntrinsicGas            = errors.New("intrinsic gas too low")
+	ErrBlockLimitExceeded      = errors.New("exceeds block gas limit")
+	ErrNegativeValue           = errors.New("negative value")
+	ErrNonEncryptedTx          = errors.New("non-encrypted transaction")
+	ErrInvalidSender           = errors.New("invalid sender")
+	ErrTxPoolOverflow          = errors.New("txpool is full")
+	ErrUnderpriced             = errors.New("transaction underpriced")
+	ErrNonceTooLow             = errors.New("nonce too low")
+	ErrInsufficientFunds       = errors.New("insufficient funds for gas * price + value")
+	ErrInvalidAccountState     = errors.New("invalid account state")
+	ErrAlreadyKnown            = errors.New("already known")
+	ErrOversizedData           = errors.New("oversized data")
+	ErrSmartContractRestricted = errors.New("Deploying smart contract from this address is disabled")
 )
 
 // indicates origin of a transaction
@@ -117,10 +118,11 @@ type promoteRequest struct {
 // transactions are the first-in-line of some promoted queue,
 // ready to be written to the state (primaries).
 type TxPool struct {
-	logger hclog.Logger
-	signer signer
-	forks  chain.ForksInTime
-	store  store
+	logger   hclog.Logger
+	signer   signer
+	forks    chain.ForksInTime
+	features chain.Features
+	store    store
 
 	// map of all accounts registered by the pool
 	accounts accountsMap
@@ -170,6 +172,7 @@ type TxPool struct {
 func NewTxPool(
 	logger hclog.Logger,
 	forks chain.ForksInTime,
+	features *chain.Features,
 	store store,
 	grpcServer *grpc.Server,
 	network *network.Server,
@@ -179,6 +182,7 @@ func NewTxPool(
 	pool := &TxPool{
 		logger:      logger.Named("txpool"),
 		forks:       forks,
+		features:    *features,
 		store:       store,
 		metrics:     metrics,
 		accounts:    accountsMap{},
@@ -541,7 +545,25 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 	if tx.Gas > latestBlockGasLimit {
 		return ErrBlockLimitExceeded
 	}
+	fmt.Println("USAOOO")
+	fmt.Println("USAOOO")
+	fmt.Println("USAOOO")
+	fmt.Println("USAOOO")
+	fmt.Println("USAOOO")
+	fmt.Println("USAOOO")
+	fmt.Println("USAOOO")
+	fmt.Println("TX to", tx.To)
 
+	if !tx.CanApplyNewContract(p.features.ContractDeployment.WhiteList) {
+		fmt.Println("PUKAO")
+		fmt.Println("PUKAO")
+		fmt.Println("PUKAO")
+		fmt.Println("PUKAO")
+		fmt.Println("PUKAO")
+		fmt.Println("PUKAO")
+
+		return ErrSmartContractRestricted
+	}
 	return nil
 }
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -74,6 +74,7 @@ func newTestPool(header *types.Header) (*TxPool, error) {
 	return NewTxPool(
 		hclog.NewNullLogger(),
 		forks.At(0),
+		nil,
 		NewDefaultMockStore(header),
 		nil,
 		nil,

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -96,6 +96,19 @@ func (t *Transaction) ExceedsBlockGasLimit(blockGasLimit uint64) bool {
 	return t.Gas > blockGasLimit
 }
 
+func (t *Transaction) CanApplyNewContract(whiteList []string) bool {
+	//Contra t creation not restricted or is not create contract transaction
+	if len(whiteList) == 0 || t.To != nil {
+		return true
+	}
+	for _, address := range whiteList {
+		if t.From == StringToAddress(address) {
+			return true
+		}
+	}
+	return false
+}
+
 func (t *Transaction) IsUnderpriced(priceLimit uint64) bool {
 	return t.GasPrice.Cmp(big.NewInt(0).SetUint64(priceLimit)) < 0
 }


### PR DESCRIPTION
# Description
!IMPORTANT! This is just working Proof of Concept. Not official PR

Create a whitelist for contract deployment.
if the list is empty everyone can deploy a smart contract
if any address is in the list, only these acc can deploy

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

1. Started network with 4 nodes

2. Deployed contract from one ACC (successful)

3. Added some random acc to white list:
go run main.go ibft contract_whitelist --addAccount 0x618b3B9D713276d793915D7418a527B9D8285109
Now you can only deploy from 0x618b3B9D713276d793915D7418a527B9D8285109 ACC

4. Restarted nodes

5. Tried to deploy from any other ACC (it will fail)

6. Added my acc to whitelist 

7. Restarted nodes

8. Now we can deploy onces again



# Additional comments

Fixes EDGE-24
