### PR TITLE
Docker setup: Wait for genesis file to exist before starting nodes

### DIFF
--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -24,7 +24,8 @@ services:
       dockerfile: docker/local/Dockerfile
     command: ["server", "--data-dir", "/data", "--chain", "/genesis/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--seal"]
     depends_on:
-      - init
+      init:
+        condition: service_completed_successfully
     ports:
       - '10000:9632'
       - '10002:8545'
@@ -41,7 +42,8 @@ services:
       dockerfile: docker/local/Dockerfile
     command: ["server", "--data-dir", "/data", "--chain", "/genesis/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--seal"]
     depends_on:
-      - init
+      init:
+        condition: service_completed_successfully
     ports:
       - '20000:9632'
       - '20002:8545'
@@ -58,7 +60,8 @@ services:
       dockerfile: docker/local/Dockerfile
     command: ["server", "--data-dir", "/data", "--chain", "/genesis/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--seal"]
     depends_on:
-      - init
+      init:
+        condition: service_completed_successfully
     ports:
       - '30000:9632'
       - '30002:8545'
@@ -75,7 +78,8 @@ services:
       dockerfile: docker/local/Dockerfile
     command: ["server", "--data-dir", "/data", "--chain", "/genesis/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--seal"]
     depends_on:
-      - init
+      init:
+        condition: service_completed_successfully
     ports:
       - '40000:9632'
       - '40002:8545'

--- a/docker/local/polygon-edge.sh
+++ b/docker/local/polygon-edge.sh
@@ -8,18 +8,22 @@ GENESIS_PATH=/genesis/genesis.json
 case "$1" in
 
    "init")
-      echo "Generating secrets..."
-      secrets=$("$POLYGON_EDGE_BIN" secrets init --num 4 --data-dir data- --json)
-      echo "Secrets have been successfully generated"
+      if [ -f "$GENESIS_PATH" ]; then
+          echo "Secrets have already been generated."
+      else
+          echo "Generating secrets..."
+          secrets=$("$POLYGON_EDGE_BIN" secrets init --num 4 --data-dir data- --json)
+          echo "Secrets have been successfully generated"
 
-      echo "Generating genesis file..."
-      "$POLYGON_EDGE_BIN" genesis \
-        --dir "$GENESIS_PATH" \
-        --consensus ibft \
-        --ibft-validators-prefix-path data- \
-        --bootnode /dns4/node-1/tcp/1478/p2p/$(echo $secrets | jq -r '.[0] | .node_id') \
-        --bootnode /dns4/node-2/tcp/1478/p2p/$(echo $secrets | jq -r '.[1] | .node_id')
-      echo "Genesis file has been successfully generated"
+          echo "Generating genesis file..."
+          "$POLYGON_EDGE_BIN" genesis \
+            --dir "$GENESIS_PATH" \
+            --consensus ibft \
+            --ibft-validators-prefix-path data- \
+            --bootnode /dns4/node-1/tcp/1478/p2p/$(echo $secrets | jq -r '.[0] | .node_id') \
+            --bootnode /dns4/node-2/tcp/1478/p2p/$(echo $secrets | jq -r '.[1] | .node_id')
+          echo "Genesis file has been successfully generated"
+      fi
       ;;
 
    *)

--- a/docker/local/polygon-edge.sh
+++ b/docker/local/polygon-edge.sh
@@ -3,6 +3,7 @@
 set -e
 
 POLYGON_EDGE_BIN=./polygon-edge
+GENESIS_PATH=/genesis/genesis.json
 
 case "$1" in
 
@@ -13,7 +14,7 @@ case "$1" in
 
       echo "Generating genesis file..."
       "$POLYGON_EDGE_BIN" genesis \
-        --dir /genesis/genesis.json \
+        --dir "$GENESIS_PATH" \
         --consensus ibft \
         --ibft-validators-prefix-path data- \
         --bootnode /dns4/node-1/tcp/1478/p2p/$(echo $secrets | jq -r '.[0] | .node_id') \
@@ -22,6 +23,11 @@ case "$1" in
       ;;
 
    *)
+      until [ -f "$GENESIS_PATH" ]
+      do
+          echo "Waiting 1s for genesis file $GENESIS_PATH to be created by init container..."
+          sleep 1
+      done
       echo "Executing polygon-edge..."
       exec "$POLYGON_EDGE_BIN" "$@"
       ;;


### PR DESCRIPTION
# Description

The Docker image entrypoint `docker/local/polygon-edge.sh` had a race condition where if the `init` container took too long to generate the `genesis.json` genesis file, nodes would fail with `Error: open /genesis/genesis.json: no such file or directory`.

This fix ensures that nodes wait for this file to exist (by polling for its existence in a loop) prior to starting up.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Manually tested by running `docker-compose up`
