### PR TITLE
Ignore patch updates from awsgo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     target-branch: "develop"
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "github.com/aws/aws-sdk-go"
+        update-types: [ "version-update:semver-patch" ]
     open-pull-requests-limit: 10
     pull-request-branch-name:
       separator: "-"


### PR DESCRIPTION
# Description

This PR makes the dependabot ignore patch updates (which are very, very frequent) for the aws-go package.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
