### PR TITLE
Fix faulty check in estimateGas

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -575,12 +575,7 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 			return true, applyErr
 		}
 
-		// Check the EVM error
-		if result.Failed() {
-			return true, result.Err
-		}
-
-		return false, nil
+		return result.Failed(), result.Err
 	}
 
 	isGasError := func(err error) bool {


### PR DESCRIPTION
# Description

This PR fixes a few faulty checks inside `eth_estimateGas`, namely:
* If the transaction has a value of `0` and the account has a balance of `0`, this shouldn't be a reason to fail
* EVM application errors were not being taken into account during transaction execution

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

#### Account balance fix
An easy way to test this out would be to send transactions from an account that has 0 balance, and the value of the transaction being 0.

#### EVM reverts fix
To test out the EVM revert error fix during `eth_estimateGas`, a dummy SC can be deployed with a method that always fails (for example, it has a `require` statement that is always triggered), and `eth_estimateGas` called on a transaction that calls that method - the call should fail, and not return a gas estimate value.

# Additional comments

Fixed EDGE-403
