### PR TITLE
Fix unstable behaviour in TestContractValidatorStore_CacheChange

### DIFF
--- a/validators/store/contract/contract_test.go
+++ b/validators/store/contract/contract_test.go
@@ -475,21 +475,26 @@ func TestContractValidatorStore_CacheChange(t *testing.T) {
 		)
 	)
 
-	testCache := func(t *testing.T, expectedCache map[uint64]validators.Validators) {
+	type testCase struct {
+		height uint64
+		expected validators.Validators
+	}
+
+	testCache := func(t *testing.T, testCases ...testCase) {
 		t.Helper()
 
-		assert.Equal(t, len(expectedCache), store.validatorSetCache.Len())
+		assert.Equal(t, len(testCases), store.validatorSetCache.Len())
 
-		for height, expected := range expectedCache {
-			cache, ok := store.validatorSetCache.Get(height)
+		for _, testCase := range testCases {
+			cache, ok := store.validatorSetCache.Get(testCase.height)
 
-			assert.Truef(t, ok, "validators for %d must exist, but not found")
-			assert.Equal(t, expected, cache)
+			assert.Truef(t, ok, "validators at %d must exist, but not found", testCase.height)
+			assert.Equal(t, testCase.expected, cache)
 		}
 	}
 
 	// initial cache is empty
-	testCache(t, nil)
+	testCache(t)
 
 	// overflow doesn't occur
 	assert.False(
@@ -497,19 +502,21 @@ func TestContractValidatorStore_CacheChange(t *testing.T) {
 		store.saveToValidatorSetCache(0, ecdsaValidators1),
 	)
 
-	testCache(t, map[uint64]validators.Validators{
-		0: ecdsaValidators1,
-	})
+	testCache(
+		t,
+		testCase{height: 0, expected: ecdsaValidators1},
+	)
 
 	assert.False(
 		t,
 		store.saveToValidatorSetCache(1, ecdsaValidators2),
 	)
-
-	testCache(t, map[uint64]validators.Validators{
-		0: ecdsaValidators1,
-		1: ecdsaValidators2,
-	})
+	
+	testCache(
+		t,
+		testCase{height: 0, expected: ecdsaValidators1},
+		testCase{height: 1, expected: ecdsaValidators2},
+	)
 
 	// make sure ecdsaValidators2 is loaded at the end for LRU cache
 	store.validatorSetCache.Get(1)
@@ -520,10 +527,11 @@ func TestContractValidatorStore_CacheChange(t *testing.T) {
 		store.saveToValidatorSetCache(2, blsValidators),
 	)
 
-	testCache(t, map[uint64]validators.Validators{
-		1: ecdsaValidators2,
-		2: blsValidators,
-	})
+	testCache(
+		t,
+		testCase{height: 1, expected: ecdsaValidators2},
+		testCase{height: 2, expected: blsValidators},
+	)
 }
 
 func TestContractValidatorStore_NoCache(t *testing.T) {

--- a/validators/store/contract/contract_test.go
+++ b/validators/store/contract/contract_test.go
@@ -476,7 +476,7 @@ func TestContractValidatorStore_CacheChange(t *testing.T) {
 	)
 
 	type testCase struct {
-		height uint64
+		height   uint64
 		expected validators.Validators
 	}
 
@@ -511,7 +511,7 @@ func TestContractValidatorStore_CacheChange(t *testing.T) {
 		t,
 		store.saveToValidatorSetCache(1, ecdsaValidators2),
 	)
-	
+
 	testCache(
 		t,
 		testCase{height: 0, expected: ecdsaValidators1},


### PR DESCRIPTION
# Description

This PR fixes the issue that TestContractValidatorStore_CacheChange are failing sometimes. Just stop using map to list testcases

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Run `TestContractValidatorStore_CacheChange` several times

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
