### PR TITLE
EVM-220 TestClusterBlockSync/BLS fails in voting power branch

### DIFF
--- a/consensus/ibft/consensus_backend.go
+++ b/consensus/ibft/consensus_backend.go
@@ -132,8 +132,13 @@ func (i *backendIBFT) HasQuorum(
 
 	switch msgType {
 	case protoIBFT.MessageType_PREPREPARE:
-		return len(messages) >= 0
+		return len(messages) >= 1
 	case protoIBFT.MessageType_PREPARE:
+		// two cases -> first message is MessageType_PREPREPARE, and other -> MessageType_PREPREPARE is not included
+		if len(messages) > 0 && messages[0].Type == protoIBFT.MessageType_PREPREPARE {
+			return len(messages) >= int(quorum)
+		}
+
 		return len(messages) >= int(quorum)-1
 	case protoIBFT.MessageType_ROUND_CHANGE, protoIBFT.MessageType_COMMIT:
 		return len(messages) >= int(quorum)

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -1059,8 +1059,13 @@ func (c *consensusRuntime) HasQuorum(
 
 	switch msgType {
 	case protoIBFT.MessageType_PREPREPARE:
-		return len(messages) >= 0
+		return len(messages) >= 1
 	case protoIBFT.MessageType_PREPARE:
+		// two cases -> first message is MessageType_PREPREPARE, and other -> MessageType_PREPREPARE is not included
+		if len(messages) > 0 && messages[0].Type == protoIBFT.MessageType_PREPREPARE {
+			return len(messages) >= int(quorum)
+		}
+
 		return len(messages) >= int(quorum)-1
 	case protoIBFT.MessageType_ROUND_CHANGE, protoIBFT.MessageType_COMMIT:
 		return len(messages) >= int(quorum)

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 )
 
 require (
-	github.com/0xPolygon/go-ibft v0.0.0-20221109165724-ff0b77dd5f69
+	github.com/0xPolygon/go-ibft v0.1.1-0.20221128092443-8b1e3f20c4c3
 	github.com/docker/docker v20.10.18+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/mitchellh/go-glint v0.0.0-20210722152315-6515ceb4a127

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D
 filippo.io/edwards25519 v1.0.0-rc.1 h1:m0VOOB23frXZvAOK44usCgLWvtsxIoMCTBGJZlpmGfU=
 filippo.io/edwards25519 v1.0.0-rc.1/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
-github.com/0xPolygon/go-ibft v0.0.0-20221109165724-ff0b77dd5f69 h1:7WV/2aoWQSEVdu4SglqKuwdKylhq1Cl/zXX/9GjreY0=
-github.com/0xPolygon/go-ibft v0.0.0-20221109165724-ff0b77dd5f69/go.mod h1:uJ9EHbl+8StbRhvKgfxDextK32FlVNOiBnRPlAgrQK8=
+github.com/0xPolygon/go-ibft v0.1.1-0.20221128092443-8b1e3f20c4c3 h1:q5TnFEnzDwaSOZGVkOhBzCkpHFY2zhCjYLkQuRCFR9c=
+github.com/0xPolygon/go-ibft v0.1.1-0.20221128092443-8b1e3f20c4c3/go.mod h1:uJ9EHbl+8StbRhvKgfxDextK32FlVNOiBnRPlAgrQK8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=


### PR DESCRIPTION
# Description

`go.mod` must be updated to the latest `go-ibft` commit introduced with https://github.com/0xPolygon/go-ibft/pull/48
`HasQuorum` methods must properly handle `protoIBFT.MessageType_PREPREPARE` and `protoIBFT.MessageType_PREPARE` cases

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually
