### PR TITLE
Fix assigned boot nodes port number in genesis

### DIFF
--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -39,7 +39,7 @@ const (
 	defaultPolyBftValidatorPrefixPath = "test-chain-"
 	defaultBridge                     = false
 
-	bootnodePortStart   = 1
+	bootnodePortStart   = 30301
 	defaultStakeBalance = 100
 )
 
@@ -102,7 +102,7 @@ func (p *genesisParams) generatePolyBFTConfig() (*chain.Chain, error) {
 	// set generic validators as bootnodes if needed
 	if len(p.bootnodes) == 0 {
 		for i, validator := range validatorsInfo {
-			bnode := fmt.Sprintf("/ip4/%s/tcp/%d0001/p2p/%s", "127.0.0.1", bootnodePortStart+i, validator.NodeID)
+			bnode := fmt.Sprintf("/ip4/%s/tcp/%d/p2p/%s", "127.0.0.1", bootnodePortStart+i, validator.NodeID)
 			chainConfig.Bootnodes = append(chainConfig.Bootnodes, bnode)
 		}
 	}


### PR DESCRIPTION
# Description

This PR fixes bootnodes port assignment changed through #912, which was wrong, because it assigned port numbers greater than 65536.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually