### PR TITLE
Remove io/ioutil package due to deprecation

### DIFF
--- a/blockchain/storage/leveldb/leveldb_test.go
+++ b/blockchain/storage/leveldb/leveldb_test.go
@@ -1,7 +1,6 @@
 package leveldb
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -12,7 +11,7 @@ import (
 func newStorage(t *testing.T) (storage.Storage, func()) {
 	t.Helper()
 
-	path, err := ioutil.TempDir("/tmp", "minimal_storage")
+	path, err := os.MkdirTemp("/tmp", "minimal_storage")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -4,8 +4,8 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -355,7 +355,7 @@ func ImportFromName(chain string) (*Chain, error) {
 
 // ImportFromFile imports a chain from a filepath
 func ImportFromFile(filename string) (*Chain, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/chain_bindata.go
+++ b/chain/chain_bindata.go
@@ -11,7 +11,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -283,7 +282,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -2,8 +2,8 @@ package chain
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -155,7 +155,7 @@ func TestGenesisX(t *testing.T) {
 
 func TestChainFolder(t *testing.T) {
 	// it should be able to parse all the chains in the ./chains folder
-	files, err := ioutil.ReadDir("./chains")
+	files, err := os.ReadDir("./chains")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/command/common.go
+++ b/command/common.go
@@ -2,7 +2,7 @@ package command
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/0xPolygon/polygon-edge/crypto"
@@ -59,7 +59,7 @@ func GetValidatorsFromPrefixPath(
 	prefix string,
 	validatorType validators.ValidatorType,
 ) (validators.Validators, error) {
-	files, err := ioutil.ReadDir(".")
+	files, err := os.ReadDir(".")
 	if err != nil {
 		return nil, err
 	}

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -234,7 +234,7 @@ func WriteGenesisConfigToDisk(genesisConfig *chain.Chain, genesisPath string) er
 		return fmt.Errorf("failed to generate genesis: %w", err)
 	}
 
-	if err := os.WriteFile(genesisPath, data, 0644); err != nil {
+	if err := os.WriteFile(genesisPath, data, os.ModePerm); err != nil {
 		return fmt.Errorf("failed to write genesis: %w", err)
 	}
 

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -4,23 +4,22 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/command"
 	ibftOp "github.com/0xPolygon/polygon-edge/consensus/ibft/proto"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/server"
 	"github.com/0xPolygon/polygon-edge/server/proto"
 	txpoolOp "github.com/0xPolygon/polygon-edge/txpool/proto"
+	"github.com/ryanuber/columnize"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-
-	"github.com/0xPolygon/polygon-edge/helper/common"
-	"github.com/ryanuber/columnize"
 )
 
 type ClientCloseResult struct {
@@ -235,8 +234,7 @@ func WriteGenesisConfigToDisk(genesisConfig *chain.Chain, genesisPath string) er
 		return fmt.Errorf("failed to generate genesis: %w", err)
 	}
 
-	//nolint:gosec
-	if err := ioutil.WriteFile(genesisPath, data, 0644); err != nil {
+	if err := os.WriteFile(genesisPath, data, 0644); err != nil {
 		return fmt.Errorf("failed to write genesis: %w", err)
 	}
 

--- a/command/loadbot/generator/generator.go
+++ b/command/loadbot/generator/generator.go
@@ -3,12 +3,11 @@ package generator
 import (
 	"crypto/ecdsa"
 	"encoding/json"
-	"io/ioutil"
 	"math/big"
-
-	"github.com/umbracle/ethgo"
+	"os"
 
 	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/umbracle/ethgo"
 	"github.com/umbracle/ethgo/abi"
 )
 
@@ -75,7 +74,7 @@ type GeneratorParams struct {
 
 // ReadContractArtifact reads the contract bytecode from the specified path
 func ReadContractArtifact(configPath string) (*ContractArtifact, error) {
-	rawData, readErr := ioutil.ReadFile(configPath)
+	rawData, readErr := os.ReadFile(configPath)
 	if readErr != nil {
 		return nil, readErr
 	}

--- a/command/server/config/config.go
+++ b/command/server/config/config.go
@@ -3,13 +3,12 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/0xPolygon/polygon-edge/network"
-	"gopkg.in/yaml.v3"
-
 	"github.com/hashicorp/hcl"
+	"gopkg.in/yaml.v3"
 )
 
 // Config defines the server configuration params
@@ -119,7 +118,7 @@ func DefaultConfig() *Config {
 //
 // Supported file types: .json, .hcl, .yaml, .yml
 func ReadConfigFile(path string) (*Config, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/ibft/fork/helper.go
+++ b/consensus/ibft/fork/helper.go
@@ -53,7 +53,7 @@ func writeDataStore(path string, obj interface{}) error {
 		return err
 	}
 
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	if err := os.WriteFile(path, data, os.ModePerm); err != nil {
 		return err
 	}
 

--- a/consensus/ibft/fork/helper.go
+++ b/consensus/ibft/fork/helper.go
@@ -53,7 +53,7 @@ func writeDataStore(path string, obj interface{}) error {
 		return err
 	}
 
-	if err := os.WriteFile(path, data, 0755); err != nil {
+	if err := os.WriteFile(path, data, 0644); err != nil {
 		return err
 	}
 

--- a/consensus/ibft/fork/helper.go
+++ b/consensus/ibft/fork/helper.go
@@ -2,7 +2,6 @@ package fork
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 
 	"github.com/0xPolygon/polygon-edge/validators/store/snapshot"
@@ -35,7 +34,7 @@ func readDataStore(path string, obj interface{}) error {
 		return nil
 	}
 
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -54,8 +53,7 @@ func writeDataStore(path string, obj interface{}) error {
 		return err
 	}
 
-	//nolint: gosec
-	if err := ioutil.WriteFile(path, data, 0755); err != nil {
+	if err := os.WriteFile(path, data, 0755); err != nil {
 		return err
 	}
 

--- a/consensus/ibft/fork/helper_test.go
+++ b/consensus/ibft/fork/helper_test.go
@@ -67,7 +67,7 @@ func Test_loadSnapshotMetadata(t *testing.T) {
 
 		dirPath := createTestTempDirectory(t)
 		filePath := path.Join(dirPath, "test.dat")
-		assert.NoError(t, os.WriteFile(filePath, fileData, 0600))
+		assert.NoError(t, os.WriteFile(filePath, fileData, os.ModePerm))
 
 		res, err := loadSnapshotMetadata(filePath)
 
@@ -124,7 +124,7 @@ func Test_loadSnapshots(t *testing.T) {
 
 		dirPath := createTestTempDirectory(t)
 		filePath := path.Join(dirPath, "test.dat")
-		assert.NoError(t, os.WriteFile(filePath, fileData, 0600))
+		assert.NoError(t, os.WriteFile(filePath, fileData, os.ModePerm))
 
 		res, err := loadSnapshots(filePath)
 
@@ -166,7 +166,7 @@ func Test_readDataStore(t *testing.T) {
 
 		assert.NoError(
 			t,
-			os.WriteFile(filePath, []byte("hello: world"), 0600),
+			os.WriteFile(filePath, []byte("hello: world"), os.ModePerm),
 		)
 
 		data := map[string]interface{}{}
@@ -186,7 +186,7 @@ func Test_readDataStore(t *testing.T) {
 
 		assert.NoError(
 			t,
-			os.WriteFile(filePath, []byte(sampleJSON), 0600),
+			os.WriteFile(filePath, []byte(sampleJSON), os.ModePerm),
 		)
 
 		data := map[string]interface{}{}

--- a/consensus/ibft/fork/storewrapper_test.go
+++ b/consensus/ibft/fork/storewrapper_test.go
@@ -112,12 +112,12 @@ func TestSnapshotValidatorStoreWrapper(t *testing.T) {
 
 			assert.NoError(
 				t,
-				os.WriteFile(path.Join(dirPath, snapshotMetadataFilename), []byte(test.storedSnapshotMetadata), 0600),
+				os.WriteFile(path.Join(dirPath, snapshotMetadataFilename), []byte(test.storedSnapshotMetadata), os.ModePerm),
 			)
 
 			assert.NoError(
 				t,
-				os.WriteFile(path.Join(dirPath, snapshotSnapshotsFilename), []byte(test.storedSnapshots), 0600),
+				os.WriteFile(path.Join(dirPath, snapshotSnapshotsFilename), []byte(test.storedSnapshots), os.ModePerm),
 			)
 
 			store, err := NewSnapshotValidatorStoreWrapper(

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -5,7 +5,6 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
@@ -13,8 +12,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/umbracle/ethgo"
 
 	"github.com/0xPolygon/polygon-edge/contracts/abis"
 	"github.com/0xPolygon/polygon-edge/contracts/staking"
@@ -25,6 +22,7 @@ import (
 	txpoolProto "github.com/0xPolygon/polygon-edge/txpool/proto"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/umbracle/ethgo"
 	"github.com/umbracle/ethgo/jsonrpc"
 	"golang.org/x/crypto/sha3"
 	empty "google.golang.org/protobuf/types/known/emptypb"
@@ -382,7 +380,7 @@ func MethodSigWithParams(nameWithParams string) []byte {
 
 // tempDir returns directory path in tmp with random directory name
 func tempDir() (string, error) {
-	return ioutil.TempDir("/tmp", "polygon-edge-e2e-")
+	return os.MkdirTemp("/tmp", "polygon-edge-e2e-")
 }
 
 func ToLocalIPv4LibP2pAddr(port int, nodeID string) string {

--- a/helper/keystore/keystore.go
+++ b/helper/keystore/keystore.go
@@ -3,7 +3,6 @@ package keystore
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -20,7 +19,7 @@ func CreateIfNotExists(path string, create createFn) ([]byte, error) {
 	var keyBuff []byte
 	if !os.IsNotExist(err) {
 		// Key exists
-		keyBuff, err = ioutil.ReadFile(path)
+		keyBuff, err = os.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read private key from disk (%s), %w", path, err)
 		}
@@ -36,7 +35,7 @@ func CreateIfNotExists(path string, create createFn) ([]byte, error) {
 
 	// Encode it to a readable format (Base64) and write to disk
 	keyBuff = []byte(hex.EncodeToString(keyBuff))
-	if err = ioutil.WriteFile(path, keyBuff, 0600); err != nil {
+	if err = os.WriteFile(path, keyBuff, 0600); err != nil {
 		return nil, fmt.Errorf("unable to write private key to disk (%s), %w", path, err)
 	}
 

--- a/helper/keystore/keystore.go
+++ b/helper/keystore/keystore.go
@@ -35,7 +35,7 @@ func CreateIfNotExists(path string, create createFn) ([]byte, error) {
 
 	// Encode it to a readable format (Base64) and write to disk
 	keyBuff = []byte(hex.EncodeToString(keyBuff))
-	if err = os.WriteFile(path, keyBuff, 0600); err != nil {
+	if err = os.WriteFile(path, keyBuff, os.ModePerm); err != nil {
 		return nil, fmt.Errorf("unable to write private key to disk (%s), %w", path, err)
 	}
 

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -2,7 +2,7 @@ package jsonrpc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"sync"
@@ -273,7 +273,7 @@ func (j *JSONRPC) handle(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	data, err := ioutil.ReadAll(req.Body)
+	data, err := io.ReadAll(req.Body)
 
 	if err != nil {
 		_, _ = w.Write([]byte(err.Error()))

--- a/network/e2e_testing.go
+++ b/network/e2e_testing.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
@@ -371,7 +370,7 @@ func MeshJoin(servers ...*Server) []error {
 func GenerateTestLibp2pKey(t *testing.T) (crypto.PrivKey, string) {
 	t.Helper()
 
-	dir, err := ioutil.TempDir(os.TempDir(), "")
+	dir, err := os.MkdirTemp(os.TempDir(), "")
 	assert.NoError(t, err)
 
 	// Instantiate the correct folder structure

--- a/secrets/config.go
+++ b/secrets/config.go
@@ -2,7 +2,7 @@ package secrets
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 )
 
 // SecretsManagerConfig is the configuration that gets
@@ -20,12 +20,12 @@ type SecretsManagerConfig struct {
 func (c *SecretsManagerConfig) WriteConfig(path string) error {
 	jsonBytes, _ := json.MarshalIndent(c, "", " ")
 
-	return ioutil.WriteFile(path, jsonBytes, 0600)
+	return os.WriteFile(path, jsonBytes, 0600)
 }
 
 // ReadConfig reads the SecretsManagerConfig from the specified path
 func ReadConfig(path string) (*SecretsManagerConfig, error) {
-	configFile, readErr := ioutil.ReadFile(path)
+	configFile, readErr := os.ReadFile(path)
 	if readErr != nil {
 		return nil, readErr
 	}

--- a/secrets/config.go
+++ b/secrets/config.go
@@ -20,7 +20,7 @@ type SecretsManagerConfig struct {
 func (c *SecretsManagerConfig) WriteConfig(path string) error {
 	jsonBytes, _ := json.MarshalIndent(c, "", " ")
 
-	return os.WriteFile(path, jsonBytes, 0600)
+	return os.WriteFile(path, jsonBytes, os.ModePerm)
 }
 
 // ReadConfig reads the SecretsManagerConfig from the specified path

--- a/secrets/local/local.go
+++ b/secrets/local/local.go
@@ -133,7 +133,7 @@ func (l *LocalSecretsManager) SetSecret(name string, value []byte) error {
 	}
 
 	// Write the secret to disk
-	if err := os.WriteFile(secretPath, value, 0600); err != nil {
+	if err := os.WriteFile(secretPath, value, os.ModePerm); err != nil {
 		return fmt.Errorf(
 			"unable to write secret to disk (%s), %w",
 			secretPath,

--- a/secrets/local/local.go
+++ b/secrets/local/local.go
@@ -3,7 +3,6 @@ package local
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -106,7 +105,7 @@ func (l *LocalSecretsManager) GetSecret(name string) ([]byte, error) {
 	}
 
 	// Read the secret from disk
-	secret, err := ioutil.ReadFile(secretPath)
+	secret, err := os.ReadFile(secretPath)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"unable to read secret from disk (%s), %w",
@@ -134,7 +133,7 @@ func (l *LocalSecretsManager) SetSecret(name string, value []byte) error {
 	}
 
 	// Write the secret to disk
-	if err := ioutil.WriteFile(secretPath, value, 0600); err != nil {
+	if err := os.WriteFile(secretPath, value, 0600); err != nil {
 		return fmt.Errorf(
 			"unable to write secret to disk (%s), %w",
 			secretPath,

--- a/secrets/local/local_test.go
+++ b/secrets/local/local_test.go
@@ -2,7 +2,6 @@ package local
 
 import (
 	"encoding/hex"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -16,7 +15,7 @@ import (
 
 func TestLocalSecretsManagerFactory(t *testing.T) {
 	// Set up the expected folder structure
-	workingDirectory, tempErr := ioutil.TempDir("/tmp", "local-secrets-manager")
+	workingDirectory, tempErr := os.MkdirTemp("/tmp", "local-secrets-manager")
 	if tempErr != nil {
 		t.Fatalf("Unable to instantiate local secrets manager directories, %v", tempErr)
 	}
@@ -73,7 +72,7 @@ func getLocalSecretsManager(t *testing.T) secrets.SecretsManager {
 	t.Helper()
 
 	// Set up the expected folder structure
-	workingDirectory, tempErr := ioutil.TempDir("/tmp", "local-secrets-manager")
+	workingDirectory, tempErr := os.MkdirTemp("/tmp", "local-secrets-manager")
 	if tempErr != nil {
 		t.Fatalf("Unable to instantiate local secrets manager directories, %v", tempErr)
 	}

--- a/state/runtime/precompiled/testing.go
+++ b/state/runtime/precompiled/testing.go
@@ -3,7 +3,7 @@ package precompiled
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -33,7 +33,7 @@ func ReadTestCase(t *testing.T, path string, f func(t *testing.T, c *TestCase)) 
 	t.Helper()
 	t.Parallel()
 
-	data, err := ioutil.ReadFile(filepath.Join("./fixtures", path))
+	data, err := os.ReadFile(filepath.Join("./fixtures", path))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/evm_test.go
+++ b/tests/evm_test.go
@@ -2,23 +2,21 @@ package tests
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/go-hclog"
-	"github.com/umbracle/fastrlp"
-
 	"github.com/0xPolygon/polygon-edge/chain"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/helper/keccak"
 	"github.com/0xPolygon/polygon-edge/state"
 	"github.com/0xPolygon/polygon-edge/state/runtime"
 	"github.com/0xPolygon/polygon-edge/state/runtime/evm"
 	"github.com/0xPolygon/polygon-edge/types"
-
-	"github.com/0xPolygon/polygon-edge/crypto"
+	"github.com/hashicorp/go-hclog"
+	"github.com/umbracle/fastrlp"
 )
 
 var mainnetChainConfig = chain.Params{
@@ -167,7 +165,7 @@ func TestEVM(t *testing.T) {
 					return
 				}
 
-				data, err := ioutil.ReadFile(file)
+				data, err := os.ReadFile(file)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -3,12 +3,10 @@ package tests
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"strings"
 	"testing"
-
-	"github.com/hashicorp/go-hclog"
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
@@ -16,6 +14,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/state/runtime/evm"
 	"github.com/0xPolygon/polygon-edge/state/runtime/precompiled"
 	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/hashicorp/go-hclog"
 )
 
 var (
@@ -149,7 +148,7 @@ func TestState(t *testing.T) {
 					continue
 				}
 
-				data, err := ioutil.ReadFile(file)
+				data, err := os.ReadFile(file)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/tests/testing.go
+++ b/tests/testing.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -488,7 +487,7 @@ func listFolders(paths ...string) ([]string, error) {
 	for _, p := range paths {
 		path := filepath.Join(TESTS, p)
 
-		files, err := ioutil.ReadDir(path)
+		files, err := os.ReadDir(path)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Description

Replace all functions in `io/ioutil` package to corresponding functions in `os` package because `io/ioutil` package has been marked as decrecated from Go1.16 according to Official Release Notes https://go.dev/doc/go1.16#ioutil.

There won't be any change after replacing these functions to the new functions this doc is mentioning because most of the latest implementations in `io/ioutil` package are just wrappers of the functions in `os`.

Implementation of `io/ioutil` at Go 1.17: https://cs.opensource.google/go/go/+/refs/tags/go1.17:src/io/ioutil/ioutil.go

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
