### PR TITLE
[Checkpoints] Parse receipt logs and insert new exit events

### DIFF
--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -161,7 +161,7 @@ func (b *BlockBuilder) WriteTx(tx *types.Transaction) error {
 }
 
 // Fill fills the block with transactions from the txpool
-func (b *BlockBuilder) Fill() error {
+func (b *BlockBuilder) Fill() []*types.Receipt {
 	blockTimer := time.NewTimer(b.params.BlockTime)
 
 	b.params.TxPool.Prepare()
@@ -169,7 +169,7 @@ write:
 	for {
 		select {
 		case <-blockTimer.C:
-			return nil
+			return b.state.Receipts()
 		default:
 			tx := b.params.TxPool.Peek()
 
@@ -188,7 +188,7 @@ write:
 	//	wait for the timer to expire
 	<-blockTimer.C
 
-	return nil
+	return b.state.Receipts()
 }
 
 func (b *BlockBuilder) writeTxPoolTransaction(tx *types.Transaction) (bool, error) {

--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -161,7 +161,7 @@ func (b *BlockBuilder) WriteTx(tx *types.Transaction) error {
 }
 
 // Fill fills the block with transactions from the txpool
-func (b *BlockBuilder) Fill() []*types.Receipt {
+func (b *BlockBuilder) Fill() {
 	blockTimer := time.NewTimer(b.params.BlockTime)
 
 	b.params.TxPool.Prepare()
@@ -169,7 +169,7 @@ write:
 	for {
 		select {
 		case <-blockTimer.C:
-			return b.state.Receipts()
+			return
 		default:
 			tx := b.params.TxPool.Peek()
 
@@ -187,7 +187,10 @@ write:
 
 	//	wait for the timer to expire
 	<-blockTimer.C
+}
 
+// Receipts returns the collection of transaction receipts for given block
+func (b *BlockBuilder) Receipts() []*types.Receipt {
 	return b.state.Receipts()
 }
 

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -51,6 +51,14 @@ type txPoolInterface interface {
 	Demote(tx *types.Transaction)
 }
 
+// checkpointBackend is an interface providing functions for working with checkpoints and exit evens
+type checkpointBackend interface {
+	// BuildEventRoot generates an event root hash from exit events in given epoch
+	BuildEventRoot(epoch uint64) (types.Hash, error)
+	// InsertExitEvents inserts provided exit events to persistence storage
+	InsertExitEvents(exitEvents []*ExitEvent) error
+}
+
 // epochMetadata is the static info for epoch currently being processed
 type epochMetadata struct {
 	// Number is the number of the epoch
@@ -221,7 +229,7 @@ func (c *consensusRuntime) populateFsmIfBridgeEnabled(
 	if isEndOfEpoch {
 		commitment, err := c.getCommitmentToRegister(epoch, nextRegisteredCommitmentIndex)
 		if err != nil {
-			if errors.Is(err, ErrCommitmentNotBuilt) {
+			if errors.Is(err, errCommitmentNotBuilt) {
 				c.logger.Debug("[FSM] Have no built commitment to register",
 					"epoch", epoch.Number, "from state sync index", nextRegisteredCommitmentIndex)
 			} else if errors.Is(err, errQuorumNotReached) {
@@ -281,17 +289,17 @@ func (c *consensusRuntime) FSM() (*fsm, error) {
 	isEndOfEpoch := c.isEndOfEpoch(pendingBlockNumber)
 
 	ff := &fsm{
-		config:           c.config.PolyBFTConfig,
-		parent:           parent,
-		backend:          c.config.blockchain,
-		polybftBackend:   c.config.polybftBackend,
-		epochNumber:      epoch.Number,
-		blockBuilder:     blockBuilder,
-		validators:       newValidatorSet(types.BytesToAddress(parent.Miner), epoch.Validators),
-		isEndOfEpoch:     isEndOfEpoch,
-		isEndOfSprint:    isEndOfSprint,
-		buildEventRootFn: c.getExitEventRootHash,
-		logger:           c.logger.Named("fsm"),
+		config:            c.config.PolyBFTConfig,
+		parent:            parent,
+		backend:           c.config.blockchain,
+		polybftBackend:    c.config.polybftBackend,
+		checkpointBackend: c,
+		epochNumber:       epoch.Number,
+		blockBuilder:      blockBuilder,
+		validators:        newValidatorSet(types.BytesToAddress(parent.Miner), epoch.Validators),
+		isEndOfEpoch:      isEndOfEpoch,
+		isEndOfSprint:     isEndOfSprint,
+		logger:            c.logger.Named("fsm"),
 	}
 
 	if c.IsBridgeEnabled() {
@@ -420,7 +428,7 @@ func (c *consensusRuntime) buildCommitment(epoch, fromIndex uint64) (*Commitment
 	// if it is not already built in the previous epoch
 	stateSyncEvents, err := c.state.getStateSyncEventsForCommitment(fromIndex, toIndex)
 	if err != nil {
-		if errors.Is(err, ErrNotEnoughStateSyncs) {
+		if errors.Is(err, errNotEnoughStateSyncs) {
 			c.logger.Debug("[buildCommitment] Not enough state syncs to build a commitment",
 				"epoch", epoch, "from state sync index", fromIndex)
 			// this is a valid case, there is not enough state syncs
@@ -762,8 +770,13 @@ func (c *consensusRuntime) calculateUptime(currentBlock *types.Header) (*CommitE
 	return commitEpoch, nil
 }
 
-// getExitEventRootHash returns the exit event root hash from gathered exit events in given epoch
-func (c *consensusRuntime) getExitEventRootHash(epoch uint64) (types.Hash, error) {
+// InsertExitEvents is an implementation of checkpointBackend interface
+func (c *consensusRuntime) InsertExitEvents(exitEvents []*ExitEvent) error {
+	return c.state.insertExitEvents(exitEvents)
+}
+
+// BuildEventRoot is an implementation of checkpointBackend interface
+func (c *consensusRuntime) BuildEventRoot(epoch uint64) (types.Hash, error) {
 	exitEvents, err := c.state.getExitEventsByEpoch(epoch)
 	if err != nil {
 		return types.ZeroHash, err
@@ -896,7 +909,7 @@ func (c *consensusRuntime) getCommitmentToRegister(epoch *epochMetadata,
 	registerCommitmentIndex uint64) (*CommitmentMessageSigned, error) {
 	if epoch.Commitment == nil {
 		// we did not build a commitment, so there is nothing to register
-		return nil, ErrCommitmentNotBuilt
+		return nil, errCommitmentNotBuilt
 	}
 
 	toIndex := registerCommitmentIndex + stateSyncMainBundleSize - 1

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1659,13 +1659,13 @@ func TestConsensusRuntime_getExitEventRootHash(t *testing.T) {
 		tree, err := NewMerkleTree(encodedEvents)
 		require.NoError(t, err)
 
-		hash, err := runtime.getExitEventRootHash(1)
+		hash, err := runtime.BuildEventRoot(1)
 		require.NoError(t, err)
 		require.Equal(t, tree.Hash(), hash)
 	})
 
 	t.Run("Get exit event root hash - no events", func(t *testing.T) {
-		hash, err := runtime.getExitEventRootHash(2)
+		hash, err := runtime.BuildEventRoot(2)
 		require.NoError(t, err)
 		require.Equal(t, types.Hash{}, hash)
 	})

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1659,13 +1659,13 @@ func TestConsensusRuntime_getExitEventRootHash(t *testing.T) {
 		tree, err := NewMerkleTree(encodedEvents)
 		require.NoError(t, err)
 
-		hash, err := runtime.BuildEventRoot(1)
+		hash, err := runtime.BuildEventRoot(1, nil)
 		require.NoError(t, err)
 		require.Equal(t, tree.Hash(), hash)
 	})
 
 	t.Run("Get exit event root hash - no events", func(t *testing.T) {
-		hash, err := runtime.BuildEventRoot(2)
+		hash, err := runtime.BuildEventRoot(2, nil)
 		require.NoError(t, err)
 		require.Equal(t, types.Hash{}, hash)
 	})

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1643,6 +1643,8 @@ func TestConsensusRuntime_FSM_EndOfEpoch_PostHook(t *testing.T) {
 }
 
 func TestConsensusRuntime_getExitEventRootHash(t *testing.T) {
+	t.Parallel()
+
 	const (
 		numOfBlocks         = 10
 		numOfEventsPerBlock = 2
@@ -1656,6 +1658,8 @@ func TestConsensusRuntime_getExitEventRootHash(t *testing.T) {
 	encodedEvents := setupExitEventsForProofVerification(t, state, numOfBlocks, numOfEventsPerBlock)
 
 	t.Run("Get exit event root hash", func(t *testing.T) {
+		t.Parallel()
+
 		tree, err := NewMerkleTree(encodedEvents)
 		require.NoError(t, err)
 
@@ -1665,6 +1669,8 @@ func TestConsensusRuntime_getExitEventRootHash(t *testing.T) {
 	})
 
 	t.Run("Get exit event root hash - no events", func(t *testing.T) {
+		t.Parallel()
+
 		hash, err := runtime.BuildEventRoot(2, nil)
 		require.NoError(t, err)
 		require.Equal(t, types.Hash{}, hash)
@@ -1672,6 +1678,8 @@ func TestConsensusRuntime_getExitEventRootHash(t *testing.T) {
 }
 
 func TestConsensusRuntime_GenerateExitProof(t *testing.T) {
+	t.Parallel()
+
 	const (
 		numOfBlocks         = 10
 		numOfEventsPerBlock = 2
@@ -1694,11 +1702,14 @@ func TestConsensusRuntime_GenerateExitProof(t *testing.T) {
 	require.NotNil(t, proof)
 
 	t.Run("Generate and validate exit proof", func(t *testing.T) {
+		t.Parallel()
 		// verify generated proof on desired tree
 		require.NoError(t, VerifyProof(1, encodedEvents[1], proof, tree.Hash()))
 	})
 
 	t.Run("Generate and validate exit proof - invalid proof", func(t *testing.T) {
+		t.Parallel()
+
 		invalidProof := proof
 		invalidProof[0][0]++
 
@@ -1707,6 +1718,8 @@ func TestConsensusRuntime_GenerateExitProof(t *testing.T) {
 	})
 
 	t.Run("Generate exit proof - no event", func(t *testing.T) {
+		t.Parallel()
+
 		_, err := runtime.GenerateExitProof(21, 1, 1)
 		require.ErrorContains(t, err, "could not find any exit event that has an id")
 	})

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -538,11 +538,11 @@ func (f *fsm) Insert(p *pbft.SealedProposal) error {
 		Bitmap:              bitmap,
 	}
 
-	// Write extar data to header
+	// Write extra data to header
 	f.block.Block.Header.ExtraData = append(make([]byte, 32), extra.MarshalRLPTo(nil)...)
 
 	// commit exit events only when we finalize a block
-	events, err := getExitEventsFromReceipts(f.epochNumber, f.block.Block.Number(), f.blockBuilder.Receipts())
+	events, err := getExitEventsFromReceipts(f.epochNumber, f.block.Block.Number(), f.block.Receipts)
 	if err != nil {
 		return err
 	}
@@ -673,7 +673,7 @@ func getExitEventsFromReceipts(epoch, block uint64, receipts []*types.Receipt) (
 		}
 
 		for j := 0; j < len(receipts[i].Logs); j++ {
-			event, err := decodeExitEvent(convert(receipts[i].Logs[j]), epoch, block)
+			event, err := decodeExitEvent(convertLog(receipts[i].Logs[j]), epoch, block)
 			if err != nil {
 				return nil, err
 			}

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -23,9 +23,10 @@ var _ pbft.Backend = &fsm{}
 type blockBuilder interface {
 	Reset() error
 	WriteTx(*types.Transaction) error
-	Fill() []*types.Receipt
+	Fill()
 	Build(func(h *types.Header)) (*StateBlock, error)
 	GetState() *state.Transition
+	Receipts() []*types.Receipt
 }
 
 const maxBundlesPerSprint = 50
@@ -161,7 +162,9 @@ func (f *fsm) BuildProposal() (*pbft.Proposal, error) {
 	}
 
 	// fill the block with transactions
-	receipts := f.blockBuilder.Fill()
+	f.blockBuilder.Fill()
+
+	receipts := f.blockBuilder.Receipts()
 	events := make([]*ExitEvent, 0)
 
 	for i := 0; i < len(receipts); i++ {

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -165,13 +165,6 @@ func (f *fsm) BuildProposal() (*pbft.Proposal, error) {
 	// fill the block with transactions
 	f.blockBuilder.Fill()
 
-	// TODO - remove
-	// if len(events) > 0 {
-	// 	if err := f.checkpointBackend.InsertExitEvents(events); err != nil {
-	// 		return nil, err
-	// 	}
-	// }
-
 	// set the timestamp
 	parentTime := time.Unix(int64(parent.Timestamp), 0)
 	headerTime := parentTime.Add(f.config.BlockTime)

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -180,7 +180,8 @@ func TestFSM_BuildProposal_WithExitEvents(t *testing.T) {
 
 	mBlockBuilder := new(blockBuilderMock)
 	mBlockBuilder.On("Build", mock.Anything).Return(stateBlock).Once()
-	mBlockBuilder.On("Fill", mock.Anything).Return(receipts).Once()
+	mBlockBuilder.On("Fill").Once()
+	mBlockBuilder.On("Receipts", mock.Anything).Return(receipts).Once()
 
 	fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: &blockchainMock{},
 		validators: validators.toValidatorSet(), checkpointBackend: runtime, logger: hclog.NewNullLogger(), epochNumber: epoch}
@@ -232,7 +233,8 @@ func TestFSM_BuildProposal_WithExitEvents_ErrorInDecoding(t *testing.T) {
 	}}
 
 	mBlockBuilder := new(blockBuilderMock)
-	mBlockBuilder.On("Fill", mock.Anything).Return([]*types.Receipt{receipt}).Once()
+	mBlockBuilder.On("Fill").Once()
+	mBlockBuilder.On("Receipts", mock.Anything).Return([]*types.Receipt{receipt}).Once()
 
 	fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: &blockchainMock{},
 		validators: validators.toValidatorSet(), checkpointBackend: runtime, logger: hclog.NewNullLogger(), epochNumber: epoch}
@@ -315,9 +317,7 @@ func TestFSM_BuildProposal_WithUptimeTxGood(t *testing.T) {
 	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, extra)
 
 	transition := &state.Transition{}
-	mBlockBuilder := &blockBuilderMock{}
-	mBlockBuilder.On("Build", mock.Anything).Return(stateBlock).Once()
-	mBlockBuilder.On("Fill", mock.Anything).Return([]*types.Receipt{}).Once()
+	mBlockBuilder := newBlockBuilderMock(stateBlock)
 	mBlockBuilder.On("WriteTx", mock.Anything).Return(error(nil)).Once()
 	mBlockBuilder.On("GetState").Return(transition).Once()
 
@@ -414,9 +414,7 @@ func TestFSM_BuildProposal_EpochEndingBlock_ValidatorsDeltaExists(t *testing.T) 
 	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, extra)
 
 	transition := &state.Transition{}
-	blockBuilderMock := new(blockBuilderMock)
-	blockBuilderMock.On("Build", mock.Anything).Return(stateBlock).Once()
-	blockBuilderMock.On("Fill", mock.Anything).Return([]*types.Receipt{}).Once()
+	blockBuilderMock := newBlockBuilderMock(stateBlock)
 	blockBuilderMock.On("WriteTx", mock.Anything).Return(error(nil)).Once()
 	blockBuilderMock.On("GetState").Return(transition).Once()
 
@@ -492,7 +490,8 @@ func TestFSM_BuildProposal_NonEpochEndingBlock_ValidatorsDeltaEmpty(t *testing.T
 
 	blockBuilderMock := &blockBuilderMock{}
 	blockBuilderMock.On("Build", mock.Anything).Return(stateBlock).Once()
-	blockBuilderMock.On("Fill", mock.Anything).Return([]*types.Receipt{}).Once()
+	blockBuilderMock.On("Fill").Once()
+	blockBuilderMock.On("Receipts", mock.Anything).Return([]*types.Receipt{}).Once()
 
 	checkpointBackendMock := new(checkpointBackendMock)
 	checkpointBackendMock.On("BuildEventRoot", mock.Anything).Return(types.ZeroHash, nil).Once()
@@ -1794,7 +1793,8 @@ func createTestCommitment(t *testing.T, accounts []*wallet.Account) *CommitmentM
 func newBlockBuilderMock(stateBlock *StateBlock) *blockBuilderMock {
 	mBlockBuilder := new(blockBuilderMock)
 	mBlockBuilder.On("Build", mock.Anything).Return(stateBlock).Once()
-	mBlockBuilder.On("Fill", mock.Anything).Return([]*types.Receipt{}).Once()
+	mBlockBuilder.On("Fill", mock.Anything).Once()
+	mBlockBuilder.On("Receipts", mock.Anything).Return([]*types.Receipt{}).Once()
 
 	return mBlockBuilder
 }

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -184,7 +184,8 @@ func TestFSM_BuildProposal_WithExitEvents(t *testing.T) {
 	mBlockBuilder := new(blockBuilderMock)
 	mBlockBuilder.On("Build", mock.Anything).Return(stateBlock).Once()
 	mBlockBuilder.On("Fill").Once()
-	mBlockBuilder.On("Receipts", mock.Anything).Return(receipts).Twice()
+	mBlockBuilder.On("Receipts", mock.Anything).Return(receipts).Once()
+	stateBlock.Receipts = receipts
 
 	fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: blockchainMock,
 		validators: validators.toValidatorSet(), checkpointBackend: runtime, logger: hclog.NewNullLogger(),

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/umbracle/ethgo/abi"
 )
 
 func TestFSM_ValidateHeader(t *testing.T) {
@@ -133,6 +134,120 @@ func TestFSM_Init(t *testing.T) {
 	mblockBuilder.AssertExpectations(t)
 }
 
+func TestFSM_BuildProposal_WithExitEvents(t *testing.T) {
+	t.Parallel()
+
+	const (
+		accountCount      = 5
+		committedCount    = 4
+		parentCount       = 3
+		parentBlockNumber = 1023
+		numOfReceipts     = 10
+		epoch             = 100
+	)
+
+	runtime := &consensusRuntime{
+		state: newTestState(t),
+	}
+
+	validators := newTestValidators(accountCount)
+	validatorSet := validators.getPublicIdentities()
+	extra := createTestExtra(validatorSet, AccountSet{}, accountCount-1, committedCount, parentCount)
+
+	parent := &types.Header{Number: parentBlockNumber, ExtraData: extra}
+	parent.ComputeHash()
+	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, extra)
+	receipts := make([]*types.Receipt, numOfReceipts)
+
+	personType := abi.MustNewType("tuple(string company, string address)")
+	encodedData, err := personType.Encode(map[string]string{"company": "Polygon", "address": "Planet Earth"})
+	require.NoError(t, err)
+
+	for i := 0; i < numOfReceipts; i++ {
+		receipts[i] = &types.Receipt{Logs: []*types.Log{
+			{
+				Address: types.ZeroAddress,
+				Data:    encodedData,
+				Topics: []types.Hash{
+					types.Hash(exitEventABI.ID()),
+					types.BytesToHash([]byte{uint8(i)}),
+					types.BytesToHash(types.StringToAddress("0x1111").Bytes()),
+					types.BytesToHash(types.StringToAddress("0x2222").Bytes()),
+				},
+			},
+		}}
+	}
+
+	mBlockBuilder := new(blockBuilderMock)
+	mBlockBuilder.On("Build", mock.Anything).Return(stateBlock).Once()
+	mBlockBuilder.On("Fill", mock.Anything).Return(receipts).Once()
+
+	fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: &blockchainMock{},
+		validators: validators.toValidatorSet(), checkpointBackend: runtime, logger: hclog.NewNullLogger(), epochNumber: epoch}
+
+	proposal, err := fsm.BuildProposal()
+	assert.NoError(t, err)
+	assert.NotNil(t, proposal)
+
+	events, err := runtime.state.getExitEventsByEpoch(epoch)
+	require.NoError(t, err)
+	require.Len(t, events, numOfReceipts)
+
+	mBlockBuilder.AssertExpectations(t)
+}
+
+func TestFSM_BuildProposal_WithExitEvents_ErrorInDecoding(t *testing.T) {
+	t.Parallel()
+
+	const (
+		accountCount      = 5
+		committedCount    = 4
+		parentCount       = 3
+		parentBlockNumber = 1023
+		epoch             = 100
+	)
+
+	runtime := &consensusRuntime{
+		state: newTestState(t),
+	}
+
+	validators := newTestValidators(accountCount)
+	validatorSet := validators.getPublicIdentities()
+	extra := createTestExtra(validatorSet, AccountSet{}, accountCount-1, committedCount, parentCount)
+
+	parent := &types.Header{Number: parentBlockNumber, ExtraData: extra}
+	parent.ComputeHash()
+
+	receipt := &types.Receipt{Logs: []*types.Log{
+		{
+			Address: types.ZeroAddress,
+			Data:    []byte{0, 1}, // invalid data
+			Topics: []types.Hash{
+				types.Hash(exitEventABI.ID()),
+				types.BytesToHash([]byte{111}),
+				types.BytesToHash(types.StringToAddress("0x1111").Bytes()),
+				types.BytesToHash(types.StringToAddress("0x2222").Bytes()),
+			},
+		},
+	}}
+
+	mBlockBuilder := new(blockBuilderMock)
+	mBlockBuilder.On("Fill", mock.Anything).Return([]*types.Receipt{receipt}).Once()
+
+	fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: &blockchainMock{},
+		validators: validators.toValidatorSet(), checkpointBackend: runtime, logger: hclog.NewNullLogger(), epochNumber: epoch}
+
+	proposal, err := fsm.BuildProposal()
+	assert.Error(t, err)
+	assert.Nil(t, proposal)
+
+	events, err := runtime.state.getExitEventsByEpoch(epoch)
+	require.NoError(t, err)
+	require.Len(t, events, 0)
+
+	mBlockBuilder.AssertExpectations(t)
+}
+
 func TestFSM_BuildProposal_WithoutUptimeTxGood(t *testing.T) {
 	t.Parallel()
 
@@ -152,10 +267,11 @@ func TestFSM_BuildProposal_WithoutUptimeTxGood(t *testing.T) {
 	parent.ComputeHash()
 	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, extra)
 	mBlockBuilder := newBlockBuilderMock(stateBlock)
-	eventRootCallback := func(epoch uint64) (types.Hash, error) { return types.ZeroHash, nil }
+	checkpointBackendMock := new(checkpointBackendMock)
+	checkpointBackendMock.On("BuildEventRoot", mock.Anything).Return(types.ZeroHash, nil).Once()
 
 	fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: &blockchainMock{},
-		validators: validators.toValidatorSet(), buildEventRootFn: eventRootCallback, logger: hclog.NewNullLogger()}
+		validators: validators.toValidatorSet(), checkpointBackend: checkpointBackendMock, logger: hclog.NewNullLogger()}
 
 	proposal, err := fsm.BuildProposal()
 	assert.NoError(t, err)
@@ -177,6 +293,7 @@ func TestFSM_BuildProposal_WithoutUptimeTxGood(t *testing.T) {
 	assert.Equal(t, checkpointHash, types.BytesToHash(proposal.Hash))
 
 	mBlockBuilder.AssertExpectations(t)
+	checkpointBackendMock.AssertExpectations(t)
 }
 
 func TestFSM_BuildProposal_WithUptimeTxGood(t *testing.T) {
@@ -200,7 +317,7 @@ func TestFSM_BuildProposal_WithUptimeTxGood(t *testing.T) {
 	transition := &state.Transition{}
 	mBlockBuilder := &blockBuilderMock{}
 	mBlockBuilder.On("Build", mock.Anything).Return(stateBlock).Once()
-	mBlockBuilder.On("Fill", mock.Anything).Return(nil).Once()
+	mBlockBuilder.On("Fill", mock.Anything).Return([]*types.Receipt{}).Once()
 	mBlockBuilder.On("WriteTx", mock.Anything).Return(error(nil)).Once()
 	mBlockBuilder.On("GetState").Return(transition).Once()
 
@@ -212,14 +329,15 @@ func TestFSM_BuildProposal_WithUptimeTxGood(t *testing.T) {
 		Return(NewStateProvider(transition)).Once()
 	blockChainMock.On("GetSystemState", mock.Anything, mock.Anything).Return(systemStateMock).Once()
 
-	eventRootCallback := func(epoch uint64) (types.Hash, error) { return types.ZeroHash, nil }
+	checkpointBackendMock := new(checkpointBackendMock)
+	checkpointBackendMock.On("BuildEventRoot", mock.Anything).Return(types.ZeroHash, nil).Once()
 
 	fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: blockChainMock,
-		isEndOfEpoch:     true,
-		validators:       validators.toValidatorSet(),
-		uptimeCounter:    createTestUptimeCounter(t, nil, 10),
-		buildEventRootFn: eventRootCallback,
-		logger:           hclog.NewNullLogger(),
+		isEndOfEpoch:      true,
+		validators:        validators.toValidatorSet(),
+		uptimeCounter:     createTestUptimeCounter(t, nil, 10),
+		checkpointBackend: checkpointBackendMock,
+		logger:            hclog.NewNullLogger(),
 	}
 
 	proposal, err := fsm.BuildProposal()
@@ -246,6 +364,7 @@ func TestFSM_BuildProposal_WithUptimeTxGood(t *testing.T) {
 	mBlockBuilder.AssertExpectations(t)
 	systemStateMock.AssertExpectations(t)
 	blockChainMock.AssertExpectations(t)
+	checkpointBackendMock.AssertExpectations(t)
 }
 
 func TestFSM_BuildProposal_EpochEndingBlock_FailedToCommitStateTx(t *testing.T) {
@@ -266,13 +385,11 @@ func TestFSM_BuildProposal_EpochEndingBlock_FailedToCommitStateTx(t *testing.T) 
 	mBlockBuilder := new(blockBuilderMock)
 	mBlockBuilder.On("WriteTx", mock.Anything).Return(errors.New("error")).Once()
 
-	eventRootCallback := func(epoch uint64) (types.Hash, error) { return types.ZeroHash, nil }
-
 	fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: &blockchainMock{},
-		isEndOfEpoch:     true,
-		validators:       newValidatorSet(types.Address{}, validators.getPublicIdentities()),
-		uptimeCounter:    createTestUptimeCounter(t, nil, 10),
-		buildEventRootFn: eventRootCallback,
+		isEndOfEpoch:      true,
+		validators:        newValidatorSet(types.Address{}, validators.getPublicIdentities()),
+		uptimeCounter:     createTestUptimeCounter(t, nil, 10),
+		checkpointBackend: new(checkpointBackendMock),
 	}
 
 	_, err := fsm.BuildProposal()
@@ -299,7 +416,7 @@ func TestFSM_BuildProposal_EpochEndingBlock_ValidatorsDeltaExists(t *testing.T) 
 	transition := &state.Transition{}
 	blockBuilderMock := new(blockBuilderMock)
 	blockBuilderMock.On("Build", mock.Anything).Return(stateBlock).Once()
-	blockBuilderMock.On("Fill", mock.Anything).Return(nil).Once()
+	blockBuilderMock.On("Fill", mock.Anything).Return([]*types.Receipt{}).Once()
 	blockBuilderMock.On("WriteTx", mock.Anything).Return(error(nil)).Once()
 	blockBuilderMock.On("GetState").Return(transition).Once()
 
@@ -314,18 +431,19 @@ func TestFSM_BuildProposal_EpochEndingBlock_ValidatorsDeltaExists(t *testing.T) 
 		Return(NewStateProvider(transition)).Once()
 	blockChainMock.On("GetSystemState", mock.Anything, mock.Anything).Return(systemStateMock).Once()
 
-	eventRootCallback := func(epoch uint64) (types.Hash, error) { return types.ZeroHash, nil }
+	checkpointBackendMock := new(checkpointBackendMock)
+	checkpointBackendMock.On("BuildEventRoot", mock.Anything).Return(types.ZeroHash, nil).Once()
 
 	fsm := &fsm{
-		parent:           parent,
-		blockBuilder:     blockBuilderMock,
-		config:           &PolyBFTConfig{},
-		backend:          blockChainMock,
-		isEndOfEpoch:     true,
-		validators:       newValidatorSet(types.Address{}, validatorSet),
-		uptimeCounter:    createTestUptimeCounter(t, validatorSet, 10),
-		buildEventRootFn: eventRootCallback,
-		logger:           hclog.NewNullLogger(),
+		parent:            parent,
+		blockBuilder:      blockBuilderMock,
+		config:            &PolyBFTConfig{},
+		backend:           blockChainMock,
+		isEndOfEpoch:      true,
+		validators:        newValidatorSet(types.Address{}, validatorSet),
+		uptimeCounter:     createTestUptimeCounter(t, validatorSet, 10),
+		checkpointBackend: checkpointBackendMock,
+		logger:            hclog.NewNullLogger(),
 	}
 
 	proposal, err := fsm.BuildProposal()
@@ -354,6 +472,7 @@ func TestFSM_BuildProposal_EpochEndingBlock_ValidatorsDeltaExists(t *testing.T) 
 	blockBuilderMock.AssertExpectations(t)
 	systemStateMock.AssertExpectations(t)
 	blockChainMock.AssertExpectations(t)
+	checkpointBackendMock.AssertExpectations(t)
 }
 
 func TestFSM_BuildProposal_NonEpochEndingBlock_ValidatorsDeltaEmpty(t *testing.T) {
@@ -373,15 +492,17 @@ func TestFSM_BuildProposal_NonEpochEndingBlock_ValidatorsDeltaEmpty(t *testing.T
 
 	blockBuilderMock := &blockBuilderMock{}
 	blockBuilderMock.On("Build", mock.Anything).Return(stateBlock).Once()
-	blockBuilderMock.On("Fill", mock.Anything).Return(nil).Once()
+	blockBuilderMock.On("Fill", mock.Anything).Return([]*types.Receipt{}).Once()
+
+	checkpointBackendMock := new(checkpointBackendMock)
+	checkpointBackendMock.On("BuildEventRoot", mock.Anything).Return(types.ZeroHash, nil).Once()
 
 	systemStateMock := new(systemStateMock)
 
-	eventRootCallback := func(epoch uint64) (types.Hash, error) { return types.ZeroHash, nil }
-
 	fsm := &fsm{parent: parent, blockBuilder: blockBuilderMock,
 		config: &PolyBFTConfig{}, backend: &blockchainMock{},
-		isEndOfEpoch: false, validators: testValidators.toValidatorSet(), buildEventRootFn: eventRootCallback, logger: hclog.NewNullLogger()}
+		isEndOfEpoch: false, validators: testValidators.toValidatorSet(),
+		checkpointBackend: checkpointBackendMock, logger: hclog.NewNullLogger()}
 
 	proposal, err := fsm.BuildProposal()
 	assert.NoError(t, err)
@@ -393,6 +514,7 @@ func TestFSM_BuildProposal_NonEpochEndingBlock_ValidatorsDeltaEmpty(t *testing.T
 
 	blockBuilderMock.AssertExpectations(t)
 	systemStateMock.AssertNotCalled(t, "GetValidatorSet")
+	checkpointBackendMock.AssertExpectations(t)
 }
 
 func TestFSM_BuildProposal_EpochEndingBlock_FailToCreateValidatorsDelta(t *testing.T) {
@@ -423,16 +545,14 @@ func TestFSM_BuildProposal_EpochEndingBlock_FailToCreateValidatorsDelta(t *testi
 		Return(NewStateProvider(transition)).Once()
 	blockChainMock.On("GetSystemState", mock.Anything, mock.Anything).Return(systemStateMock).Once()
 
-	eventRootCallback := func(epoch uint64) (types.Hash, error) { return types.ZeroHash, nil }
-
 	fsm := &fsm{parent: parent,
-		blockBuilder:     blockBuilderMock,
-		config:           &PolyBFTConfig{},
-		backend:          blockChainMock,
-		isEndOfEpoch:     true,
-		validators:       testValidators.toValidatorSet(),
-		uptimeCounter:    createTestUptimeCounter(t, allAccounts, 10),
-		buildEventRootFn: eventRootCallback,
+		blockBuilder:      blockBuilderMock,
+		config:            &PolyBFTConfig{},
+		backend:           blockChainMock,
+		isEndOfEpoch:      true,
+		validators:        testValidators.toValidatorSet(),
+		uptimeCounter:     createTestUptimeCounter(t, allAccounts, 10),
+		checkpointBackend: new(checkpointBackendMock),
 	}
 
 	proposal, err := fsm.BuildProposal()
@@ -616,14 +736,17 @@ func TestFSM_ValidateCommit_WrongValidator(t *testing.T) {
 	parent.ComputeHash()
 	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, parent.ExtraData)
 	mBlockBuilder := newBlockBuilderMock(stateBlock)
-	eventRootCallback := func(epoch uint64) (types.Hash, error) { return types.ZeroHash, nil }
+	checkpointBackendMock := new(checkpointBackendMock)
+	checkpointBackendMock.On("BuildEventRoot", mock.Anything).Return(types.ZeroHash, nil).Once()
+
 	fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: &blockchainMock{},
-		validators: validators.toValidatorSet(), logger: hclog.NewNullLogger(), buildEventRootFn: eventRootCallback}
+		validators: validators.toValidatorSet(), logger: hclog.NewNullLogger(), checkpointBackend: checkpointBackendMock}
 	_, err := fsm.BuildProposal()
 	require.NoError(t, err)
 
 	err = fsm.ValidateCommit(pbft.NodeID("0x7467674"), types.ZeroAddress.Bytes())
 	require.ErrorContains(t, err, "unable to resolve validator")
+	checkpointBackendMock.AssertExpectations(t)
 }
 
 func TestFSM_ValidateCommit_InvalidHash(t *testing.T) {
@@ -643,10 +766,11 @@ func TestFSM_ValidateCommit_InvalidHash(t *testing.T) {
 	parent.ComputeHash()
 	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, parent.ExtraData)
 	mBlockBuilder := newBlockBuilderMock(stateBlock)
-	eventRootCallback := func(epoch uint64) (types.Hash, error) { return types.ZeroHash, nil }
+	checkpointBackendMock := new(checkpointBackendMock)
+	checkpointBackendMock.On("BuildEventRoot", mock.Anything).Return(types.ZeroHash, nil).Once()
 
 	fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: &blockchainMock{},
-		validators: validators.toValidatorSet(), buildEventRootFn: eventRootCallback, logger: hclog.NewNullLogger()}
+		validators: validators.toValidatorSet(), checkpointBackend: checkpointBackendMock, logger: hclog.NewNullLogger()}
 
 	_, err := fsm.BuildProposal()
 	assert.NoError(t, err)
@@ -657,6 +781,7 @@ func TestFSM_ValidateCommit_InvalidHash(t *testing.T) {
 
 	err = fsm.ValidateCommit(pbft.NodeID(validators.getValidator("0").Address().String()), wrongSignature)
 	require.ErrorContains(t, err, "incorrect commit signature from")
+	checkpointBackendMock.AssertExpectations(t)
 }
 
 func TestFSM_ValidateCommit_Good(t *testing.T) {
@@ -671,10 +796,11 @@ func TestFSM_ValidateCommit_Good(t *testing.T) {
 	parent.ComputeHash()
 	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, parent.ExtraData)
 	mBlockBuilder := newBlockBuilderMock(stateBlock)
-	eventRootCallback := func(epoch uint64) (types.Hash, error) { return types.ZeroHash, nil }
+	checkpointBackendMock := new(checkpointBackendMock)
+	checkpointBackendMock.On("BuildEventRoot", mock.Anything).Return(types.ZeroHash, nil).Once()
 
 	fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: &blockchainMock{},
-		validators: newValidatorSet(types.Address{}, validatorSet), buildEventRootFn: eventRootCallback, logger: hclog.NewNullLogger()}
+		validators: newValidatorSet(types.Address{}, validatorSet), checkpointBackend: checkpointBackendMock, logger: hclog.NewNullLogger()}
 	_, err := fsm.BuildProposal()
 	require.NoError(t, err)
 
@@ -683,6 +809,8 @@ func TestFSM_ValidateCommit_Good(t *testing.T) {
 	require.NoError(t, err)
 	err = fsm.ValidateCommit(validator.Key().NodeID(), seal)
 	require.NoError(t, err)
+
+	checkpointBackendMock.AssertExpectations(t)
 }
 
 func TestFSM_Validate_IncorrectSignHash(t *testing.T) {
@@ -701,10 +829,11 @@ func TestFSM_Validate_IncorrectSignHash(t *testing.T) {
 	parent.ComputeHash()
 	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, parent.ExtraData)
 	mBlockBuilder := newBlockBuilderMock(stateBlock)
-	eventRootCallback := func(epoch uint64) (types.Hash, error) { return types.ZeroHash, nil }
+	checkpointBackendMock := new(checkpointBackendMock)
+	checkpointBackendMock.On("BuildEventRoot", mock.Anything).Return(types.ZeroHash, nil).Once()
 
 	fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: &blockchainMock{},
-		validators: validators.toValidatorSet(), buildEventRootFn: eventRootCallback, logger: hclog.NewNullLogger(),
+		validators: validators.toValidatorSet(), checkpointBackend: checkpointBackendMock, logger: hclog.NewNullLogger(),
 	}
 	proposal, err := fsm.BuildProposal()
 	require.NoError(t, err)
@@ -713,6 +842,7 @@ func TestFSM_Validate_IncorrectSignHash(t *testing.T) {
 
 	err = fsm.Validate(proposal)
 	require.ErrorContains(t, err, "incorrect sign hash")
+	checkpointBackendMock.AssertExpectations(t)
 }
 
 func TestFSM_Validate_IncorrectHeaderParentHash(t *testing.T) {
@@ -1664,7 +1794,7 @@ func createTestCommitment(t *testing.T, accounts []*wallet.Account) *CommitmentM
 func newBlockBuilderMock(stateBlock *StateBlock) *blockBuilderMock {
 	mBlockBuilder := new(blockBuilderMock)
 	mBlockBuilder.On("Build", mock.Anything).Return(stateBlock).Once()
-	mBlockBuilder.On("Fill", mock.Anything).Return(nil).Once()
+	mBlockBuilder.On("Fill", mock.Anything).Return([]*types.Receipt{}).Once()
 
 	return mBlockBuilder
 }

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/umbracle/ethgo/contract"
 )
 
-var _ blockchainBackend = &blockchainMock{}
+var _ blockchainBackend = (*blockchainMock)(nil)
 
 type blockchainMock struct {
 	mock.Mock
@@ -118,7 +118,7 @@ func (m *blockchainMock) GetChainID() uint64 {
 	return 0
 }
 
-var _ polybftBackend = &polybftBackendMock{}
+var _ polybftBackend = (*polybftBackendMock)(nil)
 
 type polybftBackendMock struct {
 	mock.Mock
@@ -158,7 +158,7 @@ func (p *polybftBackendMock) GetValidators(blockNumber uint64, parents []*types.
 	panic("polybftBackendMock.GetValidators doesn't support such combination of arguments")
 }
 
-var _ blockBuilder = &blockBuilderMock{}
+var _ blockBuilder = (*blockBuilderMock)(nil)
 
 type blockBuilderMock struct {
 	mock.Mock
@@ -205,7 +205,7 @@ func (m *blockBuilderMock) GetState() *state.Transition {
 	return args.Get(0).(*state.Transition) //nolint:forcetypeassert
 }
 
-var _ SystemState = &systemStateMock{}
+var _ SystemState = (*systemStateMock)(nil)
 
 type systemStateMock struct {
 	mock.Mock
@@ -276,7 +276,7 @@ func (m *systemStateMock) GetEpoch() (uint64, error) {
 	return 0, nil
 }
 
-var _ contract.Provider = &stateProviderMock{}
+var _ contract.Provider = (*stateProviderMock)(nil)
 
 type stateProviderMock struct {
 	mock.Mock
@@ -290,7 +290,7 @@ func (s *stateProviderMock) Txn(ethgo.Address, ethgo.Key, []byte) (contract.Txn,
 	return nil, nil
 }
 
-var _ Transport = &transportMock{}
+var _ Transport = (*transportMock)(nil)
 
 type transportMock struct {
 	mock.Mock
@@ -300,7 +300,7 @@ func (t *transportMock) Gossip(message interface{}) {
 	_ = t.Called(message)
 }
 
-var _ checkpointBackend = &checkpointBackendMock{}
+var _ checkpointBackend = (*checkpointBackendMock)(nil)
 
 type checkpointBackendMock struct {
 	mock.Mock

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -179,13 +179,13 @@ func (m *blockBuilderMock) WriteTx(tx *types.Transaction) error {
 	return args.Error(0)
 }
 
-func (m *blockBuilderMock) Fill() error {
+func (m *blockBuilderMock) Fill() []*types.Receipt {
 	args := m.Called()
 	if len(args) == 0 {
 		return nil
 	}
 
-	return args.Error(0)
+	return args.Get(0).([]*types.Receipt) //nolint:forcetypeassert
 }
 
 func (m *blockBuilderMock) Build(handler func(*types.Header)) (*StateBlock, error) {
@@ -296,6 +296,24 @@ type transportMock struct {
 
 func (t *transportMock) Gossip(message interface{}) {
 	_ = t.Called(message)
+}
+
+var _ checkpointBackend = &checkpointBackendMock{}
+
+type checkpointBackendMock struct {
+	mock.Mock
+}
+
+func (c *checkpointBackendMock) BuildEventRoot(epoch uint64) (types.Hash, error) {
+	args := c.Called()
+
+	return args.Get(0).(types.Hash), args.Error(1) //nolint:forcetypeassert
+}
+
+func (c *checkpointBackendMock) InsertExitEvents(exitEvents []*ExitEvent) error {
+	c.Called()
+
+	return nil
 }
 
 type testValidators struct {

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -179,11 +179,13 @@ func (m *blockBuilderMock) WriteTx(tx *types.Transaction) error {
 	return args.Error(0)
 }
 
-func (m *blockBuilderMock) Fill() []*types.Receipt {
+func (m *blockBuilderMock) Fill() {
+	m.Called()
+}
+
+// Receipts returns the collection of transaction receipts for given block
+func (m *blockBuilderMock) Receipts() []*types.Receipt {
 	args := m.Called()
-	if len(args) == 0 {
-		return nil
-	}
 
 	return args.Get(0).([]*types.Receipt) //nolint:forcetypeassert
 }

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -306,7 +306,7 @@ type checkpointBackendMock struct {
 	mock.Mock
 }
 
-func (c *checkpointBackendMock) BuildEventRoot(epoch uint64) (types.Hash, error) {
+func (c *checkpointBackendMock) BuildEventRoot(epoch uint64, nonCommittedExitEvents []*ExitEvent) (types.Hash, error) {
 	args := c.Called()
 
 	return args.Get(0).(types.Hash), args.Error(1) //nolint:forcetypeassert

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -187,16 +187,16 @@ func decodeEventData(eventDataMap map[string]interface{}, log *ethgo.Log,
 	return eventCreator(id, sender, receiver, data), nil
 }
 
-// convert converts types.Log to ethgo.Log
-func convert(log *types.Log) *ethgo.Log {
+// convertLog converts types.Log to ethgo.Log
+func convertLog(log *types.Log) *ethgo.Log {
 	l := &ethgo.Log{
 		Address: ethgo.Address(log.Address),
 		Data:    log.Data,
 		Topics:  make([]ethgo.Hash, len(log.Topics)),
 	}
 
-	for i := 0; i < len(log.Topics); i++ {
-		l.Topics[i] = ethgo.Hash(log.Topics[i])
+	for i, topic := range log.Topics {
+		l.Topics[i] = ethgo.Hash(topic)
 	}
 
 	return l

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -358,7 +358,7 @@ func (s *State) list() ([]*StateSyncEvent, error) {
 	return events, nil
 }
 
-// insertExitEvents inserts collection of exit events to exit event bucket in bolt db
+// insertExitEvents inserts a slice of exit events to exit event bucket in bolt db
 func (s *State) insertExitEvents(exitEvents []*ExitEvent) error {
 	return s.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(exitEventsBucket)

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -131,7 +131,7 @@ func decodeStateSyncEvent(log *ethgo.Log) (*StateSyncEvent, error) {
 func decodeExitEvent(log *ethgo.Log, epoch, block uint64) (*ExitEvent, error) {
 	if !exitEventABI.Match(log) {
 		// valid case, not an exit event
-		return nil, errNotAnExitEvent
+		return nil, nil
 	}
 
 	raw, err := exitEventABI.Inputs.ParseLog(log)
@@ -448,6 +448,11 @@ func (s *State) getExitEvents(epoch uint64, filter func(exitEvent *ExitEvent) bo
 		}
 
 		return nil
+	})
+
+	// enforce sequential order
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].ID < events[j].ID
 	})
 
 	return events, err

--- a/consensus/polybft/state_test.go
+++ b/consensus/polybft/state_test.go
@@ -463,8 +463,9 @@ func TestState_decodeExitEvent_NotAnExitEvent(t *testing.T) {
 		Topics:  topics,
 	}
 
-	_, err := decodeExitEvent(log, 1, 1)
-	require.ErrorIs(t, err, errNotAnExitEvent)
+	event, err := decodeExitEvent(log, 1, 1)
+	require.NoError(t, err)
+	require.Nil(t, event)
 }
 
 func insertTestExitEvents(t *testing.T, state *State,

--- a/consensus/polybft/state_test.go
+++ b/consensus/polybft/state_test.go
@@ -422,6 +422,8 @@ func TestState_Insert_And_Get_ExitEvents_ForProof_NoEvents(t *testing.T) {
 }
 
 func TestState_decodeExitEvent(t *testing.T) {
+	t.Parallel()
+
 	const (
 		exitID      = 1
 		epoch       = 1
@@ -455,6 +457,8 @@ func TestState_decodeExitEvent(t *testing.T) {
 }
 
 func TestState_decodeExitEvent_NotAnExitEvent(t *testing.T) {
+	t.Parallel()
+
 	topics := make([]ethgo.Hash, 4)
 	topics[0] = stateTransferEventABI.ID()
 


### PR DESCRIPTION
# Description

Added parsing of receipt logs on `BuildProposal` which will identify any new exit events that happened and insert them to the `state.go` persistence storage.

Added appropriate UTs that test positive and negative cases.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually