### PR TITLE
Allowing Snyk to continue-on-error to upload

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/golang@master
+        continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:


### PR DESCRIPTION
Quick CI fix to allow Snyk to upload results to Github Code Security on scan "failure".

Missed from https://github.com/0xPolygon/polygon-edge/pull/794 