### PR TITLE
Remove store getHeaderByNumber

### DIFF
--- a/jsonrpc/eth_blockchain_test.go
+++ b/jsonrpc/eth_blockchain_test.go
@@ -450,15 +450,6 @@ func (m *mockBlockStore) GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, e
 	return receipts, nil
 }
 
-func (m *mockBlockStore) GetHeaderByNumber(blockNumber uint64) (*types.Header, bool) {
-	b, ok := m.GetBlockByNumber(blockNumber, false)
-	if !ok {
-		return nil, false
-	}
-
-	return b.Header, true
-}
-
 func (m *mockBlockStore) GetBlockByNumber(blockNumber uint64, full bool) (*types.Block, bool) {
 	for _, b := range m.blocks {
 		if b.Number() == blockNumber {

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -38,9 +38,6 @@ type ethBlockchainStore interface {
 	// Header returns the current header of the chain (genesis if empty)
 	Header() *types.Header
 
-	// GetHeaderByNumber returns the header by number
-	GetHeaderByNumber(block uint64) (*types.Header, bool)
-
 	// GetBlockByHash gets a block using the provided hash
 	GetBlockByHash(hash types.Hash, full bool) (*types.Block, bool)
 
@@ -779,24 +776,24 @@ func (e *Eth) getBlockHeader(number BlockNumber) (*types.Header, error) {
 		return e.store.Header(), nil
 
 	case EarliestBlockNumber:
-		header, ok := e.store.GetHeaderByNumber(uint64(0))
+		block, ok := e.store.GetBlockByNumber(uint64(0), false)
 		if !ok {
 			return nil, fmt.Errorf("error fetching genesis block header")
 		}
 
-		return header, nil
+		return block.Header, nil
 
 	case PendingBlockNumber:
 		return nil, fmt.Errorf("fetching the pending header is not supported")
 
 	default:
 		// Convert the block number from hex to uint64
-		header, ok := e.store.GetHeaderByNumber(uint64(number))
+		block, ok := e.store.GetBlockByNumber(uint64(number), false)
 		if !ok {
 			return nil, fmt.Errorf("error fetching block number %d header", uint64(number))
 		}
 
-		return header, nil
+		return block.Header, nil
 	}
 }
 

--- a/jsonrpc/eth_state_test.go
+++ b/jsonrpc/eth_state_test.go
@@ -792,12 +792,12 @@ func (m *mockSpecialStore) GetAccount(root types.Hash, addr types.Address) (*sta
 	return m.account.account, nil
 }
 
-func (m *mockSpecialStore) GetHeaderByNumber(blockNumber uint64) (*types.Header, bool) {
+func (m *mockSpecialStore) GetBlockByNumber(blockNumber uint64, full bool) (*types.Block, bool) {
 	if m.block.Number() != blockNumber {
 		return nil, false
 	}
 
-	return m.block.Header, true
+	return m.block, true
 }
 
 func (m *mockSpecialStore) Header() *types.Header {

--- a/jsonrpc/mocks_test.go
+++ b/jsonrpc/mocks_test.go
@@ -138,14 +138,6 @@ func (m *mockStore) SubscribeEvents() blockchain.Subscription {
 	return m.subscription
 }
 
-func (m *mockStore) GetHeaderByNumber(number uint64) (*types.Header, bool) {
-	header := m.headerLoop(func(header *types.Header) bool {
-		return header.Number == number
-	})
-
-	return header, header != nil
-}
-
 func (m *mockStore) GetBlockByHash(hash types.Hash, full bool) (*types.Block, bool) {
 	header := m.headerLoop(func(header *types.Header) bool {
 		return header.Hash == hash

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -81,7 +81,7 @@ func toTransaction(
 	return res
 }
 
-type Block struct {
+type block struct {
 	ParentHash      types.Hash          `json:"parentHash"`
 	Sha3Uncles      types.Hash          `json:"sha3Uncles"`
 	Miner           argBytes            `json:"miner"`
@@ -104,9 +104,9 @@ type Block struct {
 	Uncles          []types.Hash        `json:"uncles"`
 }
 
-func toBlock(b *types.Block, fullTx bool) *Block {
+func toBlock(b *types.Block, fullTx bool) *block {
 	h := b.Header
-	res := &Block{
+	res := &block{
 		ParentHash:      h.ParentHash,
 		Sha3Uncles:      h.Sha3Uncles,
 		Miner:           argBytes(h.Miner),

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -81,7 +81,7 @@ func toTransaction(
 	return res
 }
 
-type block struct {
+type Block struct {
 	ParentHash      types.Hash          `json:"parentHash"`
 	Sha3Uncles      types.Hash          `json:"sha3Uncles"`
 	Miner           argBytes            `json:"miner"`
@@ -104,9 +104,9 @@ type block struct {
 	Uncles          []types.Hash        `json:"uncles"`
 }
 
-func toBlock(b *types.Block, fullTx bool) *block {
+func toBlock(b *types.Block, fullTx bool) *Block {
 	h := b.Header
-	res := &block{
+	res := &Block{
 		ParentHash:      h.ParentHash,
 		Sha3Uncles:      h.Sha3Uncles,
 		Miner:           argBytes(h.Miner),


### PR DESCRIPTION
# Description

This PR removes the `GetHeaderByNumber` store method in the `jsonrpc` since its behaviour can be achieved with the `GetBlockByNumber` method.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
