### PR TITLE
Mock Host implementation in native transfer test

### DIFF
--- a/state/executor.go
+++ b/state/executor.go
@@ -266,7 +266,6 @@ func (t *Transition) WriteFailedReceipt(txn *types.Transaction) error {
 
 // Write writes another transaction to the executor
 func (t *Transition) Write(txn *types.Transaction) error {
-
 	var err error
 
 	if txn.From == emptyFrom && txn.IsLegacyTx() {

--- a/state/executor.go
+++ b/state/executor.go
@@ -61,12 +61,13 @@ func (e *Executor) WriteGenesis(alloc map[types.Address]*chain.GenesisAccount) t
 	}
 
 	transition := &Transition{
-		logger:   e.logger,
-		ctx:      env,
-		state:    txn,
-		auxState: e.state,
-		gasPool:  uint64(env.GasLimit),
-		config:   config,
+		logger:      e.logger,
+		ctx:         env,
+		state:       txn,
+		auxState:    e.state,
+		gasPool:     uint64(env.GasLimit),
+		config:      config,
+		precompiles: precompiled.NewPrecompiled(),
 	}
 
 	for addr, account := range alloc {

--- a/state/runtime/precompiled/native_transfer_test.go
+++ b/state/runtime/precompiled/native_transfer_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/contracts"
-	"github.com/0xPolygon/polygon-edge/state"
-	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
 	"github.com/0xPolygon/polygon-edge/state/runtime"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/require"
@@ -20,13 +18,6 @@ func Test_NativeTransferPrecompile(t *testing.T) {
 		receiver = types.Address{0x2}
 	)
 
-	// Create an instance of the state
-	st := itrie.NewState(itrie.NewMemoryStorage())
-	// Create a snapshot
-	snapshot := st.NewSnapshot()
-	// Create a radix
-	radix := state.NewTxn(st, snapshot)
-	transition := state.NewTransition(chain.AllForksEnabled.At(0), radix)
 	contract := &nativeTransfer{}
 	abiType := abi.MustNewType("tuple(address, address, uint256)")
 	run := func(caller, from, to types.Address, amount *big.Int, host runtime.Host) error {
@@ -39,26 +30,122 @@ func Test_NativeTransferPrecompile(t *testing.T) {
 	}
 
 	t.Run("Invalid input", func(t *testing.T) {
-		_, err := contract.run([]byte{}, types.Address{}, transition)
+		_, err := contract.run([]byte{}, types.Address{}, nil)
 		require.ErrorIs(t, err, runtime.ErrInvalidInputData)
 	})
 	t.Run("Caller not authorized", func(t *testing.T) {
-		err := run(types.ZeroAddress, sender, receiver, big.NewInt(10), transition)
+		err := run(types.ZeroAddress, sender, receiver, big.NewInt(10), nil)
 		require.ErrorIs(t, err, runtime.ErrUnauthorizedCaller)
 	})
 	t.Run("Insufficient balance", func(t *testing.T) {
-		err := run(contracts.NativeTokenContract, sender, receiver, big.NewInt(10), transition)
+		err := run(contracts.NativeTokenContract, sender, receiver, big.NewInt(10), newDummyHost())
 		require.ErrorIs(t, err, runtime.ErrInsufficientBalance)
 	})
 	t.Run("Correct transfer", func(t *testing.T) {
-		stateTrie := state.NewTxn(st, snapshot)
-		stateTrie.CreateAccount(sender)
-		stateTrie.CreateAccount(receiver)
-		stateTrie.AddBalance(sender, big.NewInt(1000))
-		transition := state.NewTransition(chain.AllForksEnabled.At(0), stateTrie)
+		host := newDummyHost()
+		host.AddBalance(sender, big.NewInt(1000))
 
-		require.NoError(t, run(contracts.NativeTokenContract, sender, receiver, big.NewInt(100), transition))
-		require.Equal(t, big.NewInt(900), stateTrie.GetBalance(sender))
-		require.Equal(t, big.NewInt(100), stateTrie.GetBalance(receiver))
+		err := run(contracts.NativeTokenContract, sender, receiver, big.NewInt(100), host)
+		require.NoError(t, err)
+		require.Equal(t, big.NewInt(900), host.GetBalance(sender))
+		require.Equal(t, big.NewInt(100), host.GetBalance(receiver))
 	})
+}
+
+var _ runtime.Host = (*dummyHost)(nil)
+
+type dummyHost struct {
+	balances map[types.Address]*big.Int
+}
+
+func newDummyHost() *dummyHost {
+	return &dummyHost{
+		balances: map[types.Address]*big.Int{},
+	}
+}
+
+func (d dummyHost) AddBalance(addr types.Address, balance *big.Int) {
+	existingBalance := d.GetBalance(addr)
+	existingBalance = new(big.Int).Add(existingBalance, balance)
+	d.balances[addr] = existingBalance
+}
+
+func (d dummyHost) AccountExists(addr types.Address) bool {
+	panic("not implemented")
+}
+
+func (d dummyHost) GetStorage(addr types.Address, key types.Hash) types.Hash {
+	panic("not implemented")
+}
+
+func (d dummyHost) SetStorage(addr types.Address, key types.Hash, value types.Hash, config *chain.ForksInTime) runtime.StorageStatus {
+	panic("not implemented")
+}
+
+func (d dummyHost) GetBalance(addr types.Address) *big.Int {
+	balance, exists := d.balances[addr]
+	if !exists {
+		return big.NewInt(0)
+	}
+
+	return balance
+}
+
+func (d dummyHost) GetCodeSize(addr types.Address) int {
+	panic("not implemented")
+}
+
+func (d dummyHost) GetCodeHash(addr types.Address) types.Hash {
+	panic("not implemented")
+}
+
+func (d dummyHost) GetCode(addr types.Address) []byte {
+	panic("not implemented")
+}
+
+func (d dummyHost) Selfdestruct(addr types.Address, beneficiary types.Address) {
+	panic("not implemented")
+}
+
+func (d dummyHost) GetTxContext() runtime.TxContext {
+	panic("not implemented")
+}
+
+func (d dummyHost) GetBlockHash(number int64) types.Hash {
+	panic("not implemented")
+}
+
+func (d dummyHost) EmitLog(addr types.Address, topics []types.Hash, data []byte) {
+	panic("not implemented")
+}
+
+func (d dummyHost) Callx(_ *runtime.Contract, _ runtime.Host) *runtime.ExecutionResult {
+	panic("not implemented")
+}
+
+func (d dummyHost) Empty(addr types.Address) bool {
+	panic("not implemented")
+}
+
+func (d dummyHost) GetNonce(addr types.Address) uint64 {
+	panic("not implemented")
+}
+
+func (d dummyHost) Transfer(from types.Address, to types.Address, amount *big.Int) error {
+	if d.balances == nil {
+		d.balances = map[types.Address]*big.Int{}
+	}
+
+	senderBalance := d.GetBalance(from)
+	if senderBalance.Cmp(amount) < 0 {
+		return runtime.ErrInsufficientBalance
+	}
+
+	senderBalance = new(big.Int).Sub(senderBalance, amount)
+	d.balances[from] = senderBalance
+
+	receiverBalance := d.GetBalance(to)
+	d.balances[to] = new(big.Int).Add(receiverBalance, amount)
+
+	return nil
 }


### PR DESCRIPTION
# Description

The problem was that `precompiled` package imports `state` and `immutable-trie` packages, because of `Test_NativeTransferPrecompile`. On the other hand, PR https://github.com/0xPolygon/polygon-edge/pull/859 introduced dependency to `precompiled` package in the `state`.

Solution proposal consists of mocking `runtime.Host` interface and basically getting rid off `state` and `immutable-trie` packages in the `Test_NativeTransferPrecompile`.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
