### PR TITLE
[TxPool] Fix duplicate transactions in account

### DIFF
--- a/txpool/lookup_map.go
+++ b/txpool/lookup_map.go
@@ -13,13 +13,17 @@ type lookupMap struct {
 }
 
 // add inserts the given transaction into the map. [thread-safe]
-func (m *lookupMap) add(txs ...*types.Transaction) {
+func (m *lookupMap) add(tx *types.Transaction) bool {
 	m.Lock()
 	defer m.Unlock()
 
-	for _, tx := range txs {
-		m.all[tx.Hash] = tx
+	if _, exists := m.all[tx.Hash]; exists {
+		return false
 	}
+
+	m.all[tx.Hash] = tx
+
+	return true
 }
 
 // remove removes the given transactions from the map. [thread-safe]

--- a/txpool/lookup_map.go
+++ b/txpool/lookup_map.go
@@ -12,7 +12,8 @@ type lookupMap struct {
 	all map[types.Hash]*types.Transaction
 }
 
-// add inserts the given transaction into the map. [thread-safe]
+// add inserts the given transaction into the map. Returns false
+// if it already exists. [thread-safe]
 func (m *lookupMap) add(tx *types.Transaction) bool {
 	m.Lock()
 	defer m.Unlock()

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -594,22 +594,6 @@ func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 		return ErrAlreadyKnown
 	}
 
-	//// check if already known
-	//if _, ok := p.index.get(tx.Hash); ok {
-	//	if origin == gossip {
-	//		// silently drop known tx
-	//		// that is gossiped back
-	//		p.logger.Debug(
-	//			"dropping known gossiped transaction",
-	//			"hash", tx.Hash.String(),
-	//		)
-	//
-	//		return nil
-	//	} else {
-	//		return ErrAlreadyKnown
-	//	}
-	//}
-
 	// initialize account for this address once
 	if !p.accounts.exists(tx.From) {
 		p.createAccountOnce(tx.From)

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -698,14 +698,20 @@ func (p *TxPool) addGossipTx(obj interface{}) {
 
 	// decode tx
 	if err := tx.UnmarshalRLP(raw.Raw.Value); err != nil {
-		p.logger.Error("failed to decode broadcasted tx", "err", err)
+		p.logger.Error("failed to decode broadcast tx", "err", err)
 
 		return
 	}
 
 	// add tx
 	if err := p.addTx(gossip, tx); err != nil {
-		p.logger.Error("failed to add broadcasted txn", "err", err)
+		if errors.Is(err, ErrAlreadyKnown) {
+			p.logger.Debug("rejecting known tx (gossip)", "hash", tx.Hash.String())
+
+			return
+		}
+
+		p.logger.Error("failed to add broadcast tx", "err", err, "hash", tx.Hash.String())
 	}
 }
 

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -590,7 +590,7 @@ func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 	tx.ComputeHash()
 
 	//	add to index
-	if known := p.index.add(tx); !known {
+	if ok := p.index.add(tx); !ok {
 		return ErrAlreadyKnown
 	}
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -402,7 +402,7 @@ func TestDropKnownGossipTx(t *testing.T) {
 		err := pool.addTx(local, tx)
 		assert.NoError(t, err)
 	}()
-	pool.handleEnqueueRequest(<-pool.enqueueReqCh)
+	<-pool.enqueueReqCh
 
 	assert.Equal(t, uint64(1), pool.accounts.get(addr1).enqueued.length())
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -389,6 +389,8 @@ func TestAddGossipTx(t *testing.T) {
 }
 
 func TestDropKnownGossipTx(t *testing.T) {
+	t.Parallel()
+
 	pool, err := newTestPool()
 	assert.NoError(t, err)
 	pool.SetSigner(&mockSigner{})

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -399,18 +399,18 @@ func TestDropKnownGossipTx(t *testing.T) {
 
 	// send tx as local
 	go func() {
-		err := pool.addTx(local, tx)
-		assert.NoError(t, err)
+		assert.NoError(t, pool.addTx(local, tx))
 	}()
 	<-pool.enqueueReqCh
 
-	assert.Equal(t, uint64(1), pool.accounts.get(addr1).enqueued.length())
+	_, exists := pool.index.get(tx.Hash)
+	assert.True(t, exists)
 
 	// send tx as gossip (will be discarded)
-	err = pool.addTx(gossip, tx)
-	assert.Nil(t, err)
-
-	assert.Equal(t, uint64(1), pool.accounts.get(addr1).enqueued.length())
+	assert.ErrorIs(t,
+		pool.addTx(gossip, tx),
+		ErrAlreadyKnown,
+	)
 }
 
 func TestAddHandler(t *testing.T) {


### PR DESCRIPTION
# Description

This PR fixes the issue of two identical transactions ending up back-to-back inside an account. This bug is the true source of the numerous `failed to apply tx: incorrect nonce` errors.

The second transaction is a gossip of the first, but because indexing happens in `handleEnqueueRequest` both of them complete the preceding call to `addTx` bypassing the (now deprecated) check for `ErrAlreadyKnown`. 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

# Additional comments

Fixes EDGE-585
