### PR TITLE
Bump the default premine balance

### DIFF
--- a/command/default.go
+++ b/command/default.go
@@ -6,7 +6,7 @@ const (
 	DefaultGenesisFileName = "genesis.json"
 	DefaultChainName       = "polygon-edge"
 	DefaultChainID         = 100
-	DefaultPremineBalance  = "0x3635C9ADC5DEA00000" // 1000 ETH
+	DefaultPremineBalance  = "0xD3C21BCECCEDA1000000" // 1 million units of native network currency
 	DefaultConsensus       = server.IBFTConsensus
 	DefaultGenesisGasUsed  = 458752  // 0x70000
 	DefaultGenesisGasLimit = 5242880 // 0x500000


### PR DESCRIPTION
# Description

This PR bumps the `DefaultPremineBalance` from 1000 units of native network currency to 1 million units of native network currency.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have updated the official documentation


## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually


# Documentation update

(https://github.com/maticnetwork/matic-docs/pull/1086)

