### PR TITLE
[IBFT] Introduce quorum calculation switch 

### DIFF
--- a/command/ibft/ibft.go
+++ b/command/ibft/ibft.go
@@ -36,7 +36,7 @@ func registerSubcommands(baseCmd *cobra.Command) {
 		candidates.GetCommand(),
 		// ibft switch
 		_switch.GetCommand(),
-		//	ibft quorum
+		// ibft quorum
 		quorum.GetCommand(),
 	)
 }

--- a/command/ibft/ibft.go
+++ b/command/ibft/ibft.go
@@ -4,6 +4,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/command/ibft/candidates"
 	"github.com/0xPolygon/polygon-edge/command/ibft/propose"
+	"github.com/0xPolygon/polygon-edge/command/ibft/quorum"
 	"github.com/0xPolygon/polygon-edge/command/ibft/snapshot"
 	"github.com/0xPolygon/polygon-edge/command/ibft/status"
 	_switch "github.com/0xPolygon/polygon-edge/command/ibft/switch"
@@ -35,5 +36,7 @@ func registerSubcommands(baseCmd *cobra.Command) {
 		candidates.GetCommand(),
 		// ibft switch
 		_switch.GetCommand(),
+		//	ibft quorum
+		quorum.GetCommand(),
 	)
 }

--- a/command/ibft/quorum/ibft_quorum.go
+++ b/command/ibft/quorum/ibft_quorum.go
@@ -25,9 +25,7 @@ func setFlags(cmd *cobra.Command) {
 		&params.genesisPath,
 		chainFlag,
 		fmt.Sprintf("./%s", command.DefaultGenesisFileName),
-		fmt.Sprintf(
-			"the genesis file to update",
-		),
+		"the genesis file to update",
 	)
 
 	cmd.Flags().Uint64Var(

--- a/command/ibft/quorum/ibft_quorum.go
+++ b/command/ibft/quorum/ibft_quorum.go
@@ -26,7 +26,7 @@ func setFlags(cmd *cobra.Command) {
 		chainFlag,
 		fmt.Sprintf("./%s", command.DefaultGenesisFileName),
 		fmt.Sprintf(
-			"the genesis file to update. Default: ./%s",
+			"the genesis file to update: ./%s",
 			command.DefaultGenesisFileName,
 		),
 	)

--- a/command/ibft/quorum/ibft_quorum.go
+++ b/command/ibft/quorum/ibft_quorum.go
@@ -26,8 +26,7 @@ func setFlags(cmd *cobra.Command) {
 		chainFlag,
 		fmt.Sprintf("./%s", command.DefaultGenesisFileName),
 		fmt.Sprintf(
-			"the genesis file to update: ./%s",
-			command.DefaultGenesisFileName,
+			"the genesis file to update",
 		),
 	)
 

--- a/command/ibft/quorum/ibft_quorum.go
+++ b/command/ibft/quorum/ibft_quorum.go
@@ -1,0 +1,69 @@
+package quorum
+
+import (
+	"fmt"
+	"github.com/0xPolygon/polygon-edge/command"
+	"github.com/spf13/cobra"
+)
+
+func GetCommand() *cobra.Command {
+	ibftQuorumCmd := &cobra.Command{
+		Use:     "quorum",
+		Short:   "Specify the block number after which quorum optimal will be used for reaching consensus",
+		PreRunE: runPreRun,
+		Run:     runCommand,
+	}
+
+	setFlags(ibftQuorumCmd)
+	setRequiredFlags(ibftQuorumCmd)
+
+	return ibftQuorumCmd
+}
+
+func setFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&params.genesisPath,
+		chainFlag,
+		fmt.Sprintf("./%s", command.DefaultGenesisFileName),
+		fmt.Sprintf(
+			"the genesis file to update. Default: ./%s",
+			command.DefaultGenesisFileName,
+		),
+	)
+
+	cmd.Flags().Uint64Var(
+		&params.from,
+		fromFlag,
+		0,
+		"the height to switch the quorum calculation",
+	)
+}
+
+func setRequiredFlags(cmd *cobra.Command) {
+	for _, requiredFlag := range params.getRequiredFlags() {
+		_ = cmd.MarkFlagRequired(requiredFlag)
+	}
+}
+
+func runPreRun(_ *cobra.Command, _ []string) error {
+	return params.initRawParams()
+}
+
+func runCommand(cmd *cobra.Command, _ []string) {
+	outputter := command.InitializeOutputter(cmd)
+	defer outputter.WriteOutput()
+
+	if err := params.updateGenesisConfig(); err != nil {
+		outputter.SetError(err)
+
+		return
+	}
+
+	if err := params.overrideGenesisConfig(); err != nil {
+		outputter.SetError(err)
+
+		return
+	}
+
+	outputter.SetCommandResult(params.getResult())
+}

