### PR TITLE
Unlock proposed block after bulk sync

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -730,6 +730,7 @@ func (i *Ibft) runAcceptState() { // start new round
 	parent := i.blockchain.Header()
 	number := parent.Number + 1
 
+	// Check whether current sequence matches the next height
 	switch {
 	case number > i.state.view.Sequence:
 		// Node has synced already but state needs to update

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -853,7 +853,7 @@ func (i *Ibft) runAcceptState() { // start new round
 
 		if block.Number() != i.state.view.Sequence {
 			i.logger.Error("sequence not correct", "block", block.Number, "sequence", i.state.view.Sequence)
-			i.setState(SyncState)
+			i.handleStateErr(errIncorrectBlockHeight)
 
 			return
 		}
@@ -1066,9 +1066,10 @@ func (i *Ibft) insertBlock(block *types.Block) error {
 }
 
 var (
-	errIncorrectBlockLocked    = fmt.Errorf("block locked is incorrect")
-	errBlockVerificationFailed = fmt.Errorf("block verification failed")
-	errFailedToInsertBlock     = fmt.Errorf("failed to insert block")
+	errIncorrectBlockLocked    = errors.New("block locked is incorrect")
+	errIncorrectBlockHeight    = errors.New("proposed block number is incorrect")
+	errBlockVerificationFailed = errors.New("block verification failed")
+	errFailedToInsertBlock     = errors.New("failed to insert block")
 )
 
 func (i *Ibft) handleStateErr(err error) {

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -983,6 +983,9 @@ func (i *Ibft) runValidateState() {
 			// update metrics
 			i.updateMetrics(block)
 
+			// increase the sequence number and reset the round if any
+			i.startNewSequence()
+
 			// move ahead to the next block
 			i.setState(AcceptState)
 		}
@@ -1059,9 +1062,6 @@ func (i *Ibft) insertBlock(block *types.Block) error {
 		"rounds", i.state.view.Round+1,
 		"committed", i.state.numCommitted(),
 	)
-
-	// increase the sequence number and reset the round if any
-	i.startNewSequence()
 
 	// broadcast the new block
 	i.syncer.Broadcast(block)

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -857,6 +857,7 @@ func (i *Ibft) runAcceptState() { // start new round
 			return
 		}
 
+		// Make sure the proposing block height match the current sequence
 		if block.Number() != i.state.view.Sequence {
 			i.logger.Error("sequence not correct", "block", block.Number, "sequence", i.state.view.Sequence)
 			i.handleStateErr(errIncorrectBlockHeight)

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -547,7 +547,7 @@ func TestTransition_AcceptState_Reject_WrongHeight_Block(t *testing.T) {
 		Proposal: &anypb.Any{
 			Value: proposedBlock.MarshalRLP(),
 		},
-		// Proposer propose block #3 but set sequence 2 in order to pass message queue in validator
+		// Proposer propose block #3 but set sequence 2 in View in order to pass message queue in other validators
 		View: proto.ViewMsg(nextSequence, 0),
 	})
 
@@ -557,7 +557,7 @@ func TestTransition_AcceptState_Reject_WrongHeight_Block(t *testing.T) {
 		sequence: nextSequence,
 		state:    RoundChangeState,
 		locked:   false,
-		outgoing: 0, // prepare message
+		outgoing: 0,
 		err:      errIncorrectBlockHeight,
 	})
 }

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -275,7 +275,7 @@ func TestTransition_AcceptState_Validator_LockWrong(t *testing.T) {
 		sequence: 1,
 		state:    RoundChangeState,
 		locked:   true,
-		err:      errIncorrectBlockLocked,
+		err:      errIncorrectBlockHeight,
 	})
 }
 
