### PR TITLE
Epikichi/edge 973 change v3 parity workflow to devnet

### DIFF
--- a/.github/workflows/deploy.devnet.eph.yml
+++ b/.github/workflows/deploy.devnet.eph.yml
@@ -169,7 +169,7 @@ jobs:
 
   pandoras_box_eoa:
     uses: ./.github/workflows/pandoras_box.yml
-    name: Pandora's Box
+    name: Pandora's Box EOA
     needs: deploy_eph_devnet
     secrets:
       SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
@@ -183,8 +183,8 @@ jobs:
       mode: EOA
   pandoras_box_erc20:
     uses: ./.github/workflows/pandoras_box.yml
-    name: Pandora's Box
-    needs: pandoras_box_eoa
+    name: Pandora's Box ERC20
+    needs: deploy_eph_devnet
     secrets:
       SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
       PANDORAS_TARGET: ${{ secrets.PANDORAS_TARGET }}
@@ -197,8 +197,8 @@ jobs:
       mode: ERC20
   pandoras_box_erc721:
     uses: ./.github/workflows/pandoras_box.yml
-    name: Pandora's Box
-    needs: pandoras_box_erc20
+    name: Pandora's Box ERC721
+    needs: deploy_eph_devnet
     secrets:
       SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
       PANDORAS_TARGET: ${{ secrets.PANDORAS_TARGET }}

--- a/.github/workflows/deploy.devnet.eph.yml
+++ b/.github/workflows/deploy.devnet.eph.yml
@@ -167,7 +167,7 @@ jobs:
               ]
             }
 
-  pandoras_box:
+  pandoras_box_eoa:
     uses: ./.github/workflows/pandoras_box.yml
     name: Pandora's Box
     needs: deploy_eph_devnet
@@ -180,3 +180,32 @@ jobs:
       environment: devnet-ephemeral
       transaction_batch: '200'
       transaction_count: '10000'
+      mode: EOA
+  pandoras_box_erc20:
+    uses: ./.github/workflows/pandoras_box.yml
+    name: Pandora's Box
+    needs: pandoras_box_eoa
+    secrets:
+      SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
+      PANDORAS_TARGET: ${{ secrets.PANDORAS_TARGET }}
+      PANDORAS_MNEMONIC: ${{ secrets.PANDORAS_MNEMONIC }}
+    with:
+      runner: devnet-ephemeral
+      environment: devnet-ephemeral
+      transaction_batch: '200'
+      transaction_count: '10000'
+      mode: ERC20
+  pandoras_box_erc721:
+    uses: ./.github/workflows/pandoras_box.yml
+    name: Pandora's Box
+    needs: pandoras_box_erc20
+    secrets:
+      SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
+      PANDORAS_TARGET: ${{ secrets.PANDORAS_TARGET }}
+      PANDORAS_MNEMONIC: ${{ secrets.PANDORAS_MNEMONIC }}
+    with:
+      runner: devnet-ephemeral
+      environment: devnet-ephemeral
+      transaction_batch: '200'
+      transaction_count: '10000'
+      mode: ERC721

--- a/.github/workflows/deploy.devnet.eph.yml
+++ b/.github/workflows/deploy.devnet.eph.yml
@@ -1,11 +1,8 @@
 ---
-name: DevNet-V3 Workflow
+name: Ephemeral DevNet Workflow
 
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
-  push:
-    branches:
-      - feature/v3-parity
 
 permissions:
   id-token: write
@@ -33,13 +30,13 @@ jobs:
     secrets:
       GH_TOKEN_CLONE_PRIVATE: ${{ secrets.GH_TOKEN_CLONE_PRIVATE }}
 
-  deploy_devnet_v3:
-    name: Deploy DevNet V3
+  deploy_eph_devnet:
+    name: Deploy Ephemeral DevNet
     needs: build
-    concurrency: deploy_devnet_v3
+    concurrency: deploy_eph_devnet
     environment:
-      name: devnet-v3-parity
-      url: https://rpc.us-east-1.dnv3.testing.psdk.io/
+      name: devnet-ephemeral
+      url: https://rpc.us-east-1.deph.testing.psdk.io/
     runs-on: ubuntu-latest
     steps:
       - name: Download Polygon Edge Artifact
@@ -68,14 +65,14 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Devnet V3 Deployment - Started"
+                    "text": "Ephemeral Devnet Deployment - Started"
                   }
                 },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Devnet V3 Deployment Status: ${{ job.status }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Job Status>"
+                    "text": "Ephemeral Devnet Deployment Status: ${{ job.status }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Job Status>"
                   }
                 }
               ]
