### PR TITLE
Fix panic issue due to sending to closed channel

### DIFF
--- a/network/identity/identity.go
+++ b/network/identity/identity.go
@@ -103,25 +103,22 @@ func (i *IdentityService) GetNotifyBundle() *network.NotifyBundle {
 			i.addPendingStatus(peerID, conn.Stat().Direction)
 
 			go func() {
-				connectEvent := &event.PeerEvent{
-					PeerID: peerID,
-					Type:   event.PeerDialCompleted,
-				}
+				eventType := event.PeerDialCompleted
 
 				if err := i.handleConnected(peerID, conn.Stat().Direction); err != nil {
 					// Close the connection to the peer
 					i.disconnectFromPeer(peerID, err.Error())
 
-					connectEvent.Type = event.PeerFailedToConnect
+					eventType = event.PeerFailedToConnect
 				}
 
 				// Mark the peer as no longer pending
-				i.removePendingStatus(connectEvent.PeerID)
+				i.removePendingStatus(peerID)
 
 				// Emit an adequate event
 				i.baseServer.EmitEvent(&event.PeerEvent{
-					PeerID: connectEvent.PeerID,
-					Type:   connectEvent.Type,
+					PeerID: peerID,
+					Type:   eventType,
 				})
 			}()
 		},

--- a/network/server.go
+++ b/network/server.go
@@ -717,16 +717,14 @@ func (s *Server) SubscribeFn(ctx context.Context, handler func(evnt *peerEvent.P
 	}
 
 	go func() {
+		defer sub.Close()
+
 		for {
 			select {
 			case <-ctx.Done():
-				sub.Close()
-
 				return
 
 			case <-s.closeCh:
-				sub.Close()
-
 				return
 
 			case evnt := <-sub.GetCh():

--- a/network/server_discovery.go
+++ b/network/server_discovery.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"math/big"
@@ -222,7 +223,7 @@ func (s *Server) setupDiscovery() error {
 	)
 
 	// Register a network event handler
-	if subscribeErr := s.SubscribeFn(discoveryService.HandleNetworkEvent); subscribeErr != nil {
+	if subscribeErr := s.SubscribeFn(context.Background(), discoveryService.HandleNetworkEvent); subscribeErr != nil {
 		return fmt.Errorf("unable to subscribe to network events, %w", subscribeErr)
 	}
 

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -685,6 +685,133 @@ func TestRunDial(t *testing.T) {
 	})
 }
 
+func TestSubscribeFn(t *testing.T) {
+	setupServer := func(t *testing.T, shouldCloseAfterTest bool) *Server {
+		t.Helper()
+
+		srv, err := CreateServer(
+			&CreateServerParams{
+				ConfigCallback: func(c *Config) {
+					c.MaxInboundPeers = 0
+					c.MaxOutboundPeers = 0
+					c.NoDiscover = true
+				},
+			},
+		)
+
+		if err != nil {
+			t.Fatalf("Unable to create server, %v", err)
+		}
+
+		if shouldCloseAfterTest {
+			t.Cleanup(func() {
+				srv.Close()
+			})
+		}
+
+		return srv
+	}
+
+	toChannel := func(t *testing.T, ctx context.Context, server *Server) <-chan *peerEvent.PeerEvent {
+		t.Helper()
+		
+		eventCh := make(chan *peerEvent.PeerEvent)
+
+		t.Cleanup(func() {
+			close(eventCh)
+		})
+
+		err := server.SubscribeFn(ctx, func(e *peerEvent.PeerEvent) {
+			eventCh <- e
+		})
+
+		assert.NoError(t, err)
+
+		return eventCh
+	}
+
+	waitForEvent := func(
+		t *testing.T,
+		eventCh <-chan *peerEvent.PeerEvent,
+		timeout time.Duration,
+	) ( *peerEvent.PeerEvent, bool) {
+		t.Helper()
+
+		select {
+		case received := <-eventCh:
+			return received, true
+		case <-time.After(timeout):
+			return nil, false
+		}
+	}
+
+	event := &peerEvent.PeerEvent{
+		PeerID: peer.ID("test"),
+		Type: peerEvent.PeerConnected,
+	}
+
+	t.Run("should call callback", func(t *testing.T) {
+		t.Parallel()
+
+		server := setupServer(t, true)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(func() {
+			cancel()
+		})
+
+		eventCh := toChannel(t, ctx, server)
+
+		server.EmitEvent(event)
+
+		res, received := waitForEvent(t, eventCh, time.Second * 5)
+
+		assert.True(t, received)
+		assert.Equal(t, event, res)
+	})
+
+	t.Run("should not call callback after context is closed", func(t *testing.T) {
+		t.Parallel()
+
+		server := setupServer(t, true)
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		eventCh := toChannel(t, ctx, server)
+
+		// cancel before emitting
+		cancel()
+
+		server.EmitEvent(event)
+
+		_, received := waitForEvent(t, eventCh, time.Second * 5)
+
+		assert.False(t, received)
+	})
+
+	t.Run("should not call callback after server closed", func(t *testing.T) {
+		t.Parallel()
+
+		server := setupServer(t, false)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(func() {
+			cancel()
+		})
+
+		eventCh := toChannel(t, ctx, server)
+
+		// close server before emitting event
+		server.Close()
+
+		server.EmitEvent(event)
+
+		_, received := waitForEvent(t, eventCh, time.Second * 5)
+
+		assert.False(t, received)
+	})
+}
+
 func TestMinimumBootNodeCount(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -686,6 +686,8 @@ func TestRunDial(t *testing.T) {
 }
 
 func TestSubscribeFn(t *testing.T) {
+	t.Parallel()
+
 	setupServer := func(t *testing.T, shouldCloseAfterTest bool) *Server {
 		t.Helper()
 
@@ -714,7 +716,7 @@ func TestSubscribeFn(t *testing.T) {
 
 	toChannel := func(t *testing.T, ctx context.Context, server *Server) <-chan *peerEvent.PeerEvent {
 		t.Helper()
-		
+
 		eventCh := make(chan *peerEvent.PeerEvent)
 
 		t.Cleanup(func() {
@@ -734,7 +736,7 @@ func TestSubscribeFn(t *testing.T) {
 		t *testing.T,
 		eventCh <-chan *peerEvent.PeerEvent,
 		timeout time.Duration,
-	) ( *peerEvent.PeerEvent, bool) {
+	) (*peerEvent.PeerEvent, bool) {
 		t.Helper()
 
 		select {
@@ -747,7 +749,7 @@ func TestSubscribeFn(t *testing.T) {
 
 	event := &peerEvent.PeerEvent{
 		PeerID: peer.ID("test"),
-		Type: peerEvent.PeerConnected,
+		Type:   peerEvent.PeerConnected,
 	}
 
 	t.Run("should call callback", func(t *testing.T) {
@@ -764,7 +766,7 @@ func TestSubscribeFn(t *testing.T) {
 
 		server.EmitEvent(event)
 
-		res, received := waitForEvent(t, eventCh, time.Second * 5)
+		res, received := waitForEvent(t, eventCh, time.Second*5)
 
 		assert.True(t, received)
 		assert.Equal(t, event, res)
@@ -784,7 +786,7 @@ func TestSubscribeFn(t *testing.T) {
 
 		server.EmitEvent(event)
 
-		_, received := waitForEvent(t, eventCh, time.Second * 5)
+		_, received := waitForEvent(t, eventCh, time.Second*5)
 
 		assert.False(t, received)
 	})
@@ -806,7 +808,7 @@ func TestSubscribeFn(t *testing.T) {
 
 		server.EmitEvent(event)
 
-		_, received := waitForEvent(t, eventCh, time.Second * 5)
+		_, received := waitForEvent(t, eventCh, time.Second*5)
 
 		assert.False(t, received)
 	})

--- a/syncer/client.go
+++ b/syncer/client.go
@@ -220,7 +220,7 @@ func (m *syncPeerClient) startNewBlockProcess() {
 
 // startPeerEventProcess starts subscribing peer connection change events and process them
 func (m *syncPeerClient) startPeerEventProcess() {
-	peerEventCh, err := m.network.SubscribeCh()
+	peerEventCh, err := m.network.SubscribeCh(context.Background())
 	if err != nil {
 		m.logger.Error("failed to subscribe", "err", err)
 

--- a/syncer/types.go
+++ b/syncer/types.go
@@ -1,6 +1,7 @@
 package syncer
 
 import (
+	"context"
 	"math/big"
 	"time"
 
@@ -36,7 +37,7 @@ type Network interface {
 	// Peers returns current connected peers
 	Peers() []*network.PeerConnInfo
 	// SubscribeCh returns a channel of peer event
-	SubscribeCh() (<-chan *event.PeerEvent, error)
+	SubscribeCh(context.Context) (<-chan *event.PeerEvent, error)
 	// GetPeerDistance returns the distance between the node and given peer
 	GetPeerDistance(peer.ID) *big.Int
 	// NewProtoConnection opens up a new stream on the set protocol to the peer,


### PR DESCRIPTION
# Description

This PR fixes the issue that panic occurs sometimes when terminating process.

```bash
panic: send on closed channel
goroutine 795 [running]: 
github.com/0xPolygon/polygon-edge/network.(*Server).runDial.func1(0xc003372fb0?) 
  /home/runner/work/polygon-edge/polygon-edge/network/server.go:372 +0x47 
github.com/0xPolygon/polygon-edge/network.(*Server).SubscribeFn.func1() 
  /home/runner/work/polygon-edge/polygon-edge/network/server.go:717 +0x58 
created by github.com/0xPolygon/polygon-edge/network.(*Server).SubscribeFn 
  /home/runner/work/polygon-edge/polygon-edge/network/server.go:713 +0xb8
```

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
