### PR TITLE
Remove `json.Marshaler` implementation from `PublicKey`

### DIFF
--- a/consensus/polybft/signer/public.go
+++ b/consensus/polybft/signer/public.go
@@ -38,25 +38,6 @@ func (p *PublicKey) MarshalJSON() ([]byte, error) {
 	return json.Marshal(p.p.Marshal())
 }
 
-// UnmarshalJSON implements the json.Marshaler interface.
-func (p *PublicKey) UnmarshalJSON(b []byte) error {
-	var d []byte
-
-	err := json.Unmarshal(b, &d)
-	if err != nil {
-		return err
-	}
-
-	pk, err := UnmarshalPublicKey(d)
-	if err != nil {
-		return err
-	}
-
-	p.p = pk.p
-
-	return nil
-}
-
 // UnmarshalPublicKey reads the public key from the given byte array
 func UnmarshalPublicKey(raw []byte) (*PublicKey, error) {
 	if len(raw) == 0 {

--- a/consensus/polybft/signer/public.go
+++ b/consensus/polybft/signer/public.go
@@ -1,7 +1,6 @@
 package bls
 
 import (
-	"encoding/json"
 	"errors"
 	"math/big"
 
@@ -31,11 +30,6 @@ func (p *PublicKey) aggregate(onemore *PublicKey) *PublicKey {
 // Marshal marshal the key to bytes.
 func (p *PublicKey) Marshal() []byte {
 	return p.p.Marshal()
-}
-
-// MarshalJSON implements the json.Marshaler interface.
-func (p *PublicKey) MarshalJSON() ([]byte, error) {
-	return json.Marshal(p.p.Marshal())
 }
 
 // UnmarshalPublicKey reads the public key from the given byte array

--- a/consensus/polybft/signer/public_test.go
+++ b/consensus/polybft/signer/public_test.go
@@ -37,20 +37,3 @@ func TestPublic_UnmarshalPublicKeyFromBigInt(t *testing.T) {
 
 	require.Equal(t, pub, pub2)
 }
-
-func TestPublic_MarshalUnmarshalJSON(t *testing.T) {
-	t.Parallel()
-
-	key, err := GenerateBlsKey()
-	require.NoError(t, err)
-
-	pubKey := key.PublicKey()
-	marshaledPubKey, err := pubKey.MarshalJSON()
-	require.NoError(t, err)
-
-	newPubKey := new(PublicKey)
-
-	err = newPubKey.UnmarshalJSON(marshaledPubKey)
-	require.NoError(t, err)
-	require.Equal(t, pubKey, newPubKey)
-}


### PR DESCRIPTION
# Description

Cleanup of `PublicKey` from polybft, `json.Marshaler` implementation is unused therefore can be safely removed.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
