### PR TITLE
[Feature] Added more information to the version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,12 @@ protoc:
 build:
 	$(eval LATEST_VERSION = $(shell git describe --tags --abbrev=0))
 	$(eval COMMIT_HASH = $(shell git rev-parse HEAD))
+	$(eval BRANCH = $(shell git rev-parse --abbrev-ref HEAD | tr -d '\040\011\012\015\n'))
 	$(eval TIME = $(shell date))
 	go build -o polygon-edge -ldflags="\
     	-X 'github.com/0xPolygon/polygon-edge/versioning.Version=$(LATEST_VERSION)' \
 		-X 'github.com/0xPolygon/polygon-edge/versioning.Commit=$(COMMIT_HASH)'\
+		-X 'github.com/0xPolygon/polygon-edge/versioning.Branch=$(BRANCH)'\
 		-X 'github.com/0xPolygon/polygon-edge/versioning.BuildTime=$(TIME)'" \
 	main.go
 

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,13 @@ protoc:
 .PHONY: build
 build:
 	$(eval LATEST_VERSION = $(shell git describe --tags --abbrev=0))
-	$(eval COMMIT_HASH = $(shell git rev-parse --short HEAD))
-	go build -ldflags="-X 'github.com/0xPolygon/polygon-edge/versioning.Version=$(LATEST_VERSION)+$(COMMIT_HASH)'" main.go
+	$(eval COMMIT_HASH = $(shell git rev-parse HEAD))
+	$(eval TIME = $(shell date))
+	go build -o polygon-edge -ldflags="\
+    	-X 'github.com/0xPolygon/polygon-edge/versioning.Version=$(LATEST_VERSION)' \
+		-X 'github.com/0xPolygon/polygon-edge/versioning.Commit=$(COMMIT_HASH)'\
+		-X 'github.com/0xPolygon/polygon-edge/versioning.BuildTime=$(TIME)'" \
+	main.go
 
 .PHONY: lint
 lint:

--- a/command/version/result.go
+++ b/command/version/result.go
@@ -5,12 +5,14 @@ import "fmt"
 type VersionResult struct {
 	Version   string `json:"version"`
 	Commit    string `json:"commit"`
+	Branch    string `json:"branch"`
 	BuildTime string `json:"buildTime"`
 }
 
 func (r *VersionResult) GetOutput() string {
 	return fmt.Sprintf("\n[VERSION INFO]\n"+
 		"Release version: %s \n"+
+		"Git branch: %s\n"+
 		"Commit hash: %s\n"+
-		"Build time: %s", r.Version, r.Commit, r.BuildTime)
+		"Build time: %s", r.Version, r.Branch, r.Commit, r.BuildTime)
 }

--- a/command/version/result.go
+++ b/command/version/result.go
@@ -1,9 +1,16 @@
 package version
 
+import "fmt"
+
 type VersionResult struct {
-	Version string `json:"version"`
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	BuildTime string `json:"buildTime"`
 }
 
 func (r *VersionResult) GetOutput() string {
-	return r.Version
+	return fmt.Sprintf("\n[VERSION INFO]\n"+
+		"Release version: %s \n"+
+		"Commit hash: %s\n"+
+		"Build time: %s", r.Version, r.Commit, r.BuildTime)
 }

--- a/command/version/result.go
+++ b/command/version/result.go
@@ -1,6 +1,10 @@
 package version
 
-import "fmt"
+import (
+	"bytes"
+	"fmt"
+	"github.com/0xPolygon/polygon-edge/command/helper"
+)
 
 type VersionResult struct {
 	Version   string `json:"version"`
@@ -10,9 +14,15 @@ type VersionResult struct {
 }
 
 func (r *VersionResult) GetOutput() string {
-	return fmt.Sprintf("\n[VERSION INFO]\n"+
-		"Release version: %s \n"+
-		"Git branch: %s\n"+
-		"Commit hash: %s\n"+
-		"Build time: %s", r.Version, r.Branch, r.Commit, r.BuildTime)
+	var buffer bytes.Buffer
+
+	buffer.WriteString("\n[VERSION INFO]\n")
+	buffer.WriteString(helper.FormatKV([]string{
+		fmt.Sprintf("Release version|%s", r.Version),
+		fmt.Sprintf("Git branch|%s", r.Branch),
+		fmt.Sprintf("Commit hash|%s", r.Commit),
+		fmt.Sprintf("Build time|%s", r.BuildTime),
+	}))
+
+	return buffer.String()
 }

--- a/command/version/version.go
+++ b/command/version/version.go
@@ -21,7 +21,9 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 	outputter.SetCommandResult(
 		&VersionResult{
-			Version: versioning.Version,
+			Version:   versioning.Version,
+			Commit:    versioning.Commit,
+			BuildTime: versioning.BuildTime,
 		},
 	)
 }

--- a/command/version/version.go
+++ b/command/version/version.go
@@ -23,6 +23,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		&VersionResult{
 			Version:   versioning.Version,
 			Commit:    versioning.Commit,
+			Branch:    versioning.Branch,
 			BuildTime: versioning.BuildTime,
 		},
 	)

--- a/versioning/versioning.go
+++ b/versioning/versioning.go
@@ -2,8 +2,12 @@ package versioning
 
 var (
 	// Version is the main version at the moment.
+	// Commit is the git commit that the binary was built on
+	// BuildTime is the timestamp of the build
 	// Embedded by --ldflags on build time
 	// Versioning should follow the SemVer guidelines
 	// https://semver.org/
-	Version = "v0.1.0"
+	Version   string
+	Commit    string
+	BuildTime string
 )

--- a/versioning/versioning.go
+++ b/versioning/versioning.go
@@ -8,6 +8,7 @@ var (
 	// Versioning should follow the SemVer guidelines
 	// https://semver.org/
 	Version   string
+	Branch    string
 	Commit    string
 	BuildTime string
 )


### PR DESCRIPTION
# Description

This PR adds more information to the `polygon-edge version` command.     
Now we have the information about the `release version` , `commit hash`, `git branch` and `build time`.   

When compiling `polygon-edge` binary ( instead of using GitHub releases ), users should use `make build` command instead of native `go build` command, as `make` feeds the required information to the compiler.

If not using `make build`, users should add `--ldflags` to the `go build` command.  
```
go build -o polygon-edge -ldflags="\
      -X 'github.com/0xPolygon/polygon-edge/versioning.Version=$(git describe --tags --abbrev=0)'\
      -X 'github.com/0xPolygon/polygon-edge/versioning.Commit=$(git rev-parse HEAD)'\
      -X 'github.com/0xPolygon/polygon-edge/versioning.Branch=$(git rev-parse --abbrev-ref HEAD | tr -d "\040\011\012\015\n")'\
      -X 'github.com/0xPolygon/polygon-edge/versioning.BuildTime=$(date)'" \
main.go
```
this will make sure that the correct information is fed to the compiler.

Once compiled the version information should be as following:
```
[VERSION INFO]
Release version: v0.5.0 
Git branch: feature/include-commit-in-version-cmd
Commit hash: 89fa3a5098398fcc21f6a8eb88dd776b81125255
Build time: Wed Aug 31 21:40:35 CEST 2022
```


# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Build the `polygon-edge` binary using `make build` command or with the above instructions, and run `polygon-edge version`.     
You should see release version, commit hash and build time information.

# Documentation update

Public that describes build procedure needs to be updated. 

# Additional comments

Fixes EDGE-746