--- a/command/ibft/quorum/params.go
+++ b/command/ibft/quorum/params.go
@@ -41,11 +41,7 @@ func (p *quorumParams) initChain() error {
 }
 
 func (p *quorumParams) initRawParams() error {
-	if err := p.initChain(); err != nil {
-		return err
-	}
-
-	return nil
+	return p.initChain()
 }
 
 func (p *quorumParams) getRequiredFlags() []string {

--- a/command/ibft/quorum/params.go
+++ b/command/ibft/quorum/params.go
@@ -1,0 +1,104 @@
+package quorum
+
+import (
+	"errors"
+	"fmt"
+	"github.com/0xPolygon/polygon-edge/chain"
+	"github.com/0xPolygon/polygon-edge/command"
+	"github.com/0xPolygon/polygon-edge/command/helper"
+	"github.com/0xPolygon/polygon-edge/helper/common"
+	"os"
+)
+
+const (
+	fromFlag  = "from"
+	chainFlag = "chain"
+)
+
+var (
+	params = &quorumParams{}
+)
+
+type quorumParams struct {
+	genesisConfig *chain.Chain
+	from          uint64
+	genesisPath   string
+}
+
+func (p *quorumParams) initChain() error {
+	cc, err := chain.Import(p.genesisPath)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to load chain config from %s: %w",
+			p.genesisPath,
+			err,
+		)
+	}
+
+	p.genesisConfig = cc
+
+	return nil
+}
+
+func (p *quorumParams) initRawParams() error {
+	if err := p.initChain(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *quorumParams) getRequiredFlags() []string {
+	return []string{
+		fromFlag,
+	}
+}
+
+func (p *quorumParams) updateGenesisConfig() error {
+	return appendIBFTQuorum(
+		p.genesisConfig,
+		p.from,
+	)
+}
+
+func (p *quorumParams) overrideGenesisConfig() error {
+	// Remove the current genesis configuration from disk
+	if err := os.Remove(p.genesisPath); err != nil {
+		return err
+	}
+
+	// Save the new genesis configuration
+	if err := helper.WriteGenesisConfigToDisk(
+		p.genesisConfig,
+		p.genesisPath,
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *quorumParams) getResult() command.CommandResult {
+	result := &IBFTQuorumResult{
+		Chain: p.genesisPath,
+		From:  common.JSONNumber{Value: p.from},
+	}
+
+	return result
+}
+
+func appendIBFTQuorum(
+	cc *chain.Chain,
+	from uint64,
+) error {
+	ibftConfig, ok := cc.Params.Engine["ibft"].(map[string]interface{})
+	if !ok {
+		return errors.New(`"ibft" setting doesn't exist in "engine" of genesis.json'`)
+	}
+
+	ibftConfig["quorumSizeBlockNum"] = from
+
+	cc.Params.Engine["ibft"] = ibftConfig
+
+	return nil
+}

--- a/command/ibft/quorum/params.go
+++ b/command/ibft/quorum/params.go
@@ -79,12 +79,10 @@ func (p *quorumParams) overrideGenesisConfig() error {
 }
 
 func (p *quorumParams) getResult() command.CommandResult {
-	result := &IBFTQuorumResult{
+	return &IBFTQuorumResult{
 		Chain: p.genesisPath,
 		From:  common.JSONNumber{Value: p.from},
 	}
-
-	return result
 }
 
 func appendIBFTQuorum(

--- a/command/ibft/quorum/result.go
+++ b/command/ibft/quorum/result.go
@@ -1,0 +1,29 @@
+package quorum
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/0xPolygon/polygon-edge/command/helper"
+	"github.com/0xPolygon/polygon-edge/helper/common"
+)
+
+type IBFTQuorumResult struct {
+	Chain string            `json:"chain"`
+	From  common.JSONNumber `json:"from"`
+}
+
+func (r *IBFTQuorumResult) GetOutput() string {
+	var buffer bytes.Buffer
+
+	buffer.WriteString("\n[NEW IBFT QUORUM START]\n")
+
+	outputs := []string{
+		fmt.Sprintf("Chain|%s", r.Chain),
+		fmt.Sprintf("From|%d", r.From.Value),
+	}
+
+	buffer.WriteString(helper.FormatKV(outputs))
+	buffer.WriteString("\n")
+
+	return buffer.String()
+}

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -1256,6 +1256,9 @@ func (i *Ibft) VerifyHeader(parent, header *types.Header) error {
 	return nil
 }
 
+//	quorumSize returns a callback that when executed on a ValidatorSet computes
+//	number of votes required to reach quorum based on the size of the set.
+//	The blockNumber argument indicates which formula was used to calculate the result (see PRs #513, #549)
 func (i *Ibft) quorumSize(blockNumber uint64) QuorumImplementation {
 	rawUint64, ok := i.config.Config["quorumSizeBlockNum"]
 	if !ok {

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -1269,9 +1269,9 @@ func (i *Ibft) quorumSize(blockNumber uint64) QuorumImplementation {
 
 	if blockNumber < uint64(cfgQuorumSizeBlockNum) {
 		return LegacyQuorumSize
-	} else {
-		return OptimalQuorumSize
 	}
+
+	return OptimalQuorumSize
 }
 
 // ProcessHeaders updates the snapshot based on previously verified headers

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -1256,6 +1256,24 @@ func (i *Ibft) VerifyHeader(parent, header *types.Header) error {
 	return nil
 }
 
+func (i *Ibft) quorumSize(validators ValidatorSet, blockNumber uint64) int {
+	rawUint64, ok := i.config.Config["quorumSizeBlockNum"]
+	if !ok {
+		return OptimalQuorumSize(validators)
+	}
+
+	cfgQuorumSizeBlockNum, ok := rawUint64.(uint64)
+	if !ok {
+		panic("bad")
+	}
+
+	if blockNumber < cfgQuorumSizeBlockNum {
+		return LegacyQuorumSize(validators)
+	} else {
+		return OptimalQuorumSize(validators)
+	}
+}
+
 // ProcessHeaders updates the snapshot based on previously verified headers
 func (i *Ibft) ProcessHeaders(headers []*types.Header) error {
 	return i.processHeaders(headers)

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -1262,12 +1262,12 @@ func (i *Ibft) quorumSize(blockNumber uint64) QuorumImplementation {
 		return OptimalQuorumSize
 	}
 
-	cfgQuorumSizeBlockNum, ok := rawUint64.(uint64)
+	cfgQuorumSizeBlockNum, ok := rawUint64.(float64)
 	if !ok {
-		panic("bad")
+		panic("invalid block number format")
 	}
 
-	if blockNumber < cfgQuorumSizeBlockNum {
+	if blockNumber < uint64(cfgQuorumSizeBlockNum) {
 		return LegacyQuorumSize
 	} else {
 		return OptimalQuorumSize

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -1256,10 +1256,10 @@ func (i *Ibft) VerifyHeader(parent, header *types.Header) error {
 	return nil
 }
 
-func (i *Ibft) quorumSize(validators ValidatorSet, blockNumber uint64) int {
+func (i *Ibft) quorumSize(blockNumber uint64) QuorumImplementation {
 	rawUint64, ok := i.config.Config["quorumSizeBlockNum"]
 	if !ok {
-		return OptimalQuorumSize(validators)
+		return OptimalQuorumSize
 	}
 
 	cfgQuorumSizeBlockNum, ok := rawUint64.(uint64)
@@ -1268,9 +1268,9 @@ func (i *Ibft) quorumSize(validators ValidatorSet, blockNumber uint64) int {
 	}
 
 	if blockNumber < cfgQuorumSizeBlockNum {
-		return LegacyQuorumSize(validators)
+		return LegacyQuorumSize
 	} else {
-		return OptimalQuorumSize(validators)
+		return OptimalQuorumSize
 	}
 }
 

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -1303,7 +1303,7 @@ func TestQuorumSizeSwitch(t *testing.T) {
 
 	testTable := []struct {
 		name           string
-		switchBlock    float64
+		switchBlock    uint64
 		currentBlock   uint64
 		set            ValidatorSet
 		expectedQuorum int
@@ -1344,11 +1344,7 @@ func TestQuorumSizeSwitch(t *testing.T) {
 			t.Parallel()
 
 			ibft := &Ibft{
-				config: &consensus.Config{
-					Config: map[string]interface{}{
-						"quorumSizeBlockNum": test.switchBlock,
-					},
-				},
+				quorumSizeBlockNum: test.switchBlock,
 			}
 
 			assert.Equal(t,

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -1303,7 +1303,7 @@ func TestQuorumSizeSwitch(t *testing.T) {
 
 	testTable := []struct {
 		name           string
-		switchBlock    uint64
+		switchBlock    float64
 		currentBlock   uint64
 		set            ValidatorSet
 		expectedQuorum int

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -1297,3 +1297,64 @@ func TestGetIBFTForks(t *testing.T) {
 		})
 	}
 }
+
+func TestQuorumSizeSwitch(t *testing.T) {
+	t.Parallel()
+
+	testTable := []struct {
+		name           string
+		switchBlock    uint64
+		currentBlock   uint64
+		set            ValidatorSet
+		expectedQuorum int
+	}{
+		{
+			"use old quorum calculation",
+			10,
+			5,
+			[]types.Address{
+				types.ZeroAddress,
+				types.ZeroAddress,
+				types.ZeroAddress,
+				types.ZeroAddress,
+				types.ZeroAddress,
+				types.ZeroAddress,
+			},
+			3,
+		},
+		{
+			"use new quorum calculation",
+			10,
+			15,
+			[]types.Address{
+				types.ZeroAddress,
+				types.ZeroAddress,
+				types.ZeroAddress,
+				types.ZeroAddress,
+				types.ZeroAddress,
+				types.ZeroAddress,
+			},
+			4,
+		},
+	}
+
+	for _, test := range testTable {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ibft := &Ibft{
+				config: &consensus.Config{
+					Config: map[string]interface{}{
+						"quorumSizeBlockNum": test.switchBlock,
+					},
+				},
+			}
+
+			assert.Equal(t,
+				test.expectedQuorum,
+				ibft.quorumSize(test.currentBlock)(test.set),
+			)
+		})
+	}
+}

--- a/consensus/ibft/sign.go
+++ b/consensus/ibft/sign.go
@@ -166,7 +166,11 @@ func verifySigner(snap *Snapshot, header *types.Header) error {
 }
 
 // verifyCommitedFields is checking for consensus proof in the header
-func verifyCommitedFields(snap *Snapshot, header *types.Header) error {
+func verifyCommitedFields(
+	snap *Snapshot,
+	header *types.Header,
+	quorumSizeFn QuorumImplementation,
+) error {
 	extra, err := getIbftExtra(header)
 	if err != nil {
 		return err
@@ -207,7 +211,7 @@ func verifyCommitedFields(snap *Snapshot, header *types.Header) error {
 	// Valid committed seals must be at least 2F+1
 	// 	2F 	is the required number of honest validators who provided the committed seals
 	// 	+1	is the proposer
-	if validSeals := len(visited); validSeals < snap.Set.QuorumSize() {
+	if validSeals := len(visited); validSeals < quorumSizeFn(snap.Set) {
 		return fmt.Errorf("not enough seals to seal block")
 	}
 

--- a/consensus/ibft/sign_test.go
+++ b/consensus/ibft/sign_test.go
@@ -59,7 +59,7 @@ func TestSign_CommittedSeals(t *testing.T) {
 
 		assert.NoError(t, err)
 
-		return verifyCommitedFields(snap, sealed)
+		return verifyCommitedFields(snap, sealed, OptimalQuorumSize)
 	}
 
 	// Correct

--- a/consensus/ibft/state.go
+++ b/consensus/ibft/state.go
@@ -304,19 +304,26 @@ func (v *ValidatorSet) MaxFaultyNodes() int {
 	return (len(*v) - 1) / 3
 }
 
-// QuorumSize returns the number of required messages for consensus
-func (v ValidatorSet) QuorumSize() int {
+//	LegacyQuorumSize returns the legacy quorum size for the given validator set
+func LegacyQuorumSize(set ValidatorSet) int {
+	// According to the IBFT spec, the number of valid messages
+	// needs to be 2F + 1
+	return 2*set.MaxFaultyNodes() + 1
+}
+
+// OptimalQuorumSize returns the optimal quorum size for the given validator set
+func OptimalQuorumSize(set ValidatorSet) int {
 	//	if the number of validators is less than 4,
 	//	then the entire set is required
-	if v.MaxFaultyNodes() == 0 {
+	if set.MaxFaultyNodes() == 0 {
 		/*
 			N: 1 -> Q: 1
 			N: 2 -> Q: 2
 			N: 3 -> Q: 3
 		*/
-		return v.Len()
+		return set.Len()
 	}
 
 	// (quorum optimal)	Q = ceil(2/3 * N)
-	return int(math.Ceil(2 * float64(v.Len()) / 3))
+	return int(math.Ceil(2 * float64(set.Len()) / 3))
 }

--- a/consensus/ibft/state.go
+++ b/consensus/ibft/state.go
@@ -304,6 +304,8 @@ func (v *ValidatorSet) MaxFaultyNodes() int {
 	return (len(*v) - 1) / 3
 }
 
+type QuorumImplementation func(ValidatorSet) int
+
 //	LegacyQuorumSize returns the legacy quorum size for the given validator set
 func LegacyQuorumSize(set ValidatorSet) int {
 	// According to the IBFT spec, the number of valid messages

--- a/consensus/ibft/state_test.go
+++ b/consensus/ibft/state_test.go
@@ -62,7 +62,7 @@ func TestNumValid(t *testing.T) {
 
 		assert.Equal(t,
 			int(c.Quorum),
-			pool.ValidatorSet().QuorumSize(),
+			OptimalQuorumSize(pool.ValidatorSet()),
 		)
 	}
 }


### PR DESCRIPTION
# Description

This PR enables users to specify a block number after which QuorumOptimal (`2/3 * N`) will be used to calculate the required number of messages for the given network size (`N`).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

1. Setup a 6-node cluster on commit 805f9ef4da0d30d142c0e4850f95f27da77243b5
2. Start 3 of the nodes
3. Start a non-validator node on this branch
4. Observe that the non-validator is unable to sync with the network
5. Run `ibft quorum --from XX --chain your_genesis_file.json` to specify the block number after which quorum optimal calculation will be used
6. Restart all (6) nodes with the binary built from this branch and the chain grow
7. Run the non-validator node and observe it is able to sync up with the network 

# Documentation update

TODO

# Additional comments

PR #513 introduced a new calculation for quorum size of a given validator set. In practical terms, this means the number of votes required for reaching consensus became more constrained. Consequentially, the PR implemented a breaking change for existing chains, as any new node joining the network would not be able to verify previously sealed blocks. 

By specifying a `--from` value for the `ibft quorum` command, new nodes syncing with the chain will be able to correctly verify seals from older blocks. Old blocks (up until the value specified) will be verified using the old formula (`LegacyQuorumSize`) and all subsequent blocks with the new (`OptimalQuorumSize`).

How-to: applying the flag for existing chains

1. Update all nodes to a version of Polygon-Edge that includes this PR
2. Modify your genesis file by running: `polygon-edge ibft quorum --from [your_quorum_switch_block_num] --chain [your_genesis_file]`. Make sure that after `your_quorum_switch_block_num` an `OptimalQuorumSize` of validators are signing the blocks
3. Observe that all (new) nodes are able to sync with the running network





Fixes EDGE-556