### PR TITLE
Adding Snyk code SAST in addition to vulerability test in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,9 @@ jobs:
         uses: snyk/actions/golang@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      - name: Run Snyk SAST to check for code vulnerabilities
+        uses: snyk/actions/golang@master
+        with:
+          command: code test
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,6 @@ jobs:
         uses: snyk/actions/golang@master
         with:
           command: code test
-          args: --org ${{ secrets.SNYK_ORG }}
+          args: --org=${{ secrets.SNYK_ORG }}
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
   snyk-code:
     name: Snyk Code
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
       - name: Run Snyk SAST to check for code vulnerabilities
         uses: snyk/actions/golang@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
         uses: snyk/actions/golang@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+  snyk-code:
+    name: Snyk Code
+    runs-on: ubuntu-latest
       - name: Run Snyk SAST to check for code vulnerabilities
         uses: snyk/actions/golang@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/golang@master
+        with:
+          args: --severity-threshold=high
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/golang@master
         with:
-          args: --severity-threshold=high
+          args: --org ${{ secrets.SNYK_ORG }} --severity-threshold=high
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
@@ -37,5 +37,6 @@ jobs:
         uses: snyk/actions/golang@master
         with:
           command: code test
+          args: --org ${{ secrets.SNYK_ORG }}
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/golang@master
         with:
-          args: --org ${{ secrets.SNYK_ORG }} --severity-threshold=high
+          args: --org=${{ secrets.SNYK_ORG }} --severity-threshold=high
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 

--- a/.github/workflows/deploy.devnet.yml
+++ b/.github/workflows/deploy.devnet.yml
@@ -18,6 +18,7 @@ jobs:
     uses: 0xpolygon/polygon-edge/.github/workflows/security.yml@develop
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      SNYK_ORG: ${{ secrets.SNYK_ORG }}
 
   build:
     name: Build

--- a/.github/workflows/deploy.testnet.yml
+++ b/.github/workflows/deploy.testnet.yml
@@ -17,6 +17,7 @@ jobs:
     uses: 0xpolygon/polygon-edge/.github/workflows/security.yml@develop
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      SNYK_ORG: ${{ secrets.SNYK_ORG }}
 
   build:
     uses: 0xpolygon/polygon-edge/.github/workflows/build.yml@develop

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,7 +28,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: snyk.sarif
-  snyk:
+  snyk-code:
     name: Snyk Code and Publish
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,3 +28,22 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: snyk.sarif
+  snyk:
+    name: Snyk Code and Publish
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@master
+      - name: Run Snyk SAST to check for vulnerabilities
+        uses: snyk/actions/golang@master
+        continue-on-error: true
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --sarif-file-output=snyk.sarif
+          command: code test
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: snyk.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,6 +5,8 @@ on:  # yamllint disable-line rule:truthy
     secrets:
       SNYK_TOKEN:
         required: true
+      SNYK_ORG:
+        required: true
   workflow_dispatch: {}
   schedule:
     - cron: '0 0 * * 0'
@@ -23,7 +25,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --org ${{ secrets.SNYK_ORG }} --sarif-file-output=snyk.sarif
+          args: --org=${{ secrets.SNYK_ORG }} --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v2
         with:
@@ -41,7 +43,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --org ${{ secrets.SNYK_ORG }} --sarif-file-output=snyk.sarif
+          args: --org=${{ secrets.SNYK_ORG }} --sarif-file-output=snyk.sarif
           command: code test
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --sarif-file-output=snyk.sarif
+          args: --org ${{ secrets.SNYK_ORG }} --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v2
         with:
@@ -41,7 +41,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --sarif-file-output=snyk.sarif
+          args: --org ${{ secrets.SNYK_ORG }} --sarif-file-output=snyk.sarif
           command: code test
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
# Description
- Adding `snyk code test` in addition to the default `snyk test` to run SAST in our workflows.
- Setting the severity threshold for workflow failure for Snyk license scans to high.
- Set Snyk org in related workflows.