### PR TITLE
EVM-25 Create state abstraction boundaries for write-ops in the state…

### DIFF
--- a/state/executor.go
+++ b/state/executor.go
@@ -71,7 +71,8 @@ func (e *Executor) WriteGenesis(alloc map[types.Address]*chain.GenesisAccount) t
 		}
 	}
 
-	_, root := txn.Commit(false)
+	objs := txn.Commit(false)
+	_, root := txn.snapshot.Commit(objs)
 
 	return types.BytesToHash(root)
 }
@@ -278,7 +279,8 @@ func (t *Transition) Write(txn *types.Transaction) error {
 			receipt.SetStatus(types.ReceiptSuccess)
 		}
 	} else {
-		ss, aux := t.state.Commit(t.config.EIP155)
+		objs := t.state.Commit(t.config.EIP155)
+		ss, aux := t.state.snapshot.Commit(objs)
 		t.state = NewTxn(t.auxState, ss)
 		root = aux
 		receipt.Root = types.BytesToHash(root)
@@ -299,7 +301,8 @@ func (t *Transition) Write(txn *types.Transaction) error {
 
 // Commit commits the final result
 func (t *Transition) Commit() (Snapshot, types.Hash) {
-	s2, root := t.state.Commit(t.config.EIP155)
+	objs := t.state.Commit(t.config.EIP155)
+	s2, root := t.state.snapshot.Commit(objs)
 
 	return s2, types.BytesToHash(root)
 }

--- a/state/executor.go
+++ b/state/executor.go
@@ -72,7 +72,7 @@ func (e *Executor) WriteGenesis(alloc map[types.Address]*chain.GenesisAccount) t
 	}
 
 	objs := txn.Commit(false)
-	_, root := txn.snapshot.Commit(objs)
+	_, root := snap.Commit(objs)
 
 	return types.BytesToHash(root)
 }

