### PR TITLE
[FIX] Disable debug/vars 

### DIFF
--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -90,7 +90,10 @@ func (j *JSONRPC) setupHTTP() error {
 		return err
 	}
 
-	mux := http.DefaultServeMux
+	// NewServeMux must be used, as it disables all debug features.
+	// For some strange reason, with DefaultServeMux debug/vars is always enabled (but not debug/pprof).
+	// If pprof need to be enabled, this should be DefaultServeMux
+	mux := http.NewServeMux()
 
 	// The middleware factory returns a handler, so we need to wrap the handler function properly.
 	jsonRPCHandler := http.HandlerFunc(j.handle)


### PR DESCRIPTION
# Description

For some reason, `debug/vars` URL endpoint on the `json-rpc` http API is enabled by default when `DefaultServeMux` is used, even though `expvar` package is not imported anywhere.     

This presents a potential security issue and needs to be disabled by using `NewServeMux` function, instead of `DefaultServeMux`.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Compile binary from this branch and query `debug/vars` GET endpoint on JSON-RPC API. For example: `localhost:8545/debug/vars`. You should get the default GET output.


# Additional comments

Fixes EDGE-856
