### PR TITLE
Add read abstraction to the State

### DIFF
--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -460,6 +460,11 @@ func NewTestServers(t *testing.T, num int, conf func(*TestServerConfig)) []*Test
 		}
 	})
 
+	logsDir, err := initLogsDir(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// It is safe to use a dummy MultiAddr here, since this init method
 	// is called for the Dev consensus mode, and IBFT servers are initialized with NewIBFTServersManager.
 	// This method needs to be standardized in the future
@@ -471,7 +476,11 @@ func NewTestServers(t *testing.T, num int, conf func(*TestServerConfig)) []*Test
 			t.Fatal(err)
 		}
 
-		srv := NewTestServer(t, dataDir, conf)
+		srv := NewTestServer(t, dataDir, func(c *TestServerConfig) {
+			c.SetLogsDir(logsDir)
+			c.SetSaveLogs(true)
+			conf(c)
+		})
 		srv.Config.SetBootnodes(bootnodes)
 
 		srvs = append(srvs, srv)

--- a/helper/predeployment/predeployment.go
+++ b/helper/predeployment/predeployment.go
@@ -141,7 +141,7 @@ func getPredeployAccount(address types.Address, input, deployedBytecode []byte) 
 	config := chain.AllForksEnabled.At(0)
 
 	// Create a transition
-	transition := state.NewTransition(config, radix)
+	transition := state.NewTransition(config, snapshot, radix)
 
 	// Run the transition through the EVM
 	res := evm.NewEVM().Run(contract, transition, &config)

--- a/helper/predeployment/predeployment.go
+++ b/helper/predeployment/predeployment.go
@@ -124,7 +124,7 @@ func getPredeployAccount(address types.Address, input, deployedBytecode []byte) 
 	snapshot := st.NewSnapshot()
 
 	// Create a radix