--- a/state/testing.go
+++ b/state/testing.go
@@ -126,7 +126,7 @@ func testDeleteCommonStateRoot(t *testing.T, buildPreState buildPreState) {
 	txn2.SetState(addr1, hash0, hash0)
 	txn2.SetState(addr1, hash1, hash0)
 
-	objs = txn.Commit(false)
+	objs = txn2.Commit(false)
 	snap3, _ := snap2.Commit(objs)
 
 	txn3 := newTxn(state, snap3)

--- a/state/testing.go
+++ b/state/testing.go
@@ -127,7 +127,7 @@ func testDeleteCommonStateRoot(t *testing.T, buildPreState buildPreState) {
 	txn2.SetState(addr1, hash1, hash0)
 
 	objs = txn.Commit(false)
-	snap3, _ := snap.Commit(objs)
+	snap3, _ := snap2.Commit(objs)
 
 	txn3 := newTxn(state, snap3)
 	assert.Equal(t, hash1, txn3.GetState(addr1, hash2))

--- a/state/testing.go
+++ b/state/testing.go
@@ -119,13 +119,13 @@ func testDeleteCommonStateRoot(t *testing.T, buildPreState buildPreState) {
 	txn.SetState(addr2, hash1, hash1)
 	txn.SetState(addr2, hash2, hash1)
 
-	snap2, _ := txn.Commit(false)
+	snap2, _ := buildNewSnapshot(txn, snap, false)
 	txn2 := newTxn(state, snap2)
 
 	txn2.SetState(addr1, hash0, hash0)
 	txn2.SetState(addr1, hash1, hash0)
 
-	snap3, _ := txn2.Commit(false)
+	snap3, _ := buildNewSnapshot(txn, snap2, false)
 
 	txn3 := newTxn(state, snap3)
 	assert.Equal(t, hash1, txn3.GetState(addr1, hash2))
@@ -146,7 +146,7 @@ func testWriteState(t *testing.T, buildPreState buildPreState) {
 	assert.Equal(t, hash1, txn.GetState(addr1, hash1))
 	assert.Equal(t, hash2, txn.GetState(addr1, hash2))
 
-	snap, _ = txn.Commit(false)
+	snap, _ = buildNewSnapshot(txn, snap, false)
 
 	txn = newTxn(state, snap)
 	assert.Equal(t, hash1, txn.GetState(addr1, hash1))
@@ -161,7 +161,7 @@ func testWriteEmptyState(t *testing.T, buildPreState buildPreState) {
 
 	// Without EIP150 the data is added
 	txn.SetState(addr1, hash1, hash0)
-	snap, _ = txn.Commit(false)
+	snap, _ = buildNewSnapshot(txn, snap, false)
 
 	txn = newTxn(state, snap)
 	assert.True(t, txn.Exist(addr1))
@@ -171,7 +171,7 @@ func testWriteEmptyState(t *testing.T, buildPreState buildPreState) {
 
 	// With EIP150 the empty data is removed
 	txn.SetState(addr1, hash1, hash0)
-	snap, _ = txn.Commit(true)
+	snap, _ = buildNewSnapshot(txn, snap, true)
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))
@@ -188,7 +188,7 @@ func testUpdateStateWithEmpty(t *testing.T, buildPreState buildPreState) {
 
 	// TODO, test with false (should not be deleted)
 	// TODO, test with balance on the account and nonce
-	snap, _ = txn.Commit(true)
+	snap, _ = buildNewSnapshot(txn, snap, true)
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))
@@ -202,7 +202,7 @@ func testSuicideAccountInPreState(t *testing.T, buildPreState buildPreState) {
 
 	txn := newTxn(state, snap)
 	txn.Suicide(addr1)
-	snap, _ = txn.Commit(true)
+	snap, _ = buildNewSnapshot(txn, snap, true)
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))
@@ -220,7 +220,7 @@ func testSuicideAccount(t *testing.T, buildPreState buildPreState) {
 	// Note, even if has commit suicide it still exists in the current txn
 	assert.True(t, txn.Exist(addr1))
 
-	snap, _ = txn.Commit(true)
+	snap, _ = buildNewSnapshot(txn, snap, true)
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))
@@ -241,7 +241,7 @@ func testSuicideAccountWithData(t *testing.T, buildPreState buildPreState) {
 	txn.SetState(addr1, hash1, hash1)
 
 	txn.Suicide(addr1)
-	snap, _ = txn.Commit(true)
+	snap, _ = buildNewSnapshot(txn, snap, true)
 
 	txn = newTxn(state, snap)
 
@@ -264,7 +264,7 @@ func testSuicideCoinbase(t *testing.T, buildPreState buildPreState) {
 	txn := newTxn(state, snap)
 	txn.Suicide(addr1)
 	txn.AddSealingReward(addr1, big.NewInt(10))
-	snap, _ = txn.Commit(true)
+	snap, _ = buildNewSnapshot(txn, snap, true)
 
 	txn = newTxn(state, snap)
 	assert.Equal(t, big.NewInt(10), txn.GetBalance(addr1))
@@ -318,7 +318,7 @@ func testChangePrestateAccountBalanceToZero(t *testing.T, buildPreState buildPre
 
 	txn := newTxn(state, snap)
 	txn.SetBalance(addr1, big.NewInt(0))
-	snap, _ = txn.Commit(true)
+	snap, _ = buildNewSnapshot(txn, snap, true)
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))
@@ -332,8 +332,13 @@ func testChangeAccountBalanceToZero(t *testing.T, buildPreState buildPreState) {
 	txn := newTxn(state, snap)
 	txn.SetBalance(addr1, big.NewInt(10))
 	txn.SetBalance(addr1, big.NewInt(0))
-	snap, _ = txn.Commit(true)
+	snap, _ = buildNewSnapshot(txn, snap, true)
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))
+}
+
+func buildNewSnapshot(txn *Txn, snapshot Snapshot, deleteEmptyObjects bool) (Snapshot, []byte) {
+	objs := txn.Commit(deleteEmptyObjects)
+	return txn.snapshot.Commit(objs)
 }

