### PR TITLE
Checkpoint data signing

### DIFF
--- a/command/e2e/register_validator.go
+++ b/command/e2e/register_validator.go
@@ -443,14 +443,9 @@ func registerValidator(sender *txnSender, account *wallet.Account) asyncTxn {
 		return &asyncTxnImpl{err: err}
 	}
 
-	pubKeys, err := account.Bls.PublicKey().ToBigInt()
-	if err != nil {
-		return &asyncTxnImpl{err: err}
-	}
-
 	input, err := registerFn.Encode([]interface{}{
 		sigMarshal,
-		pubKeys,
+		account.Bls.PublicKey().ToBigInt(),
 	})
 	if err != nil {
 		return &asyncTxnImpl{err: err}

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -88,7 +88,7 @@ func (p *genesisParams) generatePolyBFTConfig() (*chain.Chain, error) {
 			Alloc:      alloc,
 			ExtraData:  generateExtraDataPolyBft(validatorsInfo),
 			GasUsed:    command.DefaultGenesisGasUsed,
-			Mixhash:    polybft.PolyMixDigest,
+			Mixhash:    polybft.PolyBFTMixDigest,
 		},
 		Params: &chain.Params{
 			ChainID: int(p.chainID),

--- a/command/rootchain/initcontracts/init_contracts.go
+++ b/command/rootchain/initcontracts/init_contracts.go
@@ -257,11 +257,7 @@ func initializeRootValidatorSet(nonce uint64) error {
 	validatorAddresses := make([]types.Address, len(validatorsInfo))
 
 	for i, valid := range validatorsInfo {
-		pubKeyBig, err := valid.Account.Bls.PublicKey().ToBigInt()
-		if err != nil {
-			return fmt.Errorf("failed to encode pubkey for RootValidatorSet.initialize. error: %w", err)
-		}
-
+		pubKeyBig := valid.Account.Bls.PublicKey().ToBigInt()
 		validatorAddresses[i] = types.Address(valid.Account.Ecdsa.Address())
 		validatorPubKeys[i] = pubKeyBig
 	}

--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -132,7 +132,7 @@ func (b *BlockBuilder) Build(handler func(h *types.Header)) (*StateBlock, error)
 		Receipts: b.state.Receipts(),
 	})
 
-	_ = b.block.Header.ComputeHash()
+	b.block.Header.ComputeHash()
 
 	return &StateBlock{
 		Block:    b.block,

--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -132,7 +132,7 @@ func (b *BlockBuilder) Build(handler func(h *types.Header)) (*StateBlock, error)
 		Receipts: b.state.Receipts(),
 	})
 
