### PR TITLE
[TxPool] Self pruning stuck transactions

### DIFF
--- a/txpool/account.go
+++ b/txpool/account.go
@@ -150,6 +150,7 @@ type account struct {
 	init               sync.Once
 	enqueued, promoted *accountQueue
 	nextNonce          uint64
+	demotions          uint
 }
 
 // getNonce returns the next expected nonce for this account.

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -321,7 +321,7 @@ func (p *TxPool) Pop(tx *types.Transaction) {
 	// pop the top most promoted tx
 	account.promoted.pop()
 
-	//	successfully popping an account reset its demotions count to 0
+	//	successfully popping an account resets its demotions count to 0
 	account.demotions = 0
 
 	// update state

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -377,9 +377,6 @@ func (p *TxPool) Drop(tx *types.Transaction) {
 	dropped = account.enqueued.clear()
 	clearAccountQueue(dropped)
 
-	//	reset the demotions counter
-	account.demotions = 0
-
 	p.eventManager.signalEvent(proto.EventType_DROPPED, tx.Hash)
 	p.logger.Debug("dropped account txs",
 		"num", droppedCount,
@@ -400,6 +397,9 @@ func (p *TxPool) Demote(tx *types.Transaction) {
 		)
 
 		p.Drop(tx)
+
+		//	reset the demotions counter
+		account.demotions = 0
 
 		return
 	}

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -388,9 +388,17 @@ func (p *TxPool) Drop(tx *types.Transaction) {
 	)
 }
 
+//	Demote excludes an account from being further processed during block building
+//	due to a recoverable error. If an account has been demoted too many times (maxAccountDemotions),
+//	it is Dropped instead.
 func (p *TxPool) Demote(tx *types.Transaction) {
 	account := p.accounts.get(tx.From)
 	if account.demotions == maxAccountDemotions {
+		p.logger.Debug(
+			"Demote: threshold reached - dropping account",
+			"addr", tx.From.String(),
+		)
+
 		p.Drop(tx)
 
 		return

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -21,6 +21,10 @@ const (
 	txSlotSize  = 32 * 1024  // 32kB
 	txMaxSize   = 128 * 1024 //128Kb
 	topicNameV1 = "txpool/0.1"
+
+	//	maximum allowed number of times an account
+	//	was excluded from block building (ibft.writeTransactions)
+	maxAccountDemotions = uint(10)
 )
 
 // errors
@@ -317,6 +321,9 @@ func (p *TxPool) Pop(tx *types.Transaction) {
 	// pop the top most promoted tx
 	account.promoted.pop()
 
+	//	successfully popping an account reset its demotions count to 0
+	account.demotions = 0
+
 	// update state
 	p.gauge.decrease(slotsRequired(tx))
 
@@ -370,6 +377,9 @@ func (p *TxPool) Drop(tx *types.Transaction) {
 	dropped = account.enqueued.clear()
 	clearAccountQueue(dropped)
 
+	//	reset the demotions counter
+	account.demotions = 0
+
 	p.eventManager.signalEvent(proto.EventType_DROPPED, tx.Hash)
 	p.logger.Debug("dropped account txs",
 		"num", droppedCount,
@@ -379,6 +389,15 @@ func (p *TxPool) Drop(tx *types.Transaction) {
 }
 
 func (p *TxPool) Demote(tx *types.Transaction) {
+	account := p.accounts.get(tx.From)
+	if account.demotions == maxAccountDemotions {
+		p.Drop(tx)
+
+		return
+	}
+
+	account.demotions++
+
 	p.eventManager.signalEvent(proto.EventType_DEMOTED, tx.Hash)
 }
 
@@ -684,6 +703,9 @@ func (p *TxPool) resetAccounts(stateNonces map[types.Address]uint64) {
 		//	append pruned
 		allPrunedPromoted = append(allPrunedPromoted, prunedPromoted...)
 		allPrunedEnqueued = append(allPrunedEnqueued, prunedEnqueued...)
+
+		//	new state for account -> demotions are reset to 0
+		account.demotions = 0
 	}
 
 	//	pool cleanup callback

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -612,7 +612,11 @@ func TestPromoteHandler(t *testing.T) {
 }
 
 func TestResetAccount(t *testing.T) {
+	t.Parallel()
+
 	t.Run("reset promoted", func(t *testing.T) {
+		t.Parallel()
+
 		testCases := []struct {
 			name     string
 			txs      []*types.Transaction
@@ -674,7 +678,10 @@ func TestResetAccount(t *testing.T) {
 			},
 		}
 		for _, test := range testCases {
+			test := test
 			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
+
 				pool, err := newTestPool()
 				assert.NoError(t, err)
 				pool.SetSigner(&mockSigner{})
@@ -725,6 +732,8 @@ func TestResetAccount(t *testing.T) {
 	})
 
 	t.Run("reset enqueued", func(t *testing.T) {
+		t.Parallel()
+
 		testCases := []struct {
 			name     string
 			txs      []*types.Transaction
@@ -807,7 +816,10 @@ func TestResetAccount(t *testing.T) {
 		}
 
 		for _, test := range testCases {
+			test := test
 			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
+
 				pool, err := newTestPool()
 				assert.NoError(t, err)
 				pool.SetSigner(&mockSigner{})
@@ -847,6 +859,8 @@ func TestResetAccount(t *testing.T) {
 	})
 
 	t.Run("reset enqueued and promoted", func(t *testing.T) {
+		t.Parallel()
+
 		testCases := []struct {
 			name     string
 			txs      []*types.Transaction
@@ -950,7 +964,10 @@ func TestResetAccount(t *testing.T) {
 		}
 
 		for _, test := range testCases {
+			test := test
 			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
+
 				pool, err := newTestPool()
 				assert.NoError(t, err)
 				pool.SetSigner(&mockSigner{})


### PR DESCRIPTION
# Description

This PR addresses the issue of valid "stuck" transactions. These transactions remain in the pool indefinitely due to being considered recoverable by consensus during block building. 

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

# Additional comments

Fixes EDGE-45
