### PR TITLE
Consolidate BLS verification ABI type

### DIFF
--- a/consensus/polybft/state_transaction.go
+++ b/consensus/polybft/state_transaction.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 
 	"github.com/0xPolygon/polygon-edge/crypto"
+	"github.com/0xPolygon/polygon-edge/state/runtime/precompiled"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/mitchellh/mapstructure"
 	"github.com/umbracle/ethgo"
@@ -31,11 +32,6 @@ var (
 		"tuple(uint256 id, address sender, address receiver, bytes data, bool skip)[] objs)")
 
 	validatorsUptimeMethod, _ = abi.NewMethod("function uptime(bytes data)")
-
-	// BlsVerificationABIType is ABI type used for BLS signatures verification.
-	// It includes BLS public keys and bitmap representing signer validator accounts.
-	// TODO - move this to precompile, once we implement it on edge
-	BlsVerificationABIType = abi.MustNewType("tuple(bytes[], bytes)")
 )
 
 // StateTransactionInput is an abstraction for different state transaction inputs
@@ -300,7 +296,8 @@ func (cm *CommitmentMessageSigned) EncodeAbi() ([]byte, error) {
 		"root":    cm.Message.MerkleRootHash,
 	}
 
-	blsVerificationPart, err := BlsVerificationABIType.Encode([2]interface{}{cm.PublicKeys, cm.AggSignature.Bitmap})
+	blsVerificationPart, err := precompiled.BlsVerificationABIType.Encode(
+		[2]interface{}{cm.PublicKeys, cm.AggSignature.Bitmap})
 	if err != nil {
 		return nil, err
 	}
@@ -345,7 +342,7 @@ func (cm *CommitmentMessageSigned) DecodeAbi(txData []byte) error {
 		return fmt.Errorf("invalid commitment data. Could not find bls verification part")
 	}
 
-	decoded, err := BlsVerificationABIType.Decode(blsVerificationPart)
+	decoded, err := precompiled.BlsVerificationABIType.Decode(blsVerificationPart)
 	if err != nil {
 		return err
 	}

--- a/state/runtime/precompiled/bls_agg_sigs_verification.go
+++ b/state/runtime/precompiled/bls_agg_sigs_verification.go
@@ -18,9 +18,9 @@ var (
 	errBLSVInvalidMsg             = errors.New("invalid message")
 	errBLSVInvalidBlsPart         = errors.New("bls verification part not in correct format")
 	errBLSVInvalidPubKeysPart     = errors.New("could not find public keys part")
-	// blsVerificationABIType is ABI type used for BLS signatures verification.
+	// BlsVerificationABIType is ABI type used for BLS signatures verification.
 	// It includes BLS public keys and bitmap representing signer validator accounts.
-	blsVerificationABIType = abi.MustNewType("tuple(bytes[], bytes)")
+	BlsVerificationABIType = abi.MustNewType("tuple(bytes[], bytes)")
 	// inputDataABIType is the ABI signature of the precompiled contract input data
 	inputDataABIType = abi.MustNewType("tuple(bytes32, bytes, bytes)")
 )
@@ -73,7 +73,7 @@ func (c *blsAggSignsVerification) run(input []byte, caller types.Address, host r
 		return nil, errBLSVInvalidPubKeys
 	}
 
-	decoded, err := blsVerificationABIType.Decode(blsVerification)
+	decoded, err := BlsVerificationABIType.Decode(blsVerification)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

Use only single ABI type abstraction for BLS verification (remove the one from the `state_transaction` in `polybft` and use the one from the `precompiled` package instead)

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually