### PR TITLE
Fix unit test for event tracker

### DIFF
--- a/consensus/polybft/event_tracker_test.go
+++ b/consensus/polybft/event_tracker_test.go
@@ -25,8 +25,6 @@ func (m *mockEventSubscriber) AddLog(log *ethgo.Log) {
 }
 
 func TestEventTracker_TrackSyncEvents(t *testing.T) {
-	// TODO: Check with @ferranbt how to fix this test, due to the changes in https://github.com/umbracle/ethgo/pull/229
-	t.Skip("FIX ME")
 	t.Parallel()
 
 	server := testutil.DeployTestServer(t, nil)
@@ -51,7 +49,9 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 
 	// prefill with 10 events
 	for i := 0; i < 10; i++ {
-		server.TxnTo(addr, "emitEvent")
+		receipt, err := server.TxnTo(addr, "emitEvent")
+		require.NoError(t, err)
+		require.True(t, receipt.Status == uint64(types.ReceiptSuccess))
 	}
 
 	sub := &mockEventSubscriber{}
@@ -76,7 +76,9 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 
 	// send 10 more events
 	for i := 0; i < 10; i++ {
-		server.TxnTo(addr, "emitEvent")
+		receipt, err := server.TxnTo(addr, "emitEvent")
+		require.NoError(t, err)
+		require.True(t, receipt.Status == uint64(types.ReceiptSuccess))
 	}
 
 	time.Sleep(2 * time.Second)

--- a/consensus/polybft/event_tracker_test.go
+++ b/consensus/polybft/event_tracker_test.go
@@ -25,10 +25,11 @@ func (m *mockEventSubscriber) AddLog(log *ethgo.Log) {
 }
 
 func TestEventTracker_TrackSyncEvents(t *testing.T) {
+	// TODO: Check with @ferranbt how to fix this test, due to the changes in https://github.com/umbracle/ethgo/pull/229
+	t.Skip("FIX ME")
 	t.Parallel()
 
-	server := testutil.NewTestServer(t, nil)
-	defer server.Close()
+	server := testutil.DeployTestServer(t, nil)
 
 	tmpDir, err := os.MkdirTemp("/tmp", "test-event-tracker")
 	defer os.RemoveAll(tmpDir)
@@ -45,7 +46,8 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 			`
 	})
 
-	_, addr := server.DeployContract(cc)
+	_, addr, err := server.DeployContract(cc)
+	require.NoError(t, err)
 
 	// prefill with 10 events
 	for i := 0; i < 10; i++ {

--- a/consensus/polybft/event_tracker_test.go
+++ b/consensus/polybft/event_tracker_test.go
@@ -51,7 +51,7 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		receipt, err := server.TxnTo(addr, "emitEvent")
 		require.NoError(t, err)
-		require.True(t, receipt.Status == uint64(types.ReceiptSuccess))
+		require.Equal(t, uint64(types.ReceiptSuccess), receipt.Status)
 	}
 
 	sub := &mockEventSubscriber{}
@@ -78,7 +78,7 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		receipt, err := server.TxnTo(addr, "emitEvent")
 		require.NoError(t, err)
-		require.True(t, receipt.Status == uint64(types.ReceiptSuccess))
+		require.Equal(t, uint64(types.ReceiptSuccess), receipt.Status)
 	}
 
 	time.Sleep(2 * time.Second)

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/klauspost/compress v1.15.5 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/umbracle/ethgo v0.1.4-0.20221117101647-b81ef2f07953
+	github.com/umbracle/ethgo v0.1.4-0.20221121083653-944f5f94c7d2
 	github.com/valyala/fastjson v1.6.3 // indirect
 	go.uber.org/zap v1.22.0 // indirect
 	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect

--- a/go.sum
+++ b/go.sum
@@ -739,6 +739,10 @@ github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2n
 github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/umbracle/ethgo v0.1.4-0.20221117101647-b81ef2f07953 h1:ep+lwZyyeh1iw8UojTxslDsqPw0305Vu6lOiEebWS8k=
 github.com/umbracle/ethgo v0.1.4-0.20221117101647-b81ef2f07953/go.mod h1:8QIHEG/YfGnW4I5AND2Znl9W0LU3tXR9IGqgmSieiGo=
+github.com/umbracle/ethgo v0.1.4-0.20221121081716-a604043203ba h1:csHe+Ngg7CJjZcW5Y97W36SzqAYEYU/xtBzvWcVcJ3U=
+github.com/umbracle/ethgo v0.1.4-0.20221121081716-a604043203ba/go.mod h1:8QIHEG/YfGnW4I5AND2Znl9W0LU3tXR9IGqgmSieiGo=
+github.com/umbracle/ethgo v0.1.4-0.20221121083653-944f5f94c7d2 h1:ns9iYmdnoxChGWPiQnK9CkdZe3OBPat0VsSFqBB1v5A=
+github.com/umbracle/ethgo v0.1.4-0.20221121083653-944f5f94c7d2/go.mod h1:8QIHEG/YfGnW4I5AND2Znl9W0LU3tXR9IGqgmSieiGo=
 github.com/umbracle/fastrlp v0.0.0-20220527094140-59d5dd30e722 h1:10Nbw6cACsnQm7r34zlpJky+IzxVLRk6MKTS2d3Vp0E=
 github.com/umbracle/fastrlp v0.0.0-20220527094140-59d5dd30e722/go.mod h1:c8J0h9aULj2i3umrfyestM6jCq0LK0U6ly6bWy96nd4=
 github.com/umbracle/go-eth-bn256 v0.0.0-20190607160430-b36caf4e0f6b h1:t3nz9xXkLZJz+ZlTGFT3ixsCGO5AHx1Yift2EAfjnnc=


### PR DESCRIPTION
# Description

Fix linters on `v3-parity` branch and `TestEventTracker_TrackSyncEvents` unit test, due to the recent changes in the `ethgo` library (https://github.com/umbracle/ethgo/pull/229).

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually