### PR TITLE
[Hotfix] Fix failing TestBroadcast on local

### DIFF
--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -43,7 +43,7 @@ import (
 type TestServerConfigCallback func(*TestServerConfig)
 
 const (
-	serverIP    = "0.0.0.0"
+	serverIP    = "127.0.0.1"
 	initialPort = 12000
 	binaryName  = "polygon-edge"
 )

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -6,10 +6,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/0xPolygon/polygon-edge/command"
-	ibftSwitch "github.com/0xPolygon/polygon-edge/command/ibft/switch"
-	initCmd "github.com/0xPolygon/polygon-edge/command/secrets/init"
-	"google.golang.org/grpc/credentials/insecure"
 	"io"
 	"math/big"
 	"os"
@@ -20,7 +16,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/genesis"
+	ibftSwitch "github.com/0xPolygon/polygon-edge/command/ibft/switch"
+	initCmd "github.com/0xPolygon/polygon-edge/command/secrets/init"
 	"github.com/0xPolygon/polygon-edge/command/server"
 	"github.com/0xPolygon/polygon-edge/consensus/ibft"
 	ibftOp "github.com/0xPolygon/polygon-edge/consensus/ibft/proto"
@@ -37,6 +36,7 @@ import (
 	"github.com/umbracle/go-web3"
 	"github.com/umbracle/go-web3/jsonrpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	empty "google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -292,11 +292,11 @@ func (t *TestServer) Start(ctx context.Context) error {
 		// add custom chain
 		"--chain", filepath.Join(t.Config.RootDir, "genesis.json"),
 		// enable grpc
-		"--grpc-address", fmt.Sprintf(":%d", t.Config.GRPCPort),
+		"--grpc-address", fmt.Sprintf("127.0.0.1:%d", t.Config.GRPCPort),
 		// enable libp2p
-		"--libp2p", fmt.Sprintf(":%d", t.Config.LibP2PPort),
+		"--libp2p", fmt.Sprintf("127.0.0.1:%d", t.Config.LibP2PPort),
 		// enable jsonrpc
-		"--jsonrpc", fmt.Sprintf(":%d", t.Config.JSONRPCPort),
+		"--jsonrpc", fmt.Sprintf("127.0.0.1:%d", t.Config.JSONRPCPort),
 	}
 
 	switch t.Config.Consensus {

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -43,6 +43,7 @@ import (
 type TestServerConfigCallback func(*TestServerConfig)
 
 const (
+	serverIP    = "0.0.0.0"
 	initialPort = 12000
 	binaryName  = "polygon-edge"
 )
@@ -84,15 +85,27 @@ func NewTestServer(t *testing.T, rootDir string, callback TestServerConfigCallba
 }
 
 func (t *TestServer) GrpcAddr() string {
-	return fmt.Sprintf("http://127.0.0.1:%d", t.Config.GRPCPort)
+	return fmt.Sprintf("%s:%d", serverIP, t.Config.GRPCPort)
+}
+
+func (t *TestServer) LibP2PAddr() string {
+	return fmt.Sprintf("%s:%d", serverIP, t.Config.LibP2PPort)
 }
 
 func (t *TestServer) JSONRPCAddr() string {
-	return fmt.Sprintf("http://127.0.0.1:%d", t.Config.JSONRPCPort)
+	return fmt.Sprintf("%s:%d", serverIP, t.Config.JSONRPCPort)
+}
+
+func (t *TestServer) HTTPJSONRPCURL() string {
+	return fmt.Sprintf("http://%s", t.JSONRPCAddr())
+}
+
+func (t *TestServer) WSJSONRPCURL() string {
+	return fmt.Sprintf("ws://%s/ws", t.JSONRPCAddr())
 }
 
 func (t *TestServer) JSONRPC() *jsonrpc.Client {
-	clt, err := jsonrpc.NewClient(t.JSONRPCAddr())
+	clt, err := jsonrpc.NewClient(t.HTTPJSONRPCURL())
 	if err != nil {
 		t.t.Fatal(err)
 	}
@@ -102,7 +115,7 @@ func (t *TestServer) JSONRPC() *jsonrpc.Client {
 
 func (t *TestServer) Operator() proto.SystemClient {
 	conn, err := grpc.Dial(
-		fmt.Sprintf("127.0.0.1:%d", t.Config.GRPCPort),
+		t.GrpcAddr(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.t.Fatal(err)
@@ -113,7 +126,7 @@ func (t *TestServer) Operator() proto.SystemClient {
 
 func (t *TestServer) TxnPoolOperator() txpoolProto.TxnPoolOperatorClient {
 	conn, err := grpc.Dial(
-		fmt.Sprintf("127.0.0.1:%d", t.Config.GRPCPort),
+		t.GrpcAddr(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.t.Fatal(err)
@@ -124,7 +137,7 @@ func (t *TestServer) TxnPoolOperator() txpoolProto.TxnPoolOperatorClient {
 
 func (t *TestServer) IBFTOperator() ibftOp.IbftOperatorClient {
 	conn, err := grpc.Dial(
-		fmt.Sprintf("127.0.0.1:%d", t.Config.GRPCPort),
+		t.GrpcAddr(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.t.Fatal(err)
@@ -292,11 +305,11 @@ func (t *TestServer) Start(ctx context.Context) error {
 		// add custom chain
 		"--chain", filepath.Join(t.Config.RootDir, "genesis.json"),
 		// enable grpc
-		"--grpc-address", fmt.Sprintf("127.0.0.1:%d", t.Config.GRPCPort),
+		"--grpc-address", t.GrpcAddr(),
 		// enable libp2p
-		"--libp2p", fmt.Sprintf("127.0.0.1:%d", t.Config.LibP2PPort),
+		"--libp2p", t.LibP2PAddr(),
 		// enable jsonrpc
-		"--jsonrpc", fmt.Sprintf("127.0.0.1:%d", t.Config.JSONRPCPort),
+		"--jsonrpc", t.JSONRPCAddr(),
 	}
 
 	switch t.Config.Consensus {

--- a/e2e/websocket_test.go
+++ b/e2e/websocket_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"math/big"
-	"strings"
 	"testing"
 	"time"
 
@@ -70,7 +69,7 @@ func TestWS_Response(t *testing.T) {
 	srv := srvs[0]
 
 	// Convert the default JSONRPC address to a WebSocket one
-	wsURL := "ws" + strings.TrimPrefix(srv.JSONRPCAddr(), "http") + "/ws"
+	wsURL := srv.WSJSONRPCURL()
 
 	// Connect to the websocket server
 	ws, _, err := websocket.DefaultDialer.Dial(wsURL, nil)


### PR DESCRIPTION
# Description

This PR fixes the issue in TestBroadcast e2e test. This test uses NewTestServers to start multiple servers but used port is not marked occupied if IP address is not given for JSON-RPC address. then the following servers will use same port.

This PR sets default local IP address for test server in e2e.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
