### PR TITLE
Optimize TestBroadcast e2e test 

### DIFF
--- a/e2e/broadcast_test.go
+++ b/e2e/broadcast_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"sync"
 	"testing"
 	"time"
 
@@ -47,11 +48,51 @@ func TestBroadcast(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			srvs := framework.NewTestServers(t, tt.numNodes, conf)
 
 			framework.MultiJoinSerial(t, srvs[0:tt.numConnectedNodes])
+
+			// Check the connections
+			connectionErrors := framework.NewAtomicErrors(len(srvs))
+
+			var wgForConnections sync.WaitGroup
+
+			for i, srv := range srvs {
+				srv := srv
+
+				// Required number of connections
+				numRequiredConnections := 0
+				if i < tt.numConnectedNodes {
+					if i == 0 || i == tt.numConnectedNodes-1 {
+						numRequiredConnections = 1
+					} else {
+						numRequiredConnections = 2
+					}
+				}
+
+				wgForConnections.Add(1)
+				go func() {
+					defer wgForConnections.Done()
+
+					ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+					defer cancel()
+
+					_, err := framework.WaitUntilPeerConnects(ctx, srv, numRequiredConnections)
+					if err != nil {
+						connectionErrors.Append(err)
+					}
+				}()
+			}
+
+			wgForConnections.Wait()
+
+			for _, err := range connectionErrors.Errors() {
+				t.Error(err)
+			}
+
+			if len(connectionErrors.Errors()) > 0 {
+				t.Fail()
+			}
 
 			// wait until gossip protocol build mesh network
 			// (https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md)

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -38,9 +38,9 @@ type AtomicErrors struct {
 	errors []error
 }
 
-func NewAtomicErrors(cap int) AtomicErrors {
+func NewAtomicErrors(capacity int) AtomicErrors {
 	return AtomicErrors{
-		errors: make([]error, 0, cap),
+		errors: make([]error, 0, capacity),
 	}
 }
 
@@ -237,11 +237,13 @@ func MultiJoin(t *testing.T, srvs ...*TestServer) {
 		srcIndex, dstIndex := i, i+1
 
 		wg.Add(1)
+
 		go func() {
 			defer wg.Done()
 
 			srcClient, dstClient := src.Operator(), dst.Operator()
 			ctxFotStatus, cancelForStatus := context.WithTimeout(context.Background(), DefaultTimeout)
+
 			defer cancelForStatus()
 
 			dstStatus, err := dstClient.GetStatus(ctxFotStatus, &empty.Empty{})
@@ -253,6 +255,7 @@ func MultiJoin(t *testing.T, srvs ...*TestServer) {
 
 			dstAddr := strings.Split(dstStatus.P2PAddr, ",")[0]
 			ctxForConnecting, cancelForConnecting := context.WithTimeout(context.Background(), DefaultTimeout)
+
 			defer cancelForConnecting()
 
 			_, err = srcClient.PeersAdd(ctxForConnecting, &proto.PeersAddRequest{
@@ -475,6 +478,7 @@ func NewTestServers(t *testing.T, num int, conf func(*TestServerConfig)) []*Test
 		wg.Add(1)
 
 		i, srv := i, srv
+
 		go func() {
 			defer wg.Done()
 

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -34,7 +34,7 @@ var (
 )
 
 type AtomicErrors struct {
-	sync.Mutex
+	sync.RWMutex
 	errors []error
 }
 
@@ -52,6 +52,9 @@ func (a *AtomicErrors) Append(err error) {
 }
 
 func (a *AtomicErrors) Errors() []error {
+	a.RLock()
+	defer a.RUnlock()
+
 	return a.errors
 }
 


### PR DESCRIPTION
Fix EDGE-523

# Description

This PR optimizes TestBroadcast in e2e/broadcast_test.go.

Before

```bash
go test ./e2e/... -run TestBroadcast -count 1     
ok      github.com/0xPolygon/polygon-edge/e2e   179.067s
?       github.com/0xPolygon/polygon-edge/e2e/framework [no test files]
```

After

```bash
go test ./e2e/... -run TestBroadcast -count 1    
ok      github.com/0xPolygon/polygon-edge/e2e   23.810s
?       github.com/0xPolygon/polygon-edge/e2e/framework [no test files]
```

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
