### PR TITLE
[TxPool] Reduce lock time in resetAccounts

### DIFF
--- a/txpool/account.go
+++ b/txpool/account.go
@@ -135,43 +135,6 @@ func (m *accountsMap) allTxs(includeEnqueued bool) (
 	return
 }
 
-// resetWithNonce updates all accounts with the new nonce and clears any stale transactions.
-// May signal a promotion request if the account is eligible after pruning.
-func (m *accountsMap) resetWithNonce(newNonces map[types.Address]uint64, promoteCh chan<- promoteRequest) (
-	allPrunedPromoted,
-	allPrunedEnqueued []*types.Transaction,
-) {
-	//	prune each account with the new nonce
-	m.Range(func(key, value interface{}) bool {
-		addr, _ := key.(types.Address) //nolint:forcetypeassert, nolintlint
-		account, _ := value.(*account) //nolint:forcetypeassert, nolintlint
-
-		newNonce, ok := newNonces[addr]
-		if !ok {
-			// no updates for this account
-			return true
-		}
-
-		//	prune stale txs
-		prunedPromoted, prunedEnqueued := account.reset(newNonce, promoteCh)
-
-		//	update result
-		allPrunedPromoted = append(
-			allPrunedPromoted,
-			prunedPromoted...,
-		)
-
-		allPrunedEnqueued = append(
-			allPrunedEnqueued,
-			prunedEnqueued...,
-		)
-
-		return true
-	})
-
-	return
-}
-
 // An account is the core structure for processing
 // transactions from a specific address. The nextNonce
 // field is what separates the enqueued from promoted transactions:

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -143,8 +143,8 @@ func (m *accountsMap) resetWithNonce(newNonces map[types.Address]uint64, promote
 ) {
 	//	prune each account with the new nonce
 	m.Range(func(key, value interface{}) bool {
-		addr, _ := key.(types.Address) //nolint:forcetypeassert
-		account, _ := value.(*account) //nolint:forcetypeassert
+		addr, _ := key.(types.Address) //nolint:forcetypeassert, nolintlint
+		account, _ := value.(*account) //nolint:forcetypeassert, nolintlint
 
 		newNonce, ok := newNonces[addr]
 		if !ok {

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -164,8 +164,8 @@ func (a *account) setNonce(nonce uint64) {
 
 func (a *account) reset(nonce uint64) (
 	prunedPromoted,
-	prunedEnqueued []*types.Transaction) {
-
+	prunedEnqueued []*types.Transaction,
+) {
 	a.promoted.lock(true)
 	defer a.promoted.unlock()
 

--- a/txpool/queue.go
+++ b/txpool/queue.go
@@ -49,7 +49,6 @@ func (q *accountQueue) unlock() {
 // with nonce lower than given.
 func (q *accountQueue) prune(nonce uint64) (
 	pruned []*types.Transaction,
-	prunedHashes []types.Hash,
 ) {
 	for {
 		tx := q.peek()
@@ -60,7 +59,6 @@ func (q *accountQueue) prune(nonce uint64) (
 
 		tx = q.pop()
 		pruned = append(pruned, tx)
-		prunedHashes = append(prunedHashes, tx.Hash)
 	}
 
 	return

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -676,6 +676,7 @@ func (p *TxPool) resetAccounts(stateNonces map[types.Address]uint64) {
 		addr, ok := key.(types.Address)
 		if !ok {
 			p.logger.Error("failed type casting")
+
 			return false
 		}
 
@@ -688,6 +689,7 @@ func (p *TxPool) resetAccounts(stateNonces map[types.Address]uint64) {
 		account, ok := value.(*account)
 		if !ok {
 			p.logger.Error("failed type casting")
+
 			return false
 		}
 

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -664,7 +664,7 @@ func (p *TxPool) addGossipTx(obj interface{}) {
 	}
 }
 
-// resetAccounts updates existing accounts with the new nonce.
+// resetAccounts updates existing accounts with the new nonce and prunes stale transactions.
 func (p *TxPool) resetAccounts(stateNonces map[types.Address]uint64) {
 	allPrunedPromoted, allPrunedEnqueued := p.accounts.resetWithNonce(stateNonces, p.promoteReqCh)
 
@@ -689,54 +689,6 @@ func (p *TxPool) resetAccounts(stateNonces map[types.Address]uint64) {
 		)
 	}
 }
-
-// resetAccount aligns the account's state with the given nonce,
-// pruning any present stale transaction. If, afterwards, the account
-// is eligible for promotion, a promoteRequest is signaled.
-//func (p *TxPool) resetAccount(addr types.Address, nonce uint64) {
-//	account := p.accounts.get(addr)
-//
-//	// prune promoted
-//	pruned, prunedHashes := account.promoted.prune(nonce)
-//
-//	// update pool state
-//	p.index.remove(pruned...)
-//	p.gauge.decrease(slotsRequired(pruned...))
-//
-//	p.eventManager.signalEvent(
-//		proto.EventType_PRUNED_PROMOTED,
-//		prunedHashes...,
-//	)
-//
-//	// update metrics
-//	p.metrics.PendingTxs.Add(float64(-1 * len(pruned)))
-//
-//	if nonce <= account.getNonce() {
-//		// only the promoted queue needed pruning
-//		return
-//	}
-//
-//	// prune enqueued
-//	pruned, prunedHashes = account.enqueued.prune(nonce)
-//
-//	// update pool state
-//	p.index.remove(pruned...)
-//	p.gauge.decrease(slotsRequired(pruned...))
-//
-//	// update next nonce
-//	account.setNonce(nonce)
-//
-//	p.eventManager.signalEvent(
-//		proto.EventType_PRUNED_ENQUEUED,mis
-//		prunedHashes...,
-//	)
-//
-//	if first := account.enqueued.peek(); first != nil &&
-//		first.Nonce == nonce {
-//		// first enqueued tx is expected -> signal promotion
-//		p.promoteReqCh <- promoteRequest{account: addr}
-//	}
-//}
 
 // createAccountOnce creates an account and
 // ensures it is only initialized once.

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -666,38 +666,7 @@ func (p *TxPool) addGossipTx(obj interface{}) {
 
 // resetAccounts updates existing accounts with the new nonce.
 func (p *TxPool) resetAccounts(stateNonces map[types.Address]uint64) {
-	var (
-		allPrunedEnqueued []*types.Transaction
-		allPrunedPromoted []*types.Transaction
-	)
-
-	//	prune all accounts
-	p.accounts.Range(func(key, value interface{}) bool {
-		addr, _ := key.(types.Address) //nolint:forcetypeassert
-		account, _ := value.(*account) //nolint:forcetypeassert
-
-		newNonce, ok := stateNonces[addr]
-		if !ok {
-			// no updates for this account
-			return true
-		}
-
-		//	prune stale txs
-		prunedEnqueued, prunedPromoted := account.reset(newNonce, p.promoteReqCh)
-
-		//	update result
-		allPrunedEnqueued = append(
-			allPrunedEnqueued,
-			prunedEnqueued...,
-		)
-
-		allPrunedPromoted = append(
-			allPrunedPromoted,
-			prunedPromoted...,
-		)
-
-		return true
-	})
+	allPrunedPromoted, allPrunedEnqueued := p.accounts.resetWithNonce(stateNonces, p.promoteReqCh)
 
 	//	update state
 	if len(allPrunedPromoted) > 0 {
@@ -758,7 +727,7 @@ func (p *TxPool) resetAccounts(stateNonces map[types.Address]uint64) {
 //	account.setNonce(nonce)
 //
 //	p.eventManager.signalEvent(
-//		proto.EventType_PRUNED_ENQUEUED,
+//		proto.EventType_PRUNED_ENQUEUED,mis
 //		prunedHashes...,
 //	)
 //

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -1188,10 +1188,7 @@ func TestResetAccounts_Promoted(t *testing.T) {
 		for _, tx := range txs {
 			totalTx++
 
-			go func(tx *types.Transaction) {
-				err := pool.addTx(local, tx)
-				assert.NoError(t, err)
-			}(tx)
+			assert.NoError(t, pool.addTx(local, tx))
 		}
 	}
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -671,7 +671,9 @@ func TestResetAccount(t *testing.T) {
 				assert.Equal(t, uint64(0), pool.accounts.get(addr1).enqueued.length())
 				assert.Equal(t, uint64(len(test.txs)), pool.accounts.get(addr1).promoted.length())
 
-				pool.resetAccount(addr1, test.newNonce)
+				pool.resetAccounts(map[types.Address]uint64{
+					addr1: test.newNonce,
+				})
 
 				assert.Equal(t, test.expected.slots, pool.gauge.read())
 				assert.Equal(t, // enqueued
@@ -785,10 +787,14 @@ func TestResetAccount(t *testing.T) {
 				assert.Equal(t, uint64(0), pool.accounts.get(addr1).promoted.length())
 
 				if test.signal {
-					go pool.resetAccount(addr1, test.newNonce)
+					go pool.resetAccounts(map[types.Address]uint64{
+						addr1: test.newNonce,
+					})
 					pool.handlePromoteRequest(<-pool.promoteReqCh)
 				} else {
-					pool.resetAccount(addr1, test.newNonce)
+					pool.resetAccounts(map[types.Address]uint64{
+						addr1: test.newNonce,
+					})
 				}
 
 				assert.Equal(t, test.expected.slots, pool.gauge.read())
@@ -940,10 +946,14 @@ func TestResetAccount(t *testing.T) {
 				pool.handlePromoteRequest(req)
 
 				if test.signal {
-					go pool.resetAccount(addr1, test.newNonce)
+					go pool.resetAccounts(map[types.Address]uint64{
+						addr1: test.newNonce,
+					})
 					pool.handlePromoteRequest(<-pool.promoteReqCh)
 				} else {
-					pool.resetAccount(addr1, test.newNonce)
+					pool.resetAccounts(map[types.Address]uint64{
+						addr1: test.newNonce,
+					})
 				}
 
 				assert.Equal(t, test.expected.slots, pool.gauge.read())


### PR DESCRIPTION
# Description

Fixes EDGE-434

This PR reduces the amount of time account lock(s) are held during `resetAccounts`.  

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

