### PR TITLE
Fix the size of return value by eth_getStorageAt 

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -411,21 +411,22 @@ func (e *Eth) GetStorageAt(
 
 		return nil, err
 	}
+
 	// Parse the RLP value
 	p := &fastrlp.Parser{}
-	v, err := p.Parse(result)
 
+	v, err := p.Parse(result)
 	if err != nil {
 		return argBytesPtr(types.ZeroHash[:]), nil
 	}
 
 	data, err := v.Bytes()
-
 	if err != nil {
 		return argBytesPtr(types.ZeroHash[:]), nil
 	}
 
-	return argBytesPtr(data), nil
+	// Pad to return 32 bytes data
+	return argBytesPtr(types.BytesToHash(data).Bytes()), nil
 }
 
 // GasPrice returns the average gas price based on the last x blocks


### PR DESCRIPTION
# Description

This PR makes `eth_getStorageAt` return 32 bytes data for any set storage.
For example, `eth_getStorageAt`  in current Edge returns 4 bytes data for the storage where 2 uint16 values are stored. But other EVM chain always returns 32 bytes (at least as far as I checked in Goerli Ethereum Test Net and Mumbai Polygon PoS Test Net)

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
