### PR TITLE
Remove array of runtimes

### DIFF
--- a/consensus/ibft/fork/hooks_test.go
+++ b/consensus/ibft/fork/hooks_test.go
@@ -12,7 +12,6 @@ import (
 	stakingHelper "github.com/0xPolygon/polygon-edge/helper/staking"
 	"github.com/0xPolygon/polygon-edge/state"
 	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
-	"github.com/0xPolygon/polygon-edge/state/runtime/evm"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/0xPolygon/polygon-edge/validators"
 	"github.com/0xPolygon/polygon-edge/validators/store"
@@ -283,8 +282,6 @@ func newTestTransition(
 	}, st, hclog.NewNullLogger())
 
 	rootHash := ex.WriteGenesis(nil)
-
-	ex.SetRuntime(evm.NewEVM())
 	ex.GetHash = func(h *types.Header) state.GetHashByNumber {
 		return func(i uint64) types.Hash {
 			return rootHash

--- a/server/server.go
+++ b/server/server.go
@@ -27,8 +27,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/state"
 	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
 	"github.com/0xPolygon/polygon-edge/state/runtime"
-	"github.com/0xPolygon/polygon-edge/state/runtime/evm"
-	"github.com/0xPolygon/polygon-edge/state/runtime/precompiled"
 	"github.com/0xPolygon/polygon-edge/txpool"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
@@ -188,8 +186,6 @@ func NewServer(config *Config) (*Server, error) {
 	m.state = st
 
 	m.executor = state.NewExecutor(config.Chain.Params, st, logger)
-	m.executor.SetRuntime(precompiled.NewPrecompiled())
-	m.executor.SetRuntime(evm.NewEVM())
 
 	// compute the genesis root state
 	genesisRoot := m.executor.WriteGenesis(config.Chain.Genesis.Alloc)

--- a/server/server.go
+++ b/server/server.go
@@ -143,6 +143,7 @@ func NewServer(config *Config) (*Server, error) {
 	if err := m.setupTelemetry(); err != nil {
 		return nil, err
 	}
+
 	if config.Telemetry.PrometheusAddr != nil {
 		m.prometheusServer = m.startPrometheusServer(config.Telemetry.PrometheusAddr)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -27,8 +27,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/state"
 	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
 	"github.com/0xPolygon/polygon-edge/state/runtime"
-	"github.com/0xPolygon/polygon-edge/state/runtime/evm"
-	"github.com/0xPolygon/polygon-edge/state/runtime/precompiled"
 	"github.com/0xPolygon/polygon-edge/txpool"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
@@ -185,8 +183,6 @@ func NewServer(config *Config) (*Server, error) {
 	m.state = st
 
 	m.executor = state.NewExecutor(config.Chain.Params, st, logger)
-	m.executor.SetRuntime(precompiled.NewPrecompiled())
-	m.executor.SetRuntime(evm.NewEVM())
 
 	// compute the genesis root state
 	genesisRoot := m.executor.WriteGenesis(config.Chain.Genesis.Alloc)

--- a/state/executor.go
+++ b/state/executor.go
@@ -6,13 +6,13 @@ import (
 	"math"
 	"math/big"
 
-	"github.com/0xPolygon/polygon-edge/state/runtime/evm"
-
 	"github.com/hashicorp/go-hclog"
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/state/runtime"
+	"github.com/0xPolygon/polygon-edge/state/runtime/evm"
+	"github.com/0xPolygon/polygon-edge/state/runtime/precompiled"
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
@@ -32,11 +32,10 @@ type GetHashByNumberHelper = func(*types.Header) GetHashByNumber
 
 // Executor is the main entity
 type Executor struct {
-	logger   hclog.Logger
-	config   *chain.Params
-	runtimes []runtime.Runtime
-	state    State
-	GetHash  GetHashByNumberHelper
+	logger  hclog.Logger
+	config  *chain.Params
+	state   State
+	GetHash GetHashByNumberHelper
 
 	PostHook func(txn *Transition)
 }
@@ -44,10 +43,9 @@ type Executor struct {
 // NewExecutor creates a new executor
 func NewExecutor(config *chain.Params, s State, logger hclog.Logger) *Executor {
 	return &Executor{
-		logger:   logger,
-		config:   config,
-		runtimes: []runtime.Runtime{},
-		state:    s,
+		logger: logger,
+		config: config,
+		state:  s,
 	}
 }
 
@@ -77,11 +75,6 @@ func (e *Executor) WriteGenesis(alloc map[types.Address]*chain.GenesisAccount) t
 	_, root := snap.Commit(objs)
 
 	return types.BytesToHash(root)
-}
-
-// SetRuntime adds a runtime to the runtime set
-func (e *Executor) SetRuntime(r runtime.Runtime) {
-	e.runtimes = append(e.runtimes, r)
 }
 
 type BlockResult struct {
@@ -160,7 +153,6 @@ func (e *Executor) BeginTxn(
 
 	txn := &Transition{
 		logger:   e.logger,
-		r:        e,
 		ctx:      env2,
 		state:    newTxn,
 		getHash:  e.GetHash(header),
@@ -170,6 +162,10 @@ func (e *Executor) BeginTxn(
 
 		receipts: []*types.Receipt{},
 		totalGas: 0,
+
+		evm:         evm.NewEVM(),
+		precompiles: precompiled.NewPrecompiled(),
+		PostHook:    e.PostHook,
 	}
 
 	return txn, nil
@@ -184,7 +180,6 @@ type Transition struct {
 	// the current block being processed
 	block *types.Block
 
-	r       *Executor
 	config  chain.ForksInTime
 	state   *Txn
 	getHash GetHashByNumber
@@ -194,17 +189,20 @@ type Transition struct {
 	// result
 	receipts []*types.Receipt
 	totalGas uint64
+
+	PostHook func(t *Transition)
+
+	// runtimes
+	evm         *evm.EVM
+	precompiles *precompiled.Precompiled
 }
 
 func NewTransition(config chain.ForksInTime, radix *Txn) *Transition {
 	return &Transition{
-		config: config,
-		state:  radix,
-		r: &Executor{
-			runtimes: []runtime.Runtime{
-				evm.NewEVM(),
-			},
-		},
+		config:      config,
+		state:       radix,
+		evm:         evm.NewEVM(),
+		precompiles: precompiled.NewPrecompiled(),
 	}
 }
 
@@ -219,7 +217,7 @@ func (t *Transition) Receipts() []*types.Receipt {
 var emptyFrom = types.Address{}
 
 func (t *Transition) WriteFailedReceipt(txn *types.Transaction) error {
-	signer := crypto.NewSigner(t.config, uint64(t.r.config.ChainID))
+	signer := crypto.NewSigner(t.config, uint64(t.ctx.ChainID))
 
 	if txn.From == emptyFrom {
 		// Decrypt the from address
@@ -250,7 +248,7 @@ func (t *Transition) WriteFailedReceipt(txn *types.Transaction) error {
 
 // Write writes another transaction to the executor
 func (t *Transition) Write(txn *types.Transaction) error {
-	signer := crypto.NewSigner(t.config, uint64(t.r.config.ChainID))
+	signer := crypto.NewSigner(t.config, uint64(t.ctx.ChainID))
 
 	var err error
 	if txn.From == emptyFrom {
@@ -356,8 +354,8 @@ func (t *Transition) Apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 		t.state.RevertToSnapshot(s)
 	}
 
-	if t.r.PostHook != nil {
-		t.r.PostHook(t)
+	if t.PostHook != nil {
+		t.PostHook(t)
 	}
 
 	return result, err
@@ -535,14 +533,17 @@ func (t *Transition) Call2(
 }
 
 func (t *Transition) run(contract *runtime.Contract, host runtime.Host) *runtime.ExecutionResult {
-	for _, r := range t.r.runtimes {
-		if r.CanRun(contract, host, &t.config) {
-			return r.Run(contract, host, &t.config)
-		}
+	// check the precompiles
+	if t.precompiles.CanRun(contract, host, &t.config) {
+		return t.precompiles.Run(contract, host, &t.config)
+	}
+	// check the evm
+	if t.evm.CanRun(contract, host, &t.config) {
+		return t.evm.Run(contract, host, &t.config)
 	}
 
 	return &runtime.ExecutionResult{
-		Err: fmt.Errorf("not found"),
+		Err: fmt.Errorf("runtime not found"),
 	}
 }
 

--- a/state/executor.go
+++ b/state/executor.go
@@ -6,13 +6,13 @@ import (
 	"math"
 	"math/big"
 
-	"github.com/0xPolygon/polygon-edge/state/runtime/evm"
-
 	"github.com/hashicorp/go-hclog"
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/state/runtime"
+	"github.com/0xPolygon/polygon-edge/state/runtime/evm"
+	"github.com/0xPolygon/polygon-edge/state/runtime/precompiled"
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
@@ -32,11 +32,10 @@ type GetHashByNumberHelper = func(*types.Header) GetHashByNumber
 
 // Executor is the main entity
 type Executor struct {
-	logger   hclog.Logger
-	config   *chain.Params
-	runtimes []runtime.Runtime
-	state    State
-	GetHash  GetHashByNumberHelper
+	logger  hclog.Logger
+	config  *chain.Params
+	state   State
+	GetHash GetHashByNumberHelper
 
 	PostHook func(txn *Transition)
 }
@@ -44,10 +43,9 @@ type Executor struct {
 // NewExecutor creates a new executor
 func NewExecutor(config *chain.Params, s State, logger hclog.Logger) *Executor {
 	return &Executor{
-		logger:   logger,
-		config:   config,
-		runtimes: []runtime.Runtime{},
-		state:    s,
+		logger: logger,
+		config: config,
+		state:  s,
 	}
 }
 
@@ -77,11 +75,6 @@ func (e *Executor) WriteGenesis(alloc map[types.Address]*chain.GenesisAccount) t
 	_, root := snap.Commit(objs)
 
 	return types.BytesToHash(root)
-}
-
-// SetRuntime adds a runtime to the runtime set
-func (e *Executor) SetRuntime(r runtime.Runtime) {
-	e.runtimes = append(e.runtimes, r)
 }
 
 type BlockResult struct {
@@ -158,7 +151,6 @@ func (e *Executor) BeginTxn(
 
 	txn := &Transition{
 		logger:   e.logger,
-		r:        e,
 		ctx:      env2,
 		state:    newTxn,
 		getHash:  e.GetHash(header),
@@ -168,6 +160,10 @@ func (e *Executor) BeginTxn(
 
 		receipts: []*types.Receipt{},
 		totalGas: 0,
+
+		evm:         evm.NewEVM(),
+		precompiles: precompiled.NewPrecompiled(),
+		PostHook:    e.PostHook,
 	}
 
 	return txn, nil
@@ -189,17 +185,20 @@ type Transition struct {
 	// result
 	receipts []*types.Receipt
 	totalGas uint64
+
+	PostHook func(t *Transition)
+
+	// runtimes
+	evm         *evm.EVM
+	precompiles *precompiled.Precompiled
 }
 
 func NewTransition(config chain.ForksInTime, radix *Txn) *Transition {
 	return &Transition{
-		config: config,
-		state:  radix,
-		r: &Executor{
-			runtimes: []runtime.Runtime{
-				evm.NewEVM(),
-			},
-		},
+		config:      config,
+		state:       radix,
+		evm:         evm.NewEVM(),
+		precompiles: precompiled.NewPrecompiled(),
 	}
 }
 
@@ -214,7 +213,7 @@ func (t *Transition) Receipts() []*types.Receipt {
 var emptyFrom = types.Address{}
 
 func (t *Transition) WriteFailedReceipt(txn *types.Transaction) error {
-	signer := crypto.NewSigner(t.config, uint64(t.r.config.ChainID))
+	signer := crypto.NewSigner(t.config, uint64(t.ctx.ChainID))
 
 	if txn.From == emptyFrom {
 		// Decrypt the from address
@@ -245,7 +244,7 @@ func (t *Transition) WriteFailedReceipt(txn *types.Transaction) error {
 
 // Write writes another transaction to the executor
 func (t *Transition) Write(txn *types.Transaction) error {
-	signer := crypto.NewSigner(t.config, uint64(t.r.config.ChainID))
+	signer := crypto.NewSigner(t.config, uint64(t.ctx.ChainID))
 
 	var err error
 	if txn.From == emptyFrom {
@@ -347,8 +346,8 @@ func (t *Transition) Apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 		t.state.RevertToSnapshot(s)
 	}
 
-	if t.r.PostHook != nil {
-		t.r.PostHook(t)
+	if t.PostHook != nil {
+		t.PostHook(t)
 	}
 
 	return result, err
@@ -526,14 +525,17 @@ func (t *Transition) Call2(
 }
 
 func (t *Transition) run(contract *runtime.Contract, host runtime.Host) *runtime.ExecutionResult {
-	for _, r := range t.r.runtimes {
-		if r.CanRun(contract, host, &t.config) {
-			return r.Run(contract, host, &t.config)
-		}
+	// check the precompiles
+	if t.precompiles.CanRun(contract, host, &t.config) {
+		return t.precompiles.Run(contract, host, &t.config)
+	}
+	// check the evm
+	if t.evm.CanRun(contract, host, &t.config) {
+		return t.evm.Run(contract, host, &t.config)
 	}
 
 	return &runtime.ExecutionResult{
-		Err: fmt.Errorf("not found"),
+		Err: fmt.Errorf("runtime not found"),
 	}
 }
 

--- a/state/executor.go
+++ b/state/executor.go
@@ -175,7 +175,6 @@ type Transition struct {
 	// dummy
 	auxState State
 
-	r       *Executor
 	config  chain.ForksInTime
 	state   *Txn
 	getHash GetHashByNumber

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/state"
-	"github.com/0xPolygon/polygon-edge/state/runtime/evm"
-	"github.com/0xPolygon/polygon-edge/state/runtime/precompiled"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
 )
@@ -51,8 +49,6 @@ func RunSpecificTest(t *testing.T, file string, c stateCase, name, fork string, 
 	forks := config.At(uint64(env.Number))
 
 	xxx := state.NewExecutor(&chain.Params{Forks: config, ChainID: 1}, s, hclog.NewNullLogger())
-	xxx.SetRuntime(precompiled.NewPrecompiled())
-	xxx.SetRuntime(evm.NewEVM())
 
 	xxx.PostHook = func(t *state.Transition) {
 		if name == "failed_tx_xcf416c53" {

--- a/validators/store/contract/contract_test.go
+++ b/validators/store/contract/contract_test.go
@@ -11,7 +11,6 @@ import (
 	testHelper "github.com/0xPolygon/polygon-edge/helper/tests"
 	"github.com/0xPolygon/polygon-edge/state"
 	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
-	"github.com/0xPolygon/polygon-edge/state/runtime/evm"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/0xPolygon/polygon-edge/validators"
 	"github.com/0xPolygon/polygon-edge/validators/store"
@@ -87,7 +86,6 @@ func newTestTransition(
 
 	rootHash := ex.WriteGenesis(nil)
 
-	ex.SetRuntime(evm.NewEVM())
 	ex.GetHash = func(h *types.Header) state.GetHashByNumber {
 		return func(i uint64) types.Hash {
 			return rootHash


### PR DESCRIPTION
# Description

This PR removes the list of runtimes that the `state transition` can use and defaults to `evm` and `precompiles`. Initially, it was envisioned that the client could have different runtimes to execute transitions (evm, wasm,?). However, at this point, I am not sure that idea has solidified in something tangible. Thus, this PR removes that complexity and simplifies the code. This can be introduced later if the need for new runtimes appears again.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
