### PR TITLE
EVM-50: Add --num feature to "secrets init" command

### DIFF
--- a/command/secrets/init/params.go
+++ b/command/secrets/init/params.go
@@ -14,10 +14,7 @@ const (
 	ecdsaFlag   = "ecdsa"
 	blsFlag     = "bls"
 	networkFlag = "network"
-)
-
-var (
-	params = &initParams{}
+	numFlag     = "num"
 )
 
 var (

--- a/command/secrets/init/result.go
+++ b/command/secrets/init/result.go
@@ -4,9 +4,23 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/0xPolygon/polygon-edge/command"
+
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/types"
 )
+
+type Results []command.CommandResult
+
+func (r Results) GetOutput() string {
+	var buffer bytes.Buffer
+
+	for _, result := range r {
+		buffer.WriteString(result.GetOutput())
+	}
+
+	return buffer.String()
+}
 
 type SecretsInitResult struct {
 	Address   types.Address `json:"address"`

--- a/command/secrets/init/secrets_init.go
+++ b/command/secrets/init/secrets_init.go
@@ -8,7 +8,6 @@ import (
 )
 
 const (
-
 	// maxInitNum is the maximum value for "num" flag
 	maxInitNum = 1000
 )
@@ -116,6 +115,8 @@ func setFlags(cmd *cobra.Command, params *initParams, num *int) {
 	)
 }
 
