### PR TITLE
[TxPool] Fix double nonce in promoted

### DIFF
--- a/txpool/account.go
+++ b/txpool/account.go
@@ -287,7 +287,7 @@ func (a *account) promote() (promoted []*types.Transaction, pruned []*types.Tran
 		nextNonce = tx.Nonce + 1
 
 		// prune the transactions with lower nonce
-		pruned = a.enqueued.prune(nextNonce)
+		pruned = append(pruned, a.enqueued.prune(nextNonce)...)
 
 		// update return result
 		promoted = append(promoted, tx)

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -156,7 +156,7 @@ type account struct {
 	init               sync.Once
 	enqueued, promoted *accountQueue
 	nextNonce          uint64
-	demotions          uint
+	demotions          uint64
 
 	//	maximum number of enqueued transactions
 	maxEnqueued uint64
@@ -172,6 +172,21 @@ func (a *account) setNonce(nonce uint64) {
 	atomic.StoreUint64(&a.nextNonce, nonce)
 }
 
+// Demotions returns the current value of demotions
+func (a *account) Demotions() uint64 {
+	return atomic.LoadUint64(&a.demotions)
+}
+
+// resetDemotions sets 0 to demotions to clear count
+func (a *account) resetDemotions() {
+	atomic.StoreUint64(&a.demotions, 0)
+}
+
+// incrementDemotions increments demotions
+func (a *account) incrementDemotions() {
+	atomic.AddUint64(&a.demotions, 1)
+}
+
 // reset aligns the account with the new nonce
 // by pruning all transactions with nonce lesser than new.
 // After pruning, a promotion may be signaled if the first
@@ -184,10 +199,7 @@ func (a *account) reset(nonce uint64, promoteCh chan<- promoteRequest) (
 	defer a.promoted.unlock()
 
 	// prune the promoted txs
-	prunedPromoted = append(
-		prunedPromoted,
-		a.promoted.prune(nonce)...,
-	)
+	prunedPromoted = a.promoted.prune(nonce)
 
 	if nonce <= a.getNonce() {
 		// only the promoted queue needed pruning
@@ -198,10 +210,7 @@ func (a *account) reset(nonce uint64, promoteCh chan<- promoteRequest) (
 	defer a.enqueued.unlock()
 
 	// prune the enqueued txs
-	prunedEnqueued = append(
-		prunedEnqueued,
-		a.enqueued.prune(nonce)...,
-	)
+	prunedEnqueued = a.enqueued.prune(nonce)
 
 	// update nonce expected for this account
 	a.setNonce(nonce)
@@ -209,8 +218,7 @@ func (a *account) reset(nonce uint64, promoteCh chan<- promoteRequest) (
 	// it is important to signal promotion while
 	// the locks are held to ensure no other
 	// handler will mutate the account
-	if first := a.enqueued.peek(); first != nil &&
-		first.Nonce == nonce {
+	if first := a.enqueued.peek(); first != nil && first.Nonce == nonce {
 		// first enqueued tx is expected -> signal promotion
 		promoteCh <- promoteRequest{account: first.From}
 	}
@@ -243,7 +251,7 @@ func (a *account) enqueue(tx *types.Transaction) error {
 // Eligible transactions are all sequential in order of nonce
 // and the first one has to have nonce less (or equal) to the account's
 // nextNonce.
-func (a *account) promote() []*types.Transaction {
+func (a *account) promote() (promoted []*types.Transaction, pruned []*types.Transaction) {
 	a.promoted.lock(true)
 	a.enqueued.lock(true)
 
@@ -254,21 +262,18 @@ func (a *account) promote() []*types.Transaction {
 
 	// sanity check
 	currentNonce := a.getNonce()
-	if a.enqueued.length() == 0 ||
-		a.enqueued.peek().Nonce > currentNonce {
+	if a.enqueued.length() == 0 || a.enqueued.peek().Nonce > currentNonce {
 		// nothing to promote
-		return nil
+		return
 	}
 
-	promoted := make([]*types.Transaction, 0)
 	nextNonce := a.enqueued.peek().Nonce
 
 	// move all promotable txs (enqueued txs that are sequential in nonce)
 	// to the account's promoted queue
 	for {
 		tx := a.enqueued.peek()
-		if tx == nil ||
-			tx.Nonce != nextNonce {
+		if tx == nil || tx.Nonce != nextNonce {
 			break
 		}
 
@@ -279,7 +284,10 @@ func (a *account) promote() []*types.Transaction {
 		a.promoted.push(tx)
 
 		// update counters
-		nextNonce += 1
+		nextNonce = tx.Nonce + 1
+
+		// prune the transactions with lower nonce
+		pruned = a.enqueued.prune(nextNonce)
 
 		// update return result
 		promoted = append(promoted, tx)
@@ -291,5 +299,5 @@ func (a *account) promote() []*types.Transaction {
 		a.setNonce(nextNonce)
 	}
 
-	return promoted
+	return
 }

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -174,17 +174,17 @@ func (a *account) setNonce(nonce uint64) {
 
 // Demotions returns the current value of demotions
 func (a *account) Demotions() uint64 {
-	return atomic.LoadUint64(&a.demotions)
+	return a.demotions
 }
 
 // resetDemotions sets 0 to demotions to clear count
 func (a *account) resetDemotions() {
-	atomic.StoreUint64(&a.demotions, 0)
+	a.demotions = 0
 }
 
 // incrementDemotions increments demotions
 func (a *account) incrementDemotions() {
-	atomic.AddUint64(&a.demotions, 1)
+	a.demotions++
 }
 
 // reset aligns the account with the new nonce

--- a/txpool/queue.go
+++ b/txpool/queue.go
@@ -51,14 +51,11 @@ func (q *accountQueue) prune(nonce uint64) (
 	pruned []*types.Transaction,
 ) {
 	for {
-		tx := q.peek()
-		if tx == nil ||
-			tx.Nonce >= nonce {
+		if tx := q.peek(); tx == nil || tx.Nonce >= nonce {
 			break
 		}
 
-		tx = q.pop()
-		pruned = append(pruned, tx)
+		pruned = append(pruned, q.pop())
 	}
 
 	return
@@ -130,6 +127,11 @@ func (q *minNonceQueue) Swap(i, j int) {
 }
 
 func (q *minNonceQueue) Less(i, j int) bool {
+	// The higher gas price Tx comes first if the nonces are same
+	if (*q)[i].Nonce == (*q)[j].Nonce {
+		return (*q)[i].GasPrice.Cmp((*q)[j].GasPrice) > 0
+	}
+
 	return (*q)[i].Nonce < (*q)[j].Nonce
 }
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -1458,7 +1458,7 @@ func TestDemote(t *testing.T) {
 		assert.Equal(t, uint64(1), pool.gauge.read())
 		assert.Equal(t, uint64(1), pool.accounts.get(addr1).getNonce())
 		assert.Equal(t, uint64(1), pool.accounts.get(addr1).promoted.length())
-		assert.Equal(t, uint(0), pool.accounts.get(addr1).demotions)
+		assert.Equal(t, uint64(0), pool.accounts.get(addr1).Demotions())
 
 		// call demote
 		pool.Prepare()
@@ -1470,7 +1470,7 @@ func TestDemote(t *testing.T) {
 		assert.Equal(t, uint64(1), pool.accounts.get(addr1).promoted.length())
 
 		// assert counter was incremented
-		assert.Equal(t, uint(1), pool.accounts.get(addr1).demotions)
+		assert.Equal(t, uint64(1), pool.accounts.get(addr1).Demotions())
 	})
 
 	t.Run("Demote calls Drop", func(t *testing.T) {
@@ -1507,7 +1507,7 @@ func TestDemote(t *testing.T) {
 		assert.Equal(t, uint64(0), pool.accounts.get(addr1).promoted.length())
 
 		// demotions are reset to 0
-		assert.Equal(t, uint(0), pool.accounts.get(addr1).demotions)
+		assert.Equal(t, uint64(0), pool.accounts.get(addr1).Demotions())
 	})
 }
 


### PR DESCRIPTION
Fix EDGE-813

# Description

This PR fixes the [issue](https://github.com/0xPolygon/polygon-edge/issues/711) of transactions sharing nonce ending up in `promoted` queue of an account. 

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
