### PR TITLE
Make "pending" block param act as "latest"

### DIFF
--- a/jsonrpc/codec.go
+++ b/jsonrpc/codec.go
@@ -154,11 +154,9 @@ func stringToBlockNumber(str string) (BlockNumber, error) {
 
 	str = strings.Trim(str, "\"")
 	switch str {
-	case "pending":
-		return PendingBlockNumber, nil
-	case "latest":
+	case pending, latest:
 		return LatestBlockNumber, nil
-	case "earliest":
+	case earliest:
 		return EarliestBlockNumber, nil
 	}
 

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -276,7 +276,7 @@ func TestDispatcherFuncDecode(t *testing.T) {
 		{
 			"filter",
 			`[{"fromBlock": "pending", "toBlock": "earliest"}]`,
-			LogQuery{fromBlock: PendingBlockNumber, toBlock: EarliestBlockNumber},
+			LogQuery{fromBlock: LatestBlockNumber, toBlock: EarliestBlockNumber}, // pending = latest
 		},
 	}
 

--- a/jsonrpc/helper.go
+++ b/jsonrpc/helper.go
@@ -24,7 +24,7 @@ type latestHeaderGetter interface {
 // GetNumericBlockNumber returns block number based on current state or specified number
 func GetNumericBlockNumber(number BlockNumber, store latestHeaderGetter) (uint64, error) {
 	switch number {
-	case LatestBlockNumber:
+	case LatestBlockNumber, PendingBlockNumber:
 		latest := store.Header()
 		if latest == nil {
 			return 0, ErrLatestNotFound
@@ -34,9 +34,6 @@ func GetNumericBlockNumber(number BlockNumber, store latestHeaderGetter) (uint64
 
 	case EarliestBlockNumber:
 		return 0, nil
-
-	case PendingBlockNumber:
-		return 0, ErrPendingBlockNumber
 
 	default:
 		if number < 0 {
@@ -55,7 +52,7 @@ type headerGetter interface {
 // GetBlockHeader returns a header using the provided number
 func GetBlockHeader(number BlockNumber, store headerGetter) (*types.Header, error) {
 	switch number {
-	case LatestBlockNumber:
+	case PendingBlockNumber, LatestBlockNumber:
 		return store.Header(), nil
 
 	case EarliestBlockNumber:
@@ -65,9 +62,6 @@ func GetBlockHeader(number BlockNumber, store headerGetter) (*types.Header, erro
 		}
 
 		return header, nil
-
-	case PendingBlockNumber:
-		return nil, ErrPendingBlockNumber
 
 	default:
 		// Convert the block number from hex to uint64

--- a/jsonrpc/helper.go
+++ b/jsonrpc/helper.go
@@ -11,7 +11,6 @@ import (
 var (
 	ErrHeaderNotFound           = errors.New("header not found")
 	ErrLatestNotFound           = errors.New("latest header not found")
-	ErrPendingBlockNumber       = errors.New("fetching the pending header is not supported")
 	ErrNegativeBlockNumber      = errors.New("invalid argument 0: block number must not be negative")
 	ErrFailedFetchGenesis       = errors.New("error fetching genesis block header")
 	ErrNoDataInContractCreation = errors.New("contract creation without data provided")

--- a/jsonrpc/helper_test.go
+++ b/jsonrpc/helper_test.go
@@ -72,7 +72,7 @@ func TestGetNumericBlockNumber(t *testing.T) {
 		err      error
 	}{
 		{
-			name: "should return the latest block's number if latest is given",
+			name: "should return the latest block's number if it is found",
 			num:  LatestBlockNumber,
 			store: &debugEndpointMockStore{
 				headerFn: func() *types.Header {
@@ -85,7 +85,7 @@ func TestGetNumericBlockNumber(t *testing.T) {
 			err:      nil,
 		},
 		{
-			name: "should return the latest block's number if latest is given",
+			name: "should return error if the latest block's number is not found",
 			num:  LatestBlockNumber,
 			store: &debugEndpointMockStore{
 				headerFn: func() *types.Header {
@@ -103,11 +103,41 @@ func TestGetNumericBlockNumber(t *testing.T) {
 			err:      nil,
 		},
 		{
-			name:     "should return error if pending is given",
-			num:      PendingBlockNumber,
-			store:    &debugEndpointMockStore{},
+			name: "should return latest if found and pending is given",
+			num:  PendingBlockNumber,
+			store: &debugEndpointMockStore{
+				headerFn: func() *types.Header {
+					return &types.Header{
+						Number: 10,
+					}
+				},
+			},
+			expected: 10,
+			err:      nil,
+		},
+		{
+			name: "should return error if given pending and the latest block's number is not found",
+			num:  PendingBlockNumber,
+			store: &debugEndpointMockStore{
+				headerFn: func() *types.Header {
+					return nil
+				},
+			},
 			expected: 0,
-			err:      ErrPendingBlockNumber,
+			err:      ErrLatestNotFound,
+		},
+		{
+			name: "should return error for latest if not found and pending is given",
+			num:  PendingBlockNumber,
+			store: &debugEndpointMockStore{
+				headerFn: func() *types.Header {
+					return &types.Header{
+						Number: 10,
+					}
+				},
+			},
+			expected: 10,
+			err:      nil,
 		},
 		{
 			name:     "should return error if negative number is given",

--- a/jsonrpc/helper_test.go
+++ b/jsonrpc/helper_test.go
@@ -187,11 +187,15 @@ func TestGetBlockHeader(t *testing.T) {
 			err:      ErrFailedFetchGenesis,
 		},
 		{
-			name:     "should return error if pending is given",
-			num:      PendingBlockNumber,
-			store:    &debugEndpointMockStore{},
-			expected: nil,
-			err:      ErrPendingBlockNumber,
+			name: "should return latest if pending is given",
+			num:  PendingBlockNumber,
+			store: &debugEndpointMockStore{
+				headerFn: func() *types.Header {
+					return testLatestHeader
+				},
+			},
+			expected: testLatestHeader,
+			err:      nil,
 		},
 		{
 			name: "should return header at arbitrary height",

--- a/jsonrpc/query_test.go
+++ b/jsonrpc/query_test.go
@@ -105,7 +105,7 @@ func TestFilterDecode(t *testing.T) {
 				"toBlock": "earliest"
 			}`,
 			&LogQuery{
-				fromBlock: PendingBlockNumber,
+				fromBlock: LatestBlockNumber, // pending = latest
 				toBlock:   EarliestBlockNumber,
 			},
 		},


### PR DESCRIPTION
Fixes EVM-231.

# Description

Changed the behaviour of functions that do:
 - fetching blocks by Number/String/Hash
 - decoding JSON-RPC requests
 - fetching blocks by number

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Ran various JSON-RPC queries with "pending" as the block parameter.

# Documentation update

`//TODO`