+// newParamsList creates a list of initParams with num elements.
+// This function basically copies the given initParams but updating dataDir by applying an index.
 func newParamsList(params initParams, num int) []initParams {
 	if num == 1 {
 		return []initParams{params}

--- a/command/secrets/init/secrets_init.go
+++ b/command/secrets/init/secrets_init.go
@@ -3,8 +3,9 @@ package init
 import (
 	"fmt"
 
-	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/spf13/cobra"
+
+	"github.com/0xPolygon/polygon-edge/command"
 )
 
 const (
@@ -99,6 +100,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 	paramsList := newParamsList(basicParams, initNumber)
 	results := make(Results, len(paramsList))
+
 	for i, params := range paramsList {
 		if err := params.initSecrets(); err != nil {
 			outputter.SetError(err)

--- a/command/secrets/init/secrets_init.go
+++ b/command/secrets/init/secrets_init.go
@@ -17,8 +17,10 @@ var (
 )
 
 func GetCommand() *cobra.Command {
-	var basicParams initParams
-	var number int
+	var (
+		basicParams initParams
+		number      int
+	)
 
 	secretsInitCmd := &cobra.Command{
 		Use: "init",

--- a/command/secrets/init/secrets_init.go
+++ b/command/secrets/init/secrets_init.go
@@ -1,25 +1,70 @@
 package init
 
 import (
+	"fmt"
+
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/spf13/cobra"
 )
 
+const (
+
+	// maxInitNum is the maximum value for "num" flag
+	maxInitNum = 1000
+)
+
+var (
+	errInvalidNum = fmt.Errorf("num flag value should be between 1 and %d", maxInitNum)
+)
+
 func GetCommand() *cobra.Command {
+	var basicParams initParams
+	var number int
+
 	secretsInitCmd := &cobra.Command{
 		Use: "init",
 		Short: "Initializes private keys for the Polygon Edge (Validator + Networking) " +
 			"to the specified Secrets Manager",
-		PreRunE: runPreRun,
-		Run:     runCommand,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if number < 1 || number > maxInitNum {
+				return errInvalidNum
+			}
+
+			return basicParams.validateFlags()
+		},
+		Run: func(cmd *cobra.Command, _ []string) {
+			outputter := command.InitializeOutputter(cmd)
+			defer outputter.WriteOutput()
+
+			paramsList := newParamsList(basicParams, number)
+			results := make(Results, len(paramsList))
+			for i, params := range paramsList {
+				if err := params.initSecrets(); err != nil {
+					outputter.SetError(err)
+
+					return
+				}
+
+				res, err := params.getResult()
+				if err != nil {
+					outputter.SetError(err)
+
+					return
+				}
+
+				results[i] = res
+			}
+
+			outputter.SetCommandResult(results)
+		},
 	}
 
-	setFlags(secretsInitCmd)
+	setFlags(secretsInitCmd, &basicParams, &number)
 
 	return secretsInitCmd
 }
 
-func setFlags(cmd *cobra.Command) {
+func setFlags(cmd *cobra.Command, params *initParams, num *int) {
 	cmd.Flags().StringVar(
 		&params.dataDir,
 		dataDirFlag,
@@ -35,7 +80,19 @@ func setFlags(cmd *cobra.Command) {
 			"if omitted, the local FS secrets manager is used",
 	)
 
+	cmd.Flags().IntVar(
+		num,
+		numFlag,
+		1,
+		"the flag indicating how many secrets should be created, only for the local FS",
+	)
+
+	// Don't accept data-dir and config flags because they are related to different secrets managers.
+	// data-dir is about the local FS as secrets storage, config is about remote secrets manager.
 	cmd.MarkFlagsMutuallyExclusive(dataDirFlag, configFlag)
+
+	// num flag should be used with data-dir flag only so it should not be used with config flag.
+	cmd.MarkFlagsMutuallyExclusive(numFlag, configFlag)
 
 	cmd.Flags().BoolVar(
 		&params.generatesECDSA,
@@ -59,26 +116,20 @@ func setFlags(cmd *cobra.Command) {
 	)
 }
 
-func runPreRun(_ *cobra.Command, _ []string) error {
-	return params.validateFlags()
-}
-
-func runCommand(cmd *cobra.Command, _ []string) {
-	outputter := command.InitializeOutputter(cmd)
-	defer outputter.WriteOutput()
-
-	if err := params.initSecrets(); err != nil {
-		outputter.SetError(err)
-
-		return
+func newParamsList(params initParams, num int) []initParams {
+	if num == 1 {
+		return []initParams{params}
 	}
 
-	res, err := params.getResult()
-	if err != nil {
-		outputter.SetError(err)
-
-		return
+	paramsList := make([]initParams, num)
+	for i := 1; i <= num; i++ {
+		paramsList[i-1] = initParams{
+			dataDir:          fmt.Sprintf("%s%d", params.dataDir, i),
+			generatesECDSA:   params.generatesECDSA,
+			generatesBLS:     params.generatesBLS,
+			generatesNetwork: params.generatesNetwork,
+		}
 	}
 
-	outputter.SetCommandResult(res)
+	return paramsList
 }

--- a/command/secrets/init/secrets_init.go
+++ b/command/secrets/init/secrets_init.go
@@ -9,72 +9,40 @@ import (
 
 const (
 	// maxInitNum is the maximum value for "num" flag
-	maxInitNum = 1000
+	maxInitNum = 30
 )
 
 var (
 	errInvalidNum = fmt.Errorf("num flag value should be between 1 and %d", maxInitNum)
+
+	basicParams initParams
+	initNumber  int
 )
 
 func GetCommand() *cobra.Command {
-	var (
-		basicParams initParams
-		number      int
-	)
-
 	secretsInitCmd := &cobra.Command{
 		Use: "init",
 		Short: "Initializes private keys for the Polygon Edge (Validator + Networking) " +
 			"to the specified Secrets Manager",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if number < 1 || number > maxInitNum {
-				return errInvalidNum
-			}
-
-			return basicParams.validateFlags()
-		},
-		Run: func(cmd *cobra.Command, _ []string) {
-			outputter := command.InitializeOutputter(cmd)
-			defer outputter.WriteOutput()
-
-			paramsList := newParamsList(basicParams, number)
-			results := make(Results, len(paramsList))
-			for i, params := range paramsList {
-				if err := params.initSecrets(); err != nil {
-					outputter.SetError(err)
-
-					return
-				}
-
-				res, err := params.getResult()
-				if err != nil {
-					outputter.SetError(err)
-
-					return
-				}
-
-				results[i] = res
-			}
-
-			outputter.SetCommandResult(results)
-		},
+		PreRunE: runPreRun,
+		Run:     runCommand,
 	}
 
-	setFlags(secretsInitCmd, &basicParams, &number)
+	setFlags(secretsInitCmd)
 
 	return secretsInitCmd
 }
 
-func setFlags(cmd *cobra.Command, params *initParams, num *int) {
+func setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
-		&params.dataDir,
+		&basicParams.dataDir,
 		dataDirFlag,
 		"",
 		"the directory for the Polygon Edge data if the local FS is used",
 	)
 
 	cmd.Flags().StringVar(
-		&params.configPath,
+		&basicParams.configPath,
 		configFlag,
 		"",
 		"the path to the SecretsManager config file, "+
@@ -82,7 +50,7 @@ func setFlags(cmd *cobra.Command, params *initParams, num *int) {
 	)
 
 	cmd.Flags().IntVar(
-		num,
+		&initNumber,
 		numFlag,
 		1,
 		"the flag indicating how many secrets should be created, only for the local FS",
@@ -96,25 +64,59 @@ func setFlags(cmd *cobra.Command, params *initParams, num *int) {
 	cmd.MarkFlagsMutuallyExclusive(numFlag, configFlag)
 
 	cmd.Flags().BoolVar(
-		&params.generatesECDSA,
+		&basicParams.generatesECDSA,
 		ecdsaFlag,
 		true,
 		"the flag indicating whether new ECDSA key is created",
 	)
 
 	cmd.Flags().BoolVar(
-		&params.generatesNetwork,
+		&basicParams.generatesNetwork,
 		networkFlag,
 		true,
 		"the flag indicating whether new Network key is created",
 	)
 
 	cmd.Flags().BoolVar(
-		&params.generatesBLS,
+		&basicParams.generatesBLS,
 		blsFlag,
 		true,
 		"the flag indicating whether new BLS key is created",
 	)
+}
+
+func runPreRun(_ *cobra.Command, _ []string) error {
+	if initNumber < 1 || initNumber > maxInitNum {
+		return errInvalidNum
+	}
+
+	return basicParams.validateFlags()
+}
+
+func runCommand(cmd *cobra.Command, _ []string) {
+	outputter := command.InitializeOutputter(cmd)
+	defer outputter.WriteOutput()
+
+	paramsList := newParamsList(basicParams, initNumber)
+	results := make(Results, len(paramsList))
+	for i, params := range paramsList {
+		if err := params.initSecrets(); err != nil {
+			outputter.SetError(err)
+
+			return
+		}
+
+		res, err := params.getResult()
+		if err != nil {
+			outputter.SetError(err)
+
+			return
+		}
+
+		results[i] = res
+	}
+
+	outputter.SetCommandResult(results)
 }
 
 // newParamsList creates a list of initParams with num elements.

--- a/docker/local/polygon-edge.sh
+++ b/docker/local/polygon-edge.sh
@@ -8,10 +8,7 @@ case "$1" in
 
    "init")
       echo "Generating secrets..."
-      node1id=$("$POLYGON_EDGE_BIN" secrets init --data-dir data-1 --json | jq -r '.node_id')
-      node2id=$("$POLYGON_EDGE_BIN" secrets init --data-dir data-2 --json | jq -r '.node_id')
-      "$POLYGON_EDGE_BIN" secrets init --data-dir data-3
-      "$POLYGON_EDGE_BIN" secrets init --data-dir data-4
+      secrets=$("$POLYGON_EDGE_BIN" secrets init --num 4 --data-dir data- --json)
       echo "Secrets have been successfully generated"
 
       echo "Generating genesis file..."
@@ -19,8 +16,8 @@ case "$1" in
         --dir /genesis/genesis.json \
         --consensus ibft \
         --ibft-validators-prefix-path data- \
-        --bootnode /dns4/node-1/tcp/1478/p2p/"$node1id" \
-        --bootnode /dns4/node-2/tcp/1478/p2p/"$node2id"
+        --bootnode /dns4/node-1/tcp/1478/p2p/$(echo $secrets | jq -r '.[0] | .node_id') \
+        --bootnode /dns4/node-2/tcp/1478/p2p/$(echo $secrets | jq -r '.[1] | .node_id')
       echo "Genesis file has been successfully generated"
       ;;
 


### PR DESCRIPTION
# Description

In order to generate multiple secrets within one command, there should be `--num` feature flag that accepts an integer value of the number of secrets that should be generated. `--data-dir` flag value is used as a prefix of the directory. 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Tested manually using the local docker setup. 
