### PR TITLE
Change the default value for buffers in pubsub

### DIFF
--- a/network/gossip.go
+++ b/network/gossip.go
@@ -10,10 +10,10 @@ import (
 )
 
 const (
-	// bufferSize is the size of the queue in go-libp2p-pubsub
+	// subscribeOutputBufferSize is the size of subscribe output buffer in go-libp2p-pubsub
 	// we should have enough capacity of the queue
-	// because there is possibility of that node lose gossip messages when the queue is full
-	bufferSize = 512
+	// because when queue is full, if the consumer does not read fast enough, new messages are dropped
+	subscribeOutputBufferSize = 1000
 )
 
 type Topic struct {
@@ -43,7 +43,7 @@ func (t *Topic) Publish(obj proto.Message) error {
 }
 
 func (t *Topic) Subscribe(handler func(obj interface{})) error {
-	sub, err := t.topic.Subscribe(pubsub.WithBufferSize(bufferSize))
+	sub, err := t.topic.Subscribe(pubsub.WithBufferSize(subscribeOutputBufferSize))
 	if err != nil {
 		return err
 	}

--- a/network/gossip.go
+++ b/network/gossip.go
@@ -13,7 +13,7 @@ const (
 	// subscribeOutputBufferSize is the size of subscribe output buffer in go-libp2p-pubsub
 	// we should have enough capacity of the queue
 	// because when queue is full, if the consumer does not read fast enough, new messages are dropped
-	subscribeOutputBufferSize = 1000
+	subscribeOutputBufferSize = 1024
 )
 
 type Topic struct {

--- a/network/server.go
+++ b/network/server.go
@@ -47,12 +47,12 @@ const (
 	// peerOutboundBufferSize is the size of outbound messages to a peer buffers in go-libp2p-pubsub
 	// we should have enough capacity of the queue
 	// because we start dropping messages to a peer if the outbound queue is full
-	peerOutboundBufferSize = 1000
+	peerOutboundBufferSize = 1024
 
 	// validateBufferSize is the size of validate buffers in go-libp2p-pubsub
 	// we should have enough capacity of the queue
 	// because when queue is full, validation is throttled and new messages are dropped.
-	validateBufferSize = 1000
+	validateBufferSize = 1024
 )
 
 // regex string  to match against a valid dns/dns4/dns6 addr

--- a/network/server.go
+++ b/network/server.go
@@ -43,6 +43,18 @@ const (
 	PriorityRandomDial uint64 = 10
 )
 
+const (
+	// peerOutboundBufferSize is the size of outbound messages to a peer buffers in go-libp2p-pubsub
+	// we should have enough capacity of the queue
+	// because we start dropping messages to a peer if the outbound queue is full
+	peerOutboundBufferSize = 1000
+
+	// validateBufferSize is the size of validate buffers in go-libp2p-pubsub
+	// we should have enough capacity of the queue
+	// because when queue is full, validation is throttled and new messages are dropped.
+	validateBufferSize = 1000
+)
+
 // regex string  to match against a valid dns/dns4/dns6 addr
 const DNSRegex = `^/?(dns)(4|6)?/[^-|^/][A-Za-z0-9-]([^-|^/]?)+([\\-\\.]{1}[a-z0-9]+)*\\.[A-Za-z]{2,}(/?)$`
 
@@ -211,7 +223,11 @@ func NewServer(logger hclog.Logger, config *Config) (*Server, error) {
 	srv.identity.setup()
 
 	// start gossip protocol
-	ps, err := pubsub.NewGossipSub(context.Background(), host)
+	ps, err := pubsub.NewGossipSub(
+		context.Background(),
+		host, pubsub.WithPeerOutboundQueueSize(peerOutboundBufferSize),
+		pubsub.WithValidateQueueSize(validateBufferSize),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

There are 3 buffers in the PubSub library. 

1. Subscribe output buffer 
2. Outbound messages to a peer buffer
3. Validation buffer

When any of these buffers get full, the message is going to be dropped. 
The default length of the buffers is 32. This value can be changed easily to any number. 

This PR increase the value for all of these buffers

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

1. Start 4 node cluster on the cloud 
2. Enable network logs: export IPFS_LOGGING=DEBUG
3. Start the nodes with --pubSub-buffer-size 10
4. Run SportX spam script https://github.com/mrwillis/eth-txn-spam
These errors should start occurring:
      - subscriber too slow
      - queue full
 5. Stop nodes and spam test
 6. Start the network with default value for --pubSub-buffer-size or any value higher than 512
 No error should occur

# Additional comments

Fixes Edge-433
