### PR TITLE
Hotfix to solve a backup stream limit Issue

### DIFF
--- a/server/system_service.go
+++ b/server/system_service.go
@@ -251,7 +251,7 @@ func newBlockStreamWriter(
 
 func (w *blockStreamWriter) appendBlock(b *types.Block) error {
 	data := b.MarshalRLP()
-	if maxHeaderInfoSize+w.buf.Len()+len(data) >= w.maxPayload {
+	if uint64(maxHeaderInfoSize+w.buf.Len()+len(data)) >= w.maxPayload {
 		// send buffered data to client first
 		if err := w.flush(); err != nil {
 			return err

--- a/server/system_service.go
+++ b/server/system_service.go
@@ -224,6 +224,7 @@ func (s *systemService) Export(req *proto.ExportRequest, stream proto.System_Exp
 
 const (
 	defaultMaxGRPCPayloadSize uint64 = 512 * 1024 // 4MB
+	maxHeaderInfoSize         uint8  = 3 * 8      //Number of header fields * bytes per field (From, To, Latest all them uint64)
 )
 
 type blockStreamWriter struct {
@@ -250,8 +251,7 @@ func newBlockStreamWriter(
 
 func (w *blockStreamWriter) appendBlock(b *types.Block) error {
 	data := b.MarshalRLP()
-
-	if uint64(w.buf.Len()+len(data)) >= w.maxPayload {
+	if uint64(int(maxHeaderInfoSize)+w.buf.Len()+len(data)) >= w.maxPayload {
 		// send buffered data to client first
 		if err := w.flush(); err != nil {
 			return err

--- a/server/system_service.go
+++ b/server/system_service.go
@@ -224,7 +224,7 @@ func (s *systemService) Export(req *proto.ExportRequest, stream proto.System_Exp
 
 const (
 	defaultMaxGRPCPayloadSize uint64 = 512 * 1024 // 4MB
-	maxHeaderInfoSize         uint8  = 3 * 8      //Number of header fields * bytes per field (From, To, Latest all them uint64)
+	maxHeaderInfoSize         int = 3 * 8      //Number of header fields * bytes per field (From, To, Latest all them uint64)
 )
 
 type blockStreamWriter struct {
@@ -251,7 +251,7 @@ func newBlockStreamWriter(
 
 func (w *blockStreamWriter) appendBlock(b *types.Block) error {
 	data := b.MarshalRLP()
-	if uint64(int(maxHeaderInfoSize)+w.buf.Len()+len(data)) >= w.maxPayload {
+	if maxHeaderInfoSize+w.buf.Len()+len(data) >= w.maxPayload {
 		// send buffered data to client first
 		if err := w.flush(); err != nil {
 			return err


### PR DESCRIPTION
# Description

We're trying to backup our blockchain but at some point we get the following error:
`rpc error: code = ResourceExhausted desc = grpc: received message larger than max (4194312 vs. 4194304)` 

We did some tests and we found out that an interval of blocks, `32000 to 36981`, every single time returns this error.
Looking through the code we find out that the read limit for a stream is `4MB`, but the write limit is `21MB`. Checking the error message we understand that the backup process is receiving more than `4MB`.

We check the [appending block function](https://github.com/0xPolygon/polygon-edge/blob/46a988b2061dd8699fb3f236cc034e06e7d7ba7c/server/system_service.go#L251), it checks the size of blocks that will be written to the stream:
```
	if uint64(w.buf.Len()+len(data)) >= w.maxPayload {
		// send buffered data to client first
		if err := w.flush(); err != nil {
			return err
		}
	}
```
This code considers only the sum of block's size to be less than `4MB`. If you check the [ExportEvent Protobuf struct](https://github.com/0xPolygon/polygon-edge/blob/46a988b2061dd8699fb3f236cc034e06e7d7ba7c/server/system_service.go#L284) besides the blocks we also send 3 uint64 fields (I'm calling header) in the stream.

Using the [golang document](https://go.dev/ref/spec#Size_and_alignment_guarantees), we could realize that these 3 fields add to the stream payload `24 bytes (3 * 8)` (I know that polygon edge uses Protobuf and this is the maximum size possible for this 3 fields). So the previous validation may let out 24 bytes and may accept appending more blocks than the stream will support.

The solution that I propose here was to add a const `maxHeaderInfoSize` with the max size of the fields (that I'm calling header) and change the validation to use it

```
if uint64(int(maxHeaderInfoSize)+w.buf.Len()+len(data)) >= w.maxPayload
```

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

The manual test that we did, was to retry the backup process on our blockchain and see if it would finish without problems.
This solution work like charm!

