### PR TITLE
`GetSecret` error handling fix

### DIFF
--- a/command/common.go
+++ b/command/common.go
@@ -118,7 +118,11 @@ func GetValidatorsFromPrefixPath(
 }
 
 func getValidatorAddressFromSecretManager(manager secrets.SecretsManager) (types.Address, error) {
-	if !manager.HasSecret(secrets.ValidatorKey) {
+	hasSecret, err := manager.HasSecret(secrets.ValidatorKey)
+	if err != nil {
+		return types.ZeroAddress, err
+	}
+	if !hasSecret {
 		return types.ZeroAddress, ErrECDSAKeyNotFound
 	}
 
@@ -136,7 +140,11 @@ func getValidatorAddressFromSecretManager(manager secrets.SecretsManager) (types
 }
 
 func getBLSPublicKeyBytesFromSecretManager(manager secrets.SecretsManager) ([]byte, error) {
-	if !manager.HasSecret(secrets.ValidatorBLSKey) {
+	hasSecret, err := manager.HasSecret(secrets.ValidatorBLSKey)
+	if err != nil {
+		return nil, err
+	}
+	if !hasSecret {
 		return nil, ErrBLSKeyNotFound
 	}
 

--- a/command/secrets/init/helper.go
+++ b/command/secrets/init/helper.go
@@ -11,7 +11,11 @@ import (
 
 // loadValidatorAddress loads ECDSA key by SecretsManager and returns validator address
 func loadValidatorAddress(secretsManager secrets.SecretsManager) (types.Address, error) {
-	if !secretsManager.HasSecret(secrets.ValidatorKey) {
+	hasSecret, err := secretsManager.HasSecret(secrets.ValidatorKey)
+	if err != nil {
+		return types.ZeroAddress, nil
+	}
+	if !hasSecret {
 		return types.ZeroAddress, nil
 	}
 
@@ -30,7 +34,11 @@ func loadValidatorAddress(secretsManager secrets.SecretsManager) (types.Address,
 
 // loadValidatorAddress loads BLS key by SecretsManager and returns BLS Public Key
 func loadBLSPublicKey(secretsManager secrets.SecretsManager) (string, error) {
-	if !secretsManager.HasSecret(secrets.ValidatorBLSKey) {
+	hasSecret, err := secretsManager.HasSecret(secrets.ValidatorBLSKey)
+	if err != nil {
+		return "", nil
+	}
+	if !hasSecret {
 		return "", nil
 	}
 
@@ -54,7 +62,11 @@ func loadBLSPublicKey(secretsManager secrets.SecretsManager) (string, error) {
 
 // loadNodeID loads Libp2p key by SecretsManager and returns Node ID
 func loadNodeID(secretsManager secrets.SecretsManager) (string, error) {
-	if !secretsManager.HasSecret(secrets.NetworkKey) {
+	hasSecret, err := secretsManager.HasSecret(secrets.NetworkKey)
+	if err != nil {
+		return "", err
+	}
+	if !hasSecret {
 		return "", nil
 	}
 

--- a/consensus/ibft/fork/manager_test.go
+++ b/consensus/ibft/fork/manager_test.go
@@ -45,11 +45,11 @@ func (m *mockHooksRegister) RegisterHooks(hooks *hook.Hooks, height uint64) {
 type mockSecretManager struct {
 	secrets.SecretsManager
 
-	HasSecretFunc func(name string) bool
+	HasSecretFunc func(name string) (bool, error)
 	GetSecretFunc func(name string) ([]byte, error)
 }
 
-func (m *mockSecretManager) HasSecret(name string) bool {
+func (m *mockSecretManager) HasSecret(name string) (bool, error) {
 	return m.HasSecretFunc(name)
 }
 
@@ -91,8 +91,8 @@ func TestNewForkManager(t *testing.T) {
 			epochSize uint64 = 10
 
 			secretManager = &mockSecretManager{
-				HasSecretFunc: func(name string) bool {
-					return true
+				HasSecretFunc: func(name string) (bool, error) {
+					return true, errTest
 				},
 				GetSecretFunc: func(name string) ([]byte, error) {
 					return nil, errTest
@@ -133,10 +133,10 @@ func TestNewForkManager(t *testing.T) {
 			}
 
 			secretManager = &mockSecretManager{
-				HasSecretFunc: func(name string) bool {
+				HasSecretFunc: func(name string) (bool, error) {
 					assert.Equal(t, secrets.ValidatorKey, name)
 
-					return true
+					return true, nil
 				},
 				GetSecretFunc: func(name string) ([]byte, error) {
 					assert.Equal(t, secrets.ValidatorKey, name)
@@ -204,10 +204,10 @@ func TestNewForkManager(t *testing.T) {
 			}
 
 			secretManager = &mockSecretManager{
-				HasSecretFunc: func(name string) bool {
+				HasSecretFunc: func(name string) (bool, error) {
 					assert.Equal(t, secrets.ValidatorKey, name)
 
-					return true
+					return true, nil
 				},
 				GetSecretFunc: func(name string) ([]byte, error) {
 					assert.Equal(t, secrets.ValidatorKey, name)
@@ -257,10 +257,10 @@ func TestNewForkManager(t *testing.T) {
 			epochSize uint64 = 10
 
 			secretManager = &mockSecretManager{
-				HasSecretFunc: func(name string) bool {
+				HasSecretFunc: func(name string) (bool, error) {
 					assert.True(t, name == secrets.ValidatorKey || name == secrets.ValidatorBLSKey)
 
-					return true
+					return true, nil
 				},
 				GetSecretFunc: func(name string) ([]byte, error) {
 					assert.True(t, name == secrets.ValidatorKey || name == secrets.ValidatorBLSKey)
@@ -793,10 +793,10 @@ func TestForkManager_initializeKeyManagers(t *testing.T) {
 				},
 			},
 			secretManager: &mockSecretManager{
-				HasSecretFunc: func(name string) bool {
+				HasSecretFunc: func(name string) (bool, error) {
 					assert.Equal(t, secrets.ValidatorKey, name)
 
-					return true
+					return true, nil
 				},
 				GetSecretFunc: func(name string) ([]byte, error) {
 					assert.Equal(t, secrets.ValidatorKey, name)

--- a/consensus/ibft/signer/bls_test.go
+++ b/consensus/ibft/signer/bls_test.go
@@ -117,10 +117,10 @@ func TestNewBLSKeyManager(t *testing.T) {
 		{
 			name: "should initialize BLSKeyManager from the loaded ECDSA and BLS key",
 			mockSecretManager: &MockSecretManager{
-				HasSecretFn: func(name string) bool {
+				HasSecretFn: func(name string) (bool, error) {
 					testSecretName(name)
 
-					return true
+					return true, nil
 				},
 				GetSecretFn: func(name string) ([]byte, error) {
 					testSecretName(name)
@@ -145,10 +145,10 @@ func TestNewBLSKeyManager(t *testing.T) {
 		{
 			name: "should return error if getOrCreateECDSAKey returns error",
 			mockSecretManager: &MockSecretManager{
-				HasSecretFn: func(name string) bool {
+				HasSecretFn: func(name string) (bool, error) {
 					testSecretName(name)
 
-					return true
+					return true, nil
 				},
 				GetSecretFn: func(name string) ([]byte, error) {
 					testSecretName(name)
@@ -170,10 +170,10 @@ func TestNewBLSKeyManager(t *testing.T) {
 		{
 			name: "should return error if getOrCreateBLSKey returns error",
 			mockSecretManager: &MockSecretManager{
-				HasSecretFn: func(name string) bool {
+				HasSecretFn: func(name string) (bool, error) {
 					testSecretName(name)
 
-					return true
+					return true, nil
 				},
 				GetSecretFn: func(name string) ([]byte, error) {
 					testSecretName(name)

--- a/consensus/ibft/signer/ecdsa_test.go
+++ b/consensus/ibft/signer/ecdsa_test.go
@@ -44,10 +44,10 @@ func TestNewECDSAKeyManager(t *testing.T) {
 		{
 			name: "should initialize ECDSAKeyManager from the loaded ECDSA key",
 			mockSecretManager: &MockSecretManager{
-				HasSecretFn: func(name string) bool {
+				HasSecretFn: func(name string) (bool, error) {
 					testSecretName(name)
 
-					return true
+					return true, nil
 				},
 				GetSecretFn: func(name string) ([]byte, error) {
 					testSecretName(name)
@@ -64,10 +64,10 @@ func TestNewECDSAKeyManager(t *testing.T) {
 		{
 			name: "should return error if getOrCreateECDSAKey returns error",
 			mockSecretManager: &MockSecretManager{
-				HasSecretFn: func(name string) bool {
+				HasSecretFn: func(name string) (bool, error) {
 					testSecretName(name)
 
-					return true
+					return true, nil
 				},
 				GetSecretFn: func(name string) ([]byte, error) {
 					testSecretName(name)

--- a/consensus/ibft/signer/helper.go
+++ b/consensus/ibft/signer/helper.go
@@ -49,7 +49,7 @@ func getOrCreateECDSAKey(manager secrets.SecretsManager) (*ecdsa.PrivateKey, err
 
 // getOrCreateECDSAKey loads BLS key or creates a new key
 func getOrCreateBLSKey(manager secrets.SecretsManager) (*bls_sig.SecretKey, error) {
-	hasSecret, err := manager.HasSecret(secrets.ValidatorKey)
+	hasSecret, err := manager.HasSecret(secrets.ValidatorBLSKey)
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/ibft/signer/helper.go
+++ b/consensus/ibft/signer/helper.go
@@ -29,7 +29,11 @@ func wrapCommitHash(data []byte) []byte {
 
 // getOrCreateECDSAKey loads ECDSA key or creates a new key
 func getOrCreateECDSAKey(manager secrets.SecretsManager) (*ecdsa.PrivateKey, error) {
-	if !manager.HasSecret(secrets.ValidatorKey) {
+	hasSecret, err := manager.HasSecret(secrets.ValidatorKey)
+	if err != nil {
+		return nil, err
+	}
+	if !hasSecret {
 		if _, err := helper.InitECDSAValidatorKey(manager); err != nil {
 			return nil, err
 		}
@@ -45,7 +49,11 @@ func getOrCreateECDSAKey(manager secrets.SecretsManager) (*ecdsa.PrivateKey, err
 
 // getOrCreateECDSAKey loads BLS key or creates a new key
 func getOrCreateBLSKey(manager secrets.SecretsManager) (*bls_sig.SecretKey, error) {
-	if !manager.HasSecret(secrets.ValidatorBLSKey) {
+	hasSecret, err := manager.HasSecret(secrets.ValidatorKey)
+	if err != nil {
+		return nil, err
+	}
+	if !hasSecret {
 		if _, err := helper.InitBLSValidatorKey(manager); err != nil {
 			return nil, err
 		}

--- a/consensus/ibft/signer/helper_test.go
+++ b/consensus/ibft/signer/helper_test.go
@@ -96,10 +96,10 @@ func Test_getOrCreateECDSAKey(t *testing.T) {
 		{
 			name: "should load ECDSA key from secret manager if the key exists",
 			mockSecretManager: &MockSecretManager{
-				HasSecretFn: func(name string) bool {
+				HasSecretFn: func(name string) (bool, error) {
 					testSecretName(name)
 
-					return true
+					return true, nil
 				},
 				GetSecretFn: func(name string) ([]byte, error) {
 					testSecretName(name)
@@ -113,10 +113,10 @@ func Test_getOrCreateECDSAKey(t *testing.T) {
 		{
 			name: "should create new ECDSA key if the key doesn't exist",
 			mockSecretManager: &MockSecretManager{
-				HasSecretFn: func(name string) bool {
+				HasSecretFn: func(name string) (bool, error) {
 					testSecretName(name)
 
-					return false
+					return false, nil
 				},
 				SetSecretFn: func(name string, key []byte) error {
 					testSecretName(name)
@@ -137,10 +137,10 @@ func Test_getOrCreateECDSAKey(t *testing.T) {
 		{
 			name: "should return error if secret manager returns error",
 			mockSecretManager: &MockSecretManager{
-				HasSecretFn: func(name string) bool {
+				HasSecretFn: func(name string) (bool, error) {
 					testSecretName(name)
 
-					return true
+					return true, nil
 				},
 				GetSecretFn: func(name string) ([]byte, error) {
 					testSecretName(name)
@@ -154,10 +154,10 @@ func Test_getOrCreateECDSAKey(t *testing.T) {
 		{
 			name: "should return error if the key manager fails to generate new ECDSA key",
 			mockSecretManager: &MockSecretManager{
-				HasSecretFn: func(name string) bool {
+				HasSecretFn: func(name string) (bool, error) {
 					testSecretName(name)
 
-					return false
+					return false, nil
 				},
 				SetSecretFn: func(name string, key []byte) error {
 					testSecretName(name)
@@ -206,10 +206,10 @@ func Test_getOrCreateBLSKey(t *testing.T) {
 		{
 			name: "should load BLS key from secret manager if the key exists",
 			mockSecretManager: &MockSecretManager{
-				HasSecretFn: func(name string) bool {
+				HasSecretFn: func(name string) (bool, error) {
 					testSecretName(name)
 
-					return true
+					return true, nil
 				},
 				GetSecretFn: func(name string) ([]byte, error) {
 					testSecretName(name)
@@ -223,10 +223,10 @@ func Test_getOrCreateBLSKey(t *testing.T) {
 		{
 			name: "should create new BLS key if the key doesn't exist",
 			mockSecretManager: &MockSecretManager{
-				HasSecretFn: func(name string) bool {
+				HasSecretFn: func(name string) (bool, error) {
 					testSecretName(name)
 
-					return false
+					return false, nil
 				},
 				SetSecretFn: func(name string, key []byte) error {
 					testSecretName(name)
@@ -247,10 +247,10 @@ func Test_getOrCreateBLSKey(t *testing.T) {
 		{
 			name: "should return error if secret manager returns error",
 			mockSecretManager: &MockSecretManager{
-				HasSecretFn: func(name string) bool {
+				HasSecretFn: func(name string) (bool, error) {
 					testSecretName(name)
 
-					return true
+					return true, nil
 				},
 				GetSecretFn: func(name string) ([]byte, error) {
 					testSecretName(name)
@@ -264,10 +264,10 @@ func Test_getOrCreateBLSKey(t *testing.T) {
 		{
 			name: "should return error if the key manager fails to generate new BLS key",
 			mockSecretManager: &MockSecretManager{
-				HasSecretFn: func(name string) bool {
+				HasSecretFn: func(name string) (bool, error) {
 					testSecretName(name)
 
-					return false
+					return false, nil
 				},
 				SetSecretFn: func(name string, key []byte) error {
 					testSecretName(name)
@@ -346,8 +346,8 @@ func TestNewKeyManagerFromType(t *testing.T) {
 			name:          "ECDSAValidatorType",
 			validatorType: validators.ECDSAValidatorType,
 			mockSecretManager: &MockSecretManager{
-				HasSecretFn: func(name string) bool {
-					return true
+				HasSecretFn: func(name string) (bool, error) {
+					return true, nil
 				},
 				GetSecretFn: func(name string) ([]byte, error) {
 					return testECDSAKeyEncoded, nil
@@ -360,8 +360,8 @@ func TestNewKeyManagerFromType(t *testing.T) {
 			name:          "BLSValidatorType",
 			validatorType: validators.BLSValidatorType,
 			mockSecretManager: &MockSecretManager{
-				HasSecretFn: func(name string) bool {
-					return true
+				HasSecretFn: func(name string) (bool, error) {
+					return true, nil
 				},
 				GetSecretFn: func(name string) ([]byte, error) {
 					switch name {

--- a/consensus/ibft/signer/mock_test.go
+++ b/consensus/ibft/signer/mock_test.go
@@ -10,12 +10,12 @@ type MockSecretManager struct {
 	// skip implementing the methods not to be used
 	secrets.SecretsManager
 
-	HasSecretFn func(string) bool
+	HasSecretFn func(string) (bool, error)
 	GetSecretFn func(string) ([]byte, error)
 	SetSecretFn func(string, []byte) error
 }
 
-func (m *MockSecretManager) HasSecret(name string) bool {
+func (m *MockSecretManager) HasSecret(name string) (bool, error) {
 	return m.HasSecretFn(name)
 }
 

--- a/network/server.go
+++ b/network/server.go
@@ -214,7 +214,11 @@ func (pci *PeerConnInfo) getProtocolStream(protocol string) *rawGrpc.ClientConn 
 func setupLibp2pKey(secretsManager secrets.SecretsManager) (crypto.PrivKey, error) {
 	var key crypto.PrivKey
 
-	if secretsManager.HasSecret(secrets.NetworkKey) {
+	hasSecret, err := secretsManager.HasSecret(secrets.NetworkKey)
+	if err != nil {
+		return nil, err
+	}
+	if hasSecret {
 		// The key is present in the secrets manager, read it
 		networkingKey, readErr := ReadLibp2pKey(secretsManager)
 		if readErr != nil {

--- a/network/server.go
+++ b/network/server.go
@@ -233,10 +233,6 @@ func setupLibp2pKey(secretsManager secrets.SecretsManager) (crypto.PrivKey, erro
 			return nil, fmt.Errorf("unable to generate networking private key for Secrets Manager, %w", keyErr)
 		}
 
-		if deleteErr := secretsManager.RemoveSecret(secrets.NetworkKey); deleteErr != nil {
-			return nil, fmt.Errorf("unable to delete pre-existing networking private key in Secrets Manager, %w", deleteErr)
-		}
-
 		// Write the networking private key to disk
 		if setErr := secretsManager.SetSecret(secrets.NetworkKey, libp2pKeyEncoded); setErr != nil {
 			return nil, fmt.Errorf("unable to store networking private key to Secrets Manager, %w", setErr)

--- a/network/server.go
+++ b/network/server.go
@@ -229,6 +229,10 @@ func setupLibp2pKey(secretsManager secrets.SecretsManager) (crypto.PrivKey, erro
 			return nil, fmt.Errorf("unable to generate networking private key for Secrets Manager, %w", keyErr)
 		}
 
+		if deleteErr := secretsManager.RemoveSecret(secrets.NetworkKey); deleteErr != nil {
+			return nil, fmt.Errorf("unable to delete pre-existing networking private key in Secrets Manager, %w", deleteErr)
+		}
+
 		// Write the networking private key to disk
 		if setErr := secretsManager.SetSecret(secrets.NetworkKey, libp2pKeyEncoded); setErr != nil {
 			return nil, fmt.Errorf("unable to store networking private key to Secrets Manager, %w", setErr)

--- a/secrets/awsssm/aws_ssm.go
+++ b/secrets/awsssm/aws_ssm.go
@@ -110,10 +110,12 @@ func (a *AwsSsmManager) SetSecret(name string, value []byte) error {
 }
 
 // HasSecret checks if the secret is present on AWS SSM ParameterStore
-func (a *AwsSsmManager) HasSecret(name string) bool {
-	_, err := a.GetSecret(name)
+func (a *AwsSsmManager) HasSecret(name string) (bool, error) {
+	if _, err := a.GetSecret(name); err != nil {
+		return false, fmt.Errorf("unable to fetch secret (%s), %w", name, err);
+	}
 
-	return err == nil
+	return true, nil
 }
 
 // RemoveSecret removes a secret from AWS SSM ParameterStore

--- a/secrets/gcpssm/gcp_ssm.go
+++ b/secrets/gcpssm/gcp_ssm.go
@@ -155,11 +155,12 @@ func (gm *GCPSecretsManager) SetSecret(name string, value []byte) error {
 }
 
 // HasSecret checks if the secret is present
-func (gm *GCPSecretsManager) HasSecret(name string) bool {
-	_, err := gm.GetSecret(name)
+func (gm *GCPSecretsManager) HasSecret(name string) (bool, error) {
+	if _, err := gm.GetSecret(name); err != nil {
+		return false, fmt.Errorf("unable to fetch secret (%s), %w", name, err);
+	}
 
-	// if there is no error fetching secret return true
-	return err == nil
+	return true, nil
 }
 
 // RemoveSecret removes the secret from storage used only for tests

--- a/secrets/hashicorpvault/hashicorp_vault.go
+++ b/secrets/hashicorpvault/hashicorp_vault.go
@@ -181,10 +181,12 @@ func (v *VaultSecretsManager) SetSecret(name string, value []byte) error {
 }
 
 // HasSecret checks if the secret is present on the Hashicorp Vault server
-func (v *VaultSecretsManager) HasSecret(name string) bool {
-	_, err := v.GetSecret(name)
+func (v *VaultSecretsManager) HasSecret(name string) (bool, error) {
+	if _, err := v.GetSecret(name); err != nil {
+		return false, fmt.Errorf("unable to fetch secret (%s), %w", name, err);
+	}
 
-	return err == nil
+	return true, nil
 }
 
 // RemoveSecret removes a secret from the Hashicorp Vault server

--- a/secrets/helper/helper.go
+++ b/secrets/helper/helper.go
@@ -154,7 +154,11 @@ func InitNetworkingPrivateKey(secretsManager secrets.SecretsManager) (libp2pCryp
 
 // LoadValidatorAddress loads ECDSA key by SecretsManager and returns validator address
 func LoadValidatorAddress(secretsManager secrets.SecretsManager) (types.Address, error) {
-	if !secretsManager.HasSecret(secrets.ValidatorKey) {
+	hasSecret, err := secretsManager.HasSecret(secrets.ValidatorKey)
+	if err != nil {
+		return types.ZeroAddress, nil
+	}
+	if !hasSecret {
 		return types.ZeroAddress, nil
 	}
 
@@ -173,7 +177,11 @@ func LoadValidatorAddress(secretsManager secrets.SecretsManager) (types.Address,
 
 // LoadValidatorAddress loads BLS key by SecretsManager and returns BLS Public Key
 func LoadBLSPublicKey(secretsManager secrets.SecretsManager) (string, error) {
-	if !secretsManager.HasSecret(secrets.ValidatorBLSKey) {
+	hasSecret, err := secretsManager.HasSecret(secrets.ValidatorBLSKey)
+	if err != nil {
+		return "", nil
+	}
+	if !hasSecret {
 		return "", nil
 	}
 
@@ -197,7 +205,11 @@ func LoadBLSPublicKey(secretsManager secrets.SecretsManager) (string, error) {
 
 // LoadNodeID loads Libp2p key by SecretsManager and returns Node ID
 func LoadNodeID(secretsManager secrets.SecretsManager) (string, error) {
-	if !secretsManager.HasSecret(secrets.NetworkKey) {
+	hasSecret, err := secretsManager.HasSecret(secrets.NetworkKey)
+	if err != nil {
+		return "", err
+	}
+	if !hasSecret {
 		return "", nil
 	}
 

--- a/secrets/helper/helper.go
+++ b/secrets/helper/helper.go
@@ -66,7 +66,11 @@ func SetupGCPSSM(
 
 // InitECDSAValidatorKey creates new ECDSA key and set as a validator key
 func InitECDSAValidatorKey(secretsManager secrets.SecretsManager) (types.Address, error) {
-	if secretsManager.HasSecret(secrets.ValidatorKey) {
+	hasSecret, err := secretsManager.HasSecret(secrets.ValidatorKey)
+	if err != nil {
+		return types.ZeroAddress, err
+	}
+	if hasSecret {
 		return types.ZeroAddress, fmt.Errorf(`secrets "%s" has been already initialized`, secrets.ValidatorKey)
 	}
 
@@ -89,7 +93,12 @@ func InitECDSAValidatorKey(secretsManager secrets.SecretsManager) (types.Address
 }
 
 func InitBLSValidatorKey(secretsManager secrets.SecretsManager) ([]byte, error) {
-	if secretsManager.HasSecret(secrets.ValidatorBLSKey) {
+	hasSecret, err := secretsManager.HasSecret(secrets.ValidatorBLSKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if hasSecret {
 		return nil, fmt.Errorf(`secrets "%s" has been already initialized`, secrets.ValidatorBLSKey)
 	}
 
@@ -115,7 +124,11 @@ func InitBLSValidatorKey(secretsManager secrets.SecretsManager) ([]byte, error) 
 }
 
 func InitNetworkingPrivateKey(secretsManager secrets.SecretsManager) (libp2pCrypto.PrivKey, error) {
-	if secretsManager.HasSecret(secrets.NetworkKey) {
+	hasSecret, err := secretsManager.HasSecret(secrets.NetworkKey)
+	if err != nil {
+		return nil, err
+	}
+	if hasSecret {
 		return nil, fmt.Errorf(`secrets "%s" has been already initialized`, secrets.NetworkKey)
 	}
 

--- a/secrets/local/local.go
+++ b/secrets/local/local.go
@@ -146,10 +146,12 @@ func (l *LocalSecretsManager) SetSecret(name string, value []byte) error {
 }
 
 // HasSecret checks if the secret is present on disk
-func (l *LocalSecretsManager) HasSecret(name string) bool {
-	_, err := l.GetSecret(name)
+func (l *LocalSecretsManager) HasSecret(name string) (bool, error) {
+	if _, err := l.GetSecret(name); err != nil {
+		return false, fmt.Errorf("unable to fetch secret (%s), %w", name, err);
+	}
 
-	return err == nil
+	return true, nil
 }
 
 // RemoveSecret removes the local SecretsManager's secret from disk

--- a/secrets/local/local_test.go
+++ b/secrets/local/local_test.go
@@ -268,8 +268,10 @@ func TestLocalSecretsManager_RemoveSecret(t *testing.T) {
 				assert.Error(t, removeErr)
 			}
 
+			hasSecret, _ := manager.HasSecret(testCase.secretName)
+
 			// Check that the value is not present
-			assert.False(t, manager.HasSecret(testCase.secretName))
+			assert.False(t, hasSecret)
 		})
 	}
 }

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -80,7 +80,7 @@ type SecretsManager interface {
 	SetSecret(name string, value []byte) error
 
 	// HasSecret checks if the secret is present
-	HasSecret(name string) bool
+	HasSecret(name string) (bool, error)
 
 	// RemoveSecret removes the secret from storage
 	RemoveSecret(name string) error


### PR DESCRIPTION
# Description

Kind of messed up my other branch, so this is a dupe with the same changes. Sorry!

We didn't properly handle error checking in GetSecret. If there was an error, it would return false instead of an error along with false. This PR changes the signature of that function to return both the error and if the secret exists.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
