### PR TITLE
Disabling hostname prefix in metrics configuration

### DIFF
--- a/server/server_metrics.go
+++ b/server/server_metrics.go
@@ -21,6 +21,7 @@ func (s *Server) setupTelemetry() error {
 	}
 
 	metricsConf := metrics.DefaultConfig("edge")
+	metricsConf.EnableHostname = false
 	metrics.NewGlobal(metricsConf, metrics.FanoutSink{
 		inm, promSink,
 	})


### PR DESCRIPTION
# Description

The metrics prefix context can be maintained on the metrics ingestion level. Proposing to disable the hostname prefix in the `go-metrics` library altogether unless there's an explicit need/request for the feature. 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [X] I have tested this code manually
