### PR TITLE
[Checkpointing] `ExitEvent` storage and proof generation

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -34,6 +34,9 @@ type Consensus interface {
 	// GetSyncProgression retrieves the current sync progression, if any
 	GetSyncProgression() *progress.Progression
 
+	// GetBridgeProvider returns an instance of BridgeDataProvider
+	GetBridgeProvider() BridgeDataProvider
+
 	// Initialize initializes the consensus (e.g. setup data)
 	Initialize() error
 
@@ -75,3 +78,9 @@ type Params struct {
 
 // Factory is the factory function to create a discovery consensus
 type Factory func(*Params) (Consensus, error)
+
+// BridgeDataProvider is an interface providing bridge related functions
+type BridgeDataProvider interface {
+	// GenerateExit proof generates proof of exit for given exit event
+	GenerateExitProof(exitID, epoch, checkpointBlock uint64) ([]types.Hash, error)
+}

--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -242,3 +242,7 @@ func (d *Dev) Close() error {
 
 	return nil
 }
+
+func (d *Dev) GetBridgeProvider() consensus.BridgeDataProvider {
+	return nil
+}

--- a/consensus/dummy/dummy.go
+++ b/consensus/dummy/dummy.go
@@ -75,6 +75,10 @@ func (d *Dummy) Close() error {
 	return nil
 }
 
+func (d *Dummy) GetBridgeProvider() consensus.BridgeDataProvider {
+	return nil
+}
+
 func (d *Dummy) run() {
 	d.logger.Info("started")
 	// do nothing

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -532,6 +532,11 @@ func (i *backendIBFT) SetHeaderHash() {
 	}
 }
 
+// GetBridgeProvider returns an instance of BridgeDataProvider
+func (i *backendIBFT) GetBridgeProvider() consensus.BridgeDataProvider {
+	return nil
+}
+
 // updateCurrentModules updates Signer, Hooks, and Validators
 // that are used at specified height
 // by fetching from ForkManager

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -780,8 +780,8 @@ func (c *consensusRuntime) getExitEventRootHash(epoch uint64) (types.Hash, error
 	return tree.Hash(), nil
 }
 
-// generateExitProof generates proof of exit
-func (c *consensusRuntime) generateExitProof(exitID, epoch, checkpointBlock uint64) ([]types.Hash, error) {
+// GenerateExitProof generates proof of exit
+func (c *consensusRuntime) GenerateExitProof(exitID, epoch, checkpointBlock uint64) ([]types.Hash, error) {
 	exitEvent, err := c.state.getExitEvent(exitID, epoch, checkpointBlock)
 	if err != nil {
 		return nil, err

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -150,7 +150,7 @@ func (c *consensusRuntime) AddLog(eventLog *ethgo.Log) {
 		"index", eventLog.LogIndex,
 	)
 
-	event, err := decodeEvent(eventLog)
+	event, err := decodeStateSyncEvent(eventLog)
 	if err != nil {
 		c.logger.Error("failed to decode state sync event", "hash", eventLog.TransactionHash, "err", err)
 

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -276,26 +276,21 @@ func (c *consensusRuntime) FSM() (*fsm, error) {
 		return nil, err
 	}
 
-	eventRoot, err := c.getExitEventRootHash(epoch.Number)
-	if err != nil {
-		return nil, err
-	}
-
 	pendingBlockNumber := c.getPendingBlockNumber()
 	isEndOfSprint := c.isEndOfSprint(pendingBlockNumber)
 	isEndOfEpoch := c.isEndOfEpoch(pendingBlockNumber)
 
 	ff := &fsm{
-		config:         c.config.PolyBFTConfig,
-		parent:         parent,
-		backend:        c.config.blockchain,
-		polybftBackend: c.config.polybftBackend,
-		blockBuilder:   blockBuilder,
-		validators:     newValidatorSet(types.BytesToAddress(parent.Miner), epoch.Validators),
-		isEndOfEpoch:   isEndOfEpoch,
-		isEndOfSprint:  isEndOfSprint,
-		eventRoot:      eventRoot,
-		logger:         c.logger.Named("fsm"),
+		config:            c.config.PolyBFTConfig,
+		parent:            parent,
+		backend:           c.config.blockchain,
+		polybftBackend:    c.config.polybftBackend,
+		blockBuilder:      blockBuilder,
+		validators:        newValidatorSet(types.BytesToAddress(parent.Miner), epoch.Validators),
+		isEndOfEpoch:      isEndOfEpoch,
+		isEndOfSprint:     isEndOfSprint,
+		generateEventRoot: c.getExitEventRootHash,
+		logger:            c.logger.Named("fsm"),
 	}
 
 	if c.IsBridgeEnabled() {

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -770,16 +770,16 @@ func (c *consensusRuntime) calculateUptime(currentBlock *types.Header) (*CommitE
 func (c *consensusRuntime) getExitEventRootHash(epoch uint64) (types.Hash, error) {
 	exitEvents, err := c.state.getExitEventsByEpoch(epoch)
 	if err != nil {
-		return types.Hash{}, err
+		return types.ZeroHash, err
 	}
 
 	if len(exitEvents) == 0 {
-		return types.Hash{}, nil
+		return types.ZeroHash, nil
 	}
 
 	tree, err := createExitTree(exitEvents)
 	if err != nil {
-		return types.Hash{}, err
+		return types.ZeroHash, err
 	}
 
 	return tree.Hash(), nil

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -150,7 +150,7 @@ func TestConsensusRuntime_AddLog(t *testing.T) {
 		config: &runtimeConfig{Key: createTestKey(t)},
 	}
 	topics := make([]ethgo.Hash, 4)
-	topics[0] = stateTransferEvent.ID()
+	topics[0] = stateTransferEventABI.ID()
 	topics[1] = ethgo.BytesToHash([]byte{0x1})
 	topics[2] = ethgo.BytesToHash(runtime.config.Key.Address().Bytes())
 	topics[3] = ethgo.BytesToHash(contracts.NativeTokenContract[:])
@@ -167,7 +167,7 @@ func TestConsensusRuntime_AddLog(t *testing.T) {
 		Topics:          topics,
 		Data:            encodedData,
 	}
-	event, err := decodeEvent(log)
+	event, err := decodeStateSyncEvent(log)
 	require.NoError(t, err)
 	runtime.AddLog(log)
 

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1671,7 +1671,7 @@ func TestConsensusRuntime_getExitEventRootHash(t *testing.T) {
 	})
 }
 
-func TestConsensusRuntime_generateExitProof(t *testing.T) {
+func TestConsensusRuntime_GenerateExitProof(t *testing.T) {
 	const (
 		numOfBlocks         = 10
 		numOfEventsPerBlock = 2
@@ -1689,7 +1689,7 @@ func TestConsensusRuntime_generateExitProof(t *testing.T) {
 	tree, err := NewMerkleTree(checkpointEvents)
 	require.NoError(t, err)
 
-	proof, err := runtime.generateExitProof(1, 1, 1)
+	proof, err := runtime.GenerateExitProof(1, 1, 1)
 	require.NoError(t, err)
 	require.NotNil(t, proof)
 
@@ -1707,7 +1707,7 @@ func TestConsensusRuntime_generateExitProof(t *testing.T) {
 	})
 
 	t.Run("Generate exit proof - no event", func(t *testing.T) {
-		_, err := runtime.generateExitProof(21, 1, 1)
+		_, err := runtime.GenerateExitProof(21, 1, 1)
 		require.ErrorContains(t, err, "could not find any exit event that has an id")
 	})
 }

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -85,6 +85,9 @@ type fsm struct {
 	// stateSyncExecutionIndex is the next state sync execution index in smart contract
 	stateSyncExecutionIndex uint64
 
+	// eventRoot is the root hash of exit event tree
+	eventRoot types.Hash
+
 	logger hcf.Logger // The logger object
 }
 

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -85,8 +85,8 @@ type fsm struct {
 	// stateSyncExecutionIndex is the next state sync execution index in smart contract
 	stateSyncExecutionIndex uint64
 
-	// eventRoot is the root hash of exit event tree
-	eventRoot types.Hash
+	// generateEventRoot returns the root hash of exit event tree
+	generateEventRoot func(epoch uint64) (types.Hash, error)
 
 	logger hcf.Logger // The logger object
 }
@@ -160,6 +160,8 @@ func (f *fsm) BuildProposal() (*pbft.Proposal, error) {
 	if headerTime.Before(time.Now()) {
 		headerTime = time.Now()
 	}
+
+	// TODO - Here we will call f.generateEventRootFunc(epoch) to get the exit root after adding transactions
 
 	stateBlock, err := f.blockBuilder.Build(func(h *types.Header) {
 		h.Timestamp = uint64(headerTime.Unix())

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -1559,7 +1559,7 @@ func createTestCommitment(t *testing.T, accounts []*wallet.Account) *CommitmentM
 			uint64(i),
 			accounts[i].Ecdsa.Address(),
 			accounts[0].Ecdsa.Address(),
-			[]byte{}, nil,
+			[]byte{},
 		)
 
 		bitmap.Set(uint64(i))

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -618,6 +618,11 @@ func (p *Polybft) PreCommitState(_ *types.Header, _ *state.Transition) error {
 	return nil
 }
 
+// GetBridgeProvider returns an instance of BridgeDataProvider
+func (p *Polybft) GetBridgeProvider() consensus.BridgeDataProvider {
+	return p.runtime
+}
+
 type pbftTransportWrapper struct {
 	topic *network.Topic
 }

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -318,22 +318,6 @@ func (s *State) list() ([]*StateSyncEvent, error) {
 	return events, nil
 }
 
-func compose(slices [][]byte) []byte {
-	var totalLen, i int
-
-	for _, s := range slices {
-		totalLen += len(s)
-	}
-
-	tmp := make([]byte, totalLen)
-
-	for _, s := range slices {
-		i += copy(tmp[i:], s)
-	}
-
-	return tmp
-}
-
 // insertStateSyncEvent inserts a new state sync event to state event bucket in db
 func (s *State) insertExitEvent(event *ExitEvent) error {
 	return s.db.Update(func(tx *bolt.Tx) error {
@@ -344,7 +328,7 @@ func (s *State) insertExitEvent(event *ExitEvent) error {
 
 		bucket := tx.Bucket(exitEventsBucket)
 
-		return bucket.Put(compose([][]byte{itob(event.Epoch), itob(event.ID), itob(event.BlockNumber)}), raw)
+		return bucket.Put(bytes.Join([][]byte{itob(event.Epoch), itob(event.ID), itob(event.BlockNumber)}, nil), raw)
 	})
 }
 
@@ -355,7 +339,7 @@ func (s *State) getExitEvent(exitEventID, epoch, checkpointBlockNumber uint64) (
 	err := s.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(exitEventsBucket)
 
-		key := compose([][]byte{itob(epoch), itob(exitEventID), itob(checkpointBlockNumber)})
+		key := bytes.Join([][]byte{itob(epoch), itob(exitEventID), itob(checkpointBlockNumber)}, nil)
 		v := bucket.Get(key)
 		if v == nil {
 			return &ExitEventNotFoundError{exitEventID, checkpointBlockNumber, epoch}

--- a/consensus/polybft/state_test.go
+++ b/consensus/polybft/state_test.go
@@ -363,11 +363,7 @@ func TestState_Insert_And_Get_ExitEvents_PerEpoch(t *testing.T) {
 	insertTestExitEvents(t, state, numOfEpochs, numOfBlocksPerEpoch, numOfEventsPerBlock)
 
 	t.Run("Get events for existing epoch", func(t *testing.T) {
-		start := time.Now()
-
 		events, err := state.getExitEventsByEpoch(1)
-
-		fmt.Printf("Gotten events for epoch in: %v", time.Since(start))
 
 		assert.NoError(t, err)
 		assert.Len(t, events, numOfBlocksPerEpoch*numOfEventsPerBlock)
@@ -429,7 +425,6 @@ func insertTestExitEvents(t *testing.T, state *State,
 	t.Helper()
 
 	index, block := uint64(1), uint64(1)
-	start := time.Now()
 
 	for i := uint64(1); i <= uint64(numOfEpochs); i++ {
 		for j := 1; j <= numOfBlocksPerEpoch; j++ {
@@ -442,9 +437,6 @@ func insertTestExitEvents(t *testing.T, state *State,
 			block++
 		}
 	}
-
-	fmt.Printf("Inserted %v exit events in: %v\n", numOfEpochs*numOfBlocksPerEpoch*numOfEventsPerBlock,
-		time.Since(start))
 }
 
 func insertTestCommitments(t *testing.T, state *State, epoch, numberOfCommitments uint64) {

--- a/consensus/polybft/state_test.go
+++ b/consensus/polybft/state_test.go
@@ -362,23 +362,23 @@ func TestState_Insert_And_Get_ExitEvents_PerEpoch(t *testing.T) {
 	state := newTestState(t)
 	insertTestExitEvents(t, state, numOfEpochs, numOfBlocksPerEpoch, numOfEventsPerBlock)
 
-	start := time.Now()
+	t.Run("Get events for existing epoch", func(t *testing.T) {
+		start := time.Now()
 
-	events, err := state.getExitEventsByEpoch(1)
+		events, err := state.getExitEventsByEpoch(1)
 
-	fmt.Printf("Gotten events for epoch in: %v", time.Since(start))
+		fmt.Printf("Gotten events for epoch in: %v", time.Since(start))
 
-	assert.NoError(t, err)
-	assert.Len(t, events, numOfBlocksPerEpoch*numOfEventsPerBlock)
-}
+		assert.NoError(t, err)
+		assert.Len(t, events, numOfBlocksPerEpoch*numOfEventsPerBlock)
+	})
 
-func TestState_Insert_And_Get_ExitEvents_PerEpoch_NoEventsInEpoch(t *testing.T) {
-	state := newTestState(t)
+	t.Run("Get events for non-existing epoch", func(t *testing.T) {
+		events, err := state.getExitEventsByEpoch(12)
 
-	events, err := state.getExitEventsByEpoch(1)
-
-	assert.NoError(t, err)
-	assert.Len(t, events, 0)
+		assert.NoError(t, err)
+		assert.Len(t, events, 0)
+	})
 }
 
 func TestState_Insert_And_Get_ExitEvents_ForProof(t *testing.T) {

--- a/jsonrpc/bridge_endpoint.go
+++ b/jsonrpc/bridge_endpoint.go
@@ -1,0 +1,20 @@
+package jsonrpc
+
+import (
+	"github.com/0xPolygon/polygon-edge/types"
+)
+
+// bridgeStore interface provides access to the methods needed by bridge endpoint
+type bridgeStore interface {
+	GenerateExitProof(exitID, epoch, checkpointBlock uint64) ([]types.Hash, error)
+}
+
+// Bridge is the bridge jsonrpc endpoint
+type Bridge struct {
+	store bridgeStore
+}
+
+// GenerateExitProof generates exit proof for given exit event
+func (b *Bridge) GenerateExitProof(exitID, epoch, checkpointBlock argUint64) (interface{}, error) {
+	return b.store.GenerateExitProof(uint64(exitID), uint64(epoch), uint64(checkpointBlock))
+}

--- a/jsonrpc/bridge_endpoint_test.go
+++ b/jsonrpc/bridge_endpoint_test.go
@@ -1,0 +1,40 @@
+package jsonrpc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBridgeEndpoint(t *testing.T) {
+	store := newMockStore()
+
+	dispatcher := newDispatcher(
+		hclog.NewNullLogger(),
+		store,
+		&dispatcherParams{
+			chainID:                 0,
+			priceLimit:              0,
+			jsonRPCBatchLengthLimit: 20,
+			blockRangeLimit:         1000,
+		},
+	)
+
+	mockConnection, _ := newMockWsConnWithMsgCh()
+
+	msg := []byte(`{
+		"method": "bridge_generateExitProof",
+		"params": ["0x0001", "0x0001", "0x0002"],
+		"id": 1
+	}`)
+
+	data, err := dispatcher.HandleWs(msg, mockConnection)
+	require.NoError(t, err)
+
+	resp := new(SuccessResponse)
+	require.NoError(t, json.Unmarshal(data, resp))
+	require.Nil(t, resp.Error)
+	require.NotNil(t, resp.Result)
+}

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -34,6 +34,7 @@ type endpoints struct {
 	Web3   *Web3
 	Net    *Net
 	TxPool *TxPool
+	Bridge *Bridge
 }
 
 // Dispatcher handles all json rpc requests by delegating
@@ -93,11 +94,13 @@ func (d *Dispatcher) registerEndpoints(store JSONRPCStore) {
 		d.params.chainName,
 	}
 	d.endpoints.TxPool = &TxPool{store}
+	d.endpoints.Bridge = &Bridge{store}
 
 	d.registerService("eth", d.endpoints.Eth)
 	d.registerService("net", d.endpoints.Net)
 	d.registerService("web3", d.endpoints.Web3)
 	d.registerService("txpool", d.endpoints.TxPool)
+	d.registerService("bridge", d.endpoints.Bridge)
 }
 
 func (d *Dispatcher) getFnHandler(req Request) (*serviceData, *funcData, Error) {

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -55,6 +55,7 @@ type JSONRPCStore interface {
 	networkStore
 	txPoolStore
 	filterManagerStore
+	bridgeStore
 }
 
 type Config struct {

--- a/jsonrpc/mocks_test.go
+++ b/jsonrpc/mocks_test.go
@@ -133,3 +133,9 @@ func (m *mockStore) GetTxs(inclQueued bool) (
 func (m *mockStore) GetCapacity() (uint64, uint64) {
 	return 0, 0
 }
+
+func (m *mockStore) GenerateExitProof(exitID, epoch, checkpointNumber uint64) ([]types.Hash, error) {
+	hash := types.BytesToHash([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+
+	return []types.Hash{hash}, nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -446,6 +446,7 @@ type jsonRPCHub struct {
 	*state.Executor
 	*network.Server
 	consensus.Consensus
+	consensus.BridgeDataProvider
 }
 
 // HELPER + WRAPPER METHODS //
@@ -563,6 +564,7 @@ func (s *Server) setupJSONRPC() error {
 		Executor:           s.executor,
 		Consensus:          s.consensus,
 		Server:             s.network,
+		BridgeDataProvider: s.consensus.GetBridgeProvider(),
 	}
 
 	conf := &jsonrpc.Config{


### PR DESCRIPTION
# Description

Added functions to store and query exit events in `state.go`.
Added event root hash calculation which will be used as a parameter in block extra (one of the parameters for checkpoint), that gets signed by validators.
Added exit proof generation for users that want to exit.
Added relevant UTs for positive and negative cases.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually
