### PR TITLE
[FIX] Properly handle block-gas-target flag

### DIFF
--- a/command/server/init.go
+++ b/command/server/init.go
@@ -123,6 +123,11 @@ func (p *serverParams) initGenesisConfig() error {
 		return parseErr
 	}
 
+	// if block-gas-target flag is set override genesis.json value
+	if p.blockGasTarget != 0 {
+		p.genesisConfig.Params.BlockGasTarget = p.blockGasTarget
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
# Description

This PR fixes `--block-gas-target` flag as it is currently broken - it can be set but gas limit wont budge.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Deploy a cluster let it run for a while, set your desired `--block-gas-target` and check if `gasLimit` value is changing towards set value. Eventually, it should fixate on your defined gas target value.

Fixes EDGE-800