@@ -942,35 +942,35 @@ type expectResult struct {
 
 func (m *mockIbft) expect(res expectResult) {
 	if sequence := m.state.view.Sequence; sequence != res.sequence {
-		m.t.Fatalf("incorrect sequence %d %d", sequence, res.sequence)
+		m.t.Fatalf("incorrect sequence got=%d expected=%d", sequence, res.sequence)
 	}
 
 	if round := m.state.view.Round; round != res.round {
-		m.t.Fatalf("incorrect round %d %d", round, res.round)
+		m.t.Fatalf("incorrect round got=%d expected=%d", round, res.round)
 	}
 
 	if m.getState() != res.state {
-		m.t.Fatalf("incorrect state %s %s", m.getState(), res.state)
+		m.t.Fatalf("incorrect state got=%s expected=%s", m.getState(), res.state)
 	}
 
 	if size := len(m.state.prepared); uint64(size) != res.prepareMsgs {
-		m.t.Fatalf("incorrect prepared messages %d %d", size, res.prepareMsgs)
+		m.t.Fatalf("incorrect prepared messages got=%d expected=%d", size, res.prepareMsgs)
 	}
 
 	if size := len(m.state.committed); uint64(size) != res.commitMsgs {
-		m.t.Fatalf("incorrect commit messages %d %d", size, res.commitMsgs)
+		m.t.Fatalf("incorrect commit messages got=%d expected=%d", size, res.commitMsgs)
 	}
 
 	if m.state.locked != res.locked {
-		m.t.Fatalf("incorrect locked %v %v", m.state.locked, res.locked)
+		m.t.Fatalf("incorrect locked got=%v expected=%v", m.state.locked, res.locked)
 	}
 
 	if size := len(m.respMsg); uint64(size) != res.outgoing {
-		m.t.Fatalf("incorrect outgoing messages %v %v", size, res.outgoing)
+		m.t.Fatalf("incorrect outgoing messages got=%v expected=%v", size, res.outgoing)
 	}
 
 	if !errors.Is(m.state.err, res.err) {
-		m.t.Fatalf("incorrect error %v %v", m.state.err, res.err)
+		m.t.Fatalf("incorrect error got=%v expected=%v", m.state.err, res.err)
 	}
 }
 

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -42,6 +42,7 @@ type MockBlockchain struct {
 
 func (m *MockBlockchain) Header() *types.Header {
 	m.t.Helper()
+
 	if m.HeaderHandler == nil {
 		m.errorByUndefinedMethod("Header")
 	}
@@ -51,6 +52,7 @@ func (m *MockBlockchain) Header() *types.Header {
 
 func (m *MockBlockchain) GetHeaderByNumber(i uint64) (*types.Header, bool) {
 	m.t.Helper()
+
 	if m.GetHeaderByNumberHandler == nil {
 		m.errorByUndefinedMethod("GetHeaderByNumber")
 	}
@@ -60,6 +62,7 @@ func (m *MockBlockchain) GetHeaderByNumber(i uint64) (*types.Header, bool) {
 
 func (m *MockBlockchain) WriteBlock(block *types.Block) error {
 	m.t.Helper()
+
 	if m.WriteBlockHandler == nil {
 		m.errorByUndefinedMethod("WriteBlock")
 	}
@@ -69,6 +72,7 @@ func (m *MockBlockchain) WriteBlock(block *types.Block) error {
 
 func (m *MockBlockchain) VerifyPotentialBlock(block *types.Block) error {
 	m.t.Helper()
+
 	if m.VerifyPotentialBlockHandler == nil {
 		m.errorByUndefinedMethod("VerifyPotentialBlock")
 	}
@@ -78,6 +82,7 @@ func (m *MockBlockchain) VerifyPotentialBlock(block *types.Block) error {
 
 func (m *MockBlockchain) CalculateGasLimit(number uint64) (uint64, error) {
 	m.t.Helper()
+
 	if m.CalculateGasLimitHandler == nil {
 		m.errorByUndefinedMethod("CalculateGasLimit")
 	}
@@ -106,12 +111,19 @@ func (m *MockBlockchain) SetGenesis(validators []types.Address) *types.Block {
 		Header: header,
 	}
 
-	m.writeBlock(block)
+	if err := m.writeBlock(block); err != nil {
+		m.t.Errorf("failed to insert genesis block: %v", err)
+	}
 
 	return block
 }
 
-func (m *MockBlockchain) MockBlock(height uint64, parentHash types.Hash, proposer *ecdsa.PrivateKey, validators []types.Address) *types.Block {
+func (m *MockBlockchain) MockBlock(
+	height uint64,
+	parentHash types.Hash,
+	proposer *ecdsa.PrivateKey,
+	validators []types.Address,
+) *types.Block {
 	m.t.Helper()
 
 	var err error
@@ -1221,7 +1233,12 @@ func newMockIbft(t *testing.T, accounts []string, account string) *mockIbft {
 	return m
 }
 
-func newMockIBFTWithMockBlockchain(t *testing.T, pool *testerAccountPool, mockBlockchain *MockBlockchain, account string) *mockIbft {
+func newMockIBFTWithMockBlockchain(
+	t *testing.T,
+	pool *testerAccountPool,
+	mockBlockchain *MockBlockchain,
+	account string,
+) *mockIbft {
 	t.Helper()
 
 	m := &mockIbft{

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -919,6 +919,7 @@ func TestRunSyncState_BulkSyncWithPeer_CallsTxPoolResetWithHeaders(t *testing.T)
 	)
 }
 
+// Tests whether validator unlock block if it syncs blocks during sync process
 func TestRunSyncState_Unlock_After_Sync(t *testing.T) {
 	pool := newTesterAccountPool()
 	pool.add("A", "B", "C", "D")
@@ -933,6 +934,7 @@ func TestRunSyncState_Unlock_After_Sync(t *testing.T) {
 	// Locking block #1
 	m.state.locked = true
 
+	// Sync blocks to #3
 	expectedNewBlocksToSync := []*types.Block{
 		{Header: &types.Header{Number: 1}},
 		{Header: &types.Header{Number: 2}},
@@ -955,7 +957,7 @@ func TestRunSyncState_Unlock_After_Sync(t *testing.T) {
 
 	m.runSyncState()
 
-	// Validator should start new round from next of latest block and unlock block
+	// Validator should start new sequence from the next of the latest block and unlock block in state
 	m.expect(expectResult{
 		sequence: 4,
 		state:    AcceptState,


### PR DESCRIPTION
Fix EDGE-573

# Description

This PR fixes the issue that a validator will not unlock the proposed block if it's left at past height for some reason.
And this PR adds safe check to the correctness of proposing block height because validator can propose block with wrong height by setting wrong view in preprepare message.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
