### PR TITLE
Epikichi/edge 904 investigate and add reproducable build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,17 +31,25 @@ jobs:
           path: polygon-edge.tar.gz
           retention-days: 3
 
-      - name: 'Verify Build Reproducability'
+  go_build_reproducibility:
+    name: Verify Build Reproducibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Go environment
+        uses: actions/setup-go@v3.3.0
+        with:
+          go-version: 1.18.x
+
+      - name: 'Reproduce builds'
         continue-on-error: true
-        env:
-          CC: gcc
-          CXX: g++
-          GOARC: amd64
-          GOOS: linux
         run: |
-          buildsha1=$(shasum -a256 ./polygon-edge | awk '{print $1}')
-          go build -tags netgo -ldflags="-s -w -linkmode external -extldflags "-static" -X \"github.com/0xPolygon/polygon-edge/versioning.Version=${GITHUB_REF_NAME}\" -X \"github.com/0xPolygon/polygon-edge/versioning.Commit=${GITHUB_SHA}\""
-          buildsha2=$(shasum -a256 ./polygon-edge | awk '{print $1}')
+          go build -o ./edge-1 -trimpath -buildvcs=false
+          go build -o ./edge-2 -trimpath -buildvcs=false
+
+          buildsha1=$(shasum -a256 ./edge-1 | awk '{print $1}')
+          buildsha2=$(shasum -a256 ./edge-2 | awk '{print $1}')
 
           echo "Build 1 SHA: $buildsha1"
           echo "Build 2 SHA: $buildsha2"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,21 @@ jobs:
           name: polygon-edge
           path: polygon-edge.tar.gz
           retention-days: 3
+      
+      - name: 'Verify Build Reproducability'
+        continue-on-error: true
+        env:
+          CC: gcc
+          CXX: g++
+          GOARC: amd64
+          GOOS: linux
+        run: |
+          buildsha1=$(shasum -a256 ./polygon-edge)
+          go build -tags netgo -ldflags="-s -w -linkmode external -extldflags "-static" -X \"github.com/0xPolygon/polygon-edge/versioning.Version=${GITHUB_REF_NAME}\" -X \"github.com/0xPolygon/polygon-edge/versioning.Commit=${GITHUB_SHA}\""
+          buildsha2=$(shasum -a256 ./polygon-edge)
+          if [ "$buildsha1" != "$buildsha2" ]; then
+            echo "Build artifact does not match original"
+            exit 1
+          else
+            echo "Build artifact matches original"
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,9 +39,13 @@ jobs:
           GOARC: amd64
           GOOS: linux
         run: |
-          buildsha1=$(shasum -a256 ./polygon-edge)
+          buildsha1=$(shasum -a256 ./polygon-edge | awk '{print 1}')
           go build -tags netgo -ldflags="-s -w -linkmode external -extldflags "-static" -X \"github.com/0xPolygon/polygon-edge/versioning.Version=${GITHUB_REF_NAME}\" -X \"github.com/0xPolygon/polygon-edge/versioning.Commit=${GITHUB_SHA}\""
-          buildsha2=$(shasum -a256 ./polygon-edge)
+          buildsha2=$(shasum -a256 ./polygon-edge | awk '{print 1}')
+
+          echo "Build 1 SHA: $buildsha1"
+          echo "Build 2 SHA: $buildsha2"
+
           if [ "$buildsha1" != "$buildsha2" ]; then
             echo "Build artifact does not match original"
             exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,9 +39,9 @@ jobs:
           GOARC: amd64
           GOOS: linux
         run: |
-          buildsha1=$(shasum -a256 ./polygon-edge | awk '{print 1}')
+          buildsha1=$(shasum -a256 ./polygon-edge | awk '{print $1}')
           go build -tags netgo -ldflags="-s -w -linkmode external -extldflags "-static" -X \"github.com/0xPolygon/polygon-edge/versioning.Version=${GITHUB_REF_NAME}\" -X \"github.com/0xPolygon/polygon-edge/versioning.Commit=${GITHUB_SHA}\""
-          buildsha2=$(shasum -a256 ./polygon-edge | awk '{print 1}')
+          buildsha2=$(shasum -a256 ./polygon-edge | awk '{print $1}')
 
           echo "Build 1 SHA: $buildsha1"
           echo "Build 2 SHA: $buildsha2"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
   go_build_reproducibility:
     name: Verify Build Reproducibility
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           name: polygon-edge
           path: polygon-edge.tar.gz
           retention-days: 3
-      
+
       - name: 'Verify Build Reproducability'
         continue-on-error: true
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: Pull Request CI
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch: {}
   pull_request:
-    paths:
-      - '**.go'
 
 jobs:
   build:


### PR DESCRIPTION
# Description

Adding build reproducible validation step in the build workflow. 

## Notes on Behavior
- Reproducibility errors  will not fail the job nor the step, but will show in the workflow.
- Builds with `-trimpath` and `-buildvcs=false` to prevent build context info from being injected into the artifact. 