### PR TITLE
[Fix] Add disable for batch request limit

### DIFF
--- a/command/server/config/config.go
+++ b/command/server/config/config.go
@@ -61,17 +61,18 @@ type Headers struct {
 }
 
 const (
-	// minimum block generation time in seconds
+	// DefaultBlockTime minimum block generation time in seconds
 	DefaultBlockTime uint64 = 2
 
-	// Multiplier to get IBFT timeout from block time
+	// BlockTimeMultiplierForTimeout Multiplier to get IBFT timeout from block time
 	// timeout is calculated when IBFT timeout is not specified
 	BlockTimeMultiplierForTimeout uint64 = 5
 
-	// maximum length allowed for json_rpc batch requests
+	// DefaultJSONRPCBatchRequestLimit maximum length allowed for json_rpc batch requests
 	DefaultJSONRPCBatchRequestLimit uint64 = 20
 
-	// maximum block range allowed for json_rpc requests with fromBlock/toBlock values (e.g. eth_getLogs)
+	// DefaultJSONRPCBlockRangeLimit maximum block range allowed for json_rpc
+	// requests with fromBlock/toBlock values (e.g. eth_getLogs)
 	DefaultJSONRPCBlockRangeLimit uint64 = 1000
 )
 

--- a/command/server/init.go
+++ b/command/server/init.go
@@ -60,8 +60,19 @@ func (p *serverParams) initRawParams() error {
 
 	p.initPeerLimits()
 	p.initLogFileLocation()
+	p.initJsonRpcBulkLimits()
 
 	return p.initAddresses()
+}
+
+func (p *serverParams) initJsonRpcBulkLimits() {
+	if p.rawConfig.JSONRPCBatchRequestLimit != config.DefaultJSONRPCBatchRequestLimit {
+		p.jsonRPCBatchLengthLimit = p.rawConfig.JSONRPCBatchRequestLimit
+	}
+
+	if p.rawConfig.JSONRPCBlockRangeLimit != config.DefaultJSONRPCBlockRangeLimit {
+		p.jsonRPCBlockRangeLimit = p.rawConfig.JSONRPCBlockRangeLimit
+	}
 }
 
 func (p *serverParams) initBlockTime() error {

--- a/command/server/init.go
+++ b/command/server/init.go
@@ -60,12 +60,12 @@ func (p *serverParams) initRawParams() error {
 
 	p.initPeerLimits()
 	p.initLogFileLocation()
-	p.initJsonRpcBulkLimits()
+	p.initJSONRPCBulkLimits()
 
 	return p.initAddresses()
 }
 
-func (p *serverParams) initJsonRpcBulkLimits() {
+func (p *serverParams) initJSONRPCBulkLimits() {
 	if p.rawConfig.JSONRPCBatchRequestLimit != config.DefaultJSONRPCBatchRequestLimit {
 		p.jsonRPCBatchLengthLimit = p.rawConfig.JSONRPCBatchRequestLimit
 	}

--- a/command/server/init.go
+++ b/command/server/init.go
@@ -60,19 +60,8 @@ func (p *serverParams) initRawParams() error {
 
 	p.initPeerLimits()
 	p.initLogFileLocation()
-	p.initJSONRPCBulkLimits()
 
 	return p.initAddresses()
-}
-
-func (p *serverParams) initJSONRPCBulkLimits() {
-	if p.rawConfig.JSONRPCBatchRequestLimit != config.DefaultJSONRPCBatchRequestLimit {
-		p.jsonRPCBatchLengthLimit = p.rawConfig.JSONRPCBatchRequestLimit
-	}
-
-	if p.rawConfig.JSONRPCBlockRangeLimit != config.DefaultJSONRPCBlockRangeLimit {
-		p.jsonRPCBlockRangeLimit = p.rawConfig.JSONRPCBlockRangeLimit
-	}
 }
 
 func (p *serverParams) initBlockTime() error {

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -80,9 +80,6 @@ type serverParams struct {
 
 	corsAllowedOrigins []string
 
-	jsonRPCBatchLengthLimit uint64
-	jsonRPCBlockRangeLimit  uint64
-
 	ibftBaseTimeoutLegacy uint64
 
 	genesisConfig *chain.Chain
@@ -146,8 +143,8 @@ func (p *serverParams) generateConfig() *server.Config {
 		JSONRPC: &server.JSONRPC{
 			JSONRPCAddr:              p.jsonRPCAddress,
 			AccessControlAllowOrigin: p.corsAllowedOrigins,
-			BatchLengthLimit:         p.jsonRPCBatchLengthLimit,
-			BlockRangeLimit:          p.jsonRPCBlockRangeLimit,
+			BatchLengthLimit:         p.rawConfig.JSONRPCBatchRequestLimit,
+			BlockRangeLimit:          p.rawConfig.JSONRPCBlockRangeLimit,
 		},
 		GRPCAddr:   p.grpcAddress,
 		LibP2PAddr: p.libp2pAddress,

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -194,14 +194,14 @@ func setFlags(cmd *cobra.Command) {
 	)
 
 	cmd.Flags().Uint64Var(
-		&params.jsonRPCBatchLengthLimit,
+		&params.rawConfig.JSONRPCBatchRequestLimit,
 		jsonRPCBatchRequestLimitFlag,
 		defaultConfig.JSONRPCBatchRequestLimit,
 		"max length to be considered when handling json-rpc batch requests, value of 0 disables it",
 	)
 
 	cmd.Flags().Uint64Var(
-		&params.jsonRPCBlockRangeLimit,
+		&params.rawConfig.JSONRPCBlockRangeLimit,
 		jsonRPCBlockRangeLimitFlag,
 		defaultConfig.JSONRPCBlockRangeLimit,
 		"max block range to be considered when executing json-rpc requests "+

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -197,15 +197,15 @@ func setFlags(cmd *cobra.Command) {
 		&params.jsonRPCBatchLengthLimit,
 		jsonRPCBatchRequestLimitFlag,
 		defaultConfig.JSONRPCBatchRequestLimit,
-		"the max length to be considered when handling json-rpc batch requests",
+		"max length to be considered when handling json-rpc batch requests, value of 0 disables it",
 	)
 
-	//nolint:lll
 	cmd.Flags().Uint64Var(
 		&params.jsonRPCBlockRangeLimit,
 		jsonRPCBlockRangeLimitFlag,
 		defaultConfig.JSONRPCBlockRangeLimit,
-		"the max block range to be considered when executing json-rpc requests that consider fromBlock/toBlock values (e.g. eth_getLogs)",
+		"max block range to be considered when executing json-rpc requests "+
+			"that consider fromBlock/toBlock values (e.g. eth_getLogs), value of 0 disables it",
 	)
 
 	cmd.Flags().StringVar(

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -262,8 +262,9 @@ func (d *Dispatcher) Handle(reqBody []byte) ([]byte, error) {
 		return NewRPCResponse(nil, "2.0", nil, NewInvalidRequestError("Invalid json request")).Bytes()
 	}
 
-	// avoid handling long batch requests
-	if len(requests) > int(d.jsonRPCBatchLengthLimit) {
+	// if not disabled, avoid handling long batch requests
+	if d.jsonRPCBatchLengthLimit != 0 &&
+		len(requests) > int(d.jsonRPCBatchLengthLimit) {
 		return NewRPCResponse(nil, "2.0", nil, NewInvalidRequestError("Batch request length too long")).Bytes()
 	}
 

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -265,6 +265,7 @@ func (d *Dispatcher) Handle(reqBody []byte) ([]byte, error) {
 	// if not disabled, avoid handling long batch requests
 	if d.jsonRPCBatchLengthLimit != 0 &&
 		len(requests) > int(d.jsonRPCBatchLengthLimit) {
+		d.logger.Info("Entered batch request limit", "batch_request_limit_is", d.jsonRPCBatchLengthLimit)
 		return NewRPCResponse(nil, "2.0", nil, NewInvalidRequestError("Batch request length too long")).Bytes()
 	}
 

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -265,7 +265,6 @@ func (d *Dispatcher) Handle(reqBody []byte) ([]byte, error) {
 	// if not disabled, avoid handling long batch requests
 	if d.jsonRPCBatchLengthLimit != 0 &&
 		len(requests) > int(d.jsonRPCBatchLengthLimit) {
-		d.logger.Info("Entered batch request limit", "batch_request_limit_is", d.jsonRPCBatchLengthLimit)
 		return NewRPCResponse(nil, "2.0", nil, NewInvalidRequestError("Batch request length too long")).Bytes()
 	}
 

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -330,6 +330,40 @@ func TestDispatcherBatchRequest(t *testing.T) {
 			&ObjectError{Code: -32600, Message: "Batch request length too long"},
 			nil,
 		},
+		{
+			"no-limits",
+			"test when limits are not set",
+			newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 0, 0, 0),
+			[]byte(`[
+				{"id":1,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
+				{"id":2,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
+				{"id":3,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
+				{"id":4,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
+				{"id":5,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
+				{"id":6,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
+				{"id":7,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
+				{"id":8,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
+				{"id":9,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
+				{"id":10,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
+				{"id":11,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
+				{"id":12,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]}]`,
+			),
+			nil,
+			[]*SuccessResponse{
+				{Error: nil},
+				{Error: nil},
+				{Error: nil},
+				{Error: nil},
+				{Error: nil},
+				{Error: nil},
+				{Error: nil},
+				{Error: nil},
+				{Error: nil},
+				{Error: nil},
+				{Error: nil},
+				{Error: nil},
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -351,6 +385,11 @@ func TestDispatcherBatchRequest(t *testing.T) {
 				}
 			} else if c.name == "valid-batch-req" {
 				assert.Len(t, batchResp, 6)
+				for index, resp := range batchResp {
+					assert.Equal(t, resp.Error, c.batchResponse[index].Error)
+				}
+			} else if c.name == "no-limits" {
+				assert.Len(t, batchResp, 12)
 				for index, resp := range batchResp {
 					assert.Equal(t, resp.Error, c.batchResponse[index].Error)
 				}

--- a/jsonrpc/filter_manager.go
+++ b/jsonrpc/filter_manager.go
@@ -429,8 +429,8 @@ func (f *FilterManager) getLogsFromBlocks(query *LogQuery) ([]*Log, error) {
 		from = 1
 	}
 
-	// avoid handling large block ranges
-	if to-from > f.blockRangeLimit {
+	// if not disabled, avoid handling large block ranges
+	if f.blockRangeLimit != 0 && to-from > f.blockRangeLimit {
 		return nil, ErrBlockRangeTooHigh
 	}
 


### PR DESCRIPTION
# Description

This PR adds the ability to disable `json-rpc` batch request limits, introduced in #638.

Some tools, like Blockscout are using batch requests in order to efficiently gather data from the chain.    
With current default limits, Blockscout in production, is not working as it is hitting this limits.   
Also, this protection is not needed for nodes that are not interacting with general public, for example a dedicated non-validator node that will serve only Blockscout.

To disable this limits just set the values to `0`:     
`--json-rpc-block-range-limit 0 ` and     
`--json-rpc-batch-request-limit 0`

Also, this PR fixes the issue that these values could not be fed trough config file. Right now, they can be set only with flags.     

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Set the flags `--json-rpc-block-range-limit 0 `  , `--json-rpc-batch-request-limit 0` and you should not see `Batch request length too long` error