-	b.block.Header.ComputeHash()
+	_ = b.block.Header.ComputeHash()
 
 	return &StateBlock{
 		Block:    b.block,

--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -64,7 +64,7 @@ type blockchainBackend interface {
 	CalculateGasLimit(number uint64) (uint64, error)
 
 	// GetChainID returns chain id of the current blockchain
-	GetChainID() int
+	GetChainID() uint64
 }
 
 var _ blockchainBackend = &blockchainWrapper{}
@@ -188,8 +188,8 @@ func (p *blockchainWrapper) CalculateGasLimit(number uint64) (uint64, error) {
 	return p.blockchain.CalculateGasLimit(number)
 }
 
-func (p *blockchainWrapper) GetChainID() int {
-	return p.blockchain.Config().ChainID
+func (p *blockchainWrapper) GetChainID() uint64 {
+	return uint64(p.blockchain.Config().ChainID)
 }
 
 var _ contract.Provider = &stateProvider{}

--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -60,8 +60,11 @@ type blockchainBackend interface {
 
 	SubscribeEvents() blockchain.Subscription
 
-	// CalculateGasLimit for specifici block
+	// CalculateGasLimit calculates required gas limit for specific block
 	CalculateGasLimit(number uint64) (uint64, error)
+
+	// GetChainID returns chain id of the current blockchain
+	GetChainID() int
 }
 
 var _ blockchainBackend = &blockchainWrapper{}
@@ -183,6 +186,10 @@ func (p *blockchainWrapper) SubscribeEvents() blockchain.Subscription {
 // CalculateGasLimit for specific block
 func (p *blockchainWrapper) CalculateGasLimit(number uint64) (uint64, error) {
 	return p.blockchain.CalculateGasLimit(number)
+}
+
+func (p *blockchainWrapper) GetChainID() int {
+	return p.blockchain.Config().ChainID
 }
 
 var _ contract.Provider = &stateProvider{}

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -285,6 +285,7 @@ func (c *consensusRuntime) FSM() (*fsm, error) {
 		parent:            parent,
 		backend:           c.config.blockchain,
 		polybftBackend:    c.config.polybftBackend,
+		epochNumber:       epoch.Number,
 		blockBuilder:      blockBuilder,
 		validators:        newValidatorSet(types.BytesToAddress(parent.Miner), epoch.Validators),
 		isEndOfEpoch:      isEndOfEpoch,

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -281,17 +281,17 @@ func (c *consensusRuntime) FSM() (*fsm, error) {
 	isEndOfEpoch := c.isEndOfEpoch(pendingBlockNumber)
 
 	ff := &fsm{
-		config:            c.config.PolyBFTConfig,
-		parent:            parent,
-		backend:           c.config.blockchain,
-		polybftBackend:    c.config.polybftBackend,
-		epochNumber:       epoch.Number,
-		blockBuilder:      blockBuilder,
-		validators:        newValidatorSet(types.BytesToAddress(parent.Miner), epoch.Validators),
-		isEndOfEpoch:      isEndOfEpoch,
-		isEndOfSprint:     isEndOfSprint,
-		generateEventRoot: c.getExitEventRootHash,
-		logger:            c.logger.Named("fsm"),
+		config:           c.config.PolyBFTConfig,
+		parent:           parent,
+		backend:          c.config.blockchain,
+		polybftBackend:   c.config.polybftBackend,
+		epochNumber:      epoch.Number,
+		blockBuilder:     blockBuilder,
+		validators:       newValidatorSet(types.BytesToAddress(parent.Miner), epoch.Validators),
+		isEndOfEpoch:     isEndOfEpoch,
+		isEndOfSprint:    isEndOfSprint,
+		buildEventRootFn: c.getExitEventRootHash,
+		logger:           c.logger.Named("fsm"),
 	}
 
 	if c.IsBridgeEnabled() {

--- a/consensus/polybft/contracts_initializer.go
+++ b/consensus/polybft/contracts_initializer.go
@@ -56,10 +56,7 @@ func getInitChildValidatorSetInput(validators []*Validator, governanceAddr types
 			return nil, err
 		}
 
-		pubKeyBig, err := pubKey.ToBigInt()
-		if err != nil {
-			return nil, err
-		}
+		pubKeyBig := pubKey.ToBigInt()
 
 		validatorPubkeys[i] = pubKeyBig
 		validatorAddresses[i] = g.Address

--- a/consensus/polybft/extra.go
+++ b/consensus/polybft/extra.go
@@ -447,7 +447,7 @@ func (c *CheckpointData) UnmarshalRLPWith(v *fastrlp.Value) error {
 
 // Hash calculates keccak256 hash of the CheckpointData.
 // CheckpointData is ABI encoded and then hashed.
-func (c *CheckpointData) Hash(chainID uint64, blockNumber uint64, blockHash types.Hash) ([]byte, error) {
+func (c *CheckpointData) Hash(chainID uint64, blockNumber uint64, blockHash types.Hash) (types.Hash, error) {
 	checkpointMap := map[string]interface{}{
 		"chainId":               new(big.Int).SetUint64(chainID),
 		"blockNumber":           new(big.Int).SetUint64(blockNumber),
@@ -461,10 +461,10 @@ func (c *CheckpointData) Hash(chainID uint64, blockNumber uint64, blockHash type
 
 	abiEncoded, err := checkpointDataABIType.Encode(checkpointMap)
 	if err != nil {
-		return nil, err
+		return types.ZeroHash, err
 	}
 
-	return crypto.Keccak256(abiEncoded), nil
+	return types.BytesToHash(crypto.Keccak256(abiEncoded)), nil
 }
 
 // GetIbftExtraClean returns unmarshaled extra field from the passed in header,

--- a/consensus/polybft/extra_test.go
+++ b/consensus/polybft/extra_test.go
@@ -88,8 +88,6 @@ func TestExtra_Encoding(t *testing.T) {
 				Parent:    &Signature{AggregatedSignature: parentStr, Bitmap: bitmapStr},
 				Committed: &Signature{AggregatedSignature: committedStr, Bitmap: bitmapStr},
 				Checkpoint: &CheckpointData{
-					BlockNumber:           25,
-					BlockHash:             types.BytesToHash(generateRandomBytes(t)),
 					BlockRound:            0,
 					EpochNumber:           3,
 					CurrentValidatorsHash: types.BytesToHash(generateRandomBytes(t)),
@@ -586,9 +584,13 @@ func Test_GetIbftExtraClean_Fail(t *testing.T) {
 }
 
 func TestCheckpointData_Hash(t *testing.T) {
+	const (
+		chainID     = uint64(1)
+		blockNumber = uint64(27)
+	)
+
+	blockHash := types.BytesToHash(generateRandomBytes(t))
 	origCheckpoint := &CheckpointData{
-		BlockNumber:           25,
-		BlockHash:             types.BytesToHash(generateRandomBytes(t)),
 		BlockRound:            0,
 		EpochNumber:           3,
 		CurrentValidatorsHash: types.BytesToHash(generateRandomBytes(t)),
@@ -598,10 +600,10 @@ func TestCheckpointData_Hash(t *testing.T) {
 	copyCheckpoint := &CheckpointData{}
 	*copyCheckpoint = *origCheckpoint
 
-	origHash, err := origCheckpoint.Hash()
+	origHash, err := origCheckpoint.Hash(chainID, blockNumber, blockHash)
 	require.NoError(t, err)
 
-	copyHash, err := copyCheckpoint.Hash()
+	copyHash, err := copyCheckpoint.Hash(chainID, blockNumber, blockHash)
 	require.NoError(t, err)
 
 	require.Equal(t, origHash, copyHash)

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -119,7 +119,8 @@ func (f *fsm) BuildProposal() (*pbft.Proposal, error) {
 
 	// TODO: we will need to revisit once slashing is implemented
 	extra := &Extra{Parent: extraParent.Committed}
-	nextValidators := AccountSet{}
+	// for non-epoch ending blocks, currentValidatorsHash is the same as the nextValidatorsHash
+	nextValidators := f.validators.Accounts()
 
 	if f.isEndOfEpoch {
 		tx, err := f.createValidatorsUptimeTx()

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -91,8 +91,8 @@ type fsm struct {
 	// stateSyncExecutionIndex is the next state sync execution index in smart contract
 	stateSyncExecutionIndex uint64
 
-	// generateEventRoot returns the root hash of exit event tree
-	generateEventRoot func(epoch uint64) (types.Hash, error)
+	// buildEventRootFn returns the root hash of exit event tree
+	buildEventRootFn func(epoch uint64) (types.Hash, error)
 
 	// logger instance
 	logger hcf.Logger
@@ -183,13 +183,17 @@ func (f *fsm) BuildProposal() (*pbft.Proposal, error) {
 		return nil, err
 	}
 
-	// TODO: Set EventRoot
+	eventRoot, err := f.buildEventRootFn(f.epochNumber)
+	if err != nil {
+		return nil, err
+	}
+
 	extra.Checkpoint = &CheckpointData{
 		BlockRound:            f.blockRound,
 		EpochNumber:           f.epochNumber,
 		CurrentValidatorsHash: currentValidatorsHash,
 		NextValidatorsHash:    nextValidatorsHash,
-		EventRoot:             types.ZeroHash,
+		EventRoot:             eventRoot,
 	}
 	stateBlock, err := f.blockBuilder.Build(func(h *types.Header) {
 		h.Timestamp = uint64(headerTime.Unix())

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -166,7 +166,7 @@ func (f *fsm) BuildProposal() (*pbft.Proposal, error) {
 	stateBlock, err := f.blockBuilder.Build(func(h *types.Header) {
 		h.Timestamp = uint64(headerTime.Unix())
 		h.ExtraData = append(make([]byte, signer.IstanbulExtraVanity), extra.MarshalRLPTo(nil)...)
-		h.MixHash = PolyMixDigest
+		h.MixHash = PolyBFTMixDigest
 	})
 
 	if err != nil {
@@ -564,7 +564,7 @@ func validateHeaderFields(parent *types.Header, header *types.Header) error {
 		return fmt.Errorf("timestamp older than parent")
 	}
 	// verify mix digest
-	if header.MixHash != PolyMixDigest {
+	if header.MixHash != PolyBFTMixDigest {
 		return fmt.Errorf("mix digest is not correct")
 	}
 	// difficulty must be > 0

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -44,7 +44,7 @@ func TestFSM_ValidateHeader(t *testing.T) {
 
 	// mix digest
 	assert.ErrorContains(t, validateHeaderFields(parent, header), "mix digest is not correct")
-	header.MixHash = PolyMixDigest
+	header.MixHash = PolyBFTMixDigest
 
 	// difficulty
 	header.Difficulty = 0
@@ -1470,7 +1470,7 @@ func TestFSM_Validate_FailToVerifySignatures(t *testing.T) {
 			Number:     parentBlockNumber + 1,
 			ParentHash: parent.Hash,
 			Timestamp:  parent.Timestamp + 1,
-			MixHash:    PolyMixDigest,
+			MixHash:    PolyBFTMixDigest,
 			Difficulty: 1,
 			ExtraData:  parent.ExtraData,
 		},

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -26,7 +26,7 @@ func TestFSM_ValidateHeader(t *testing.T) {
 	t.Parallel()
 
 	parent := &types.Header{Number: 0}
-	_ = parent.ComputeHash()
+	parent.ComputeHash()
 
 	header := &types.Header{Number: 0}
 
@@ -149,7 +149,7 @@ func TestFSM_BuildProposal_WithoutUptimeTxGood(t *testing.T) {
 	extra := createTestExtra(validatorSet, AccountSet{}, accountCount-1, committedCount, parentCount)
 
 	parent := &types.Header{Number: parentBlockNumber, ExtraData: extra}
-	_ = parent.ComputeHash()
+	parent.ComputeHash()
 	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, extra)
 	mBlockBuilder := newBlockBuilderMock(stateBlock)
 
@@ -171,12 +171,12 @@ func TestFSM_BuildProposal_WithoutUptimeTxGood(t *testing.T) {
 		NextValidatorsHash:    nextValidatorsHash,
 	}
 
-	proposalHash, err := getSignHash(fsm.backend.GetChainID(), checkpoint, stateBlock.Block.Number(), stateBlock.Block.Hash())
+	checkpointHash, err := checkpoint.Hash(fsm.backend.GetChainID(), stateBlock.Block.Number(), stateBlock.Block.Hash())
 	require.NoError(t, err)
 
 	rlpBlock := stateBlock.Block.MarshalRLP()
 	assert.Equal(t, rlpBlock, proposal.Data)
-	assert.Equal(t, proposalHash, types.BytesToHash(proposal.Hash))
+	assert.Equal(t, checkpointHash, types.BytesToHash(proposal.Hash))
 
 	mBlockBuilder.AssertExpectations(t)
 }
@@ -196,7 +196,7 @@ func TestFSM_BuildProposal_WithUptimeTxGood(t *testing.T) {
 	extra := createTestExtra(validators.getPublicIdentities(), AccountSet{}, accountCount-1, committedCount, parentCount)
 
 	parent := &types.Header{Number: parentBlockNumber, ExtraData: extra}
-	_ = parent.ComputeHash()
+	parent.ComputeHash()
 	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, extra)
 
 	transition := &state.Transition{}
@@ -237,10 +237,10 @@ func TestFSM_BuildProposal_WithUptimeTxGood(t *testing.T) {
 		NextValidatorsHash:    nextValidatorsHash,
 	}
 
-	proposalHash, err := getSignHash(fsm.backend.GetChainID(), checkpoint, stateBlock.Block.Number(), stateBlock.Block.Hash())
+	checkpointHash, err := checkpoint.Hash(fsm.backend.GetChainID(), stateBlock.Block.Number(), stateBlock.Block.Hash())
 	require.NoError(t, err)
 	assert.Equal(t, rlpBlock, proposal.Data)
-	assert.Equal(t, proposalHash.Bytes(), proposal.Hash)
+	assert.Equal(t, checkpointHash.Bytes(), proposal.Hash)
 
 	mBlockBuilder.AssertExpectations(t)
 	systemStateMock.AssertExpectations(t)
@@ -289,7 +289,7 @@ func TestFSM_BuildProposal_EpochEndingBlock_ValidatorsDeltaExists(t *testing.T) 
 	validatorSet := newTestValidators(validatorsCount).getPublicIdentities()
 	extra := createTestExtra(validatorSet, AccountSet{}, validatorsCount-1, signaturesCount, signaturesCount)
 	parent := &types.Header{Number: parentBlockNumber, ExtraData: extra}
-	_ = parent.ComputeHash()
+	parent.ComputeHash()
 	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, extra)
 
 	transition := &state.Transition{}
@@ -361,7 +361,7 @@ func TestFSM_BuildProposal_NonEpochEndingBlock_ValidatorsDeltaEmpty(t *testing.T
 	testValidators := newTestValidators(accountCount)
 	extra := createTestExtra(testValidators.getPublicIdentities(), AccountSet{}, accountCount-1, signaturesCount, signaturesCount)
 	parent := &types.Header{Number: parentBlockNumber, ExtraData: extra}
-	_ = parent.ComputeHash()
+	parent.ComputeHash()
 	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, extra)
 
 	blockBuilderMock := &blockBuilderMock{}
@@ -601,7 +601,7 @@ func TestFSM_ValidateCommit_WrongValidator(t *testing.T) {
 		Number:    parentBlockNumber,
 		ExtraData: createTestExtra(validators.getPublicIdentities(), AccountSet{}, 5, 3, 3),
 	}
-	_ = parent.ComputeHash()
+	parent.ComputeHash()
 	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, parent.ExtraData)
 	mBlockBuilder := newBlockBuilderMock(stateBlock)
 	fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: &blockchainMock{},
@@ -627,7 +627,7 @@ func TestFSM_ValidateCommit_InvalidHash(t *testing.T) {
 		Number:    parentBlockNumber,
 		ExtraData: createTestExtra(validators.getPublicIdentities(), AccountSet{}, 5, 3, 3),
 	}
-	_ = parent.ComputeHash()
+	parent.ComputeHash()
 	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, parent.ExtraData)
 	mBlockBuilder := newBlockBuilderMock(stateBlock)
 	fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: &blockchainMock{},
@@ -653,7 +653,7 @@ func TestFSM_ValidateCommit_Good(t *testing.T) {
 	validatorSet := validators.getPublicIdentities()
 
 	parent := &types.Header{Number: parentBlockNumber, ExtraData: createTestExtra(validatorSet, AccountSet{}, 5, 3, 3)}
-	_ = parent.ComputeHash()
+	parent.ComputeHash()
 	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, parent.ExtraData)
 	mBlockBuilder := newBlockBuilderMock(stateBlock)
 
@@ -682,7 +682,7 @@ func TestFSM_Validate_IncorrectSignHash(t *testing.T) {
 
 	parent := &types.Header{Number: parentBlockNumber,
 		ExtraData: createTestExtra(validators.getPublicIdentities(), AccountSet{}, accountsCount, signaturesCount, signaturesCount)}
-	_ = parent.ComputeHash()
+	parent.ComputeHash()
 	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, parent.ExtraData)
 	mBlockBuilder := newBlockBuilderMock(stateBlock)
 
@@ -712,19 +712,19 @@ func TestFSM_Validate_IncorrectHeaderParentHash(t *testing.T) {
 		Number:    parentBlockNumber,
 		ExtraData: createTestExtra(validators.getPublicIdentities(), AccountSet{}, 4, signaturesCount, signaturesCount),
 	}
-	_ = parent.ComputeHash()
+	parent.ComputeHash()
 
 	fsm := &fsm{parent: parent, config: &PolyBFTConfig{}, backend: &blockchainMock{},
 		validators: validators.toValidatorSet(), logger: hclog.NewNullLogger()}
 
 	stateBlock := createDummyStateBlock(parent.Number+1, types.Hash{100, 15}, parent.ExtraData)
 
-	proposalHash, err := getSignHash(fsm.backend.GetChainID(), &CheckpointData{}, stateBlock.Block.Number(), stateBlock.Block.Hash())
+	checkpointHash, err := new(CheckpointData).Hash(fsm.backend.GetChainID(), stateBlock.Block.Number(), stateBlock.Block.Hash())
 	require.NoError(t, err)
 
 	proposal := &pbft.Proposal{
 		Data: stateBlock.Block.MarshalRLP(),
-		Hash: proposalHash.Bytes(),
+		Hash: checkpointHash.Bytes(),
 	}
 
 	err = fsm.Validate(proposal)
@@ -745,7 +745,7 @@ func TestFSM_Validate_InvalidNumber(t *testing.T) {
 		Number:    parentBlockNumber,
 		ExtraData: createTestExtra(validators.getPublicIdentities(), AccountSet{}, 4, signaturesCount, signaturesCount),
 	}
-	_ = parent.ComputeHash()
+	parent.ComputeHash()
 
 	// try some invalid block numbers, parentBlockNumber + 1 should be correct
 	for _, blockNum := range []uint64{parentBlockNumber - 1, parentBlockNumber, parentBlockNumber + 2} {
@@ -754,7 +754,7 @@ func TestFSM_Validate_InvalidNumber(t *testing.T) {
 		fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: &blockchainMock{},
 			validators: validators.toValidatorSet(), logger: hclog.NewNullLogger()}
 
-		proposalHash, err := getSignHash(fsm.backend.GetChainID(), &CheckpointData{}, stateBlock.Block.Number(), stateBlock.Block.Hash())
+		proposalHash, err := new(CheckpointData).Hash(fsm.backend.GetChainID(), stateBlock.Block.Number(), stateBlock.Block.Hash())
 		require.NoError(t, err)
 
 		proposal := &pbft.Proposal{
@@ -778,7 +778,7 @@ func TestFSM_Validate_TimestampOlder(t *testing.T) {
 		ExtraData: createTestExtra(validators.getPublicIdentities(), AccountSet{}, 4, 3, 3),
 		Timestamp: uint64(time.Now().Unix()),
 	}
-	_ = parent.ComputeHash()
+	parent.ComputeHash()
 
 	// try some invalid times
 	for _, blockTime := range []uint64{parent.Timestamp - 1, parent.Timestamp} {
@@ -792,12 +792,12 @@ func TestFSM_Validate_TimestampOlder(t *testing.T) {
 		fsm := &fsm{parent: parent, config: &PolyBFTConfig{}, backend: &blockchainMock{},
 			validators: validators.toValidatorSet(), logger: hclog.NewNullLogger()}
 
-		proposalHash, err := getSignHash(fsm.backend.GetChainID(), &CheckpointData{}, header.Number, header.Hash)
+		checkpointHash, err := new(CheckpointData).Hash(fsm.backend.GetChainID(), header.Number, header.Hash)
 		require.NoError(t, err)
 
 		proposal := &pbft.Proposal{
 			Data: stateBlock.Block.MarshalRLP(),
-			Hash: proposalHash.Bytes(),
+			Hash: checkpointHash.Bytes(),
 		}
 
 		err = fsm.Validate(proposal)
@@ -816,7 +816,7 @@ func TestFSM_Validate_IncorrectMixHash(t *testing.T) {
 		ExtraData: createTestExtra(validators.getPublicIdentities(), AccountSet{}, 4, 3, 3),
 		Timestamp: uint64(100),
 	}
-	_ = parent.ComputeHash()
+	parent.ComputeHash()
 
 	header := &types.Header{
 		Number:     parentBlockNumber + 1,
@@ -837,12 +837,12 @@ func TestFSM_Validate_IncorrectMixHash(t *testing.T) {
 	}
 	rlpBlock := buildBlock.Block.MarshalRLP()
 
-	proposalHash, err := getSignHash(fsm.backend.GetChainID(), &CheckpointData{}, header.Number, header.Hash)
+	checkpointHash, err := new(CheckpointData).Hash(fsm.backend.GetChainID(), header.Number, header.Hash)
 	require.NoError(t, err)
 
 	proposal := &pbft.Proposal{
 		Data: rlpBlock,
-		Hash: proposalHash.Bytes(),
+		Hash: checkpointHash.Bytes(),
 	}
 
 	err = fsm.Validate(proposal)
@@ -937,7 +937,8 @@ func TestFSM_Insert_InvalidNode(t *testing.T) {
 	validatorSet := validators.getPublicIdentities()
 
 	parent := &types.Header{Number: parentBlockNumber}
-	_ = parent.ComputeHash()
+	parent.ComputeHash()
+
 	extraBlock := createTestExtra(validatorSet, AccountSet{}, len(validators.validators)-1, signaturesCount, signaturesCount)
 	finalBlock := consensus.BuildBlock(
 		consensus.BuildBlockParams{
@@ -1484,7 +1485,7 @@ func TestFSM_Validate_FailToVerifySignatures(t *testing.T) {
 		Number:    parentBlockNumber,
 		ExtraData: createTestExtra(validatorSet, AccountSet{}, 4, signaturesCount, signaturesCount),
 	}
-	_ = parent.ComputeHash()
+	parent.ComputeHash()
 
 	polybftBackendMock := new(polybftBackendMock)
 	polybftBackendMock.On("GetValidators", mock.Anything, mock.Anything).Return(validatorSet, nil).Once()
@@ -1512,12 +1513,12 @@ func TestFSM_Validate_FailToVerifySignatures(t *testing.T) {
 		},
 	})
 
-	proposalHash, err := getSignHash(fsm.backend.GetChainID(), &CheckpointData{}, finalBlock.Number(), finalBlock.Hash())
+	checkpointHash, err := new(CheckpointData).Hash(fsm.backend.GetChainID(), finalBlock.Number(), finalBlock.Hash())
 	require.NoError(t, err)
 
 	proposal := &pbft.Proposal{
 		Data: finalBlock.MarshalRLP(),
-		Hash: proposalHash.Bytes(),
+		Hash: checkpointHash.Bytes(),
 	}
 
 	assert.ErrorContains(t, fsm.Validate(proposal), "failed to verify signatures")

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -163,12 +163,9 @@ func TestFSM_BuildProposal_WithoutUptimeTxGood(t *testing.T) {
 	currentValidatorsHash, err := validatorSet.Hash()
 	require.NoError(t, err)
 
-	nextValidatorsHash, err := AccountSet{}.Hash()
-	require.NoError(t, err)
-
 	checkpoint := &CheckpointData{
 		CurrentValidatorsHash: currentValidatorsHash,
-		NextValidatorsHash:    nextValidatorsHash,
+		NextValidatorsHash:    currentValidatorsHash,
 	}
 
 	checkpointHash, err := checkpoint.Hash(fsm.backend.GetChainID(), stateBlock.Block.Number(), stateBlock.Block.Hash())

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -171,7 +171,7 @@ func TestFSM_BuildProposal_WithoutUptimeTxGood(t *testing.T) {
 		NextValidatorsHash:    nextValidatorsHash,
 	}
 
-	proposalHash, err := fsm.getProposalHash(checkpoint, stateBlock.Block.Number(), stateBlock.Block.Hash())
+	proposalHash, err := getSignHash(fsm.backend.GetChainID(), checkpoint, stateBlock.Block.Number(), stateBlock.Block.Hash())
 	require.NoError(t, err)
 
 	rlpBlock := stateBlock.Block.MarshalRLP()
@@ -237,7 +237,7 @@ func TestFSM_BuildProposal_WithUptimeTxGood(t *testing.T) {
 		NextValidatorsHash:    nextValidatorsHash,
 	}
 
-	proposalHash, err := fsm.getProposalHash(checkpoint, stateBlock.Block.Number(), stateBlock.Block.Hash())
+	proposalHash, err := getSignHash(fsm.backend.GetChainID(), checkpoint, stateBlock.Block.Number(), stateBlock.Block.Hash())
 	require.NoError(t, err)
 	assert.Equal(t, rlpBlock, proposal.Data)
 	assert.Equal(t, proposalHash.Bytes(), proposal.Hash)
@@ -719,7 +719,7 @@ func TestFSM_Validate_IncorrectHeaderParentHash(t *testing.T) {
 
 	stateBlock := createDummyStateBlock(parent.Number+1, types.Hash{100, 15}, parent.ExtraData)
 
-	proposalHash, err := fsm.getProposalHash(&CheckpointData{}, stateBlock.Block.Number(), stateBlock.Block.Hash())
+	proposalHash, err := getSignHash(fsm.backend.GetChainID(), &CheckpointData{}, stateBlock.Block.Number(), stateBlock.Block.Hash())
 	require.NoError(t, err)
 
 	proposal := &pbft.Proposal{
@@ -754,7 +754,7 @@ func TestFSM_Validate_InvalidNumber(t *testing.T) {
 		fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: &blockchainMock{},
 			validators: validators.toValidatorSet(), logger: hclog.NewNullLogger()}
 
-		proposalHash, err := fsm.getProposalHash(&CheckpointData{}, stateBlock.Block.Number(), stateBlock.Block.Hash())
+		proposalHash, err := getSignHash(fsm.backend.GetChainID(), &CheckpointData{}, stateBlock.Block.Number(), stateBlock.Block.Hash())
 		require.NoError(t, err)
 
 		proposal := &pbft.Proposal{
@@ -792,7 +792,7 @@ func TestFSM_Validate_TimestampOlder(t *testing.T) {
 		fsm := &fsm{parent: parent, config: &PolyBFTConfig{}, backend: &blockchainMock{},
 			validators: validators.toValidatorSet(), logger: hclog.NewNullLogger()}
 
-		proposalHash, err := fsm.getProposalHash(&CheckpointData{}, header.Number, header.Hash)
+		proposalHash, err := getSignHash(fsm.backend.GetChainID(), &CheckpointData{}, header.Number, header.Hash)
 		require.NoError(t, err)
 
 		proposal := &pbft.Proposal{
@@ -837,7 +837,7 @@ func TestFSM_Validate_IncorrectMixHash(t *testing.T) {
 	}
 	rlpBlock := buildBlock.Block.MarshalRLP()
 
-	proposalHash, err := fsm.getProposalHash(&CheckpointData{}, header.Number, header.Hash)
+	proposalHash, err := getSignHash(fsm.backend.GetChainID(), &CheckpointData{}, header.Number, header.Hash)
 	require.NoError(t, err)
 
 	proposal := &pbft.Proposal{
@@ -1512,7 +1512,7 @@ func TestFSM_Validate_FailToVerifySignatures(t *testing.T) {
 		},
 	})
 
-	proposalHash, err := fsm.getProposalHash(&CheckpointData{}, finalBlock.Number(), finalBlock.Hash())
+	proposalHash, err := getSignHash(fsm.backend.GetChainID(), &CheckpointData{}, finalBlock.Number(), finalBlock.Hash())
 	require.NoError(t, err)
 
 	proposal := &pbft.Proposal{

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -114,7 +114,7 @@ func (m *blockchainMock) CalculateGasLimit(number uint64) (uint64, error) {
 	return 0, nil
 }
 
-func (m *blockchainMock) GetChainID() int {
+func (m *blockchainMock) GetChainID() uint64 {
 	return 0
 }
 

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -114,6 +114,10 @@ func (m *blockchainMock) CalculateGasLimit(number uint64) (uint64, error) {
 	return 0, nil
 }
 
+func (m *blockchainMock) GetChainID() int {
+	return 0
+}
+
 var _ polybftBackend = &polybftBackendMock{}
 
 type polybftBackendMock struct {

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -516,13 +516,6 @@ func (p *Polybft) VerifyHeader(header *types.Header) error {
 
 func (p *Polybft) verifyHeaderImpl(parent, header *types.Header, parents []*types.Header) error {
 	blockNumber := header.Number
-	if blockNumber == 0 {
-		// TODO: Remove, this was just for simplicity since I had started the chain already,
-		//  add the mix hash into the genesis command
-		p.logger.Info("We are here, block number = 0!")
-
-		return nil
-	}
 
 	//validate header fields
 	if err := validateHeaderFields(parent, header); err != nil {

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -537,13 +537,13 @@ func (p *Polybft) verifyHeaderImpl(parent, header *types.Header, parents []*type
 		return fmt.Errorf("failed to verify signatures for block %d because signatures are not present", blockNumber)
 	}
 
-	signedHash, err := getSignHash(p.blockchain.GetChainID(), extra.Checkpoint, header.Number, header.Hash)
+	checkpointHash, err := extra.Checkpoint.Hash(p.blockchain.GetChainID(), header.Number, header.Hash)
 	if err != nil {
 		return err
 	}
 
-	if err := extra.Committed.VerifyCommittedFields(validators, signedHash); err != nil {
-		return fmt.Errorf("failed to verify signatures for block %d. Signed hash %v", blockNumber, signedHash)
+	if err := extra.Committed.VerifyCommittedFields(validators, checkpointHash); err != nil {
+		return fmt.Errorf("failed to verify signatures for block %d. Signed hash %v", blockNumber, checkpointHash)
 	}
 
 	// validate the signatures for parent (skip block 1 because genesis does not have committed)
@@ -567,12 +567,12 @@ func (p *Polybft) verifyHeaderImpl(parent, header *types.Header, parents []*type
 			return err
 		}
 
-		signHash, err := getSignHash(p.blockchain.GetChainID(), parentExtra.Checkpoint, parent.Number, parent.Hash)
+		parentCheckpointHash, err := parentExtra.Checkpoint.Hash(p.blockchain.GetChainID(), parent.Number, parent.Hash)
 		if err != nil {
 			return err
 		}
 
-		if err := extra.Parent.VerifyCommittedFields(parentValidators, signHash); err != nil {
+		if err := extra.Parent.VerifyCommittedFields(parentValidators, parentCheckpointHash); err != nil {
 			return fmt.Errorf("failed to verify signatures for parent of block %d. Parent hash: %v", blockNumber, parent.Hash)
 		}
 	}

--- a/consensus/polybft/polybft_test.go
+++ b/consensus/polybft/polybft_test.go
@@ -104,7 +104,7 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 		Number:     polyBftConfig.EpochSize + 1,
 		ParentHash: parentHeader.Hash,
 		Timestamp:  parentHeader.Timestamp + 1,
-		MixHash:    PolyMixDigest,
+		MixHash:    PolyBFTMixDigest,
 		Difficulty: 1,
 	}
 	_ = currentHeader.ComputeHash()

--- a/consensus/polybft/polybft_test.go
+++ b/consensus/polybft/polybft_test.go
@@ -54,7 +54,7 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 		Number:    0,
 		ExtraData: append(make([]byte, signer.IstanbulExtraVanity), genesisExtra.MarshalRLPTo(nil)...),
 	}
-	genesisHeader.ComputeHash()
+	_ = genesisHeader.ComputeHash()
 
 	// add genesis header to map
 	headersMap.addHeader(genesisHeader)
@@ -64,7 +64,7 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 		delta, err := createValidatorSetDelta(hclog.NewNullLogger(), validatorSetParent, validatorSetParent)
 		require.NoError(t, err)
 
-		extra := &Extra{Validators: delta}
+		extra := &Extra{Validators: delta, Checkpoint: &CheckpointData{}}
 		header := &types.Header{
 			Number:    uint64(i),
 			ExtraData: append(make([]byte, signer.IstanbulExtraVanity), extra.MarshalRLPTo(nil)...),
@@ -75,31 +75,40 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 		headersMap.addHeader(header)
 	}
 
+	// mock blockchain
+	blockchainMock := new(blockchainMock)
+	blockchainMock.On("GetHeaderByNumber", mock.Anything).Return(headersMap.getHeader)
+	blockchainMock.On("GetHeaderByHash", mock.Anything).Return(headersMap.getHeaderByHash)
+
 	// create parent header (block 10)
 	parentDelta, err := createValidatorSetDelta(hclog.NewNullLogger(), validatorSetParent, validatorSetCurrent)
 	require.NoError(t, err)
 
-	parentExtra := &Extra{Validators: parentDelta}
+	parentExtra := &Extra{Validators: parentDelta, Checkpoint: &CheckpointData{}}
 	parentHeader := &types.Header{
 		Number:    polyBftConfig.EpochSize,
 		ExtraData: append(make([]byte, signer.IstanbulExtraVanity), parentExtra.MarshalRLPTo(nil)...),
-		Timestamp: uint64(time.Now().UTC().UnixMilli()),
+		Timestamp: uint64(time.Now().UnixMilli()),
 	}
 	_ = parentHeader.ComputeHash()
-	parentCommitted := createSignature(t, accountSetParent, parentHeader.Hash)
+
+	signHash, err := getSignHash(blockchainMock.GetChainID(), parentExtra.Checkpoint, parentHeader.Number, parentHeader.Hash)
+	require.NoError(t, err)
+
+	parentCommitted := createSignature(t, accountSetParent, signHash)
 
 	// now create new extra with committed and add it to parent header
-	parentExtra = &Extra{Validators: parentDelta, Committed: parentCommitted}
+	parentExtra = &Extra{Validators: parentDelta, Committed: parentCommitted, Checkpoint: &CheckpointData{}}
 	parentHeader.ExtraData = append(make([]byte, signer.IstanbulExtraVanity), parentExtra.MarshalRLPTo(nil)...)
 
-	// add parent header  to map
+	// add parent header to map
 	headersMap.addHeader(parentHeader)
 
 	// create current header (block 11) with all appropriate fields required for validation
 	currentDelta, err := createValidatorSetDelta(hclog.NewNullLogger(), validatorSetCurrent, validatorSetCurrent)
 	require.NoError(t, err)
 
-	currentExtra := &Extra{Validators: currentDelta, Parent: parentCommitted}
+	currentExtra := &Extra{Validators: currentDelta, Parent: parentCommitted, Checkpoint: &CheckpointData{}}
 	currentHeader := &types.Header{
 		Number:     polyBftConfig.EpochSize + 1,
 		ParentHash: parentHeader.Hash,
@@ -109,15 +118,13 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 	}
 	_ = currentHeader.ComputeHash()
 
-	currentCommitted := createSignature(t, accountSetCurrent, currentHeader.Hash)
-	// forget Parent field (parent signature) intentionally
-	currentExtra = &Extra{Validators: currentDelta, Committed: currentCommitted}
-	currentHeader.ExtraData = append(make([]byte, signer.IstanbulExtraVanity), currentExtra.MarshalRLPTo(nil)...)
+	signingHash, err := getSignHash(blockchainMock.GetChainID(), &CheckpointData{}, currentHeader.Number, currentHeader.Hash)
+	require.NoError(t, err)
 
-	// mock blockchain
-	blockchainMock := new(blockchainMock)
-	blockchainMock.On("GetHeaderByNumber", mock.Anything).Return(headersMap.getHeader)
-	blockchainMock.On("GetHeaderByHash", mock.Anything).Return(headersMap.getHeaderByHash)
+	currentCommitted := createSignature(t, accountSetCurrent, signingHash)
+	// forget Parent field (parent signature) intentionally
+	currentExtra = &Extra{Validators: currentDelta, Committed: currentCommitted, Checkpoint: &CheckpointData{}}
+	currentHeader.ExtraData = append(make([]byte, signer.IstanbulExtraVanity), currentExtra.MarshalRLPTo(nil)...)
 
 	// create polybft with appropriate mocks
 	polybft := &Polybft{
@@ -128,12 +135,17 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 		validatorsCache: newValidatorsSnapshotCache(hclog.NewNullLogger(), newTestState(t), polyBftConfig.EpochSize, blockchainMock),
 	}
 
-	// sice parent signature is intentionally disregarded the following error is expected
+	// since parent signature is intentionally disregarded the following error is expected
 	assert.ErrorContains(t, polybft.VerifyHeader(currentHeader), "failed to verify signatures for parent of block")
 
 	// create valid extra filed for current header and check the header
 	// this is the situation before a block (a valid header) is added to the blockchain
-	currentExtra = &Extra{Validators: currentDelta, Committed: currentCommitted, Parent: parentCommitted}
+	currentExtra = &Extra{
+		Validators: currentDelta,
+		Committed:  currentCommitted,
+		Parent:     parentCommitted,
+		Checkpoint: &CheckpointData{},
+	}
 	currentHeader.ExtraData = append(make([]byte, signer.IstanbulExtraVanity), currentExtra.MarshalRLPTo(nil)...)
 	assert.NoError(t, polybft.VerifyHeader(currentHeader))
 

--- a/consensus/polybft/polybft_test.go
+++ b/consensus/polybft/polybft_test.go
@@ -54,7 +54,7 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 		Number:    0,
 		ExtraData: append(make([]byte, signer.IstanbulExtraVanity), genesisExtra.MarshalRLPTo(nil)...),
 	}
-	_ = genesisHeader.ComputeHash()
+	genesisHeader.ComputeHash()
 
 	// add genesis header to map
 	headersMap.addHeader(genesisHeader)
@@ -90,12 +90,12 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 		ExtraData: append(make([]byte, signer.IstanbulExtraVanity), parentExtra.MarshalRLPTo(nil)...),
 		Timestamp: uint64(time.Now().UnixMilli()),
 	}
-	_ = parentHeader.ComputeHash()
+	parentHeader.ComputeHash()
 
-	signHash, err := getSignHash(blockchainMock.GetChainID(), parentExtra.Checkpoint, parentHeader.Number, parentHeader.Hash)
+	checkpointHash, err := parentExtra.Checkpoint.Hash(blockchainMock.GetChainID(), parentHeader.Number, parentHeader.Hash)
 	require.NoError(t, err)
 
-	parentCommitted := createSignature(t, accountSetParent, signHash)
+	parentCommitted := createSignature(t, accountSetParent, checkpointHash)
 
 	// now create new extra with committed and add it to parent header
 	parentExtra = &Extra{Validators: parentDelta, Committed: parentCommitted, Checkpoint: &CheckpointData{}}
@@ -116,9 +116,9 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 		MixHash:    PolyBFTMixDigest,
 		Difficulty: 1,
 	}
-	_ = currentHeader.ComputeHash()
+	currentHeader.ComputeHash()
 
-	signingHash, err := getSignHash(blockchainMock.GetChainID(), &CheckpointData{}, currentHeader.Number, currentHeader.Hash)
+	signingHash, err := new(CheckpointData).Hash(blockchainMock.GetChainID(), currentHeader.Number, currentHeader.Hash)
 	require.NoError(t, err)
 
 	currentCommitted := createSignature(t, accountSetCurrent, signingHash)

--- a/consensus/polybft/signer/public.go
+++ b/consensus/polybft/signer/public.go
@@ -70,7 +70,7 @@ func UnmarshalPublicKey(raw []byte) (*PublicKey, error) {
 }
 
 // ToBigInt converts public key to 4 big ints
-func (p PublicKey) ToBigInt() ([4]*big.Int, error) {
+func (p PublicKey) ToBigInt() [4]*big.Int {
 	blsKey := p.Marshal()
 	res := [4]*big.Int{
 		new(big.Int).SetBytes(blsKey[32:64]),
@@ -79,7 +79,7 @@ func (p PublicKey) ToBigInt() ([4]*big.Int, error) {
 		new(big.Int).SetBytes(blsKey[64:96]),
 	}
 
-	return res, nil
+	return res
 }
 
 // UnmarshalPublicKeyFromBigInt unmarshals public key from 4 big ints

--- a/consensus/polybft/signer/public_test.go
+++ b/consensus/polybft/signer/public_test.go
@@ -32,10 +32,7 @@ func TestPublic_UnmarshalPublicKeyFromBigInt(t *testing.T) {
 	key, _ := GenerateBlsKey()
 	pub := key.PublicKey()
 
-	res, err := pub.ToBigInt()
-	require.NoError(t, err)
-
-	pub2, err := UnmarshalPublicKeyFromBigInt(res)
+	pub2, err := UnmarshalPublicKeyFromBigInt(pub.ToBigInt())
 	require.NoError(t, err)
 
 	require.Equal(t, pub, pub2)

--- a/consensus/polybft/validator_account_test.go
+++ b/consensus/polybft/validator_account_test.go
@@ -8,6 +8,7 @@ import (
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAccountSet_GetAddresses(t *testing.T) {
@@ -159,4 +160,26 @@ func TestAccountSet_ApplyDelta(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAccountSet_Hash(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Hash non-empty account set", func(t *testing.T) {
+		t.Parallel()
+
+		v := newTestValidatorsWithAliases([]string{"A", "B", "C", "D", "E", "F"})
+		hash, err := v.getPublicIdentities().Hash()
+		require.NoError(t, err)
+		require.NotEqual(t, types.ZeroHash, hash)
+	})
+
+	t.Run("Hash empty account set", func(t *testing.T) {
+		t.Parallel()
+
+		empty := AccountSet{}
+		hash, err := empty.Hash()
+		require.NoError(t, err)
+		require.NotEqual(t, types.ZeroHash, hash)
+	})
 }

--- a/e2e-polybft/bridge_test.go
+++ b/e2e-polybft/bridge_test.go
@@ -83,7 +83,7 @@ func TestE2E_Bridge_MainWorkflow(t *testing.T) {
 	)
 
 	// wait for a few more sprints
-	require.NoError(t, cluster.WaitForBlock(30, 2*time.Minute))
+	require.NoError(t, cluster.WaitForBlock(40, 2*time.Minute))
 
 	// the transaction is mined and there should be a success event
 	id := stateSyncResultEvent.ID()


### PR DESCRIPTION
# Description

This PR introduces new fields to the `Header.Extra`, which are required for checkpointing mechanism and are part of consensus protocol.

Checkpoint data consists of: 
- `BlockRound` - round for which we are building block at given height, 
- `EpochNumber` - denoting current epoch,
- `CurrentValidatorsHash` - hash of the current validator set (for the current epoch), 
- `NextValidatorsHash` - hash of the next validator set (applicable for next epoch, namely epoch ending blocks which contain such information),
- `EventRoot` - merkle root hash of all exit events triggered by the appropriate smart contract.

Other than that, checkpoint is described with `BlockNumber`, `BlockHash` and `ChainID`, but we don't write those information into the blockchain, as it would be redundant.

Checkpoint data hash is in the following format:
```solidity
keccak256(abi.encode(uint256 chainId, uint256 blockNumber, bytes32 blockHash, uint256 blockRound, 
   uint256 epochNumber, bytes32 currentValidatorsHash, bytes32 nextValidatorsHash, bytes32 eventRoot))
```

Current validators and next validators hash is in the following format:
```solidity
keccak256(abi.encode(tuple(address _address, uint256[4] blsKey)[]))
```

Also format of the proposal hash being signed by the validators has changed. Prior to this PR, it was corresponding to `BlockHash`. However now it is the same as `checkpointHash`.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually