### PR TITLE
[ssm secrets manager] Delete networking private key before setting a new one

### DIFF
--- a/network/server.go
+++ b/network/server.go
@@ -229,6 +229,10 @@ func setupLibp2pKey(secretsManager secrets.SecretsManager) (crypto.PrivKey, erro
 			return nil, fmt.Errorf("unable to generate networking private key for Secrets Manager, %w", keyErr)
 		}
 
+		if deleteErr := secretsManager.RemoveSecret(secrets.NetworkKey); deleteErr != nil {
+			return nil, fmt.Errorf("unable to delete pre-existing networking private key in Secrets Manager, %w", deleteErr)
+		}
+
 		// Write the networking private key to disk
 		if setErr := secretsManager.SetSecret(secrets.NetworkKey, libp2pKeyEncoded); setErr != nil {
 			return nil, fmt.Errorf("unable to store networking private key to Secrets Manager, %w", setErr)


### PR DESCRIPTION
# Description

There is an error if SSM Secrets Manager is used when a node restarts. The SSM secrets manager `SetSecret` has `overwrite: false`, meaning that if the key already exists from a previous run, when it restarts it will try to set it to set it again but fail. 

Instead of seting `overwrite: true` which would potentially affect other secrets, we just simply delete the networking key which will no-op if it doesn't exist yet. 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
