### PR TITLE
Adding netgo build tag for Linux releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,6 +45,8 @@ builds:
     ldflags:
       # We need to build a static binary because we are building in a glibc based system and running in a musl container
       -s -w -linkmode external -extldflags "-static" -X 'github.com/0xPolygon/polygon-edge/versioning.Version=v{{ .Version }}'
+    tags:
+      - netgo
 
   - id: linux-arm64
     main: ./main.go
@@ -59,12 +61,14 @@ builds:
     ldflags:
       # We need to build a static binary because we are building in a glibc based system and running in a musl container
       -s -w -linkmode external -extldflags "-static" -X 'github.com/0xPolygon/polygon-edge/versioning.Version=v{{ .Version }}'
+    tags:
+      - netgo
 
 archives:
   -
     files:
-    - LICENSE
-    - README.md
+      - LICENSE
+      - README.md
 
 #nfpms:
 #  - vendor: 0xPolygon


### PR DESCRIPTION
# Description

Introducing this release change to provide more consistent network behaviors. A common reported behavior is chain configurations with `dns` multiaddr ending in `.local` do not resolve correctly. This change will set the release package/image to use the Go resolver.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [X] I have updated the official documentation
- [X] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [X] I have tested this code manually
