### PR TITLE
Make the server config init default values for unset params

### DIFF
--- a/command/server/config.go
+++ b/command/server/config.go
@@ -109,7 +109,7 @@ func readConfigFile(path string) (*Config, error) {
 		return nil, fmt.Errorf("suffix of %s is neither hcl nor json", path)
 	}
 
-	config := new(Config)
+	config := DefaultConfig()
 	config.Network = new(Network)
 	config.Network.MaxPeers = -1
 	config.Network.MaxInboundPeers = -1


### PR DESCRIPTION
# Description

This PR changes the way config files are read, to use default values for unspecified fields.

Previously, if a config file was specified, the fields that were not contained in the configuration were not initialized to their default values, causing a problem when starting the server.

The PR introduces default value setting for unset fields in the config file, as was previous to PR #410 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Tested out with the scripts from [GH issue #411](https://github.com/0xPolygon/polygon-edge/issues/441)
