### PR TITLE
EVM-69 Fix panic issue in opReturnDataCopy

### DIFF
--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -419,7 +419,7 @@ func opMStore(c *state) {
 	offset := c.pop()
 	val := c.pop()
 
-	if !c.checkMemory(offset, wordSize) {
+	if !c.allocateMemory(offset, wordSize) {
 		return
 	}
 
@@ -452,7 +452,7 @@ func opMStore8(c *state) {
 	offset := c.pop()
 	val := c.pop()
 
-	if !c.checkMemory(offset, one) {
+	if !c.allocateMemory(offset, one) {
 		return
 	}
 
@@ -757,7 +757,7 @@ func opExtCodeCopy(c *state) {
 	codeOffset := c.pop()
 	length := c.pop()
 
-	if !c.checkMemory(memOffset, length) {
+	if !c.allocateMemory(memOffset, length) {
 		return
 	}
 
@@ -788,7 +788,7 @@ func opCallDataCopy(c *state) {
 	dataOffset := c.pop()
 	length := c.pop()
 
-	if !c.checkMemory(memOffset, length) {
+	if !c.allocateMemory(memOffset, length) {
 		return
 	}
 
@@ -813,7 +813,7 @@ func opReturnDataCopy(c *state) {
 	dataOffset := c.pop()
 	length := c.pop()
 
-	if !c.checkMemory(memOffset, length) {
+	if !c.allocateMemory(memOffset, length) {
 		return
 	}
 
@@ -850,7 +850,7 @@ func opCodeCopy(c *state) {
 	dataOffset := c.pop()
 	length := c.pop()
 
-	if !c.checkMemory(memOffset, length) {
+	if !c.allocateMemory(memOffset, length) {
 		return
 	}
 
@@ -1207,7 +1207,7 @@ func (c *state) buildCallContract(op OpCode) (*runtime.Contract, uint64, uint64,
 		return nil, 0, 0, nil
 	}
 	// Check if the memory return offsets are out of bounds
-	if !c.checkMemory(retOffset, retSize) {
+	if !c.allocateMemory(retOffset, retSize) {
 		return nil, 0, 0, nil
 	}
 

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -817,6 +817,12 @@ func opReturnDataCopy(c *state) {
 		return
 	}
 
+	if !dataOffset.IsUint64() {
+		c.exit(errGasUintOverflow)
+
+		return
+	}
+
 	size := length.Uint64()
 	if !c.consumeGas(((size + 31) / 32) * copyGas) {
 		return

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -823,27 +823,25 @@ func opReturnDataCopy(c *state) {
 		return
 	}
 
-	size := length.Uint64()
-	if !c.consumeGas(((size + 31) / 32) * copyGas) {
+	if ulength := length.Uint64(); !c.consumeGas(((ulength + 31) / 32) * copyGas) {
 		return
 	}
 
-	end := length.Add(dataOffset, length)
-	if !end.IsUint64() {
+	dataEnd := length.Add(dataOffset, length)
+	if !dataEnd.IsUint64() {
 		c.exit(errReturnDataOutOfBounds)
 
 		return
 	}
 
-	size = end.Uint64()
-
-	if uint64(len(c.returnData)) < size {
+	dataEndIndex := dataEnd.Uint64()
+	if uint64(len(c.returnData)) < dataEndIndex {
 		c.exit(errReturnDataOutOfBounds)
 
 		return
 	}
 
-	data := c.returnData[dataOffset.Uint64():size]
+	data := c.returnData[dataOffset.Uint64():dataEndIndex]
 	copy(c.memory[memOffset.Uint64():], data)
 }
 

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -382,6 +382,8 @@ func TestCreate(t *testing.T) {
 }
 
 func Test_opReturnDataCopy(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		config      *chain.ForksInTime
@@ -509,6 +511,8 @@ func Test_opReturnDataCopy(t *testing.T) {
 		test := test
 
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			state, closeFn := getState()
 			defer closeFn()
 
@@ -518,6 +522,11 @@ func Test_opReturnDataCopy(t *testing.T) {
 			state.memory = test.initState.memory
 			state.returnData = test.initState.returnData
 			state.config = test.config
+
+			// assign nil to some fields in cached state object
+			state.code = nil
+			state.host = nil
+			state.msg = nil
 
 			opReturnDataCopy(state)
 

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -527,6 +527,9 @@ func Test_opReturnDataCopy(t *testing.T) {
 			state.code = nil
 			state.host = nil
 			state.msg = nil
+			state.evm = nil
+			state.bitmap = bitmap{}
+			state.ret = nil
 
 			opReturnDataCopy(state)
 

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -505,6 +505,40 @@ func Test_opReturnDataCopy(t *testing.T) {
 				err:         nil,
 			},
 		},
+		{
+			name:   "should expand memory and copy data returnData",
+			config: &allEnabledForks,
+			initState: &state{
+				stack: []*big.Int{
+					big.NewInt(5), // length
+					big.NewInt(1), // dataOffset
+					big.NewInt(2), // memOffset
+				},
+				sp:         3,
+				returnData: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+				memory:     []byte{0x11, 0x22},
+				gas:        20,
+			},
+			resultState: &state{
+				config: &allEnabledForks,
+				stack: []*big.Int{
+					big.NewInt(6), // updated for end index
+					big.NewInt(1),
+					big.NewInt(2),
+				},
+				sp:         0,
+				returnData: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+				memory: append(
+					// 1 word (32 bytes)
+					[]byte{0x11, 0x22, 0x02, 0x03, 0x04, 0x05, 0x06},
+					make([]byte, 25)...,
+				),
+				gas:         14,
+				lastGasCost: 3,
+				stop:        false,
+				err:         nil,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -272,7 +272,10 @@ func (c *state) Len() int {
 	return len(c.memory)
 }
 
-func (c *state) checkMemory(offset, size *big.Int) bool {
+// allocateMemory allocates memory to enable accessing in the range of [offset, offset+size]
+// throws error if the given offset and size are negative
+// consumes gas if memory needs to be expanded
+func (c *state) allocateMemory(offset, size *big.Int) bool {
 	if !offset.IsUint64() || !size.IsUint64() {
 		c.exit(errGasUintOverflow)
 
@@ -325,7 +328,7 @@ func (c *state) get2(dst []byte, offset, length *big.Int) ([]byte, bool) {
 		return nil, true
 	}
 
-	if !c.checkMemory(offset, length) {
+	if !c.allocateMemory(offset, length) {
 		return nil, false
 	}
 

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -273,14 +273,14 @@ func (c *state) Len() int {
 }
 
 func (c *state) checkMemory(offset, size *big.Int) bool {
-	if size.Sign() == 0 {
-		return true
-	}
-
 	if !offset.IsUint64() || !size.IsUint64() {
 		c.exit(errGasUintOverflow)
 
 		return false
+	}
+
+	if size.Sign() == 0 {
+		return true
 	}
 
 	o := offset.Uint64()

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -292,7 +292,7 @@ func (c *state) checkMemory(offset, size *big.Int) bool {
 		return false
 	}
 
-	if newSize, m := o+s, uint64(len(c.memory)); m < newSize {
+	if newSize, currentSize := o+s, uint64(len(c.memory)); currentSize < newSize {
 		w := (newSize + 31) / 32
 		newCost := 3*w + w*w/512
 		cost := newCost - c.lastGasCost


### PR DESCRIPTION
# Description

This PR fixes the issue that may cause panic in opReturnDataCopy. `dataOffset` is expected to be uint64 value but this function doesn't check the negativity before using. This PR adds such a check.

In addition, this PR change the order of checks in `checkMemory` function because it always passes when the `size` argument is zero, even thought `offset` is negative

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