-	radix := state.NewTxn(st, snapshot)
+	radix := state.NewTxn(snapshot)
 
 	// Create the contract object for the EVM
 	contract := runtime.NewContractCreation(

--- a/server/server.go
+++ b/server/server.go
@@ -303,10 +303,12 @@ func (t *txpoolHub) GetNonce(root types.Hash, addr types.Address) uint64 {
 	if err != nil {
 		return 0
 	}
+
 	account, err := snap.GetAccount(addr)
 	if err != nil {
 		return 0
 	}
+
 	return account.Nonce
 }
 
@@ -315,10 +317,12 @@ func (t *txpoolHub) GetBalance(root types.Hash, addr types.Address) (*big.Int, e
 	if err != nil {
 		return nil, fmt.Errorf("unable to get snapshot for root, %w", err)
 	}
+
 	account, err := snap.GetAccount(addr)
 	if err != nil {
 		return big.NewInt(0), nil
 	}
+
 	return account.Balance, nil
 }
 
@@ -432,10 +436,12 @@ func (j *jsonRPCHub) GetAccount(root types.Hash, addr types.Address) (*state.Acc
 	if err != nil {
 		return nil, err
 	}
+
 	account, err := snap.GetAccount(addr)
 	if err != nil {
 		return nil, err
 	}
+
 	return account, nil
 }
 
@@ -449,7 +455,9 @@ func (j *jsonRPCHub) GetStorage(root types.Hash, addr types.Address, slot types.
 	if err != nil {
 		return nil, err
 	}
+
 	res := snap.GetStorage(addr, root, slot)
+
 	return res.Bytes(), nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -431,7 +431,13 @@ func (j *jsonRPCHub) GetPeers() int {
 	return len(j.Server.Peers())
 }
 
+// GetForksInTime returns the active forks at the given block height
+func (j *jsonRPCHub) GetForksInTime(blockNumber uint64) chain.ForksInTime {
+	return j.Executor.GetForksInTime(blockNumber)
+}
+
 func (j *jsonRPCHub) GetAccount(root types.Hash, addr types.Address) (*state.Account, error) {
+	fmt.Println("get account", root, addr, j.state)
 	snap, err := j.state.NewSnapshotAt(root)
 	if err != nil {
 		return nil, err
@@ -442,15 +448,15 @@ func (j *jsonRPCHub) GetAccount(root types.Hash, addr types.Address) (*state.Acc
 		return nil, err
 	}
 
+	if account == nil {
+		return nil, jsonrpc.ErrStateNotFound
+	}
+
 	return account, nil
 }
 
-// GetForksInTime returns the active forks at the given block height
-func (j *jsonRPCHub) GetForksInTime(blockNumber uint64) chain.ForksInTime {
-	return j.Executor.GetForksInTime(blockNumber)
-}
-
 func (j *jsonRPCHub) GetStorage(root types.Hash, addr types.Address, slot types.Hash) ([]byte, error) {
+	fmt.Println("get storage", root, addr, j.state)
 	snap, err := j.state.NewSnapshotAt(root)
 	if err != nil {
 		return nil, err
@@ -463,7 +469,6 @@ func (j *jsonRPCHub) GetStorage(root types.Hash, addr types.Address, slot types.
 
 func (j *jsonRPCHub) GetCode(hash types.Hash) ([]byte, error) {
 	res, ok := j.state.GetCode(hash)
-
 	if !ok {
 		return nil, fmt.Errorf("unable to fetch code")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -437,7 +437,6 @@ func (j *jsonRPCHub) GetForksInTime(blockNumber uint64) chain.ForksInTime {
 }
 
 func (j *jsonRPCHub) GetAccount(root types.Hash, addr types.Address) (*state.Account, error) {
-	fmt.Println("get account", root, addr, j.state)
 	snap, err := j.state.NewSnapshotAt(root)
 	if err != nil {
 		return nil, err
@@ -456,7 +455,6 @@ func (j *jsonRPCHub) GetAccount(root types.Hash, addr types.Address) (*state.Acc
 }
 
 func (j *jsonRPCHub) GetStorage(root types.Hash, addr types.Address, slot types.Hash) ([]byte, error) {
-	fmt.Println("get storage", root, addr, j.state)
 	snap, err := j.state.NewSnapshotAt(root)
 	if err != nil {
 		return nil, err

--- a/server/server.go
+++ b/server/server.go
@@ -320,7 +320,7 @@ func (t *txpoolHub) GetBalance(root types.Hash, addr types.Address) (*big.Int, e
 
 	account, err := snap.GetAccount(addr)
 	if err != nil {
-		return big.NewInt(0), nil
+		return big.NewInt(0), err
 	}
 
 	return account.Balance, nil

--- a/server/server.go
+++ b/server/server.go
@@ -18,7 +18,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	configHelper "github.com/0xPolygon/polygon-edge/helper/config"
-	"github.com/0xPolygon/polygon-edge/helper/keccak"
 	"github.com/0xPolygon/polygon-edge/helper/progress"
 	"github.com/0xPolygon/polygon-edge/jsonrpc"
 	"github.com/0xPolygon/polygon-edge/network"
@@ -299,22 +298,15 @@ type txpoolHub struct {
 }
 
 func (t *txpoolHub) GetNonce(root types.Hash, addr types.Address) uint64 {
+	// TODO: Use a function that returns only Account
 	snap, err := t.state.NewSnapshotAt(root)
 	if err != nil {
 		return 0
 	}
-
-	result, ok := snap.Get(keccak.Keccak256(nil, addr.Bytes()))
-	if !ok {
+	account, err := snap.GetAccount(addr)
+	if err != nil {
 		return 0
 	}
-
-	var account state.Account
-
-	if err := account.UnmarshalRlp(result); err != nil {
-		return 0
-	}
-
 	return account.Nonce
 }
 
@@ -323,17 +315,10 @@ func (t *txpoolHub) GetBalance(root types.Hash, addr types.Address) (*big.Int, e
 	if err != nil {
 		return nil, fmt.Errorf("unable to get snapshot for root, %w", err)
 	}
-
-	result, ok := snap.Get(keccak.Keccak256(nil, addr.Bytes()))
-	if !ok {
+	account, err := snap.GetAccount(addr)
+	if err != nil {
 		return big.NewInt(0), nil
 	}
-
-	var account state.Account
-	if err = account.UnmarshalRlp(result); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal account from snapshot, %w", err)
-	}
-
 	return account.Balance, nil
 }
 
@@ -442,36 +427,16 @@ func (j *jsonRPCHub) GetPeers() int {
 	return len(j.Server.Peers())
 }
 
-func (j *jsonRPCHub) getState(root types.Hash, slot []byte) ([]byte, error) {
-	// the values in the trie are the hashed objects of the keys
-	key := keccak.Keccak256(nil, slot)
-
+func (j *jsonRPCHub) GetAccount(root types.Hash, addr types.Address) (*state.Account, error) {
 	snap, err := j.state.NewSnapshotAt(root)
 	if err != nil {
 		return nil, err
 	}
-
-	result, ok := snap.Get(key)
-
-	if !ok {
-		return nil, jsonrpc.ErrStateNotFound
-	}
-
-	return result, nil
-}
-
-func (j *jsonRPCHub) GetAccount(root types.Hash, addr types.Address) (*state.Account, error) {
-	obj, err := j.getState(root, addr.Bytes())
+	account, err := snap.GetAccount(addr)
 	if err != nil {
 		return nil, err
 	}
-
-	var account state.Account
-	if err := account.UnmarshalRlp(obj); err != nil {
-		return nil, err
-	}
-
-	return &account, nil
+	return account, nil
 }
 
 // GetForksInTime returns the active forks at the given block height
@@ -480,19 +445,12 @@ func (j *jsonRPCHub) GetForksInTime(blockNumber uint64) chain.ForksInTime {
 }
 
 func (j *jsonRPCHub) GetStorage(root types.Hash, addr types.Address, slot types.Hash) ([]byte, error) {
-	account, err := j.GetAccount(root, addr)
-
+	snap, err := j.state.NewSnapshotAt(root)
 	if err != nil {
 		return nil, err
 	}
-
-	obj, err := j.getState(account.Root, slot.Bytes())
-
-	if err != nil {
-		return nil, err
-	}
-
-	return obj, nil
+	res := snap.GetStorage(addr, root, slot)
+	return res.Bytes(), nil
 }
 
 func (j *jsonRPCHub) GetCode(hash types.Hash) ([]byte, error) {

--- a/state/executor.go
+++ b/state/executor.go
@@ -198,6 +198,7 @@ func NewTransition(config chain.ForksInTime, snap Snapshot, radix *Txn) *Transit
 	return &Transition{
 		config:      config,
 		state:       radix,
+		snap:        snap,
 		evm:         evm.NewEVM(),
 		precompiles: precompiled.NewPrecompiled(),
 	}

--- a/state/executor.go
+++ b/state/executor.go
@@ -51,7 +51,7 @@ func NewExecutor(config *chain.Params, s State, logger hclog.Logger) *Executor {
 
 func (e *Executor) WriteGenesis(alloc map[types.Address]*chain.GenesisAccount) types.Hash {
 	snap := e.state.NewSnapshot()
-	txn := NewTxn(e.state, snap)
+	txn := NewTxn(snap)
 
 	for addr, account := range alloc {
 		if account.Balance != nil {
@@ -138,7 +138,7 @@ func (e *Executor) BeginTxn(
 		return nil, err
 	}
 
-	newTxn := NewTxn(e.state, auxSnap2)
+	newTxn := NewTxn(auxSnap2)
 
 	env2 := runtime.TxContext{
 		Coinbase:   coinbaseReceiver,
@@ -153,6 +153,7 @@ func (e *Executor) BeginTxn(
 		logger:   e.logger,
 		ctx:      env2,
 		state:    newTxn,
+		snap:     auxSnap2,
 		getHash:  e.GetHash(header),
 		auxState: e.state,
 		config:   config,
@@ -174,6 +175,7 @@ type Transition struct {
 
 	// dummy
 	auxState State
+	snap     Snapshot
 
 	config  chain.ForksInTime
 	state   *Txn
@@ -268,29 +270,19 @@ func (t *Transition) Write(txn *types.Transaction) error {
 
 	logs := t.state.Logs()
 
-	var root []byte
-
 	receipt := &types.Receipt{
 		CumulativeGasUsed: t.totalGas,
 		TxHash:            txn.Hash,
 		GasUsed:           result.GasUsed,
 	}
 
-	if t.config.Byzantium {
-		// The suicided accounts are set as deleted for the next iteration
-		t.state.CleanDeleteObjects(true)
+	// The suicided accounts are set as deleted for the next iteration
+	t.state.CleanDeleteObjects(true)
 
-		if result.Failed() {
-			receipt.SetStatus(types.ReceiptFailed)
-		} else {
-			receipt.SetStatus(types.ReceiptSuccess)
-		}
+	if result.Failed() {
+		receipt.SetStatus(types.ReceiptFailed)
 	} else {
-		objs := t.state.Commit(t.config.EIP155)
-		ss, aux := t.state.snapshot.Commit(objs)
-		t.state = NewTxn(t.auxState, ss)
-		root = aux
-		receipt.Root = types.BytesToHash(root)
+		receipt.SetStatus(types.ReceiptSuccess)
 	}
 
 	// if the transaction created a contract, store the creation address in the receipt.
@@ -309,7 +301,7 @@ func (t *Transition) Write(txn *types.Transaction) error {
 // Commit commits the final result
 func (t *Transition) Commit() (Snapshot, types.Hash) {
 	objs := t.state.Commit(t.config.EIP155)
-	s2, root := t.state.snapshot.Commit(objs)
+	s2, root := t.snap.Commit(objs)
 
 	return s2, types.BytesToHash(root)
 }
@@ -326,10 +318,6 @@ func (t *Transition) subGasPool(amount uint64) error {
 
 func (t *Transition) addGasPool(amount uint64) {
 	t.gasPool += amount
-}
-
-func (t *Transition) SetTxn(txn *Txn) {
-	t.state = txn
 }
 
 func (t *Transition) Txn() *Txn {

--- a/state/executor.go
+++ b/state/executor.go
@@ -194,7 +194,7 @@ type Transition struct {
 	precompiles *precompiled.Precompiled
 }
 
-func NewTransition(config chain.ForksInTime, radix *Txn) *Transition {
+func NewTransition(config chain.ForksInTime, snap Snapshot, radix *Txn) *Transition {
 	return &Transition{
 		config:      config,
 		state:       radix,

--- a/state/immutable-trie/snapshot.go
+++ b/state/immutable-trie/snapshot.go
@@ -1,0 +1,73 @@
+package itrie
+
+import (
+	"github.com/0xPolygon/polygon-edge/crypto"
+	"github.com/0xPolygon/polygon-edge/state"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/umbracle/fastrlp"
+)
+
+type Snapshot struct {
+	state *State
+	trie  *Trie
+}
+
+var emptyStateHash = types.StringToHash("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+
+func (s *Snapshot) GetStorage(addr types.Address, root types.Hash, rawkey types.Hash) types.Hash {
+	var err error
+	var trie *Trie
+
+	if root == emptyStateHash {
+		trie = s.state.newTrie()
+	} else {
+		trie, err = s.state.newTrieAt(root)
+		if err != nil {
+			return types.Hash{}
+		}
+	}
+
+	key := crypto.Keccak256(rawkey.Bytes())
+
+	val, ok := trie.Get(key)
+	if !ok {
+		return types.Hash{}
+	}
+
+	p := &fastrlp.Parser{}
+	v, err := p.Parse(val)
+	if err != nil {
+		return types.Hash{}
+	}
+
+	res := []byte{}
+	if res, err = v.GetBytes(res[:0]); err != nil {
+		return types.Hash{}
+	}
+
+	return types.BytesToHash(res)
+}
+
+func (s *Snapshot) GetAccount(addr types.Address) (*state.Account, error) {
+	key := crypto.Keccak256(addr.Bytes())
+
+	data, ok := s.trie.Get(key)
+	if !ok {
+		return nil, nil
+	}
+	var account state.Account
+	if err := account.UnmarshalRlp(data); err != nil {
+		return nil, err
+	}
+	return &account, nil
+}
+
+func (s *Snapshot) Commit(objs []*state.Object) (state.Snapshot, []byte) {
+	trie, root := s.trie.Commit(objs)
+
+	return &Snapshot{trie: trie, state: s.state}, root
+}
+
+func (s *Snapshot) GetCode(hash types.Hash) ([]byte, bool) {
+	return s.state.GetCode(hash)
+}

--- a/state/immutable-trie/snapshot.go
+++ b/state/immutable-trie/snapshot.go
@@ -15,8 +15,10 @@ type Snapshot struct {
 var emptyStateHash = types.StringToHash("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
 
 func (s *Snapshot) GetStorage(addr types.Address, root types.Hash, rawkey types.Hash) types.Hash {
-	var err error
-	var trie *Trie
+	var (
+		err  error
+		trie *Trie
+	)
 
 	if root == emptyStateHash {
 		trie = s.state.newTrie()
@@ -35,6 +37,7 @@ func (s *Snapshot) GetStorage(addr types.Address, root types.Hash, rawkey types.
 	}
 
 	p := &fastrlp.Parser{}
+
 	v, err := p.Parse(val)
 	if err != nil {
 		return types.Hash{}
@@ -55,10 +58,12 @@ func (s *Snapshot) GetAccount(addr types.Address) (*state.Account, error) {
 	if !ok {
 		return nil, nil
 	}
+
 	var account state.Account
 	if err := account.UnmarshalRlp(data); err != nil {
 		return nil, err
 	}
+
 	return &account, nil
 }
 

--- a/state/immutable-trie/snapshot.go
+++ b/state/immutable-trie/snapshot.go
@@ -67,12 +67,12 @@ func (s *Snapshot) GetAccount(addr types.Address) (*state.Account, error) {
 	return &account, nil
 }
 
+func (s *Snapshot) GetCode(hash types.Hash) ([]byte, bool) {
+	return s.state.GetCode(hash)
+}
+
 func (s *Snapshot) Commit(objs []*state.Object) (state.Snapshot, []byte) {
 	trie, root := s.trie.Commit(objs)
 
 	return &Snapshot{trie: trie, state: s.state}, root
-}
-
-func (s *Snapshot) GetCode(hash types.Hash) ([]byte, bool) {
-	return s.state.GetCode(hash)
 }

--- a/state/immutable-trie/state.go
+++ b/state/immutable-trie/state.go
@@ -28,6 +28,7 @@ func NewState(storage Storage) *State {
 
 func (s *State) NewSnapshot() state.Snapshot {
 	t := s.newTrie()
+
 	return &Snapshot{state: s, trie: t}
 }
 
@@ -36,6 +37,7 @@ func (s *State) NewSnapshotAt(root types.Hash) (state.Snapshot, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &Snapshot{state: s, trie: t}, nil
 }
 

--- a/state/immutable-trie/state.go
+++ b/state/immutable-trie/state.go
@@ -27,6 +27,19 @@ func NewState(storage Storage) *State {
 }
 
 func (s *State) NewSnapshot() state.Snapshot {
+	t := s.newTrie()
+	return &Snapshot{state: s, trie: t}
+}
+
+func (s *State) NewSnapshotAt(root types.Hash) (state.Snapshot, error) {
+	t, err := s.newTrieAt(root)
+	if err != nil {
+		return nil, err
+	}
+	return &Snapshot{state: s, trie: t}, nil
+}
+
+func (s *State) newTrie() *Trie {
 	t := NewTrie()
 	t.state = s
 	t.storage = s.storage
@@ -42,10 +55,10 @@ func (s *State) GetCode(hash types.Hash) ([]byte, bool) {
 	return s.storage.GetCode(hash)
 }
 
-func (s *State) NewSnapshotAt(root types.Hash) (state.Snapshot, error) {
+func (s *State) newTrieAt(root types.Hash) (*Trie, error) {
 	if root == types.EmptyRootHash {
 		// empty state
-		return s.NewSnapshot(), nil
+		return s.newTrie(), nil
 	}
 
 	tt, ok := s.cache.Get(root)

--- a/state/immutable-trie/state.go
+++ b/state/immutable-trie/state.go
@@ -1,7 +1,6 @@
 package itrie
 
 import (
-	"errors"
 	"fmt"
 
 	lru "github.com/hashicorp/golang-lru"
@@ -65,23 +64,22 @@ func (s *State) newTrieAt(root types.Hash) (*Trie, error) {
 	if ok {
 		t, ok := tt.(*Trie)
 		if !ok {
-			return nil, errors.New("invalid type assertion")
+			return nil, fmt.Errorf("invalid type assertion on root: %s", root)
 		}
 
 		t.state = s
 
 		trie, ok := tt.(*Trie)
 		if !ok {
-			return nil, errors.New("invalid type assertion")
+			return nil, fmt.Errorf("invalid type assertion on root: %s", root)
 		}
 
 		return trie, nil
 	}
 
 	n, ok, err := GetNode(root.Bytes(), s.storage)
-
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get storage root %s: %w", root, err)
 	}
 
 	if !ok {

--- a/state/immutable-trie/state.go
+++ b/state/immutable-trie/state.go
@@ -27,9 +27,7 @@ func NewState(storage Storage) *State {
 }
 
 func (s *State) NewSnapshot() state.Snapshot {
-	t := s.newTrie()
-
-	return &Snapshot{state: s, trie: t}
+	return &Snapshot{state: s, trie: s.newTrie()}
 }
 
 func (s *State) NewSnapshotAt(root types.Hash) (state.Snapshot, error) {

--- a/state/immutable-trie/state_test.go
+++ b/state/immutable-trie/state_test.go
@@ -10,10 +10,10 @@ func TestState(t *testing.T) {
 	state.TestState(t, buildPreState)
 }
 
-func buildPreState(pre state.PreStates) (state.State, state.Snapshot) {
+func buildPreState(pre state.PreStates) state.Snapshot {
 	storage := NewMemoryStorage()
 	st := NewState(storage)
 	snap := st.NewSnapshot()
 
-	return st, snap
+	return snap
 }

--- a/state/immutable-trie/trie.go
+++ b/state/immutable-trie/trie.go
@@ -118,7 +118,7 @@ var accountArenaPool fastrlp.ArenaPool
 
 var stateArenaPool fastrlp.ArenaPool // TODO, Remove once we do update in fastrlp
 
-func (t *Trie) Commit(objs []*state.Object) (state.Snapshot, []byte) {
+func (t *Trie) Commit(objs []*state.Object) (*Trie, []byte) {
 	// Create an insertion batch for all the entries
 	batch := t.storage.Batch()
 
@@ -143,14 +143,9 @@ func (t *Trie) Commit(objs []*state.Object) (state.Snapshot, []byte) {
 			}
 
 			if len(obj.Storage) != 0 {
-				localSnapshot, err := t.state.NewSnapshotAt(obj.Root)
+				trie, err := t.state.newTrieAt(obj.Root)
 				if err != nil {
 					panic(err)
-				}
-
-				trie, ok := localSnapshot.(*Trie)
-				if !ok {
-					panic("invalid type assertion")
 				}
 
 				localTxn := trie.Txn()

--- a/state/txn.go
+++ b/state/txn.go
@@ -107,9 +107,11 @@ func (txn *Txn) getStateObject(addr types.Address) (*StateObject, bool) {
 	if account == nil {
 		return nil, false
 	}
+
 	obj := &StateObject{
 		Account: account.Copy(),
 	}
+
 	return obj, true
 }
 

--- a/state/txn.go
+++ b/state/txn.go
@@ -103,6 +103,7 @@ func (txn *Txn) getStateObject(addr types.Address) (*StateObject, bool) {
 	if err != nil {
 		return nil, false
 	}
+
 	if account == nil {
 		return nil, false
 	}
@@ -476,6 +477,7 @@ func (txn *Txn) GetCommittedState(addr types.Address, key types.Hash) types.Hash
 	if !ok {
 		return types.Hash{}
 	}
+
 	return txn.snapshot.GetStorage(addr, obj.Account.Root, key)
 }
 

--- a/state/txn.go
+++ b/state/txn.go
@@ -8,12 +8,17 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/crypto"
-	"github.com/0xPolygon/polygon-edge/helper/keccak"
 	"github.com/0xPolygon/polygon-edge/state/runtime"
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
 var emptyStateHash = types.StringToHash("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+
+type readSnapshot interface {
+	GetStorage(addr types.Address, root types.Hash, key types.Hash) types.Hash
+	GetAccount(addr types.Address) (*Account, error)
+	GetCode(hash types.Hash) ([]byte, bool)
+}
 
 var (
 	// logIndex is the index of the logs in the trie
@@ -25,43 +30,31 @@ var (
 
 // Txn is a reference of the state
 type Txn struct {
-	snapshot  Snapshot
-	state     State
+	snapshot  readSnapshot
 	snapshots []*iradix.Tree
 	txn       *iradix.Txn
 	codeCache *lru.Cache
-	hash      *keccak.Keccak
 }
 
-func NewTxn(state State, snapshot Snapshot) *Txn {
-	return newTxn(state, snapshot)
+func NewTxn(snapshot Snapshot) *Txn {
+	return newTxn(snapshot)
 }
 
 func (txn *Txn) GetRadix() *iradix.Txn {
 	return txn.txn
 }
 
-func newTxn(state State, snapshot Snapshot) *Txn {
+func newTxn(snapshot readSnapshot) *Txn {
 	i := iradix.New()
 
 	codeCache, _ := lru.New(20)
 
 	return &Txn{
 		snapshot:  snapshot,
-		state:     state,
 		snapshots: []*iradix.Tree{},
 		txn:       i.Txn(),
 		codeCache: codeCache,
-		hash:      keccak.NewKeccak256(),
 	}
-}
-
-func (txn *Txn) hashit(src []byte) []byte {
-	txn.hash.Reset()
-	txn.hash.Write(src)
-	// hashit is used to make queries so we do not need to
-	// make copies of the result
-	return txn.hash.Read()
 }
 
 // Snapshot takes a snapshot at this point in time
@@ -106,32 +99,16 @@ func (txn *Txn) getStateObject(addr types.Address) (*StateObject, bool) {
 		return obj.Copy(), true
 	}
 
-	data, ok := txn.snapshot.Get(txn.hashit(addr.Bytes()))
-	if !ok {
+	account, err := txn.snapshot.GetAccount(addr)
+	if err != nil {
 		return nil, false
 	}
-
-	var err error
-
-	var account Account
-	if err = account.UnmarshalRlp(data); err != nil {
+	if account == nil {
 		return nil, false
 	}
-
-	// Load trie from memory if there is some state
-	if account.Root == emptyStateHash {
-		account.Trie = txn.state.NewSnapshot()
-	} else {
-		account.Trie, err = txn.state.NewSnapshotAt(account.Root)
-		if err != nil {
-			return nil, false
-		}
-	}
-
 	obj := &StateObject{
 		Account: account.Copy(),
 	}
-
 	return obj, true
 }
 
@@ -141,7 +118,6 @@ func (txn *Txn) upsertAccount(addr types.Address, create bool, f func(object *St
 		object = &StateObject{
 			Account: &Account{
 				Balance:  big.NewInt(0),
-				Trie:     txn.state.NewSnapshot(),
 				CodeHash: emptyCodeHash,
 				Root:     emptyStateHash,
 			},
@@ -360,10 +336,7 @@ func (txn *Txn) GetState(addr types.Address, key types.Hash) types.Hash {
 		}
 	}
 
-	// If the object was not found in the radix trie due to no state update, we fetch it from the trie tre
-	k := txn.hashit(key.Bytes())
-
-	return object.GetCommitedState(types.BytesToHash(k))
+	return txn.snapshot.GetStorage(addr, object.Account.Root, key)
 }
 
 // Nonce
@@ -420,7 +393,7 @@ func (txn *Txn) GetCode(addr types.Address) []byte {
 		return v.([]byte)
 	}
 
-	code, _ := txn.state.GetCode(types.BytesToHash(object.Account.CodeHash))
+	code, _ := txn.snapshot.GetCode(types.BytesToHash(object.Account.CodeHash))
 	txn.codeCache.Add(addr, code)
 
 	return code
@@ -503,8 +476,7 @@ func (txn *Txn) GetCommittedState(addr types.Address, key types.Hash) types.Hash
 	if !ok {
 		return types.Hash{}
 	}
-
-	return obj.GetCommitedState(types.BytesToHash(txn.hashit(key.Bytes())))
+	return txn.snapshot.GetStorage(addr, obj.Account.Root, key)
 }
 
 func (txn *Txn) TouchAccount(addr types.Address) {
@@ -534,7 +506,6 @@ func newStateObject(txn *Txn) *StateObject {
 	return &StateObject{
 		Account: &Account{
 			Balance:  big.NewInt(0),
-			Trie:     txn.state.NewSnapshot(),
 			CodeHash: emptyCodeHash,
 			Root:     emptyStateHash,
 		},
@@ -545,7 +516,6 @@ func (txn *Txn) CreateAccount(addr types.Address) {
 	obj := &StateObject{
 		Account: &Account{
 			Balance:  big.NewInt(0),
-			Trie:     txn.state.NewSnapshot(),
 			CodeHash: emptyCodeHash,
 			Root:     emptyStateHash,
 		},

--- a/state/txn_test.go
+++ b/state/txn_test.go
@@ -18,10 +18,12 @@ func (m *mockSnapshot) GetStorage(addr types.Address, root types.Hash, key types
 	if !ok {
 		return types.Hash{}
 	}
+
 	res, ok := raw.State[key]
 	if !ok {
 		return types.Hash{}
 	}
+
 	return res
 }
 
@@ -30,10 +32,12 @@ func (m *mockSnapshot) GetAccount(addr types.Address) (*Account, error) {
 	if !ok {
 		return nil, fmt.Errorf("account not found")
 	}
+
 	acct := &Account{
 		Balance: new(big.Int).SetUint64(raw.Balance),
 		Nonce:   raw.Nonce,
 	}
+
 	return acct, nil
 }
 

--- a/state/txn_test.go
+++ b/state/txn_test.go
@@ -1,128 +1,52 @@
 package state
 
 import (
-	"bytes"
-	"crypto/rand"
 	"fmt"
 	"math/big"
 	"testing"
 
-	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/assert"
-	"github.com/umbracle/fastrlp"
-	"golang.org/x/crypto/sha3"
 )
 
-type mockState struct {
-	snapshots map[types.Hash]Snapshot
-}
-
-func (m *mockState) NewSnapshotAt(root types.Hash) (Snapshot, error) {
-	t, ok := m.snapshots[root]
-	if !ok {
-		return nil, fmt.Errorf("not found")
-	}
-
-	return t, nil
-}
-
-func (m *mockState) NewSnapshot() Snapshot {
-	return &mockSnapshot{data: map[string][]byte{}}
-}
-
-func (m *mockState) GetCode(hash types.Hash) ([]byte, bool) {
-	panic("Not implemented in tests")
-}
-
 type mockSnapshot struct {
-	data map[string][]byte
+	state map[types.Address]*PreState
 }
 
-func (m *mockSnapshot) Get(k []byte) ([]byte, bool) {
-	v, ok := m.data[hex.EncodeToHex(k)]
-
-	return v, ok
+func (m *mockSnapshot) GetStorage(addr types.Address, root types.Hash, key types.Hash) types.Hash {
+	raw, ok := m.state[addr]
+	if !ok {
+		return types.Hash{}
+	}
+	res, ok := raw.State[key]
+	if !ok {
+		return types.Hash{}
+	}
+	return res
 }
 
-func (m *mockSnapshot) Commit(objs []*Object) (Snapshot, []byte) {
-	panic("Not implemented in tests")
+func (m *mockSnapshot) GetAccount(addr types.Address) (*Account, error) {
+	raw, ok := m.state[addr]
+	if !ok {
+		return nil, fmt.Errorf("account not found")
+	}
+	acct := &Account{
+		Balance: new(big.Int).SetUint64(raw.Balance),
+		Nonce:   raw.Nonce,
+	}
+	return acct, nil
 }
 
-func newStateWithPreState(preState map[types.Address]*PreState) (*mockState, *mockSnapshot) {
-	state := &mockState{
-		snapshots: map[types.Hash]Snapshot{},
-	}
-	snapshot := &mockSnapshot{
-		data: map[string][]byte{},
-	}
+func (m *mockSnapshot) GetCode(hash types.Hash) ([]byte, bool) {
+	return nil, false
+}
 
-	ar := &fastrlp.Arena{}
-
-	for addr, p := range preState {
-		account, snap := buildMockPreState(p)
-		if snap != nil {
-			state.snapshots[account.Root] = snap
-		}
-
-		v := account.MarshalWith(ar)
-		accountRlp := v.MarshalTo(nil)
-		/*
-			accountRlp, err := rlp.EncodeToBytes(account)
-			if err != nil {
-				panic(err)
-			}
-		*/
-		snapshot.data[hex.EncodeToHex(hashit(addr.Bytes()))] = accountRlp
-	}
-
-	return state, snapshot
+func newStateWithPreState(preState map[types.Address]*PreState) readSnapshot {
+	return &mockSnapshot{state: preState}
 }
 
 func newTestTxn(p map[types.Address]*PreState) *Txn {
 	return newTxn(newStateWithPreState(p))
-}
-
-func buildMockPreState(p *PreState) (*Account, *mockSnapshot) {
-	var snap *mockSnapshot
-
-	root := emptyStateHash
-
-	ar := &fastrlp.Arena{}
-
-	if p.State != nil {
-		data := map[string][]byte{}
-
-		for k, v := range p.State {
-			vv := ar.NewBytes(bytes.TrimLeft(v.Bytes(), "\x00"))
-			data[k.String()] = vv.MarshalTo(nil)
-		}
-
-		root = randomHash()
-		snap = &mockSnapshot{
-			data: data,
-		}
-	}
-
-	account := &Account{
-		Nonce:   p.Nonce,
-		Balance: big.NewInt(int64(p.Balance)),
-		Root:    root,
-	}
-
-	return account, snap
-}
-
-const letterBytes = "0123456789ABCDEF"
-
-func randomHash() types.Hash {
-	b := make([]byte, types.HashLength)
-	for i := range b {
-		randNum, _ := rand.Int(rand.Reader, big.NewInt(int64(len(letterBytes))))
-		b[i] = letterBytes[randNum.Int64()]
-	}
-
-	return types.BytesToHash(b)
 }
 
 func TestSnapshotUpdateData(t *testing.T) {
@@ -137,11 +61,4 @@ func TestSnapshotUpdateData(t *testing.T) {
 
 	txn.RevertToSnapshot(ss)
 	assert.Equal(t, hash1, txn.GetState(addr1, hash1))
-}
-
-func hashit(k []byte) []byte {
-	h := sha3.NewLegacyKeccak256()
-	h.Write(k)
-
-	return h.Sum(nil)
 }

--- a/tests/testing.go
+++ b/tests/testing.go
@@ -228,7 +228,7 @@ func buildState(
 	s := itrie.NewState(itrie.NewMemoryStorage())
 	snap := s.NewSnapshot()
 
-	txn := state.NewTxn(s, snap)
+	txn := state.NewTxn(snap)
 
 	for addr, alloc := range allocs {
 		txn.CreateAccount(addr)


### PR DESCRIPTION
# Description

This PR is a follow-up for #753. It adds a new abstraction for the `State` such that instead of having access to a low-level interface with a method `Get` to query for account and storage, now, we get a much richer abstraction with two methods:
```
GetAccount() *Account
GetStorage(...) Hash
```
There are two benefits of this new data layer. First, the layers that want to access the state do not have to perform extra computation on top of the raw result of `Get` to parse the objects. Second, it gives more flexibility to the state storage to decide how it wants to store information and not force it to adapt to the `Get` interface (i.e Erigon).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
