### PR TITLE
Extracted GetAccountImpl into fn for use in txPoolHub and jsonRPCHub 

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -305,10 +305,6 @@ func (t *txpoolHub) GetNonce(root types.Hash, addr types.Address) uint64 {
 		return 0
 	}
 
-	if account == nil {
-		return 0
-	}
-
 	return account.Nonce
 }
 
@@ -317,10 +313,6 @@ func (t *txpoolHub) GetBalance(root types.Hash, addr types.Address) (*big.Int, e
 
 	if err != nil {
 		return big.NewInt(0), err
-	}
-
-	if account == nil {
-		return big.NewInt(0), nil
 	}
 
 	return account.Balance, nil

--- a/server/server.go
+++ b/server/server.go
@@ -298,6 +298,25 @@ type txpoolHub struct {
 	*blockchain.Blockchain
 }
 
+// getAccountImpl is used for fetching account state from both TxPool and JSON-RPC
+func getAccountImpl(state state.State, root types.Hash, addr types.Address) (*state.Account, error) {
+	snap, err := state.NewSnapshotAt(root)
+	if err != nil {
+		return nil, err
+	}
+
+	account, err := snap.GetAccount(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	if account == nil {
+		return nil, jsonrpc.ErrStateNotFound
+	}
+
+	return account, nil
+}
+
 func (t *txpoolHub) GetNonce(root types.Hash, addr types.Address) uint64 {
 	account, err := getAccountImpl(t.state, root, addr)
 
@@ -417,28 +436,8 @@ type jsonRPCHub struct {
 	consensus.Consensus
 }
 
-// HELPER + WRAPPER METHODS //
-
 func (j *jsonRPCHub) GetPeers() int {
 	return len(j.Server.Peers())
-}
-
-func getAccountImpl(state state.State, root types.Hash, addr types.Address) (*state.Account, error) {
-	snap, err := state.NewSnapshotAt(root)
-	if err != nil {
-		return nil, err
-	}
-
-	account, err := snap.GetAccount(addr)
-	if err != nil {
-		return nil, err
-	}
-
-	if account == nil {
-		return nil, jsonrpc.ErrStateNotFound
-	}
-
-	return account, nil
 }
 
 func (j *jsonRPCHub) GetAccount(root types.Hash, addr types.Address) (*jsonrpc.Account, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -426,7 +426,7 @@ func (j *jsonRPCHub) GetPeers() int {
 func getAccountImpl(state state.State, root types.Hash, addr types.Address) (*state.Account, error) {
 	snap, err := state.NewSnapshotAt(root)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to get snapshot for root '%s': %w", root, err)
 	}
 
 	account, err := snap.GetAccount(addr)


### PR DESCRIPTION
Fixes EVM-241

# Description

Streamlined error handling on non-existent accounts which caused a runtime error on pending block param with `eth_getTransactionCount`.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Ran `eth_getTransactionCount` with pending block param.

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
