### PR TITLE
Recognize JSON Log format flag in downstream server logs

### DIFF
--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -162,6 +162,11 @@ func GetJSONRPCAddress(cmd *cobra.Command) string {
 	return cmd.Flag(command.JSONRPCFlag).Value.String()
 }
 
+// GetJSONLogFormat extracts the set JSON Format flag
+func GetJSONLogFormat(cmd *cobra.Command) bool {
+	return cmd.Flag(command.JSONOutputFlag).Changed
+}
+
 // RegisterJSONOutputFlag registers the --json output setting for all child commands
 func RegisterJSONOutputFlag(cmd *cobra.Command) {
 	cmd.PersistentFlags().Bool(

--- a/command/server/config/config.go
+++ b/command/server/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	LogFilePath              string     `json:"log_to" yaml:"log_to"`
 	JSONRPCBatchRequestLimit uint64     `json:"json_rpc_batch_request_limit" yaml:"json_rpc_batch_request_limit"`
 	JSONRPCBlockRangeLimit   uint64     `json:"json_rpc_block_range_limit" yaml:"json_rpc_block_range_limit"`
+	JSONLogFormat            bool       `json:"json_log_format" yaml:"json_log_format"`
 }
 
 // Telemetry holds the config details for metric services.

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -138,6 +138,10 @@ func (p *serverParams) setRawJSONRPCAddress(jsonRPCAddress string) {
 	p.rawConfig.JSONRPCAddr = jsonRPCAddress
 }
 
+func (p *serverParams) setJSONLogFormat(jsonLogFormat bool) {
+	p.rawConfig.JSONLogFormat = jsonLogFormat
+}
+
 func (p *serverParams) generateConfig() *server.Config {
 	return &server.Config{
 		Chain: p.genesisConfig,
@@ -172,6 +176,7 @@ func (p *serverParams) generateConfig() *server.Config {
 		RestoreFile:        p.getRestoreFilePath(),
 		BlockTime:          p.rawConfig.BlockTime,
 		LogLevel:           hclog.LevelFromString(p.rawConfig.LogLevel),
+		JSONLogFormat:      p.rawConfig.JSONLogFormat,
 		LogFilePath:        p.logFileLocation,
 	}
 }

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -265,6 +265,7 @@ func runPreRun(cmd *cobra.Command, _ []string) error {
 	// The config file will have precedence over --flag
 	params.setRawGRPCAddress(helper.GetGRPCAddress(cmd))
 	params.setRawJSONRPCAddress(helper.GetJSONRPCAddress(cmd))
+	params.setJSONLogFormat(helper.GetJSONLogFormat(cmd))
 
 	// Check if the config file has been specified
 	// Config file settings will override JSON-RPC and GRPC address values

--- a/server/config.go
+++ b/server/config.go
@@ -38,6 +38,8 @@ type Config struct {
 
 	LogLevel hclog.Level
 
+	JSONLogFormat bool
+
 	LogFilePath string
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -90,17 +90,19 @@ func newFileLogger(config *Config) (hclog.Logger, error) {
 	}
 
 	return hclog.New(&hclog.LoggerOptions{
-		Name:   "polygon",
-		Level:  config.LogLevel,
-		Output: logFileWriter,
+		Name:       "polygon",
+		Level:      config.LogLevel,
+		Output:     logFileWriter,
+		JSONFormat: config.JSONLogFormat,
 	}), nil
 }
 
 // newCLILogger returns minimal logger instance that sends all logs to standard output
 func newCLILogger(config *Config) hclog.Logger {
 	return hclog.New(&hclog.LoggerOptions{
-		Name:  "polygon",
-		Level: config.LogLevel,
+		Name:       "polygon",
+		Level:      config.LogLevel,
+		JSONFormat: config.JSONLogFormat,
 	})
 }
 


### PR DESCRIPTION
# Description

This PR extends the `--json` flag behavior to server implemented `hc-log` logger options, allowing the server to respect the flag behavior. 

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [X] I have updated the official documentation
- [X] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [X] I have tested this code manually

### Manual tests
Below are the before/after server command behaviors with the `--json` flag.
#### Prior behavior:
```console
$ polygon-edge server --data-dir data-dir --chain genesis.json --json
2022-10-20T15:38:38.898-0400 [INFO]  polygon: Data dir: path=/home/epik/.pedge/local-networks/solo/
2022-10-20T15:38:38.937-0400 [INFO]  polygon.blockchain: Current header: hash=0xd9bacf8afba0f6ed029f891af1911ad74854c4640261a8e8c4e805be56a0f798 number=2
2022-10-20T15:38:38.937-0400 [INFO]  polygon.blockchain: genesis: hash=0x402249b98a48b2223313e2258cd686e2f9458ef770bbd152b049b8bc2d11554b
2022-10-20T15:38:38.937-0400 [INFO]  polygon.ibft: validator key: addr=0xA4F2cF6871870dE292eaDd6A000c159e521D17F5
2022-10-20T15:38:38.937-0400 [INFO]  polygon: GRPC server running: addr=127.0.0.1:9632
2022-10-20T15:38:38.937-0400 [INFO]  polygon.network: LibP2P server running: addr=/ip4/127.0.0.1/tcp/1478/p2p/16Uiu2HAmLgP3TgUjCqrJwuUKuHL93aB1gPHMz7PNcYyFnWUcTtCn
2022-10-20T15:38:38.937-0400 [INFO]  polygon.network: Omitting bootnode with same ID as host: id=16Uiu2HAmLgP3TgUjCqrJwuUKuHL93aB1gPHMz7PNcYyFnWUcTtCn
2022-10-20T15:38:38.937-0400 [INFO]  polygon.jsonrpc: http server started: addr=0.0.0.0:8545
2022-10-20T15:38:38.937-0400 [INFO]  polygon.ibft.consensus: sequence started: height=3
2022-10-20T15:38:38.937-0400 [INFO]  polygon.ibft.consensus: round started: round=0
2022-10-20T15:38:38.938-0400 [INFO]  polygon.ibft.consensus: we are the proposer
{"message":"\n[SIGNAL] Caught signal: interrupt\nGracefully shutting down client...\n"}
```
#### Corrected Behavior
```console
$ polygon-edge server --data-dir data-dir --chain genesis.json --json
{"@level":"info","@message":"Data dir","@module":"polygon.server","@timestamp":"2022-10-20T15:40:09.728642-04:00","path":"/home/epik/.pedge/local-networks/solo/"}
{"@level":"info","@message":"Current header","@module":"polygon.blockchain","@timestamp":"2022-10-20T15:40:09.781799-04:00","hash":"0xd9bacf8afba0f6ed029f891af1911ad74854c4640261a8e8c4e805be56a0f798","number":2}
{"@level":"info","@message":"genesis","@module":"polygon.blockchain","@timestamp":"2022-10-20T15:40:09.781841-04:00","hash":"0x402249b98a48b2223313e2258cd686e2f9458ef770bbd152b049b8bc2d11554b"}
{"@level":"info","@message":"validator key","@module":"polygon.server.ibft","@timestamp":"2022-10-20T15:40:09.781987-04:00","addr":"0xA4F2cF6871870dE292eaDd6A000c159e521D17F5"}
{"@level":"info","@message":"GRPC server running","@module":"polygon.server","@timestamp":"2022-10-20T15:40:09.782050-04:00","addr":"127.0.0.1:9632"}
{"@level":"info","@message":"LibP2P server running","@module":"polygon.network","@timestamp":"2022-10-20T15:40:09.782066-04:00","addr":"/ip4/127.0.0.1/tcp/1478/p2p/16Uiu2HAmLgP3TgUjCqrJwuUKuHL93aB1gPHMz7PNcYyFnWUcTtCn"}
{"@level":"info","@message":"Omitting bootnode with same ID as host","@module":"polygon.network","@timestamp":"2022-10-20T15:40:09.782105-04:00","id":"16Uiu2HAmLgP3TgUjCqrJwuUKuHL93aB1gPHMz7PNcYyFnWUcTtCn"}
{"@level":"info","@message":"http server started","@module":"polygon.server.jsonrpc","@timestamp":"2022-10-20T15:40:09.782281-04:00","addr":"0.0.0.0:8545"}
{"@level":"info","@message":"sequence started","@module":"polygon.server.ibft.consensus","@timestamp":"2022-10-20T15:40:09.782408-04:00","height":3}
{"@level":"info","@message":"round started","@module":"polygon.server.ibft.consensus","@timestamp":"2022-10-20T15:40:09.782452-04:00","round":0}
{"@level":"info","@message":"we are the proposer","@module":"polygon.server.ibft.consensus","@timestamp":"2022-10-20T15:40:09.782839-04:00"}
{"message":"\n[SIGNAL] Caught signal: interrupt\nGracefully shutting down client...\n"}
```

### Additional Comments
Users that currently have this flag enabled on their `server` command can expect the behavior to work properly after the version upgrade. Existing log processors may need revisiting. 