--- a/state/testing.go
+++ b/state/testing.go
@@ -340,5 +340,6 @@ func testChangeAccountBalanceToZero(t *testing.T, buildPreState buildPreState) {
 
 func buildNewSnapshot(txn *Txn, snapshot Snapshot, deleteEmptyObjects bool) (Snapshot, []byte) {
 	objs := txn.Commit(deleteEmptyObjects)
+
 	return txn.snapshot.Commit(objs)
 }

--- a/state/testing.go
+++ b/state/testing.go
@@ -119,15 +119,13 @@ func testDeleteCommonStateRoot(t *testing.T, buildPreState buildPreState) {
 	txn.SetState(addr2, hash1, hash1)
 	txn.SetState(addr2, hash2, hash1)
 
-	objs := txn.Commit(false)
-	snap2, _ := snap.Commit(objs)
+	snap2, _ := snap.Commit(txn.Commit(false))
 	txn2 := newTxn(state, snap2)
 
 	txn2.SetState(addr1, hash0, hash0)
 	txn2.SetState(addr1, hash1, hash0)
 
-	objs = txn2.Commit(false)
-	snap3, _ := snap2.Commit(objs)
+	snap3, _ := snap2.Commit(txn2.Commit(false))
 
 	txn3 := newTxn(state, snap3)
 	assert.Equal(t, hash1, txn3.GetState(addr1, hash2))
@@ -148,8 +146,7 @@ func testWriteState(t *testing.T, buildPreState buildPreState) {
 	assert.Equal(t, hash1, txn.GetState(addr1, hash1))
 	assert.Equal(t, hash2, txn.GetState(addr1, hash2))
 
-	objs := txn.Commit(false)
-	snap, _ = snap.Commit(objs)
+	snap, _ = snap.Commit(txn.Commit(false))
 
 	txn = newTxn(state, snap)
 	assert.Equal(t, hash1, txn.GetState(addr1, hash1))
@@ -164,8 +161,7 @@ func testWriteEmptyState(t *testing.T, buildPreState buildPreState) {
 
 	// Without EIP150 the data is added
 	txn.SetState(addr1, hash1, hash0)
-	objs := txn.Commit(false)
-	snap, _ = snap.Commit(objs)
+	snap, _ = snap.Commit(txn.Commit(false))
 
 	txn = newTxn(state, snap)
 	assert.True(t, txn.Exist(addr1))
@@ -175,8 +171,7 @@ func testWriteEmptyState(t *testing.T, buildPreState buildPreState) {
 
 	// With EIP150 the empty data is removed
 	txn.SetState(addr1, hash1, hash0)
-	objs = txn.Commit(true)
-	snap, _ = snap.Commit(objs)
+	snap, _ = snap.Commit(txn.Commit(true))
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))
@@ -193,8 +188,7 @@ func testUpdateStateWithEmpty(t *testing.T, buildPreState buildPreState) {
 
 	// TODO, test with false (should not be deleted)
 	// TODO, test with balance on the account and nonce
-	objs := txn.Commit(true)
-	snap, _ = snap.Commit(objs)
+	snap, _ = snap.Commit(txn.Commit(true))
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))
@@ -208,8 +202,7 @@ func testSuicideAccountInPreState(t *testing.T, buildPreState buildPreState) {
 
 	txn := newTxn(state, snap)
 	txn.Suicide(addr1)
-	objs := txn.Commit(true)
-	snap, _ = snap.Commit(objs)
+	snap, _ = snap.Commit(txn.Commit(true))
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))
@@ -227,8 +220,7 @@ func testSuicideAccount(t *testing.T, buildPreState buildPreState) {
 	// Note, even if has commit suicide it still exists in the current txn
 	assert.True(t, txn.Exist(addr1))
 
-	objs := txn.Commit(true)
-	snap, _ = snap.Commit(objs)
+	snap, _ = snap.Commit(txn.Commit(true))
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))
@@ -249,8 +241,7 @@ func testSuicideAccountWithData(t *testing.T, buildPreState buildPreState) {
 	txn.SetState(addr1, hash1, hash1)
 
 	txn.Suicide(addr1)
-	objs := txn.Commit(true)
-	snap, _ = snap.Commit(objs)
+	snap, _ = snap.Commit(txn.Commit(true))
 
 	txn = newTxn(state, snap)
 
@@ -273,8 +264,7 @@ func testSuicideCoinbase(t *testing.T, buildPreState buildPreState) {
 	txn := newTxn(state, snap)
 	txn.Suicide(addr1)
 	txn.AddSealingReward(addr1, big.NewInt(10))
-	objs := txn.Commit(true)
-	snap, _ = snap.Commit(objs)
+	snap, _ = snap.Commit(txn.Commit(true))
 
 	txn = newTxn(state, snap)
 	assert.Equal(t, big.NewInt(10), txn.GetBalance(addr1))
@@ -328,8 +318,7 @@ func testChangePrestateAccountBalanceToZero(t *testing.T, buildPreState buildPre
 
 	txn := newTxn(state, snap)
 	txn.SetBalance(addr1, big.NewInt(0))
-	objs := txn.Commit(true)
-	snap, _ = snap.Commit(objs)
+	snap, _ = snap.Commit(txn.Commit(true))
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))
@@ -344,8 +333,7 @@ func testChangeAccountBalanceToZero(t *testing.T, buildPreState buildPreState) {
 	txn.SetBalance(addr1, big.NewInt(10))
 	txn.SetBalance(addr1, big.NewInt(0))
 
-	objs := txn.Commit(true)
-	snap, _ = snap.Commit(objs)
+	snap, _ = snap.Commit(txn.Commit(true))
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))

