### PR TITLE
Fix grpc and jsonprc bindings when set from config file

### DIFF
--- a/command/server/server.go
+++ b/command/server/server.go
@@ -213,7 +213,7 @@ func runPreRun(cmd *cobra.Command, _ []string) error {
 	params.setRawJSONRPCAddress(helper.GetJSONRPCAddress(cmd))
 
 	// Check if the config file has been specified
-	// Config file settings will override --jsonrpc and --gprc flag settings
+	// Config file settings will override JSON-RPC and GRPC address values
 	if isConfigFileSpecified(cmd) {
 		if err := params.initConfigFromFile(); err != nil {
 			return err

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -207,7 +207,13 @@ func setDevFlags(cmd *cobra.Command) {
 }
 
 func runPreRun(cmd *cobra.Command, _ []string) error {
+	// Set the grpc and json ip:port bindings
+	// The config file will have presedence over --flag
+	params.setRawGRPCAddress(helper.GetGRPCAddress(cmd))
+	params.setRawJSONRPCAddress(helper.GetJSONRPCAddress(cmd))
+
 	// Check if the config file has been specified
+	// Config file settings will override --jsonrpc and --gprc flag settings
 	if isConfigFileSpecified(cmd) {
 		if err := params.initConfigFromFile(); err != nil {
 			return err
@@ -217,9 +223,6 @@ func runPreRun(cmd *cobra.Command, _ []string) error {
 	if err := params.validateFlags(); err != nil {
 		return err
 	}
-
-	params.setRawGRPCAddress(helper.GetGRPCAddress(cmd))
-	params.setRawJSONRPCAddress(helper.GetJSONRPCAddress(cmd))
 
 	if err := params.initRawParams(); err != nil {
 		return err


### PR DESCRIPTION
# Description

This PR fixes the wrong json-rpc and grpc host bindings when the server configuration is read from config file

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Start the server with a config file instead of starting it with flags
