### PR TITLE
improving workflow dependency

### DIFF
--- a/.github/workflows/deploy.devnet.eph.yml
+++ b/.github/workflows/deploy.devnet.eph.yml
@@ -169,7 +169,7 @@ jobs:
 
   pandoras_box_eoa:
     uses: ./.github/workflows/pandoras_box.yml
-    name: Pandora's Box
+    name: Pandora's Box EOA
     needs: deploy_eph_devnet
     secrets:
       SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
@@ -183,8 +183,8 @@ jobs:
       mode: EOA
   pandoras_box_erc20:
     uses: ./.github/workflows/pandoras_box.yml
-    name: Pandora's Box
-    needs: pandoras_box_eoa
+    name: Pandora's Box ERC20
+    needs: deploy_eph_devnet
     secrets:
       SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
       PANDORAS_TARGET: ${{ secrets.PANDORAS_TARGET }}
@@ -197,8 +197,8 @@ jobs:
       mode: ERC20
   pandoras_box_erc721:
     uses: ./.github/workflows/pandoras_box.yml
-    name: Pandora's Box
-    needs: pandoras_box_erc20
+    name: Pandora's Box ERC721
+    needs: deploy_eph_devnet
     secrets:
       SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
       PANDORAS_TARGET: ${{ secrets.PANDORAS_TARGET }}

--- a/.github/workflows/deploy.devnet.yml
+++ b/.github/workflows/deploy.devnet.yml
@@ -181,23 +181,23 @@ jobs:
       transaction_count: '10000'
       mode: EOA
   pandoras_box_erc20:
-      uses: ./.github/workflows/pandoras_box.yml
-      name: Pandora's Box ERC20
-      needs: pandoras_box_eoa
-      secrets:
-        SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
-        PANDORAS_TARGET: ${{ secrets.PANDORAS_TARGET }}
-        PANDORAS_MNEMONIC: ${{ secrets.PANDORAS_MNEMONIC }}
-      with:
-        runner: devnet
-        environment: devnet
-        transaction_batch: '200'
-        transaction_count: '10000'
-        mode: ERC20
+    uses: ./.github/workflows/pandoras_box.yml
+    name: Pandora's Box ERC20
+    needs: deploy_devnet
+    secrets:
+      SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
+      PANDORAS_TARGET: ${{ secrets.PANDORAS_TARGET }}
+      PANDORAS_MNEMONIC: ${{ secrets.PANDORAS_MNEMONIC }}
+    with:
+      runner: devnet
+      environment: devnet
+      transaction_batch: '200'
+      transaction_count: '10000'
+      mode: ERC20
   pandoras_box_erc721:
     uses: ./.github/workflows/pandoras_box.yml
     name: Pandora's Box ERC721
-    needs: pandoras_box_erc20
+    needs: deploy_devnet
     secrets:
       SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
       PANDORAS_TARGET: ${{ secrets.PANDORAS_TARGET }}

--- a/.github/workflows/deploy.testnet.yml
+++ b/.github/workflows/deploy.testnet.yml
@@ -173,7 +173,7 @@ jobs:
   pandoras_box_erc20:
     uses: ./.github/workflows/pandoras_box.yml
     name: Pandora's Box ERC20
-    needs: pandoras_box_eoa
+    needs: deploy_testnet
     secrets:
       SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
       PANDORAS_TARGET: ${{ secrets.PANDORAS_TARGET }}
@@ -187,7 +187,7 @@ jobs:
   pandoras_box_erc721:
     uses: ./.github/workflows/pandoras_box.yml
     name: Pandora's Box ERC721
-    needs: pandoras_box_erc20
+    needs: deploy_testnet
     secrets:
       SLACK_PERFORMANCE_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
       PANDORAS_TARGET: ${{ secrets.PANDORAS_TARGET }}


### PR DESCRIPTION
# Description

Adding some behavioral/visual improvements to the workflows
- Display testing mode in Pandoras Box job names
- Small indentation error on `devnet` workflow
- Offloading Pandora's Box testing sequence to rely on `concurrency` rather than sequentially triggering the jobs. This allows for easier reruns without kicking off all downstream.
