### PR TITLE
Fix minor test wait bug

### DIFF
--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -1284,9 +1284,9 @@ func TestResetAccounts_Enqueued(t *testing.T) {
 
 		// setup prestate
 		totalTx := 0
-		totalPromoted := uint64(0)
+		expectedPromoted := uint64(0)
 		for addr, txs := range allTxs {
-			totalPromoted += expected.accounts[addr].promoted
+			expectedPromoted += expected.accounts[addr].promoted
 			for _, tx := range txs {
 				totalTx++
 				go func(tx *types.Transaction) {
@@ -1308,7 +1308,7 @@ func TestResetAccounts_Enqueued(t *testing.T) {
 		ctx, cancelFn = context.WithTimeout(context.Background(), time.Second*10)
 		defer cancelFn()
 
-		assert.Len(t, waitForEvents(ctx, promotedSubscription, int(totalPromoted)), int(totalPromoted))
+		assert.Len(t, waitForEvents(ctx, promotedSubscription, int(expectedPromoted)), int(expectedPromoted))
 
 		assert.Equal(t, expected.slots, pool.gauge.read())
 		commonAssert(expected.accounts, pool)
@@ -1371,12 +1371,12 @@ func TestResetAccounts_Enqueued(t *testing.T) {
 		)
 
 		// setup prestate
-		totalTx := 0
-		totalPromoted := uint64(0)
+		expectedEnqueuedTx := 0
+		expectedPromotedTx := uint64(0)
 		for addr, txs := range allTxs {
-			totalPromoted += expected.accounts[addr].promoted
+			expectedPromotedTx += expected.accounts[addr].promoted
 			for _, tx := range txs {
-				totalTx++
+				expectedEnqueuedTx++
 				go func(tx *types.Transaction) {
 					err := pool.addTx(local, tx)
 					assert.NoError(t, err)
@@ -1388,7 +1388,7 @@ func TestResetAccounts_Enqueued(t *testing.T) {
 		defer cancelFn()
 
 		// All txns should get added
-		assert.Len(t, waitForEvents(ctx, enqueuedSubscription, totalTx), totalTx)
+		assert.Len(t, waitForEvents(ctx, enqueuedSubscription, expectedEnqueuedTx), expectedEnqueuedTx)
 		pool.eventManager.cancelSubscription(enqueuedSubscription.subscriptionID)
 
 		pool.resetAccounts(newNonces)
@@ -1507,10 +1507,10 @@ func TestExecutablesOrder(t *testing.T) {
 				[]proto.EventType{proto.EventType_PROMOTED},
 			)
 
-			totalTx := 0
+			expectedPromotedTx := 0
 			for _, txs := range test.allTxs {
 				for _, tx := range txs {
-					totalTx++
+					expectedPromotedTx++
 					// send all txs
 					go func(tx *types.Transaction) {
 						err := pool.addTx(local, tx)
@@ -1523,7 +1523,7 @@ func TestExecutablesOrder(t *testing.T) {
 			defer cancelFn()
 
 			// All txns should get added
-			assert.Len(t, waitForEvents(ctx, subscription, totalTx), totalTx)
+			assert.Len(t, waitForEvents(ctx, subscription, expectedPromotedTx), expectedPromotedTx)
 			assert.Equal(t, uint64(len(test.expectedPriceOrder)), pool.accounts.promoted())
 
 			var successful []*types.Transaction
@@ -1889,7 +1889,7 @@ func TestGetTxs(t *testing.T) {
 			)
 
 			// send txs
-			totalPromotedTx := 0
+			expectedPromotedTx := 0
 			for _, txs := range test.allTxs {
 				nonce := uint64(0)
 				promotable := uint64(0)
@@ -1905,23 +1905,23 @@ func TestGetTxs(t *testing.T) {
 					}(tx)
 				}
 
-				totalPromotedTx += int(promotable)
+				expectedPromotedTx += int(promotable)
 			}
 
 			ctx, cancelFn := context.WithTimeout(context.Background(), time.Second*10)
 			defer cancelFn()
 
 			// Wait for promoted transactions
-			assert.Len(t, waitForEvents(ctx, promoteSubscription, totalPromotedTx), totalPromotedTx)
+			assert.Len(t, waitForEvents(ctx, promoteSubscription, expectedPromotedTx), expectedPromotedTx)
 
 			// Wait for enqueued transactions, if any are present
-			totalEnqueuedTx := totalPromotedTx - len(test.allTxs)
+			expectedEnqueuedTx := expectedPromotedTx - len(test.allTxs)
 
-			if totalEnqueuedTx > 0 {
+			if expectedEnqueuedTx > 0 {
 				ctx, cancelFn = context.WithTimeout(context.Background(), time.Second*10)
 				defer cancelFn()
 
-				assert.Len(t, waitForEvents(ctx, enqueueSubscription, totalEnqueuedTx), totalEnqueuedTx)
+				assert.Len(t, waitForEvents(ctx, enqueueSubscription, expectedEnqueuedTx), expectedEnqueuedTx)
 			}
 
 			allPromoted, allEnqueued := pool.GetTxs(true)


### PR DESCRIPTION
# Description

This PR fixes a minor bug in `TestGetTxs`, where there wasn't a proper event wait before checking the state of the TxPool, which would cause a race when asserting. 

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

# Additional Comments

Fixes EDGE-404
