### PR TITLE
Fix secrets generate issues when the type is aws-ssm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build:
 lint:
 	golangci-lint run -E whitespace -E wsl -E wastedassign -E unconvert -E tparallel -E thelper -E stylecheck -E prealloc \
 	-E predeclared -E nlreturn -E misspell -E makezero -E lll -E importas -E ifshort -E gosec -E  gofmt -E goconst \
-	-E forcetypeassert -E dogsled -E dupl -E errname -E errorlint -E nolintlint
+	-E forcetypeassert -E dogsled -E dupl -E errname -E errorlint -E nolintlint --timeout 2m
 
 .PHONY: generate-bsd-licenses
 generate-bsd-licenses:

--- a/command/secrets/generate/params.go
+++ b/command/secrets/generate/params.go
@@ -3,9 +3,10 @@ package generate
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/secrets"
-	"strings"
 )
 
 var (
@@ -44,9 +45,6 @@ type generateParams struct {
 
 func (p *generateParams) getRequiredFlags() []string {
 	return []string{
-		dirFlag,
-		tokenFlag,
-		serverURLFlag,
 		nameFlag,
 	}
 }
@@ -88,7 +86,7 @@ func (p *generateParams) generateSecretsConfig() (*secrets.SecretsManagerConfig,
 		Type:      secrets.SecretsManagerType(p.serviceType),
 		Name:      p.name,
 		Namespace: p.namespace,
-		Extra:     nil,
+		Extra:     extraMap,
 	}, nil
 }
 


### PR DESCRIPTION
# Description

This PR fixes some issues that were overlooked in CLI refactor.
It fixes the issue with `secrets generate` command when the type is `aws-ssm`. 
Removes some required flags, as they already have default values.
Fixes the `Extra:` field in `SecretsManagerConfig` , which was initialized with nil.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Generate secretsManagerConfig.json file by running 
`go run . secrets generate --type aws-ssm --extra region=eu-central-1,ssm-parameter-path=/polygon-edge/nodes --name node1`
and use the file to store init secrets in AWS SSM 
`go run . secrets init --config secretsManagerConfig.json`

Confirmed working by inspecting AWS SSM in web console.