@@ -85,17 +82,17 @@ jobs:
         run: |
           aws s3 cp ./polygon-edge.tar.gz s3://${{ secrets.POLYGON_EDGE_ARTIFACT_BUCKET }} --metadata "{\"commit_sha\":\"${GITHUB_SHA}\"}"
 
-      - name: Deploy DevNet V3
+      - name: Deploy Ephemeral DevNet
         continue-on-error: true
         env:
           VALIDATOR_ASGS: ${{ secrets.VALIDATOR_ASGS }}
         run: |
           # Parallel deploy all nodes, relying on ALB Health Checks
-          echo "Deploying new Devnet V3"
+          echo "Deploying Ephemeral Devnet"
           echo "--------------------"
 
           # Should finish relatively fast. Can add a check to guard against pre-mature cycle
-          echo "Cleaning up the data directories and stopping Polygon-Edge DevNet V3 service..."
+          echo "Cleaning up the data directories and stopping Polygon-Edge service..."
           aws ssm send-command --document-name polygon-edge-validators-maintenance-clean-data --targets Key=tag:aws:autoscaling:groupName,Values=$VALIDATOR_ASGS >> /dev/null
 
           for vasg in ${VALIDATOR_ASGS//,/ }
@@ -131,7 +128,7 @@ jobs:
               done
               echo ""
           done
-          echo "Devnet V3 Deployment Complete"
+          echo "Ephemeral Devnet Deployment Complete"
 
       - name: Notify Slack - Failures
         uses: slackapi/slack-github-action@v1.22.0
@@ -147,7 +144,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Devnet V3 Deployment - Failed"
+                    "text": "Ephemeral Devnet Deployment - Failed"
                   }
                 },
                 {
@@ -173,31 +170,13 @@ jobs:
   pandoras_box:
     uses: ./.github/workflows/pandoras_box.yml
     name: Pandora's Box
-    needs: deploy_devnet_v3
+    needs: deploy_eph_devnet
     secrets:
       SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
       PANDORAS_TARGET: ${{ secrets.PANDORAS_TARGET }}
       PANDORAS_MNEMONIC: ${{ secrets.PANDORAS_MNEMONIC }}
     with:
-      runner: devnet-v3-parity
-      environment: devnet-v3-parity
+      runner: devnet-ephemeral
+      environment: devnet-ephemeral
       transaction_batch: '200'
       transaction_count: '10000'
-
-  loadbot:
-    uses: ./.github/workflows/loadbot.yml
-    name: Loadbot
-    needs: deploy_devnet_v3
-    secrets:
-      SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
-      LOADBOT_JSONRPC_URL: ${{ secrets.LOADBOT_JSONRPC_URL }}
-      LOADBOT_SENDER_ADDRESS: ${{ secrets.LOADBOT_SENDER_ADDRESS }}
-      LOADBOT_GRPC_ADDRESS: ${{ secrets.LOADBOT_GRPC_ADDRESS }}
-      LOADBOT_0x1AB8C3df809b85012a009c0264eb92dB04eD6EFa: ${{ secrets.LOADBOT_0x1AB8C3df809b85012a009c0264eb92dB04eD6EFa }}
-    with:
-      runner: devnet-v3-parity
-      environment: devnet-v3-parity
-      chain_id: '750'
-      transaction_value: '100'
-      transaction_count: '10000'
-      transactions_per_second: '100'

--- a/.github/workflows/deploy.testnet.yml
+++ b/.github/workflows/deploy.testnet.yml
@@ -162,7 +162,7 @@ jobs:
 
   pandoras_box_eoa:
     uses: ./.github/workflows/pandoras_box.yml
-    name: Pandora's Box
+    name: Pandora's Box EOA
     needs: deploy_testnet
     secrets:
       SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
@@ -176,8 +176,8 @@ jobs:
       mode: EOA
   pandoras_box_erc20:
     uses: ./.github/workflows/pandoras_box.yml
-    name: Pandora's Box
-    needs: pandoras_box_eoa
+    name: Pandora's Box ERC20
+    needs: deploy_testnet
     secrets:
       SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
       PANDORAS_TARGET: ${{ secrets.PANDORAS_TARGET }}
@@ -190,8 +190,8 @@ jobs:
       mode: ERC20
   pandoras_box_erc721:
     uses: ./.github/workflows/pandoras_box.yml
-    name: Pandora's Box
-    needs: pandoras_box_erc20
+    name: Pandora's Box ERC721
+    needs: deploy_testnet
     secrets:
       SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
       PANDORAS_TARGET: ${{ secrets.PANDORAS_TARGET }}

--- a/.github/workflows/deploy.testnet.yml
+++ b/.github/workflows/deploy.testnet.yml
@@ -156,7 +156,7 @@ jobs:
               ]
             }
 
