### PR TITLE
Add gzip stream compression support

### DIFF
--- a/command/server/init.go
+++ b/command/server/init.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"github.com/0xPolygon/polygon-edge/network/common"
+	"github.com/0xPolygon/polygon-edge/network/compress"
 	"math"
 	"net"
 
@@ -34,6 +35,10 @@ func (p *serverParams) initRawParams() error {
 	}
 
 	if err := p.initGenesisConfig(); err != nil {
+		return err
+	}
+
+	if err := p.initStreamCompressor(); err != nil {
 		return err
 	}
 
@@ -84,6 +89,14 @@ func (p *serverParams) initGenesisConfig() error {
 	}
 
 	return nil
+}
+
+func (p *serverParams) initStreamCompressor() error {
+	var err error
+
+	p.streamCompressor, err = compress.GetStreamCompressor(compress.StreamCompressorType(p.streamCompressRaw))
+
+	return err
 }
 
 func (p *serverParams) initDevMode() {

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/network"
+	"github.com/0xPolygon/polygon-edge/network/compress"
 	"github.com/0xPolygon/polygon-edge/secrets"
 	"github.com/0xPolygon/polygon-edge/server"
 	"github.com/hashicorp/go-hclog"
@@ -32,6 +33,7 @@ const (
 	devIntervalFlag       = "dev-interval"
 	devFlag               = "dev"
 	corsOriginFlag        = "access-control-allow-origins"
+	streamCompressFlag    = "stream-compress"
 )
 
 const (
@@ -70,8 +72,11 @@ type serverParams struct {
 
 	corsAllowedOrigins []string
 
-	genesisConfig *chain.Chain
-	secretsConfig *secrets.SecretsManagerConfig
+	streamCompressRaw string
+
+	genesisConfig    *chain.Chain
+	secretsConfig    *secrets.SecretsManagerConfig
+	streamCompressor compress.CompressStream
 }
 
 func (p *serverParams) validateFlags() error {
@@ -150,6 +155,7 @@ func (p *serverParams) generateConfig() *server.Config {
 			MaxInboundPeers:  p.rawConfig.Network.MaxInboundPeers,
 			MaxOutboundPeers: p.rawConfig.Network.MaxOutboundPeers,
 			Chain:            p.genesisConfig,
+			StreamCompressor: p.streamCompressor,
 		},
 		DataDir:        p.rawConfig.DataDir,
 		Seal:           p.rawConfig.ShouldSeal,

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"github.com/0xPolygon/polygon-edge/network/compress"
 	"strconv"
 
 	"github.com/0xPolygon/polygon-edge/command"
@@ -109,6 +110,13 @@ func setFlags(cmd *cobra.Command) {
 		restoreFlag,
 		"",
 		"the path to the archive blockchain data to restore on initialization",
+	)
+
+	cmd.Flags().StringVar(
+		&params.streamCompressRaw,
+		streamCompressFlag,
+		string(compress.NoCompressor),
+		"the type of stream compression to be used",
 	)
 
 	cmd.Flags().BoolVar(

--- a/network/compress/base_compress.go
+++ b/network/compress/base_compress.go
@@ -1,0 +1,26 @@
+package compress
+
+import (
+	"github.com/libp2p/go-libp2p-core/network"
+)
+
+// NoStreamCompressor is the basic uncompressed stream compressor
+type NoStreamCompressor struct {
+	BaseStreamCompressor
+}
+
+func compressNoStream(stream network.Stream) network.Stream {
+	return stream
+}
+
+func (n *NoStreamCompressor) Write(b []byte) (int, error) {
+	return n.Stream.Write(b)
+}
+
+func (n *NoStreamCompressor) Read(b []byte) (int, error) {
+	return n.Stream.Read(b)
+}
+
+func (n *NoStreamCompressor) Close() error {
+	return n.Stream.Close()
+}

--- a/network/compress/compress.go
+++ b/network/compress/compress.go
@@ -1,0 +1,42 @@
+package compress
+
+import (
+	"errors"
+	"github.com/libp2p/go-libp2p-core/network"
+)
+
+var (
+	errInvalidCompressor = errors.New("invalid stream compressor type")
+)
+
+type CompressStream func(stream network.Stream) network.Stream
+
+// BaseStreamCompressor is the base stream compressor type
+type BaseStreamCompressor struct {
+	network.Stream
+}
+
+type StreamCompressorType string
+
+const (
+	GzipCompressor StreamCompressorType = "gzip"
+	NoCompressor   StreamCompressorType = "uncompressed"
+)
+
+var (
+	compressorBackends = map[StreamCompressorType]CompressStream{
+		GzipCompressor: compressGzipStream,
+		NoCompressor:   compressNoStream,
+	}
+)
+
+// GetStreamCompressor fetches the specified stream compressor. If it's not found
+// an appropriate error is returned
+func GetStreamCompressor(compressorType StreamCompressorType) (CompressStream, error) {
+	compressFunc, found := compressorBackends[compressorType]
+	if !found {
+		return nil, errInvalidCompressor
+	}
+
+	return compressFunc, nil
+}

--- a/network/compress/gzip_compress.go
+++ b/network/compress/gzip_compress.go
@@ -1,0 +1,73 @@
+package compress
+
+import (
+	"compress/gzip"
+	"github.com/libp2p/go-libp2p-core/network"
+	"sync"
+)
+
+// GzipStreamCompressor is the gzip stream compression implementation
+type GzipStreamCompressor struct {
+	BaseStreamCompressor
+
+	sync.Mutex
+
+	writer *gzip.Writer
+	reader *gzip.Reader
+}
+
+func compressGzipStream(stream network.Stream) network.Stream {
+	return &GzipStreamCompressor{
+		BaseStreamCompressor: BaseStreamCompressor{
+			Stream: stream,
+		},
+		writer: gzip.NewWriter(stream),
+	}
+}
+
+func (g *GzipStreamCompressor) Write(b []byte) (int, error) {
+	g.Lock()
+	defer g.Unlock()
+
+	n, err := g.writer.Write(b)
+	if err != nil {
+		return n, err
+	}
+
+	return n, g.writer.Flush()
+}
+
+func (g *GzipStreamCompressor) Read(b []byte) (int, error) {
+	if err := g.initReader(); err != nil {
+		return 0, err
+	}
+
+	n, err := g.reader.Read(b)
+	if err != nil {
+		_ = g.reader.Close()
+	}
+
+	return n, err
+}
+
+func (g *GzipStreamCompressor) initReader() error {
+	if g.reader != nil {
+		return nil
+	}
+
+	var err error
+	g.reader, err = gzip.NewReader(g.Stream)
+
+	return err
+}
+
+func (g *GzipStreamCompressor) Close() error {
+	g.Lock()
+	defer g.Unlock()
+
+	if err := g.writer.Close(); err != nil {
+		return err
+	}
+
+	return g.Stream.Close()
+}

--- a/network/config.go
+++ b/network/config.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"github.com/0xPolygon/polygon-edge/chain"
+	"github.com/0xPolygon/polygon-edge/network/compress"
 	"github.com/0xPolygon/polygon-edge/secrets"
 	"github.com/multiformats/go-multiaddr"
 	"net"
@@ -9,17 +10,18 @@ import (
 
 // Config details the params for the base networking server
 type Config struct {
-	NoDiscover       bool                   // flag indicating if the discovery mechanism should be turned on
-	Addr             *net.TCPAddr           // the base address
-	NatAddr          net.IP                 // the NAT address
-	DNS              multiaddr.Multiaddr    // the DNS address
-	DataDir          string                 // the base data directory for the client
-	MaxPeers         int64                  // the maximum number of peer connections
-	MaxInboundPeers  int64                  // the maximum number of inbound peer connections
-	MaxOutboundPeers int64                  // the maximum number of outbound peer connections
-	Chain            *chain.Chain           // the reference to the chain configuration
-	SecretsManager   secrets.SecretsManager // the secrets manager used for key storage
-	Metrics          *Metrics               // the metrics reporting reference
+	NoDiscover       bool                    // flag indicating if the discovery mechanism should be turned on
+	Addr             *net.TCPAddr            // the base address
+	NatAddr          net.IP                  // the NAT address
+	DNS              multiaddr.Multiaddr     // the DNS address
+	DataDir          string                  // the base data directory for the client
+	MaxPeers         int64                   // the maximum number of peer connections
+	MaxInboundPeers  int64                   // the maximum number of inbound peer connections
+	MaxOutboundPeers int64                   // the maximum number of outbound peer connections
+	Chain            *chain.Chain            // the reference to the chain configuration
+	SecretsManager   secrets.SecretsManager  // the secrets manager used for key storage
+	Metrics          *Metrics                // the metrics reporting reference
+	StreamCompressor compress.CompressStream // the stream compressor being used
 }
 
 func DefaultConfig() *Config {

--- a/network/server.go
+++ b/network/server.go
@@ -603,7 +603,12 @@ func (s *Server) newProtoConnection(protocol string, peerID peer.ID) (*rawGrpc.C
 }
 
 func (s *Server) NewStream(proto string, id peer.ID) (network.Stream, error) {
-	return s.host.NewStream(context.Background(), id, protocol.ID(proto))
+	libp2pStream, err := s.host.NewStream(context.Background(), id, protocol.ID(proto))
+	if err != nil {
+		return nil, err
+	}
+
+	return s.config.StreamCompressor(libp2pStream), nil
 }
 
 type Protocol interface {

--- a/server/config.go
+++ b/server/config.go
@@ -13,7 +13,7 @@ import (
 const DefaultGRPCPort int = 9632
 const DefaultJSONRPCPort int = 8545
 
-// Config is used to parametrize the minimal client
+// Config is used to parametrize the Polygon Edge client
 type Config struct {
 	Chain *chain.Chain
 


### PR DESCRIPTION
# Description

This PR adds support for libp2p stream compressions, namely it introduces 2 stream compression types:
* no compression
* gzip

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Regular cluster deployment with compression support enables.
Tested multiple nodes with different compression configurations

# Documentation update

// TODO

# Additional comments

// TODO post benchmark results
