### PR TITLE
Fixed eth_getCode endpoint

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -490,7 +490,7 @@ func (j *jsonRPCHub) GetCode(root types.Hash, addr types.Address) ([]byte, error
 		return nil, err
 	}
 
-	code, ok := j.state.GetCode(account.Root)
+	code, ok := j.state.GetCode(types.BytesToHash(account.CodeHash))
 	if !ok {
 		return nil, fmt.Errorf("unable to fetch code")
 	}


### PR DESCRIPTION
Fixes EVM-240

# Description

A very simple fix that calls the codehash of the account in order to find it in the KV DB.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Ran `eth_getCode` with deployed dummy SC.