--- a/state/txn.go
+++ b/state/txn.go
@@ -591,7 +591,7 @@ func (txn *Txn) CleanDeleteObjects(deleteEmptyObjects bool) {
 	txn.txn.Delete(refundIndex)
 }
 
-func (txn *Txn) Commit(deleteEmptyObjects bool) (Snapshot, []byte) {
+func (txn *Txn) Commit(deleteEmptyObjects bool) []*Object {
 	txn.CleanDeleteObjects(deleteEmptyObjects)
 
 	x := txn.txn.Commit()
@@ -638,7 +638,5 @@ func (txn *Txn) Commit(deleteEmptyObjects bool) (Snapshot, []byte) {
 		return false
 	})
 
-	t, hash := txn.snapshot.Commit(objs)
-
-	return t, hash
+	return objs
 }

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -77,6 +77,7 @@ func RunSpecificTest(t *testing.T, file string, c stateCase, name, fork string, 
 
 	objs := txn.Commit(forks.EIP155)
 	_, root := snapshot.Commit(objs)
+
 	if !bytes.Equal(root, p.Root.Bytes()) {
 		t.Fatalf(
 			"root mismatch (%s %s %s %d): expected %s but found %s",

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -48,7 +48,7 @@ func RunSpecificTest(t *testing.T, file string, c stateCase, name, fork string, 
 		t.Fatal(err)
 	}
 
-	s, _, pastRoot := buildState(c.Pre)
+	s, snapshot, pastRoot := buildState(c.Pre)
 	forks := config.At(uint64(env.Number))
 
 	xxx := state.NewExecutor(&chain.Params{Forks: config, ChainID: 1}, s, hclog.NewNullLogger())
@@ -75,7 +75,8 @@ func RunSpecificTest(t *testing.T, file string, c stateCase, name, fork string, 
 	// mining rewards
 	txn.AddSealingReward(env.Coinbase, big.NewInt(0))
 
-	_, root := txn.Commit(forks.EIP158)
+	objs := txn.Commit(forks.EIP155)
+	_, root := snapshot.Commit(objs)
 	if !bytes.Equal(root, p.Root.Bytes()) {
 		t.Fatalf(
 			"root mismatch (%s %s %s %d): expected %s but found %s",

--- a/tests/testing.go
+++ b/tests/testing.go
@@ -245,8 +245,8 @@ func buildState(
 		}
 	}
 
-	snap, root := txn.Commit(false)
-
+	objs := txn.Commit(false)
+	snap, root := snap.Commit(objs)
 	return s, snap, types.BytesToHash(root)
 }
 

--- a/tests/testing.go
+++ b/tests/testing.go
@@ -247,6 +247,7 @@ func buildState(
 
 	objs := txn.Commit(false)
 	snap, root := snap.Commit(objs)
+
 	return s, snap, types.BytesToHash(root)
 }
 


### PR DESCRIPTION
# Description

`State Transition Function` should not call `Commit` from the `Snapshot` interface and should only return the entries in the state that have been updated. Then, as part of another workflow, these entries would be updated in the `merkle trie`.
[Jira Task Link](https://polygon.atlassian.net/browse/EVM-25)

# Changes include

-  New feature (non-breaking change that adds functionality)

# Checklist

-  I have assigned this PR to myself
-  I have added at least 1 reviewer
-  I have added the relevant labels

## Testing

-  I have tested this code with the official test suite