-  pandoras_box:
+  pandoras_box_eoa:
     uses: ./.github/workflows/pandoras_box.yml
     name: Pandora's Box
     needs: deploy_testnet
@@ -169,6 +169,35 @@ jobs:
       environment: testnet
       transaction_batch: '200'
       transaction_count: '10000'
+      mode: EOA
+  pandoras_box_erc20:
+    uses: ./.github/workflows/pandoras_box.yml
+    name: Pandora's Box
+    needs: pandoras_box_eoa
+    secrets:
+      SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
+      PANDORAS_TARGET: ${{ secrets.PANDORAS_TARGET }}
+      PANDORAS_MNEMONIC: ${{ secrets.PANDORAS_MNEMONIC }}
+    with:
+      runner: testnet
+      environment: testnet
+      transaction_batch: '200'
+      transaction_count: '10000'
+      mode: ERC20
+  pandoras_box_erc721:
+    uses: ./.github/workflows/pandoras_box.yml
+    name: Pandora's Box
+    needs: pandoras_box_erc20
+    secrets:
+      SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
+      PANDORAS_TARGET: ${{ secrets.PANDORAS_TARGET }}
+      PANDORAS_MNEMONIC: ${{ secrets.PANDORAS_MNEMONIC }}
+    with:
+      runner: testnet
+      environment: testnet
+      transaction_batch: '200'
+      transaction_count: '10000'
+      mode: ERC721
 
   loadbot:
     uses: ./.github/workflows/loadbot.yml

--- a/.github/workflows/pandoras_box.yml
+++ b/.github/workflows/pandoras_box.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
       runner:
-        description: 'The runner to execute on'
+        description: The runner to execute on
         default: 'ubuntu-latest'
         type: choice
         options:
@@ -12,7 +12,7 @@ on:  # yamllint disable-line rule:truthy
           - devnet
           - testnet
       environment:
-        description: 'The environment to run against'
+        description: The environment to run against
         required: false
         type: environment
       transaction_count:
@@ -23,6 +23,14 @@ on:  # yamllint disable-line rule:truthy
         default: '100'
         description: The transaction batch size
         type: string
+      mode:
+        default: 'EOA'
+        description: The mode for the stress test
+        type: choice
+        options:
+          - EOA
+          - ERC20
+          - ERC721
   workflow_call:
     inputs:
       transaction_count:
@@ -34,13 +42,17 @@ on:  # yamllint disable-line rule:truthy
         description: The transaction batch size
         type: string
       environment:
-        description: 'The environment to run against'
+        description: The environment to run against
         type: string
         required: true
       runner:
         required: true
         type: string
         description: The runner label to use
+      mode:
+        required: true
+        description: The mode for the stress test
+        type: string
     secrets:
       SLACK_PERFORMANCE_WEBHOOK_URL:
         required: true
@@ -103,7 +115,7 @@ jobs:
       - id: pandora
         name: Open Pandora's Box
         run: |
-          pandoras-box -url ${{ secrets.PANDORAS_TARGET }} -m "${{ secrets.PANDORAS_MNEMONIC }}" -b ${{ inputs.transaction_batch }} -t ${{ inputs.transaction_count }} -o pandorasConsequences.json
+          pandoras-box -url ${{ secrets.PANDORAS_TARGET }} --mode "${{ inputs.mode }}" -m "${{ secrets.PANDORAS_MNEMONIC }}" -b ${{ inputs.transaction_batch }} -t ${{ inputs.transaction_count }} -o pandorasConsequences.json
           echo "::set-output name=tps::$(cat pandorasConsequences.json | jq -r '.averageTPS')"
       - name: Archive Pandora's Consequences
         continue-on-error: true
@@ -135,6 +147,13 @@ jobs:
                   }
                 },
                 {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Total Transactions Sent: `${{ inputs.transaction_count }}`"
+                  }
+                },
+                {
                   "type": "divider"
                 },
                 {
@@ -143,6 +162,10 @@ jobs:
                       {
                         "type": "mrkdwn",
                         "text": "Environment: `${{ inputs.environment }}`"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "Test Mode: `${{ inputs.mode }}`"
                       },
                       {
                         "type": "mrkdwn",


### PR DESCRIPTION
# Description

Adding workflow changes to this branch to allow ephemeral environment deployments. This change is necessary for us to enable workflow dispatches, as it requires the workflow to exist in the `develop` branch as well as the target branch.

Also minor change, re-naming the `devnet-v3-parity` environment to a more general `devnet-ephemeral`