### PR TITLE
Modify e2e tests to accommodate the execution of the state syncs

### DIFF
--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -913,8 +913,6 @@ func TestConsensusRuntime_FSM_EndOfSprint_HasBundlesToExecute(t *testing.T) {
 	require.True(t, fsm.isEndOfSprint)
 
 	// check if commitment message to execute is attached to fsm
-	require.Len(t, fsm.bundleProofs, 1)
-	require.Len(t, fsm.commitmentsToVerifyBundles, 1)
 	require.Nil(t, fsm.proposerCommitmentToRegister)
 
 	systemStateMock.AssertExpectations(t)
@@ -1658,7 +1656,7 @@ func TestConsensusRuntime_FSM_EndOfEpoch_OnBlockInserted(t *testing.T) {
 
 	bundles, err := state.getBundles(fromIndex, maxBundlesPerSprint)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(bundles))
+	assert.Equal(t, 10, len(bundles))
 
 	systemStateMock.AssertExpectations(t)
 	blockchainMock.AssertExpectations(t)

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -542,38 +542,6 @@ func (s *State) getCommitmentMessage(toIndex uint64) (*CommitmentMessageSigned, 
 	return commitment, err
 }
 
-// getNonExecutedCommitments gets non executed commitments
-// (commitments whose toIndex is greater than or equal to startIndex)
-func (s *State) getNonExecutedCommitments(startIndex uint64) ([]*CommitmentMessageSigned, error) {
-	var commitments []*CommitmentMessageSigned
-
-	err := s.db.View(func(tx *bolt.Tx) error {
-		c := tx.Bucket(commitmentsBucket).Cursor()
-
-		for k, v := c.Last(); k != nil; k, v = c.Prev() {
-			if itou(k) < startIndex {
-				// reached a commitment that was executed
-				break
-			}
-
-			var commitment *CommitmentMessageSigned
-			if err := json.Unmarshal(v, &commitment); err != nil {
-				return err
-			}
-
-			commitments = append(commitments, commitment)
-		}
-
-		return nil
-	})
-
-	sort.Slice(commitments, func(i, j int) bool {
-		return commitments[i].Message.FromIndex < commitments[j].Message.FromIndex
-	})
-
-	return commitments, err
-}
-
 // cleanCommitments cleans all commitments that are older than the provided fromIndex, alongside their proofs
 func (s *State) cleanCommitments(stateSyncExecutionIndex uint64) error {
 	return s.db.Update(func(tx *bolt.Tx) error {

--- a/consensus/polybft/state_test.go
+++ b/consensus/polybft/state_test.go
@@ -279,27 +279,6 @@ func TestState_insertCommitmentMessage(t *testing.T) {
 	assert.Equal(t, commitment, commitmentFromDB)
 }
 
-func TestState_getNonExecutedCommitments(t *testing.T) {
-	t.Parallel()
-
-	const (
-		numberOfCommitments    = 10
-		lastExecutedCommitment = 80
-	)
-
-	state := newTestState(t)
-
-	for i := uint64(0); i < numberOfCommitments; i++ {
-		commitment, err := createTestCommitmentMessage(i * stateSyncMainBundleSize)
-		require.NoError(t, err)
-		require.NoError(t, state.insertCommitmentMessage(commitment))
-	}
-
-	commitmentsNotExecuted, err := state.getNonExecutedCommitments(lastExecutedCommitment)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(commitmentsNotExecuted))
-}
-
 func TestState_cleanCommitments(t *testing.T) {
 	t.Parallel()
 

--- a/e2e-polybft/bridge_test.go
+++ b/e2e-polybft/bridge_test.go
@@ -6,14 +6,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/e2e-polybft/framework"
 	"github.com/0xPolygon/polygon-edge/types"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/umbracle/ethgo"
 	"github.com/umbracle/ethgo/abi"
+	ethgow "github.com/umbracle/ethgo/wallet"
 )
 
 var stateSyncResultEvent = abi.MustNewEvent(`event StateSyncResult(
@@ -56,12 +57,14 @@ func TestE2E_Bridge_MainWorkflow(t *testing.T) {
 	const num = 10
 
 	var (
+		accounts         = make([]ethgo.Key, num)
 		wallets, amounts [num]string
 		premine          [num]types.Address
 	)
 
 	for i := 0; i < num; i++ {
-		premine[i] = types.Address(wallet.GenerateAccount().Ecdsa.Address())
+		accounts[i], _ = ethgow.GenerateKey()
+		premine[i] = types.Address(accounts[i].Address())
 		wallets[i] = premine[i].String()
 		amounts[i] = fmt.Sprintf("%d", 100)
 	}
@@ -83,7 +86,47 @@ func TestE2E_Bridge_MainWorkflow(t *testing.T) {
 	)
 
 	// wait for a few more sprints
-	require.NoError(t, cluster.WaitForBlock(40, 2*time.Minute))
+	require.NoError(t, cluster.WaitForBlock(25, 1*time.Minute))
+
+	// commitments should've been stored
+	var stateSyncProof types.StateSyncProof
+
+	// retrieve state sync proofs
+	err := cluster.Servers[0].JSONRPC().Call("bridge_getStateSyncProof", &stateSyncProof, "1")
+	require.NoError(t, err)
+
+	t.Log(stateSyncProof)
+
+	// execute the state sync
+	rawTxn := &ethgo.Transaction{
+		From:     ethgo.Address(premine[0]),
+		To:       (*ethgo.Address)(&contracts.StateReceiverContract),
+		GasPrice: 0,
+		Gas:      types.StateTransactionGasLimit,
+	}
+
+	chID, err := cluster.Servers[0].JSONRPC().Eth().ChainID()
+	require.NoError(t, err)
+
+	signer := ethgow.NewEIP155Signer(chID.Uint64())
+	signedTxn, err := signer.SignTx(rawTxn, accounts[0])
+	assert.NoError(t, err)
+
+	txnRaw, err := signedTxn.MarshalRLPTo(nil)
+	assert.NoError(t, err)
+
+	hash, err := cluster.Servers[0].JSONRPC().Eth().SendRawTransaction(txnRaw)
+	assert.NoError(t, err)
+
+	var receipt *ethgo.Receipt
+	for count := 0; count < 100 || receipt == nil; count++ {
+		receipt, err = cluster.Servers[0].JSONRPC().Eth().GetTransactionReceipt(hash)
+		assert.NoError(t, err)
+
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.NotNil(t, receipt)
+	t.Log(receipt.Logs)
 
 	// the transaction is mined and there should be a success event
 	id := stateSyncResultEvent.ID()

--- a/types/state_sync.go
+++ b/types/state_sync.go
@@ -1,6 +1,13 @@
 package types
 
-import "github.com/umbracle/ethgo"
+import (
+	"github.com/umbracle/ethgo"
+	"github.com/umbracle/ethgo/abi"
+)
+
+var ExecuteBundleABIMethod, _ = abi.NewMethod("function execute(" +
+	"bytes32[] proof, " +
+	"tuple(uint256 id, address sender, address receiver, bytes data, bool skip)[] objs)")
 
 // StateSyncEvent is a bridge event from the rootchain
 type StateSyncEvent struct {


### PR DESCRIPTION
# Description

Modify e2e tests to accommodate the execution of the state syncs

This goes after:
* #964
* #963 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
