### PR TITLE
Remove storage snapshot functions

### DIFF
--- a/blockchain/storage/keyvalue.go
+++ b/blockchain/storage/keyvalue.go
@@ -221,23 +221,6 @@ func (s *KeyValueStorage) ReadBody(hash types.Hash) (*types.Body, error) {
 	return body, err
 }
 
-// SNAPSHOTS //
-
-// WriteSnapshot writes the snapshot to the DB
-func (s *KeyValueStorage) WriteSnapshot(hash types.Hash, blob []byte) error {
-	return s.set(SNAPSHOTS, hash.Bytes(), blob)
-}
-
-// ReadSnapshot reads the snapshot from the DB
-func (s *KeyValueStorage) ReadSnapshot(hash types.Hash) ([]byte, bool) {
-	data, ok := s.get(SNAPSHOTS, hash.Bytes())
-	if !ok {
-		return []byte{}, false
-	}
-
-	return data, true
-}
-
 // RECEIPTS //
 
 // WriteReceipts writes the receipts

--- a/blockchain/storage/storage.go
+++ b/blockchain/storage/storage.go
@@ -31,9 +31,6 @@ type Storage interface {
 	WriteBody(hash types.Hash, body *types.Body) error
 	ReadBody(hash types.Hash) (*types.Body, error)
 
-	WriteSnapshot(hash types.Hash, blob []byte) error
-	ReadSnapshot(hash types.Hash) ([]byte, bool)
-
 	WriteReceipts(hash types.Hash, receipts []*types.Receipt) error
 	ReadReceipts(hash types.Hash) ([]*types.Receipt, error)
 

--- a/blockchain/storage/testing.go
+++ b/blockchain/storage/testing.go
@@ -487,8 +487,6 @@ type MockStorage struct {
 	writeCanonicalHeaderFn writeCanonicalHeaderDelegate
 	writeBodyFn            writeBodyDelegate
 	readBodyFn             readBodyDelegate
-	writeSnapshotFn        writeSnapshotDelegate
-	readSnapshotFn         readSnapshotDelegate
 	writeReceiptsFn        writeReceiptsDelegate
 	readReceiptsFn         readReceiptsDelegate
 	writeTxLookupFn        writeTxLookupDelegate
@@ -678,30 +676,6 @@ func (m *MockStorage) ReadBody(hash types.Hash) (*types.Body, error) {
 
 func (m *MockStorage) HookReadBody(fn readBodyDelegate) {
 	m.readBodyFn = fn
-}
-
-func (m *MockStorage) WriteSnapshot(hash types.Hash, blob []byte) error {
-	if m.writeSnapshotFn != nil {
-		return m.writeSnapshotFn(hash, blob)
-	}
-
-	return nil
-}
-
-func (m *MockStorage) HookWriteSnapshot(fn writeSnapshotDelegate) {
-	m.writeSnapshotFn = fn
-}
-
-func (m *MockStorage) ReadSnapshot(hash types.Hash) ([]byte, bool) {
-	if m.readSnapshotFn != nil {
-		return m.readSnapshotFn(hash)
-	}
-
-	return []byte{}, true
-}
-
-func (m *MockStorage) HookReadSnapshot(fn readSnapshotDelegate) {
-	m.readSnapshotFn = fn
 }
 
 func (m *MockStorage) WriteReceipts(hash types.Hash, receipts []*types.Receipt) error {


### PR DESCRIPTION
# Description

This PR removes the `Snapshot` functions from the storage which have been long deprecated as far as I can understand.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
