### PR TITLE
EVM-232 Keep polybft bls and ecdsa keys in separate secrets manager namespaces

### DIFF
--- a/command/e2e/register_validator.go
+++ b/command/e2e/register_validator.go
@@ -11,7 +11,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/crypto"
-	"github.com/0xPolygon/polygon-edge/secrets"
 	secretsHelper "github.com/0xPolygon/polygon-edge/secrets/helper"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/mitchellh/go-glint"
@@ -63,7 +62,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	existingValidatorAccount, err := wallet.GenerateNewAccountFromSecret(secretsManager, secrets.ValidatorBLSKey)
+	existingValidatorAccount, err := wallet.NewAccountFromSecret(secretsManager)
 	if err != nil {
 		return err
 	}
@@ -75,7 +74,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	newValidatorAccount, err := wallet.GenerateNewAccountFromSecret(secretsManager, secrets.ValidatorBLSKey)
+	newValidatorAccount, err := wallet.NewAccountFromSecret(secretsManager)
 	if err != nil {
 		return err
 	}

--- a/command/genesis/utils.go
+++ b/command/genesis/utils.go
@@ -162,8 +162,7 @@ func getSecrets(directory string) (*wallet.Account, string, error) {
 		return nil, "", err
 	}
 
-	account, err := wallet.GenerateNewAccountFromSecret(
-		localManager, secrets.ValidatorBLSKey)
+	account, err := wallet.NewAccountFromSecret(localManager)
 	if err != nil {
 		return nil, "", err
 	}

--- a/command/polybftsecrets/params.go
+++ b/command/polybftsecrets/params.go
@@ -151,23 +151,15 @@ func (ip *initParams) initKeys(secretsManager secrets.SecretsManager) error {
 	}
 
 	if ip.generatesAccount {
+		if secretsManager.HasSecret(secrets.ValidatorKey) {
+			return fmt.Errorf(`secrets "%s" has been already initialized`, secrets.ValidatorKey)
+		}
+
 		if secretsManager.HasSecret(secrets.ValidatorBLSKey) {
 			return fmt.Errorf(`secrets "%s" has been already initialized`, secrets.ValidatorBLSKey)
 		}
 
-		account := wallet.GenerateAccount()
-
-		bytes, err := account.ToBytes()
-		if err != nil {
-			return err
-		}
-
-		err = secretsManager.SetSecret(
-			secrets.ValidatorBLSKey,
-			bytes)
-		if err != nil {
-			return err
-		}
+		return wallet.GenerateAccount().Save(secretsManager)
 	}
 
 	return nil
@@ -181,8 +173,7 @@ func (ip *initParams) getResult(secretsManager secrets.SecretsManager) (command.
 	)
 
 	if ip.generatesAccount {
-		account, err := wallet.GenerateNewAccountFromSecret(
-			secretsManager, secrets.ValidatorBLSKey)
+		account, err := wallet.NewAccountFromSecret(secretsManager)
 		if err != nil {
 			return nil, err
 		}

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -15,7 +15,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/helper/progress"
 	"github.com/0xPolygon/polygon-edge/network"
-	"github.com/0xPolygon/polygon-edge/secrets"
 	"github.com/0xPolygon/polygon-edge/state"
 	"github.com/0xPolygon/polygon-edge/syncer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -149,8 +148,7 @@ func (p *Polybft) Initialize() error {
 	p.logger.Info("initializing polybft...")
 
 	// read account
-	account, err := wallet.GenerateNewAccountFromSecret(
-		p.config.SecretsManager, secrets.ValidatorBLSKey)
+	account, err := wallet.NewAccountFromSecret(p.config.SecretsManager)
 	if err != nil {
 		return fmt.Errorf("failed to read account data. Error: %w", err)
 	}


### PR DESCRIPTION
# Description

Keep polybft bls and ecdsa keys in separate secrets manager namespaces

eq  for local secrets manager keep private keys in separated files

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
