### PR TITLE
Add linter guards on problematic error checks

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -117,7 +117,12 @@ func (i *Ibft) runHook(hookName HookType, height uint64, hookParam interface{}) 
 
 		// Run the hook
 		if err := hook(hookParam); err != nil {
-			return fmt.Errorf("error occurred during a call of %s hook in %s: %w", hookName, mechanism.GetType(), err)
+			return fmt.Errorf(
+				"error occurred during a call of %s hook in %s: %w",
+				hookName,
+				mechanism.GetType(),
+				err,
+			)
 		}
 	}
 
@@ -893,6 +898,8 @@ func (i *Ibft) runAcceptState() { // start new round
 			}
 
 			if hookErr := i.runHook(VerifyBlockHook, block.Number(), block); hookErr != nil {
+				// Not linting this as the underlying error is actually wrapped
+				// nolint:govet
 				if errors.As(hookErr, &errBlockVerificationFailed) {
 					i.logger.Error("block verification failed, block at the end of epoch has transactions")
 					i.handleStateErr(errBlockVerificationFailed)

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -403,6 +403,7 @@ func (e *Eth) GetStorageAt(
 	// Get the storage for the passed in location
 	result, err := e.store.GetStorage(header.StateRoot, address, index)
 	if err != nil {
+		// nolint:govet
 		if errors.As(err, &ErrStateNotFound) {
 			return argBytesPtr(types.ZeroHash[:]), nil
 		}
@@ -535,6 +536,7 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 		accountBalance := big.NewInt(0)
 		acc, err := e.store.GetAccount(header.StateRoot, transaction.From)
 
+		// nolint:govet
 		if err != nil && !errors.As(err, &ErrStateNotFound) {
 			// An unrelated error occurred, return it
 			return nil, err
@@ -577,6 +579,8 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 
 	// Checks if executor level valid gas errors occurred
 	isGasApplyError := func(err error) bool {
+		// Not linting this as the underlying error is actually wrapped
+		// nolint:govet
 		return errors.As(err, &state.ErrNotEnoughIntrinsicGas)
 	}
 
@@ -703,6 +707,7 @@ func (e *Eth) GetBalance(address types.Address, filter BlockNumberOrHash) (inter
 
 	// Extract the account balance
 	acc, err := e.store.GetAccount(header.StateRoot, address)
+	// nolint:govet
 	if errors.As(err, &ErrStateNotFound) {
 		// Account not found, return an empty account
 		return argUintPtr(0), nil
@@ -769,6 +774,7 @@ func (e *Eth) GetCode(address types.Address, filter BlockNumberOrHash) (interfac
 	emptySlice := []byte{}
 	acc, err := e.store.GetAccount(header.StateRoot, address)
 
+	// nolint:govet
 	if errors.As(err, &ErrStateNotFound) {
 		// If the account doesn't exist / is not initialized yet,
 		// return the default value
@@ -861,6 +867,7 @@ func (e *Eth) getNextNonce(address types.Address, number BlockNumber) (uint64, e
 
 	acc, err := e.store.GetAccount(header.StateRoot, address)
 
+	// nolint:govet
 	if errors.As(err, &ErrStateNotFound) {
 		// If the account doesn't exist / isn't initialized,
 		// return a nonce value of 0

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/hashicorp/go-hclog"
@@ -94,7 +95,8 @@ func (j *JSONRPC) setupHTTP() error {
 	mux.HandleFunc("/ws", j.handleWs)
 
 	srv := http.Server{
-		Handler: mux,
+		Handler:           mux,
+		ReadHeaderTimeout: 60 * time.Second,
 	}
 
 	go func() {

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/archive"
 	"github.com/0xPolygon/polygon-edge/blockchain"
@@ -641,6 +642,7 @@ func (s *Server) startPrometheusServer(listenAddr *net.TCPAddr) *http.Server {
 				promhttp.HandlerOpts{},
 			),
 		),
+		ReadHeaderTimeout: 60 * time.Second,
 	}
 
 	go func() {


### PR DESCRIPTION
# Description

This PR introduces some linting fixes.

A notable thing that was added:
* Protection against Slowris attacks (header timeouts set to `60s`)

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

# Additional comments

Fixes EDGE-696
