### PR TITLE
Add voting power to the validators

### DIFF
--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -243,7 +243,7 @@ func generateExtraDataPolyBft(validators []GenesisTarget) []byte {
 	}
 
 	for i, validator := range validators {
-		delta.Added[i] = &polybft.ValidatorAccount{
+		delta.Added[i] = &polybft.ValidatorMetadata{
 			Address: types.Address(validator.Account.Ecdsa.Address()),
 			BlsKey:  validator.Account.Bls.PublicKey(),
 		}

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -340,7 +340,7 @@ func TestConsensusRuntime_deliverMessage_EpochNotStarted(t *testing.T) {
 	assert.NoError(t, err)
 
 	// random node not among validator set
-	account := newTestValidator("A")
+	account := newTestValidator("A", 1)
 
 	runtime := &consensusRuntime{
 		logger: hclog.NewNullLogger(),
@@ -1274,7 +1274,7 @@ func TestConsensusRuntime_restartEpoch_NewEpochToRun_BuildCommitment(t *testing.
 		newValidatorSet[i-1] = oldValidatorSet[i].Copy()
 	}
 
-	newValidatorSet[validatorsCount-1] = newTestValidator("G").ValidatorAccount()
+	newValidatorSet[validatorsCount-1] = newTestValidator("G", 1).ValidatorAccount()
 
 	header := &types.Header{Number: blockNumber}
 

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1274,7 +1274,7 @@ func TestConsensusRuntime_restartEpoch_NewEpochToRun_BuildCommitment(t *testing.
 		newValidatorSet[i-1] = oldValidatorSet[i].Copy()
 	}
 
-	newValidatorSet[validatorsCount-1] = newTestValidator("G", 1).ValidatorAccount()
+	newValidatorSet[validatorsCount-1] = newTestValidator("G", 1).ValidatorMetadata()
 
 	header := &types.Header{Number: blockNumber}
 

--- a/consensus/polybft/extra.go
+++ b/consensus/polybft/extra.go
@@ -139,7 +139,7 @@ func createValidatorSetDelta(log hclog.Logger, oldValidatorSet,
 	newValidatorSet AccountSet) (*ValidatorSetDelta, error) {
 	var addedValidators AccountSet
 
-	oldValidatorSetMap := make(map[types.Address]*ValidatorAccount)
+	oldValidatorSetMap := make(map[types.Address]*ValidatorMetadata)
 	removedValidators := map[types.Address]int{}
 
 	for i, validator := range oldValidatorSet {
@@ -226,7 +226,7 @@ func (d *ValidatorSetDelta) UnmarshalRLPWith(v *fastrlp.Value) error {
 			d.Added = make(AccountSet, len(validatorsRaw))
 
 			for i, validatorRaw := range validatorsRaw {
-				acc := &ValidatorAccount{}
+				acc := &ValidatorMetadata{}
 				if err = acc.UnmarshalRLPWith(validatorRaw); err != nil {
 					return err
 				}

--- a/consensus/polybft/extra_test.go
+++ b/consensus/polybft/extra_test.go
@@ -389,7 +389,7 @@ func TestExtra_InitGenesisValidatorsDelta(t *testing.T) {
 
 		var i int
 		for _, validator := range vals.validators {
-			delta.Added[i] = &ValidatorAccount{
+			delta.Added[i] = &ValidatorMetadata{
 				Address: types.Address(validator.account.Ecdsa.Address()),
 				BlsKey:  validator.account.Bls.PublicKey(),
 			}

--- a/consensus/polybft/extra_test.go
+++ b/consensus/polybft/extra_test.go
@@ -502,7 +502,7 @@ func TestValidatorSetDelta_UnmarshalRLPWith_NegativeCases(t *testing.T) {
 		require.ErrorContains(t, delta.UnmarshalRLPWith(deltaMarshalled), "array expected for added validators")
 	})
 
-	t.Run("Incorrect RLP value type for ValidatorAccount in Added field", func(t *testing.T) {
+	t.Run("Incorrect RLP value type for ValidatorMetadata in Added field", func(t *testing.T) {
 		t.Parallel()
 
 		ar := &fastrlp.Arena{}

--- a/consensus/polybft/extra_test.go
+++ b/consensus/polybft/extra_test.go
@@ -390,8 +390,9 @@ func TestExtra_InitGenesisValidatorsDelta(t *testing.T) {
 		var i int
 		for _, validator := range vals.validators {
 			delta.Added[i] = &ValidatorMetadata{
-				Address: types.Address(validator.account.Ecdsa.Address()),
-				BlsKey:  validator.account.Bls.PublicKey(),
+				Address:     types.Address(validator.account.Ecdsa.Address()),
+				BlsKey:      validator.account.Bls.PublicKey(),
+				VotingPower: validator.votingPower,
 			}
 			i++
 		}

--- a/consensus/polybft/extra_test.go
+++ b/consensus/polybft/extra_test.go
@@ -328,10 +328,10 @@ func TestExtra_CreateValidatorSetDelta_Cases(t *testing.T) {
 			vals := newTestValidatorsWithAliases([]string{})
 
 			for _, name := range c.oldSet {
-				vals.create(name)
+				vals.create(name, 1)
 			}
 			for _, name := range c.newSet {
-				vals.create(name)
+				vals.create(name, 1)
 			}
 
 			oldValidatorSet := vals.getPublicIdentities(c.oldSet...)

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -619,7 +619,7 @@ func TestFSM_ValidateCommit_InvalidHash(t *testing.T) {
 	_, err := fsm.BuildProposal()
 	assert.NoError(t, err)
 
-	nonValidatorAcc := newTestValidator("non_validator")
+	nonValidatorAcc := newTestValidator("non_validator", 1)
 	wrongSignature, err := nonValidatorAcc.mustSign([]byte("Foo")).Marshal()
 	require.NoError(t, err)
 
@@ -936,7 +936,7 @@ func TestFSM_Insert_InvalidNode(t *testing.T) {
 	require.NoError(t, err)
 
 	// create test account outside of validator set
-	nonValidatorAccount := newTestValidator("non_validator")
+	nonValidatorAccount := newTestValidator("non_validator", 1)
 	nonValidatorSignature, err := nonValidatorAccount.mustSign(proposalHash).Marshal()
 	require.NoError(t, err)
 
@@ -1237,7 +1237,7 @@ func TestFSM_VerifyStateTransaction_InvalidSignature(t *testing.T) {
 	var txns []*types.Transaction
 
 	signature := createSignature(t, validators.getPrivateIdentities("A", "B", "C", "D"), hash)
-	invalidValidator := newTestValidator("G")
+	invalidValidator := newTestValidator("G", 1)
 	invalidSignature, err := invalidValidator.mustSign([]byte("malicious message")).Marshal()
 	require.NoError(t, err)
 

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -343,7 +343,7 @@ func (v *testValidators) getValidators(aliases ...string) (res []*testValidator)
 
 func (v *testValidators) getPublicIdentities(aliases ...string) (res AccountSet) {
 	v.iterAcct(aliases, func(t *testValidator) {
-		res = append(res, t.ValidatorAccount())
+		res = append(res, t.ValidatorMetadata())
 	})
 
 	return
@@ -402,8 +402,8 @@ func (v *testValidator) paramsValidator() *Validator {
 	}
 }
 
-func (v *testValidator) ValidatorAccount() *ValidatorAccount {
-	return &ValidatorAccount{
+func (v *testValidator) ValidatorMetadata() *ValidatorMetadata {
+	return &ValidatorMetadata{
 		Address:     types.Address(v.account.Ecdsa.Address()),
 		BlsKey:      v.account.Bls.PublicKey(),
 		VotingPower: v.votingPower,

--- a/consensus/polybft/state_test.go
+++ b/consensus/polybft/state_test.go
@@ -166,9 +166,9 @@ func TestState_insertAndGetValidatorSnapshot(t *testing.T) {
 	require.NoError(t, err)
 
 	snapshot := AccountSet{
-		&ValidatorAccount{Address: types.BytesToAddress([]byte{0x18}), BlsKey: keys[0].PublicKey()},
-		&ValidatorAccount{Address: types.BytesToAddress([]byte{0x23}), BlsKey: keys[1].PublicKey()},
-		&ValidatorAccount{Address: types.BytesToAddress([]byte{0x37}), BlsKey: keys[2].PublicKey()},
+		&ValidatorMetadata{Address: types.BytesToAddress([]byte{0x18}), BlsKey: keys[0].PublicKey()},
+		&ValidatorMetadata{Address: types.BytesToAddress([]byte{0x23}), BlsKey: keys[1].PublicKey()},
+		&ValidatorMetadata{Address: types.BytesToAddress([]byte{0x37}), BlsKey: keys[2].PublicKey()},
 	}
 
 	assert.NoError(t, state.insertValidatorSnapshot(epoch, snapshot))
@@ -192,9 +192,9 @@ func TestState_cleanValidatorSnapshotsFromDb(t *testing.T) {
 	require.NoError(t, err)
 
 	snapshot := AccountSet{
-		&ValidatorAccount{Address: types.BytesToAddress([]byte{0x18}), BlsKey: keys[0].PublicKey()},
-		&ValidatorAccount{Address: types.BytesToAddress([]byte{0x23}), BlsKey: keys[1].PublicKey()},
-		&ValidatorAccount{Address: types.BytesToAddress([]byte{0x37}), BlsKey: keys[2].PublicKey()},
+		&ValidatorMetadata{Address: types.BytesToAddress([]byte{0x18}), BlsKey: keys[0].PublicKey()},
+		&ValidatorMetadata{Address: types.BytesToAddress([]byte{0x23}), BlsKey: keys[1].PublicKey()},
+		&ValidatorMetadata{Address: types.BytesToAddress([]byte{0x37}), BlsKey: keys[2].PublicKey()},
 	}
 
 	var epoch uint64

--- a/consensus/polybft/system_state.go
+++ b/consensus/polybft/system_state.go
@@ -89,9 +89,15 @@ func (s *SystemStateImpl) GetValidatorSet() (AccountSet, error) {
 			return nil, err
 		}
 
+		stake, ok := output["1"].(*big.Int)
+		if !ok {
+			return nil, fmt.Errorf("failed to decode stake")
+		}
+
 		val := &ValidatorAccount{
-			Address: types.Address(addr),
-			BlsKey:  pubKey,
+			Address:     types.Address(addr),
+			BlsKey:      pubKey,
+			VotingPower: stake.Uint64(),
 		}
 
 		return val, nil

--- a/consensus/polybft/system_state.go
+++ b/consensus/polybft/system_state.go
@@ -73,7 +73,7 @@ func (s *SystemStateImpl) GetValidatorSet() (AccountSet, error) {
 		return nil, fmt.Errorf("failed to decode addresses of the current validator set")
 	}
 
-	queryValidator := func(addr ethgo.Address) (*ValidatorAccount, error) {
+	queryValidator := func(addr ethgo.Address) (*ValidatorMetadata, error) {
 		output, err := s.validatorContract.Call("getValidator", ethgo.Latest, addr)
 		if err != nil {
 			return nil, err
@@ -94,7 +94,7 @@ func (s *SystemStateImpl) GetValidatorSet() (AccountSet, error) {
 			return nil, fmt.Errorf("failed to decode stake")
 		}
 
-		val := &ValidatorAccount{
+		val := &ValidatorMetadata{
 			Address:     types.Address(addr),
 			BlsKey:      pubKey,
 			VotingPower: stake.Uint64(),

--- a/consensus/polybft/system_state_test.go
+++ b/consensus/polybft/system_state_test.go
@@ -29,8 +29,8 @@ func TestSystemState_GetValidatorSet(t *testing.T) {
 
 		struct Validator {
 			uint256[4] id;
-			uint256 sender;
-			uint256 receiver;
+			uint256 stake;
+			uint256 totalStake;
 			uint256 data;
 		}
 
@@ -47,7 +47,7 @@ func TestSystemState_GetValidatorSet(t *testing.T) {
 				16798350082249088544573448433070681576641749462807627179536437108134609634615,
 				21427200503135995176566340351867145775962083994845221446131416289459495591422
 			];
-			return Validator(key, 0, 0, 0);
+			return Validator(key, 10, 0, 0);
 		}
 
 		`
@@ -73,6 +73,7 @@ func TestSystemState_GetValidatorSet(t *testing.T) {
 	validators, err := st.GetValidatorSet()
 	assert.NoError(t, err)
 	assert.Equal(t, types.Address(ethgo.HexToAddress("1")), validators[0].Address)
+	assert.Equal(t, uint64(10), validators[0].VotingPower)
 }
 
 func TestSystemState_GetNextExecutionAndCommittedIndex(t *testing.T) {

--- a/consensus/polybft/validator_account.go
+++ b/consensus/polybft/validator_account.go
@@ -16,14 +16,14 @@ import (
 )
 
 // ValidatorAccount represents a validator from the validator set
-type ValidatorAccount struct {
+type ValidatorMetadata struct {
 	Address     types.Address
 	BlsKey      *bls.PublicKey
 	VotingPower uint64
 }
 
 // Equals compares ValidatorAccount equality
-func (a ValidatorAccount) Equals(b *ValidatorAccount) bool {
+func (a ValidatorMetadata) Equals(b *ValidatorMetadata) bool {
 	if b == nil {
 		return false
 	}
@@ -32,11 +32,11 @@ func (a ValidatorAccount) Equals(b *ValidatorAccount) bool {
 }
 
 // Copy returns a deep copy of ValidatorAccount
-func (a ValidatorAccount) Copy() *ValidatorAccount {
+func (a ValidatorMetadata) Copy() *ValidatorMetadata {
 	copiedBlsKey := a.BlsKey.Marshal()
 	blsKey, _ := bls.UnmarshalPublicKey(copiedBlsKey)
 
-	return &ValidatorAccount{
+	return &ValidatorMetadata{
 		Address:     types.BytesToAddress(a.Address[:]),
 		BlsKey:      blsKey,
 		VotingPower: a.VotingPower,
@@ -44,7 +44,7 @@ func (a ValidatorAccount) Copy() *ValidatorAccount {
 }
 
 // MarshalRLPWith marshals ValidatorAccount to the RLP format
-func (a ValidatorAccount) MarshalRLPWith(ar *fastrlp.Arena) *fastrlp.Value {
+func (a ValidatorMetadata) MarshalRLPWith(ar *fastrlp.Arena) *fastrlp.Value {
 	vv := ar.NewArray()
 	// Address
 	vv.Set(ar.NewBytes(a.Address.Bytes()))
@@ -57,7 +57,7 @@ func (a ValidatorAccount) MarshalRLPWith(ar *fastrlp.Arena) *fastrlp.Value {
 }
 
 // UnmarshalRLPWith unmarshals ValidatorAccount from the RLP format
-func (a *ValidatorAccount) UnmarshalRLPWith(v *fastrlp.Value) error {
+func (a *ValidatorMetadata) UnmarshalRLPWith(v *fastrlp.Value) error {
 	elems, err := v.GetElems()
 	if err != nil {
 		return err
@@ -102,13 +102,13 @@ func (a *ValidatorAccount) UnmarshalRLPWith(v *fastrlp.Value) error {
 }
 
 // fmt.Stringer implementation
-func (a ValidatorAccount) String() string {
+func (a ValidatorMetadata) String() string {
 	return fmt.Sprintf("Address=%v; BLS Key=%v; Voting Power=%d",
 		a.Address.String(), hex.EncodeToString(a.BlsKey.Marshal()), a.VotingPower)
 }
 
 // AccountSet is a type alias for slice of ValidatorAccount instances
-type AccountSet []*ValidatorAccount
+type AccountSet []*ValidatorMetadata
 
 // GetAddresses aggregates addresses for given AccountSet
 func (as AccountSet) GetAddresses() []types.Address {
@@ -165,7 +165,7 @@ func (as AccountSet) Index(addr types.Address) int {
 
 // Copy returns deep copy of AccountSet
 func (as AccountSet) Copy() AccountSet {
-	copiedAccs := make([]*ValidatorAccount, as.Len())
+	copiedAccs := make([]*ValidatorMetadata, as.Len())
 	for i, acc := range as {
 		copiedAccs[i] = acc.Copy()
 	}
@@ -175,7 +175,7 @@ func (as AccountSet) Copy() AccountSet {
 
 // GetValidatorAccount tries to retrieve validator account by given address from the account set.
 // It returns nil if such account is not found.
-func (as AccountSet) GetValidatorAccount(address types.Address) *ValidatorAccount {
+func (as AccountSet) GetValidatorAccount(address types.Address) *ValidatorMetadata {
 	i := as.Index(address)
 	if i == -1 {
 		return nil

--- a/consensus/polybft/validator_account.go
+++ b/consensus/polybft/validator_account.go
@@ -15,14 +15,14 @@ import (
 	"github.com/umbracle/fastrlp"
 )
 
-// ValidatorAccount represents a validator from the validator set
+// ValidatorMetadata represents a validator metadata (its public identity)
 type ValidatorMetadata struct {
 	Address     types.Address
 	BlsKey      *bls.PublicKey
 	VotingPower uint64
 }
 
-// Equals compares ValidatorAccount equality
+// Equals compares ValidatorMetadata equality
 func (a ValidatorMetadata) Equals(b *ValidatorMetadata) bool {
 	if b == nil {
 		return false
@@ -31,7 +31,7 @@ func (a ValidatorMetadata) Equals(b *ValidatorMetadata) bool {
 	return a.Address == b.Address && reflect.DeepEqual(a.BlsKey, b.BlsKey)
 }
 
-// Copy returns a deep copy of ValidatorAccount
+// Copy returns a deep copy of ValidatorMetadata
 func (a ValidatorMetadata) Copy() *ValidatorMetadata {
 	copiedBlsKey := a.BlsKey.Marshal()
 	blsKey, _ := bls.UnmarshalPublicKey(copiedBlsKey)
@@ -43,7 +43,7 @@ func (a ValidatorMetadata) Copy() *ValidatorMetadata {
 	}
 }
 
-// MarshalRLPWith marshals ValidatorAccount to the RLP format
+// MarshalRLPWith marshals ValidatorMetadata to the RLP format
 func (a ValidatorMetadata) MarshalRLPWith(ar *fastrlp.Arena) *fastrlp.Value {
 	vv := ar.NewArray()
 	// Address
@@ -56,7 +56,7 @@ func (a ValidatorMetadata) MarshalRLPWith(ar *fastrlp.Arena) *fastrlp.Value {
 	return vv
 }
 
-// UnmarshalRLPWith unmarshals ValidatorAccount from the RLP format
+// UnmarshalRLPWith unmarshals ValidatorMetadata from the RLP format
 func (a *ValidatorMetadata) UnmarshalRLPWith(v *fastrlp.Value) error {
 	elems, err := v.GetElems()
 	if err != nil {
@@ -107,7 +107,7 @@ func (a ValidatorMetadata) String() string {
 		a.Address.String(), hex.EncodeToString(a.BlsKey.Marshal()), a.VotingPower)
 }
 
-// AccountSet is a type alias for slice of ValidatorAccount instances
+// AccountSet is a type alias for slice of ValidatorMetadata instances
 type AccountSet []*ValidatorMetadata
 
 // GetAddresses aggregates addresses for given AccountSet
@@ -135,7 +135,7 @@ func (as AccountSet) Len() int {
 	return len(as)
 }
 
-// ContainsNodeID checks whether ValidatorAccount with given nodeID is present in the AccountSet
+// ContainsNodeID checks whether ValidatorMetadata with given nodeID is present in the AccountSet
 func (as AccountSet) ContainsNodeID(nodeID string) bool {
 	for _, validator := range as {
 		if validator.Address.String() == nodeID {
@@ -146,13 +146,13 @@ func (as AccountSet) ContainsNodeID(nodeID string) bool {
 	return false
 }
 
-// ContainsAddress checks whether ValidatorAccount with given address is present in the AccountSet
+// ContainsAddress checks whether ValidatorMetadata with given address is present in the AccountSet
 func (as AccountSet) ContainsAddress(address types.Address) bool {
 	return as.Index(address) != -1
 }
 
-// Index returns index of the given ValidatorAccount, identified by address within the AccountSet.
-// If given ValidatorAccount is not present, it returns -1.
+// Index returns index of the given ValidatorMetadata, identified by address within the AccountSet.
+// If given ValidatorMetadata is not present, it returns -1.
 func (as AccountSet) Index(addr types.Address) int {
 	for indx, validator := range as {
 		if validator.Address == addr {

--- a/consensus/polybft/validator_account_test.go
+++ b/consensus/polybft/validator_account_test.go
@@ -14,9 +14,9 @@ func TestAccountSet_GetAddresses(t *testing.T) {
 
 	address1, address2, address3 := types.Address{4, 3}, types.Address{68, 123}, types.Address{168, 123}
 	ac := AccountSet{
-		&ValidatorAccount{Address: address1},
-		&ValidatorAccount{Address: address2},
-		&ValidatorAccount{Address: address3},
+		&ValidatorMetadata{Address: address1},
+		&ValidatorMetadata{Address: address2},
+		&ValidatorMetadata{Address: address3},
 	}
 	rs := ac.GetAddresses()
 	assert.Len(t, rs, 3)
@@ -33,9 +33,9 @@ func TestAccountSet_GetBlsKeys(t *testing.T) {
 
 	key1, key2, key3 := keys[0], keys[1], keys[2]
 	ac := AccountSet{
-		&ValidatorAccount{BlsKey: key1.PublicKey()},
-		&ValidatorAccount{BlsKey: key2.PublicKey()},
-		&ValidatorAccount{BlsKey: key3.PublicKey()},
+		&ValidatorMetadata{BlsKey: key1.PublicKey()},
+		&ValidatorMetadata{BlsKey: key2.PublicKey()},
+		&ValidatorMetadata{BlsKey: key3.PublicKey()},
 	}
 	rs := ac.GetBlsKeys()
 	assert.Len(t, rs, 3)
@@ -76,7 +76,7 @@ func TestAccountSet_Len(t *testing.T) {
 	ac := AccountSet{}
 
 	for i := 0; i < count; i++ {
-		ac = append(ac, &ValidatorAccount{})
+		ac = append(ac, &ValidatorMetadata{})
 		assert.Equal(t, i+1, ac.Len())
 	}
 }
@@ -151,7 +151,7 @@ func TestAccountSet_ApplyDelta(t *testing.T) {
 				}
 				for _, acct := range step.expect {
 					v := vals.getValidator(acct)
-					if !snapshot.ContainsAddress(v.ValidatorAccount().Address) {
+					if !snapshot.ContainsAddress(v.ValidatorMetadata().Address) {
 						t.Fatalf("not found '%s'", acct)
 					}
 				}

--- a/consensus/polybft/validator_set.go
+++ b/consensus/polybft/validator_set.go
@@ -16,7 +16,7 @@ type ValidatorSet interface {
 	// Len returns the size of the validator set
 	Len() int
 
-	// Accounts returns the list of the ValidatorAccount
+	// Accounts returns the list of the ValidatorMetadata
 	Accounts() AccountSet
 }
 


### PR DESCRIPTION
# Description

PR adds `VotingPower` field to the `ValidatorMetadata` (previously referred as `ValidatorAccount`). Currently `VotingPower` is equal to staked amount of tokens. However in the future we may opt to use scaled staked amount as voting power instead.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually