### PR TITLE
Change genesis premine logic

### DIFF
--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -198,7 +198,6 @@ func setFlags(cmd *cobra.Command) {
 			defaultBridge,
 			"enabling bridge, default is not enabled",
 		)
-		cmd.MarkFlagsMutuallyExclusive(premineFlag, premineValidatorsFlag)
 		cmd.MarkFlagsMutuallyExclusive(validatorsFlag, premineValidatorsFlag)
 	}
 }

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -336,9 +336,18 @@ func (p *genesisParams) initGenesisConfig() error {
 		chainConfig.Genesis.Alloc[staking.AddrStakingContract] = stakingAccount
 	}
 
-	if err := fillPremineMap(chainConfig.Genesis.Alloc, p.premine); err != nil {
-		return err
+	premineInfos := make([]*premineInfo, len(p.premine))
+
+	for i, premineRaw := range p.premine {
+		premineInfo, err := parsePremineInfo(premineRaw)
+		if err != nil {
+			return err
+		}
+
+		premineInfos[i] = premineInfo
 	}
+
+	fillPremineMap(chainConfig.Genesis.Alloc, premineInfos)
 
 	p.genesisConfig = chainConfig
 


### PR DESCRIPTION
# Description

This PR changes genesis premine logic in a way that `premine-validators` and `premine` flags aren't mutually exclusive anymore. Instead `premine-validators` contains amount which is about to be premined to all the genesis validator accounts, whereas `premine` flag is used to set amounts to arbitrary accounts and also can override genesis validator accounts balance.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Run genesis creation command with `premine` and `premine-validators` flags and notice that `premine` flags overrides value provided by `premine-validators` for genesis validator accounts.
