### PR TITLE
Cleanup inactive transactions in non-validator

### DIFF
--- a/command/server/init.go
+++ b/command/server/init.go
@@ -135,7 +135,6 @@ func (p *serverParams) initDevMode() {
 	// Dev mode:
 	// - disables peer discovery
 	// - enables all forks
-	p.rawConfig.ShouldSeal = true
 	p.rawConfig.Network.NoDiscover = true
 	p.genesisConfig.Params.Forks = chain.AllForksEnabled
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -61,7 +61,6 @@ type Config struct {
 
 type Params struct {
 	Context        context.Context
-	Seal           bool
 	Config         *Config
 	TxPool         *txpool.TxPool
 	Network        *network.Server

--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -62,7 +62,7 @@ func Factory(
 // Initialize initializes the consensus
 func (d *Dev) Initialize() error {
 	d.txpool.SetSealing(true)
-	
+
 	return nil
 }
 

--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -61,6 +61,8 @@ func Factory(
 
 // Initialize initializes the consensus
 func (d *Dev) Initialize() error {
+	d.txpool.SetSealing(true)
+	
 	return nil
 }
 

--- a/consensus/dummy/dummy.go
+++ b/consensus/dummy/dummy.go
@@ -11,7 +11,6 @@ import (
 )
 
 type Dummy struct {
-	sealing    bool
 	logger     hclog.Logger
 	notifyCh   chan struct{}
 	closeCh    chan struct{}
@@ -24,7 +23,6 @@ func Factory(params *consensus.Params) (consensus.Consensus, error) {
 	logger := params.Logger.Named("dummy")
 
 	d := &Dummy{
-		sealing:    params.Seal,
 		logger:     logger,
 		notifyCh:   make(chan struct{}),
 		closeCh:    make(chan struct{}),
@@ -38,6 +36,8 @@ func Factory(params *consensus.Params) (consensus.Consensus, error) {
 
 // Initialize initializes the consensus
 func (d *Dummy) Initialize() error {
+	d.txpool.SetSealing(true)
+	
 	return nil
 }
 

--- a/consensus/dummy/dummy.go
+++ b/consensus/dummy/dummy.go
@@ -37,7 +37,7 @@ func Factory(params *consensus.Params) (consensus.Consensus, error) {
 // Initialize initializes the consensus
 func (d *Dummy) Initialize() error {
 	d.txpool.SetSealing(true)
-	
+
 	return nil
 }
 

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -41,6 +41,7 @@ type txPoolInterface interface {
 	Drop(tx *types.Transaction)
 	Demote(tx *types.Transaction)
 	ResetWithHeaders(headers ...*types.Header)
+	SetSealing(bool)
 }
 
 // backendIBFT represents the IBFT consensus mechanism object
@@ -392,6 +393,8 @@ func (i *backendIBFT) startConsensus() {
 		i.updateActiveValidatorSet(latest)
 
 		isValidator = i.isActiveValidator()
+
+		i.txpool.SetSealing(isValidator)
 
 		if isValidator {
 			sequenceCh = i.consensus.runSequence(pending)

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -78,8 +78,6 @@ type backendIBFT struct {
 
 	blockTime time.Duration // Minimum block generation time in seconds
 
-	sealing bool // Flag indicating if the node is a sealer
-
 	closeCh chan struct{} // Channel for closing
 }
 
@@ -122,7 +120,6 @@ func Factory(params *consensus.Params) (consensus.Consensus, error) {
 		network:            params.Network,
 		epochSize:          epochSize,
 		quorumSizeBlockNum: quorumSizeBlockNum,
-		sealing:            params.Seal,
 		metrics:            params.Metrics,
 		secretsManager:     params.SecretsManager,
 		blockTime:          time.Duration(params.BlockTime) * time.Second,
@@ -465,11 +462,6 @@ func (i *backendIBFT) updateMetrics(block *types.Block) {
 var (
 	errBlockVerificationFailed = errors.New("block verification fail")
 )
-
-// isSealing checks if the current node is sealing blocks
-func (i *backendIBFT) isSealing() bool {
-	return i.sealing
-}
 
 // verifyHeaderImpl implements the actual header verification logic
 func (i *backendIBFT) verifyHeaderImpl(snap *Snapshot, parent, header *types.Header) error {

--- a/consensus/ibft/transport.go
+++ b/consensus/ibft/transport.go
@@ -36,16 +36,14 @@ func (i *backendIBFT) setupTransport() error {
 	// Subscribe to the newly created topic
 	if err := topic.Subscribe(
 		func(obj interface{}, _ peer.ID) {
+			if !i.isActiveValidator() {
+				return
+			}
+
 			msg, ok := obj.(*proto.Message)
 			if !ok {
 				i.logger.Error("invalid type assertion for message request")
 
-				return
-			}
-
-			if !i.isSealing() {
-				// if we are not sealing we do not care about the messages
-				// but we need to subscribe to propagate the messages
 				return
 			}
 

--- a/e2e/broadcast_test.go
+++ b/e2e/broadcast_test.go
@@ -45,7 +45,6 @@ func TestBroadcast(t *testing.T) {
 	conf := func(config *framework.TestServerConfig) {
 		config.SetConsensus(framework.ConsensusDummy)
 		config.Premine(senderAddr, framework.EthToWei(10))
-		config.SetSeal(true)
 	}
 
 	for _, tt := range testCases {

--- a/e2e/framework/config.go
+++ b/e2e/framework/config.go
@@ -29,7 +29,6 @@ type TestServerConfig struct {
 	JSONRPCPort             int                  // The JSON RPC endpoint port
 	GRPCPort                int                  // The GRPC endpoint port
 	LibP2PPort              int                  // The Libp2p endpoint port
-	Seal                    bool                 // Flag indicating if blocks should be sealed
 	RootDir                 string               // The root directory for test environment
 	IBFTDirPrefix           string               // The prefix of data directory for IBFT
 	IBFTDir                 string               // The name of data directory for IBFT
@@ -134,11 +133,6 @@ func (t *TestServerConfig) SetIBFTDirPrefix(ibftDirPrefix string) {
 // SetIBFTDir callback sets the name of data directory for IBFT
 func (t *TestServerConfig) SetIBFTDir(ibftDir string) {
 	t.IBFTDir = ibftDir
-}
-
-// SetSeal callback toggles the seal mode
-func (t *TestServerConfig) SetSeal(state bool) {
-	t.Seal = state
 }
 
 // SetBootnodes sets bootnodes

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -341,10 +341,6 @@ func (t *TestServer) Start(ctx context.Context) error {
 		args = append(args, "--data-dir", t.Config.RootDir)
 	}
 
-	if t.Config.Seal {
-		args = append(args, "--seal")
-	}
-
 	if t.Config.PriceLimit != nil {
 		args = append(args, "--price-limit", strconv.FormatUint(*t.Config.PriceLimit, 10))
 	}

--- a/e2e/ibft_test.go
+++ b/e2e/ibft_test.go
@@ -48,7 +48,6 @@ func TestIbft_Transfer(t *testing.T) {
 				IBFTDirPrefix,
 				func(i int, config *framework.TestServerConfig) {
 					config.Premine(senderAddr, framework.EthToWei(10))
-					config.SetSeal(true)
 					config.SetBlockTime(tc.blockTime)
 					config.SetIBFTBaseTimeout(tc.ibftBaseTimeout)
 				},
@@ -119,7 +118,6 @@ func TestIbft_TransactionFeeRecipient(t *testing.T) {
 				IBFTDirPrefix,
 				func(i int, config *framework.TestServerConfig) {
 					config.Premine(senderAddr, framework.EthToWei(10))
-					config.SetSeal(true)
 				})
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)

--- a/e2e/pos_poa_switch_test.go
+++ b/e2e/pos_poa_switch_test.go
@@ -36,7 +36,6 @@ func TestPoAPoSSwitch(t *testing.T) {
 		IBFTMinNodes,
 		IBFTDirPrefix,
 		func(i int, config *framework.TestServerConfig) {
-			config.SetSeal(true)
 			config.PremineValidatorBalance(defaultBalance)
 		})
 

--- a/e2e/pos_test.go
+++ b/e2e/pos_test.go
@@ -113,7 +113,6 @@ func TestPoS_ValidatorBoundaries(t *testing.T) {
 		numGenesisValidators,
 		IBFTDirPrefix,
 		func(i int, config *framework.TestServerConfig) {
-			config.SetSeal(true)
 			config.SetEpochSize(2)
 			config.PremineValidatorBalance(defaultBalance)
 			for j := 0; j < numNewStakers; j++ {
@@ -175,7 +174,6 @@ func TestPoS_Stake(t *testing.T) {
 		numGenesisValidators,
 		IBFTDirPrefix,
 		func(i int, config *framework.TestServerConfig) {
-			config.SetSeal(true)
 			config.SetEpochSize(2) // Need to leave room for the endblock
 			config.PremineValidatorBalance(defaultBalance)
 			config.Premine(stakerAddr, defaultBalance)
@@ -236,7 +234,6 @@ func TestPoS_Unstake(t *testing.T) {
 		IBFTDirPrefix,
 		func(i int, config *framework.TestServerConfig) {
 			// Premine to send unstake transaction
-			config.SetSeal(true)
 			config.SetEpochSize(2) // Need to leave room for the endblock
 			config.PremineValidatorBalance(defaultBalance)
 			config.SetIBFTPoS(true)
@@ -324,7 +321,6 @@ func TestPoS_UnstakeExploit(t *testing.T) {
 	// Set up the test server
 	srvs := framework.NewTestServers(t, 1, func(config *framework.TestServerConfig) {
 		config.SetConsensus(framework.ConsensusDev)
-		config.SetSeal(true)
 		config.SetDevInterval(devInterval)
 		config.Premine(senderAddr, defaultBalance)
 		config.SetDevStakingAddresses(append(generateStakingAddresses(numDummyValidators), senderAddr))
@@ -468,7 +464,6 @@ func TestPoS_StakeUnstakeExploit(t *testing.T) {
 	// Set up the test server
 	srvs := framework.NewTestServers(t, 1, func(config *framework.TestServerConfig) {
 		config.SetConsensus(framework.ConsensusDev)
-		config.SetSeal(true)
 		config.SetDevInterval(devInterval)
 		config.Premine(senderAddr, defaultBalance)
 		config.SetBlockLimit(blockGasLimit)
@@ -609,7 +604,6 @@ func TestPoS_StakeUnstakeWithinSameBlock(t *testing.T) {
 	// Set up the test server
 	srvs := framework.NewTestServers(t, 1, func(config *framework.TestServerConfig) {
 		config.SetConsensus(framework.ConsensusDev)
-		config.SetSeal(true)
 		config.SetDevInterval(devInterval)
 		config.Premine(senderAddr, defaultBalance)
 		config.SetBlockLimit(blockGasLimit)
@@ -751,8 +745,6 @@ func TestSnapshotUpdating(t *testing.T) {
 		totalServers,
 		IBFTDirPrefix,
 		func(i int, config *framework.TestServerConfig) {
-			config.SetSeal(i < numGenesisValidators)
-
 			if i < numGenesisValidators {
 				// Only IBFTMinNodes should be validators
 				config.PremineValidatorBalance(defaultBalance)
@@ -762,6 +754,7 @@ func TestSnapshotUpdating(t *testing.T) {
 				config.SetIBFTDirPrefix(dirPrefix)
 				config.SetIBFTDir(fmt.Sprintf("%s%d", dirPrefix, i))
 			}
+
 			config.SetEpochSize(epochSize)
 			config.Premine(faucetAddr, defaultBalance)
 			config.SetIBFTPoS(true)

--- a/e2e/syncer_test.go
+++ b/e2e/syncer_test.go
@@ -26,7 +26,6 @@ func TestClusterBlockSync(t *testing.T) {
 				config.SetIBFTDirPrefix(dirPrefix)
 				config.SetIBFTDir(fmt.Sprintf("%s%d", dirPrefix, i))
 			}
-			config.SetSeal(i < IBFTMinNodes)
 		})
 
 	startContext, startCancelFn := context.WithTimeout(context.Background(), time.Minute)

--- a/e2e/transaction_test.go
+++ b/e2e/transaction_test.go
@@ -132,7 +132,6 @@ func TestEthTransfer(t *testing.T) {
 
 	srvs := framework.NewTestServers(t, 1, func(config *framework.TestServerConfig) {
 		config.SetConsensus(framework.ConsensusDev)
-		config.SetSeal(true)
 		for _, acc := range validAccounts {
 			config.Premine(acc.address, acc.balance)
 		}
@@ -362,7 +361,8 @@ func Test_TransactionIBFTLoop(t *testing.T) {
 			config.Premine(sender, defaultBalance)
 			config.SetSeal(true)
 			config.SetBlockLimit(20000000)
-		})
+		},
+	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()

--- a/e2e/transaction_test.go
+++ b/e2e/transaction_test.go
@@ -235,7 +235,6 @@ func TestFromFieldInTx(t *testing.T) {
 		IBFTDirPrefix,
 		func(i int, config *framework.TestServerConfig) {
 			config.Premine(senderAddr, framework.EthToWei(10))
-			config.SetSeal(true)
 		},
 	)
 

--- a/e2e/transaction_test.go
+++ b/e2e/transaction_test.go
@@ -359,7 +359,6 @@ func Test_TransactionIBFTLoop(t *testing.T) {
 		IBFTDirPrefix,
 		func(i int, config *framework.TestServerConfig) {
 			config.Premine(sender, defaultBalance)
-			config.SetSeal(true)
 			config.SetBlockLimit(20000000)
 		},
 	)

--- a/e2e/txpool_test.go
+++ b/e2e/txpool_test.go
@@ -103,7 +103,6 @@ func TestTxPool_ErrorCodes(t *testing.T) {
 			// Set up the test server
 			srvs := framework.NewTestServers(t, 1, func(config *framework.TestServerConfig) {
 				config.SetConsensus(framework.ConsensusDev)
-				config.SetSeal(true)
 				config.SetDevInterval(devInterval)
 				config.Premine(referenceAddr, testCase.defaultBalance)
 			})
@@ -175,7 +174,6 @@ func TestTxPool_TransactionCoalescing(t *testing.T) {
 		1,
 		IBFTDirPrefix,
 		func(i int, config *framework.TestServerConfig) {
-			config.SetSeal(true)
 			config.Premine(referenceAddr, defaultBalance)
 			config.SetBlockTime(1)
 		},
@@ -380,7 +378,6 @@ func TestTxPool_RecoverableError(t *testing.T) {
 
 	server := framework.NewTestServers(t, 1, func(config *framework.TestServerConfig) {
 		config.SetConsensus(framework.ConsensusDev)
-		config.SetSeal(true)
 		config.SetBlockLimit(2.5 * 21000)
 		config.SetDevInterval(2)
 		config.Premine(senderAddress, framework.EthToWei(100))
@@ -448,7 +445,6 @@ func TestTxPool_GetPendingTx(t *testing.T) {
 
 	server := framework.NewTestServers(t, 1, func(config *framework.TestServerConfig) {
 		config.SetConsensus(framework.ConsensusDev)
-		config.SetSeal(true)
 		config.SetDevInterval(3)
 		config.SetBlockLimit(20000000)
 		config.Premine(senderAddress, startingBalance)

--- a/e2e/websocket_test.go
+++ b/e2e/websocket_test.go
@@ -59,7 +59,6 @@ func TestWS_Response(t *testing.T) {
 
 	srvs := framework.NewTestServers(t, 1, func(config *framework.TestServerConfig) {
 		config.SetConsensus(framework.ConsensusDev)
-		config.SetSeal(true)
 
 		for _, account := range preminedAccounts {
 			config.Premine(account.address, account.balance)

--- a/server/server.go
+++ b/server/server.go
@@ -216,7 +216,6 @@ func NewServer(config *Config) (*Server, error) {
 			m.network,
 			m.serverMetrics.txpool,
 			&txpool.Config{
-				Sealing:             m.config.Seal,
 				MaxSlots:            m.config.MaxSlots,
 				PriceLimit:          m.config.PriceLimit,
 				MaxAccountEnqueued:  m.config.MaxAccountEnqueued,
@@ -404,7 +403,6 @@ func (s *Server) setupConsensus() error {
 	consensus, err := engine(
 		&consensus.Params{
 			Context:        context.Background(),
-			Seal:           s.config.Seal,
 			Config:         config,
 			TxPool:         s.txpool,
 			Network:        s.network,

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -305,3 +305,23 @@ func (a *account) resetSkips()  {
 func (a *account) incrementSkips()  {
 	a.skips++
 }
+
+// getLowestTx returns the transaction with lowest nonce, which might be popped next
+// this method don't pop a transaction from both queues
+func (a *account) getLowestTx() *types.Transaction {
+	a.promoted.lock(true)
+	defer a.promoted.unlock()
+
+	if firstPromoted := a.promoted.peek(); firstPromoted != nil {
+		return firstPromoted
+	}
+
+	a.enqueued.lock(true)
+	defer a.enqueued.unlock()
+
+	if firstEnqueued := a.enqueued.peek(); firstEnqueued != nil {
+		return firstEnqueued
+	}
+
+	return nil
+}

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -157,6 +157,7 @@ type account struct {
 	enqueued, promoted *accountQueue
 	nextNonce          uint64
 	demotions          uint
+	unadopted          uint64
 
 	//	maximum number of enqueued transactions
 	maxEnqueued uint64

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -158,7 +158,7 @@ type account struct {
 	nextNonce          uint64
 	demotions          uint
 	// the number of consecutive blocks that don't contain account's transaction
-	skips              uint64
+	skips uint64
 
 	//	maximum number of enqueued transactions
 	maxEnqueued uint64
@@ -297,12 +297,12 @@ func (a *account) promote() []*types.Transaction {
 }
 
 // resetSkips sets 0 to skips
-func (a *account) resetSkips()  {
+func (a *account) resetSkips() {
 	a.skips = 0
 }
 
 // incrementSkips increments skips
-func (a *account) incrementSkips()  {
+func (a *account) incrementSkips() {
 	a.skips++
 }
 

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -295,3 +295,13 @@ func (a *account) promote() []*types.Transaction {
 
 	return promoted
 }
+
+// resetSkips sets 0 to skips
+func (a *account) resetSkips()  {
+	a.skips = 0
+}
+
+// incrementSkips increments skips
+func (a *account) incrementSkips()  {
+	a.skips++
+}

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -157,7 +157,8 @@ type account struct {
 	enqueued, promoted *accountQueue
 	nextNonce          uint64
 	demotions          uint
-	unadopted          uint64
+	// the number of consecutive blocks that don't contain account's transaction
+	skips              uint64
 
 	//	maximum number of enqueued transactions
 	maxEnqueued uint64

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -898,7 +898,7 @@ func (p *TxPool) resetAccounts(stateNonces map[types.Address]uint64) {
 	}
 }
 
-// updateUnadoptedCounts update the accounts' unadopted counts,
+// updateUnadoptedCounts update the accounts' skips counts,
 // the number of the consecutive blocks that doesn't have the account's transactions
 func (p *TxPool) updateUnadoptedCounts(latestActiveAccounts map[types.Address]uint64) {
 	p.accounts.Range(
@@ -907,12 +907,12 @@ func (p *TxPool) updateUnadoptedCounts(latestActiveAccounts map[types.Address]ui
 			account, _ := value.(*account)
 
 			if _, ok := latestActiveAccounts[address]; ok {
-				account.unadopted = 0
+				account.skips = 0
 			} else {
-				account.unadopted++
+				account.skips++
 			}
 
-			if account.unadopted < maxAccountUnadopted {
+			if account.skips < maxAccountUnadopted {
 				return true
 			}
 
@@ -923,7 +923,7 @@ func (p *TxPool) updateUnadoptedCounts(latestActiveAccounts map[types.Address]ui
 			if firstTx != nil {
 				p.index.remove(firstTx)
 				p.gauge.decrease(slotsRequired(firstTx))
-				account.unadopted = 0
+				account.skips = 0
 			}
 
 			account.enqueued.lock(true)
@@ -933,7 +933,7 @@ func (p *TxPool) updateUnadoptedCounts(latestActiveAccounts map[types.Address]ui
 			if firstTx != nil {
 				p.index.remove(firstTx)
 				p.gauge.decrease(slotsRequired(firstTx))
-				account.unadopted = 0
+				account.skips = 0
 			}
 
 			return true

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -907,9 +907,9 @@ func (p *TxPool) updateUnadoptedCounts(latestActiveAccounts map[types.Address]ui
 			account, _ := value.(*account)
 
 			if _, ok := latestActiveAccounts[address]; ok {
-				account.skips = 0
+				account.resetSkips()
 			} else {
-				account.skips++
+				account.incrementSkips()
 			}
 
 			if account.skips < maxAccountUnadopted {
@@ -923,7 +923,7 @@ func (p *TxPool) updateUnadoptedCounts(latestActiveAccounts map[types.Address]ui
 			if firstTx != nil {
 				p.index.remove(firstTx)
 				p.gauge.decrease(slotsRequired(firstTx))
-				account.skips = 0
+				account.resetSkips()
 			}
 
 			account.enqueued.lock(true)
@@ -933,7 +933,7 @@ func (p *TxPool) updateUnadoptedCounts(latestActiveAccounts map[types.Address]ui
 			if firstTx != nil {
 				p.index.remove(firstTx)
 				p.gauge.decrease(slotsRequired(firstTx))
-				account.skips = 0
+				account.resetSkips()
 			}
 
 			return true

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -908,18 +908,27 @@ func (p *TxPool) updateAccountSkipsCounts(latestActiveAccounts map[types.Address
 
 			if _, ok := latestActiveAccounts[address]; ok {
 				account.resetSkips()
-			} else {
-				account.incrementSkips()
+
+				return true
 			}
+
+			firstPromoted := account.getLowestTx()
+			if firstPromoted == nil {
+				// no need to increment anything,
+				// account has no txs
+				return true
+			}
+
+			account.incrementSkips()
 
 			if account.skips < maxAccountSkips {
 				return true
 			}
 
-			if lowestTx := account.getLowestTx(); lowestTx != nil {
-				p.Drop(lowestTx)
-				account.resetSkips()
-			}
+			// account has been skipped too many times
+			p.Drop(firstPromoted)
+			
+			account.resetSkips()
 
 			return true
 		},

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -912,8 +912,8 @@ func (p *TxPool) updateAccountSkipsCounts(latestActiveAccounts map[types.Address
 				return true
 			}
 
-			firstPromoted := account.getLowestTx()
-			if firstPromoted == nil {
+			firstTx := account.getLowestTx()
+			if firstTx == nil {
 				// no need to increment anything,
 				// account has no txs
 				return true
@@ -926,7 +926,7 @@ func (p *TxPool) updateAccountSkipsCounts(latestActiveAccounts map[types.Address
 			}
 
 			// account has been skipped too many times
-			p.Drop(firstPromoted)
+			p.Drop(firstTx)
 
 			account.resetSkips()
 

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -328,8 +328,8 @@ func (p *TxPool) SetSealing(sealing bool) {
 	p.sealing.Store(sealing)
 }
 
-// Sealing returns the current set sealing flag
-func (p *TxPool) Sealing() bool {
+// sealing returns the current set sealing flag
+func (p *TxPool) getSealing() bool {
 	return p.sealing.Load()
 }
 
@@ -579,7 +579,7 @@ func (p *TxPool) processEvent(event *blockchain.Event) {
 	// reset accounts with the new state
 	p.resetAccounts(stateNonces)
 
-	if !p.Sealing() {
+	if !p.getSealing() {
 		// only non-validator cleanup inactive accounts
 		p.updateUnadoptedCounts(stateNonces)
 	}
@@ -804,7 +804,7 @@ func (p *TxPool) handlePromoteRequest(req promoteRequest) {
 // addGossipTx handles receiving transactions
 // gossiped by the network.
 func (p *TxPool) addGossipTx(obj interface{}, _ peer.ID) {
-	if !p.Sealing() {
+	if !p.getSealing() {
 		return
 	}
 

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -898,7 +898,7 @@ func (p *TxPool) resetAccounts(stateNonces map[types.Address]uint64) {
 	}
 }
 
-// updateUnadoptedCounts update the accounts' unadopted counts, 
+// updateUnadoptedCounts update the accounts' unadopted counts,
 // the number of the consecutive blocks that doesn't have the account's transactions
 func (p *TxPool) updateUnadoptedCounts(latestActiveAccounts map[types.Address]uint64) {
 	p.accounts.Range(

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -927,7 +927,7 @@ func (p *TxPool) updateAccountSkipsCounts(latestActiveAccounts map[types.Address
 
 			// account has been skipped too many times
 			p.Drop(firstPromoted)
-			
+
 			account.resetSkips()
 
 			return true

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -1449,24 +1449,24 @@ func Test_updateUnadoptedCounts(t *testing.T) {
 
 		accountMap := pool.accounts.get(addr1)
 
-		// make sure the transaction is promoted and unadopted count is zero
+		// make sure the transaction is promoted and skips count is zero
 		assert.Zero(t, accountMap.enqueued.length())
 		assert.Equal(t, uint64(1), accountMap.promoted.length())
-		assert.Zero(t, accountMap.unadopted)
+		assert.Zero(t, accountMap.skips)
 		assert.Equal(t, slotsRequired(tx), pool.gauge.read())
 		checkTxExistence(t, pool, tx.Hash, true)
 
-		// set 9 to unadopted in order to drop transaction next
-		accountMap.unadopted = 9
+		// set 9 to skips in order to drop transaction next
+		accountMap.skips = 9
 
 		pool.updateUnadoptedCounts(map[types.Address]uint64{
 			// empty
 		})
 
-		// make sure the account queue is empty and unadopted is reset
+		// make sure the account queue is empty and skips is reset
 		assert.Zero(t, accountMap.enqueued.length())
 		assert.Zero(t, accountMap.promoted.length())
-		assert.Zero(t, accountMap.unadopted)
+		assert.Zero(t, accountMap.skips)
 		assert.Zero(t, pool.gauge.read())
 		checkTxExistence(t, pool, tx.Hash, false)
 	})
@@ -1484,24 +1484,24 @@ func Test_updateUnadoptedCounts(t *testing.T) {
 
 		accountMap := pool.accounts.get(addr1)
 
-		// make sure the transaction is promoted and unadopted count is zero
+		// make sure the transaction is promoted and skips count is zero
 		assert.NotZero(t, accountMap.enqueued.length())
 		assert.Zero(t, accountMap.promoted.length())
-		assert.Zero(t, accountMap.unadopted)
+		assert.Zero(t, accountMap.skips)
 		assert.Equal(t, slotsRequired(tx), pool.gauge.read())
 		checkTxExistence(t, pool, tx.Hash, true)
 
-		// set 9 to unadopted in order to drop transaction next
-		accountMap.unadopted = 9
+		// set 9 to skips in order to drop transaction next
+		accountMap.skips = 9
 
 		pool.updateUnadoptedCounts(map[types.Address]uint64{
 			// empty
 		})
 
-		// make sure the account queue is empty and unadopted is reset
+		// make sure the account queue is empty and skips is reset
 		assert.Zero(t, accountMap.enqueued.length())
 		assert.Zero(t, accountMap.promoted.length())
-		assert.Zero(t, accountMap.unadopted)
+		assert.Zero(t, accountMap.skips)
 		assert.Zero(t, pool.gauge.read())
 		checkTxExistence(t, pool, tx.Hash, false)
 	})
@@ -1519,24 +1519,24 @@ func Test_updateUnadoptedCounts(t *testing.T) {
 
 		accountMap := pool.accounts.get(addr1)
 
-		// make sure the transaction is promoted and unadopted count is zero
+		// make sure the transaction is promoted and skips count is zero
 		assert.Zero(t, accountMap.enqueued.length())
 		assert.Equal(t, uint64(1), accountMap.promoted.length())
-		assert.Zero(t, accountMap.unadopted)
+		assert.Zero(t, accountMap.skips)
 		assert.Equal(t, slotsRequired(tx), pool.gauge.read())
 		checkTxExistence(t, pool, tx.Hash, true)
 
-		// set 9 to unadopted in order to drop transaction next
-		accountMap.unadopted = 5
+		// set 9 to skips in order to drop transaction next
+		accountMap.skips = 5
 
 		pool.updateUnadoptedCounts(map[types.Address]uint64{
 			addr1: 1,
 		})
 
-		// make sure the account queue is empty and unadopted is reset
+		// make sure the account queue is empty and skips is reset
 		assert.Zero(t, accountMap.enqueued.length())
 		assert.Equal(t, uint64(1), accountMap.promoted.length())
-		assert.Equal(t, uint64(0), accountMap.unadopted)
+		assert.Equal(t, uint64(0), accountMap.skips)
 		assert.Equal(t, slotsRequired(tx), pool.gauge.read())
 		checkTxExistence(t, pool, tx.Hash, true)
 	})

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -1404,7 +1404,7 @@ func TestDemote(t *testing.T) {
 	})
 }
 
-func Test_updateUnadoptedCounts(t *testing.T) {
+func Test_updateAccountSkipsCounts(t *testing.T) {
 	t.Parallel()
 
 	sendTx := func(
@@ -1459,7 +1459,7 @@ func Test_updateUnadoptedCounts(t *testing.T) {
 		// set 9 to skips in order to drop transaction next
 		accountMap.skips = 9
 
-		pool.updateUnadoptedCounts(map[types.Address]uint64{
+		pool.updateAccountSkipsCounts(map[types.Address]uint64{
 			// empty
 		})
 
@@ -1494,7 +1494,7 @@ func Test_updateUnadoptedCounts(t *testing.T) {
 		// set 9 to skips in order to drop transaction next
 		accountMap.skips = 9
 
-		pool.updateUnadoptedCounts(map[types.Address]uint64{
+		pool.updateAccountSkipsCounts(map[types.Address]uint64{
 			// empty
 		})
 
@@ -1529,7 +1529,7 @@ func Test_updateUnadoptedCounts(t *testing.T) {
 		// set 9 to skips in order to drop transaction next
 		accountMap.skips = 5
 
-		pool.updateUnadoptedCounts(map[types.Address]uint64{
+		pool.updateAccountSkipsCounts(map[types.Address]uint64{
 			addr1: 1,
 		})
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -1411,7 +1411,7 @@ func Test_updateUnadoptedCounts(t *testing.T) {
 		t *testing.T,
 		pool *TxPool,
 		tx *types.Transaction,
-		shouldPromote bool,	
+		shouldPromote bool,
 	) {
 		t.Helper()
 
@@ -1444,7 +1444,7 @@ func Test_updateUnadoptedCounts(t *testing.T) {
 
 		pool.SetSigner(&mockSigner{})
 
-		tx :=  newTx(addr1, 0, 1)
+		tx := newTx(addr1, 0, 1)
 		sendTx(t, pool, tx, true)
 
 		accountMap := pool.accounts.get(addr1)
@@ -1479,7 +1479,7 @@ func Test_updateUnadoptedCounts(t *testing.T) {
 
 		pool.SetSigner(&mockSigner{})
 
-		tx :=  newTx(addr1, 1, 1) // set non-zero nonce to prevent the tx from being added
+		tx := newTx(addr1, 1, 1) // set non-zero nonce to prevent the tx from being added
 		sendTx(t, pool, tx, false)
 
 		accountMap := pool.accounts.get(addr1)
@@ -1514,7 +1514,7 @@ func Test_updateUnadoptedCounts(t *testing.T) {
 
 		pool.SetSigner(&mockSigner{})
 
-		tx :=  newTx(addr1, 0, 1)
+		tx := newTx(addr1, 0, 1)
 		sendTx(t, pool, tx, true)
 
 		accountMap := pool.accounts.get(addr1)
@@ -1536,7 +1536,7 @@ func Test_updateUnadoptedCounts(t *testing.T) {
 		// make sure the account queue is empty and unadopted is reset
 		assert.Zero(t, accountMap.enqueued.length())
 		assert.Equal(t, uint64(1), accountMap.promoted.length())
-		assert.Equal(t, uint64(0) ,accountMap.unadopted)
+		assert.Equal(t, uint64(0), accountMap.unadopted)
 		assert.Equal(t, slotsRequired(tx), pool.gauge.read())
 		checkTxExistence(t, pool, tx.Hash, true)
 	})


### PR DESCRIPTION
Fix EDGE-843

# Description

This PR adds a function to remove the transactions that have not been adopted for a certain number of transactions.
And also this PR disable `--seal` flag but keep CLI flag because this PR is intended to be merged in the next PATCH release

Relevant: https://github.com/0xPolygon/polygon-edge/issues/731

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

1. Send the multiple transactions with consecutive nonces to **non-validator node** so that validators process the first part of transactions and fail to include the second part of the transactions (e.g. Send the bigger amount than the value account holds in a multiple transactions)
2. Make sure there are pending transactions in TxPool of validator and non-validator
3. Make sure the first part of the transactions are processed
4. Wait for a while
5. Make sure there are no transactions in TxPool of validator and non-validator

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
