### PR TITLE
Abstract `Precompiles` in `Executor`

### DIFF
--- a/blockchain/testing.go
+++ b/blockchain/testing.go
@@ -11,6 +11,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/state"
 	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
+	"github.com/0xPolygon/polygon-edge/state/runtime/precompiled"
 	"github.com/hashicorp/go-hclog"
 
 	"github.com/0xPolygon/polygon-edge/types"
@@ -108,7 +109,8 @@ func NewTestBlockchain(t *testing.T, headers []*types.Header) *Blockchain {
 	}
 
 	st := itrie.NewState(itrie.NewMemoryStorage())
-	b, err := newBlockChain(config, state.NewExecutor(config.Params, st, hclog.NewNullLogger()))
+	executor := state.NewExecutor(config.Params, st, hclog.NewNullLogger(), precompiled.NewPrecompiled())
+	b, err := newBlockChain(config, executor)
 
 	if err != nil {
 		t.Fatal(err)

--- a/consensus/ibft/fork/hooks_test.go
+++ b/consensus/ibft/fork/hooks_test.go
@@ -12,6 +12,7 @@ import (
 	stakingHelper "github.com/0xPolygon/polygon-edge/helper/staking"
 	"github.com/0xPolygon/polygon-edge/state"
 	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
+	"github.com/0xPolygon/polygon-edge/state/runtime/precompiled"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/0xPolygon/polygon-edge/validators"
 	"github.com/0xPolygon/polygon-edge/validators/store"
@@ -279,7 +280,7 @@ func newTestTransition(
 
 	ex := state.NewExecutor(&chain.Params{
 		Forks: chain.AllForksEnabled,
-	}, st, hclog.NewNullLogger())
+	}, st, hclog.NewNullLogger(), precompiled.NewPrecompiled())
 
 	rootHash := ex.WriteGenesis(nil)
 	ex.GetHash = func(h *types.Header) state.GetHashByNumber {

--- a/consensus/polybft/system_state_test.go
+++ b/consensus/polybft/system_state_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/state"
 	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
+	"github.com/0xPolygon/polygon-edge/state/runtime/precompiled"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
@@ -207,7 +208,7 @@ func newTestTransition(t *testing.T) *state.Transition {
 
 	ex := state.NewExecutor(&chain.Params{
 		Forks: chain.AllForksEnabled,
-	}, st, hclog.NewNullLogger())
+	}, st, hclog.NewNullLogger(), precompiled.NewPrecompiled())
 
 	rootHash := ex.WriteGenesis(nil)
 

--- a/helper/predeployment/predeployment.go
+++ b/helper/predeployment/predeployment.go
@@ -14,6 +14,7 @@ import (
 	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
 	"github.com/0xPolygon/polygon-edge/state/runtime"
 	"github.com/0xPolygon/polygon-edge/state/runtime/evm"
+	"github.com/0xPolygon/polygon-edge/state/runtime/precompiled"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/umbracle/ethgo/abi"
 )
@@ -141,7 +142,7 @@ func getPredeployAccount(address types.Address, input, deployedBytecode []byte) 
 	config := chain.AllForksEnabled.At(0)
 
 	// Create a transition
-	transition := state.NewTransition(config, radix)
+	transition := state.NewTransition(config, radix, precompiled.NewPrecompiled())
 
 	// Run the transition through the EVM
 	res := evm.NewEVM().Run(contract, transition, &config)

--- a/server/server.go
+++ b/server/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/state"
 	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
 	"github.com/0xPolygon/polygon-edge/state/runtime"
+	"github.com/0xPolygon/polygon-edge/state/runtime/precompiled"
 	"github.com/0xPolygon/polygon-edge/txpool"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
@@ -183,7 +184,7 @@ func NewServer(config *Config) (*Server, error) {
 	st := itrie.NewState(stateStorage)
 	m.state = st
 
-	m.executor = state.NewExecutor(config.Chain.Params, st, logger)
+	m.executor = state.NewExecutor(config.Chain.Params, st, logger, precompiled.NewPrecompiled())
 
 	// custom write genesis hook per consensus engine
 	engineName := m.config.Chain.Params.GetEngine()

--- a/state/executor.go
+++ b/state/executor.go
@@ -62,12 +62,13 @@ func (e *Executor) WriteGenesis(alloc map[types.Address]*chain.GenesisAccount) t
 	}
 
 	transition := &Transition{
-		logger:   e.logger,
-		ctx:      env,
-		state:    txn,
-		auxState: e.state,
-		gasPool:  uint64(env.GasLimit),
-		config:   config,
+		logger:      e.logger,
+		ctx:         env,
+		state:       txn,
+		auxState:    e.state,
+		gasPool:     uint64(env.GasLimit),
+		config:      config,
+		precompiles: e.precompiles,
 	}
 
 	for addr, account := range alloc {

--- a/state/runtime/precompiled/native_transfer_test.go
+++ b/state/runtime/precompiled/native_transfer_test.go
@@ -26,7 +26,7 @@ func Test_NativeTransferPrecompile(t *testing.T) {
 	snapshot := st.NewSnapshot()
 	// Create a radix
 	radix := state.NewTxn(st, snapshot)
-	transition := state.NewTransition(chain.AllForksEnabled.At(0), radix)
+	transition := state.NewTransition(chain.AllForksEnabled.At(0), radix, NewPrecompiled())
 	contract := &nativeTransfer{}
 	abiType := abi.MustNewType("tuple(address, address, uint256)")
 	run := func(caller, from, to types.Address, amount *big.Int, host runtime.Host) error {
@@ -55,7 +55,7 @@ func Test_NativeTransferPrecompile(t *testing.T) {
 		stateTrie.CreateAccount(sender)
 		stateTrie.CreateAccount(receiver)
 		stateTrie.AddBalance(sender, big.NewInt(1000))
-		transition := state.NewTransition(chain.AllForksEnabled.At(0), stateTrie)
+		transition := state.NewTransition(chain.AllForksEnabled.At(0), stateTrie, NewPrecompiled())
 
 		require.NoError(t, run(contracts.NativeTokenContract, sender, receiver, big.NewInt(100), transition))
 		require.Equal(t, big.NewInt(900), stateTrie.GetBalance(sender))

--- a/tests/evm_test.go
+++ b/tests/evm_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/state"
 	"github.com/0xPolygon/polygon-edge/state/runtime"
 	"github.com/0xPolygon/polygon-edge/state/runtime/evm"
+	"github.com/0xPolygon/polygon-edge/state/runtime/precompiled"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
 	"github.com/umbracle/fastrlp"
@@ -54,7 +55,7 @@ func testVMCase(t *testing.T, name string, c *VMCase) {
 
 	config := mainnetChainConfig.Forks.At(uint64(env.Number))
 
-	executor := state.NewExecutor(&mainnetChainConfig, s, hclog.NewNullLogger())
+	executor := state.NewExecutor(&mainnetChainConfig, s, hclog.NewNullLogger(), precompiled.NewPrecompiled())
 	executor.GetHash = func(*types.Header) func(i uint64) types.Hash {
 		return vmTestBlockHash
 	}

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/state"
+	"github.com/0xPolygon/polygon-edge/state/runtime/precompiled"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
 )
@@ -48,7 +49,7 @@ func RunSpecificTest(t *testing.T, file string, c stateCase, name, fork string, 
 	s, snapshot, pastRoot := buildState(c.Pre)
 	forks := config.At(uint64(env.Number))
 
-	xxx := state.NewExecutor(&chain.Params{Forks: config, ChainID: 1}, s, hclog.NewNullLogger())
+	xxx := state.NewExecutor(&chain.Params{Forks: config, ChainID: 1}, s, hclog.NewNullLogger(), precompiled.NewPrecompiled())
 
 	xxx.PostHook = func(t *state.Transition) {
 		if name == "failed_tx_xcf416c53" {

--- a/validators/store/contract/contract_test.go
+++ b/validators/store/contract/contract_test.go
@@ -11,6 +11,7 @@ import (
 	testHelper "github.com/0xPolygon/polygon-edge/helper/tests"
 	"github.com/0xPolygon/polygon-edge/state"
 	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
+	"github.com/0xPolygon/polygon-edge/state/runtime/precompiled"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/0xPolygon/polygon-edge/validators"
 	"github.com/0xPolygon/polygon-edge/validators/store"
@@ -82,7 +83,7 @@ func newTestTransition(
 
 	ex := state.NewExecutor(&chain.Params{
 		Forks: chain.AllForksEnabled,
-	}, st, hclog.NewNullLogger())
+	}, st, hclog.NewNullLogger(), precompiled.NewPrecompiled())
 
 	rootHash := ex.WriteGenesis(nil)
 


### PR DESCRIPTION
# Description

During merging `develop` into `v3-parity` branch, an import cycle was detected, due to these two "conflicting" PRs:
- https://github.com/0xPolygon/polygon-edge/pull/859/files#diff-f64dae91a36980ba02c538f69fb83b7c80a8b4345db96849127307d33ccfacd1R192
- https://github.com/0xPolygon/polygon-edge/pull/796/files#diff-3c839689d9951575e9f954d223536fa99ad59573ba58f4b41745941c3b44633eR24

The problem was that `precompiled` package was dependent upon `runtime`/`state` package and vice versa.

This PR consists of introducing `precompiles` to the `Executor`, but as a `runtime.Runtime` abstraction.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually