### PR TITLE
Fix data race in fsm

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -394,6 +394,7 @@ func (c *consensusRuntime) FSM() error {
 	c.lock.Lock()
 	c.fsm = ff
 	c.lock.Unlock()
+
 	return nil
 }
 
@@ -999,6 +1000,7 @@ func (c *consensusRuntime) IsValidBlock(proposal []byte) bool {
 func (c *consensusRuntime) IsValidSender(msg *proto.Message) bool {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+
 	err := c.fsm.ValidateSender(msg)
 	if err != nil {
 		c.logger.Error("invalid sender", "error", err)
@@ -1012,6 +1014,7 @@ func (c *consensusRuntime) IsValidSender(msg *proto.Message) bool {
 func (c *consensusRuntime) IsProposer(id []byte, height, round uint64) bool {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+
 	nextProposer, err := c.fsm.validators.CalcProposer(round)
 	if err != nil {
 		c.logger.Error("cannot calculate proposer", "error", err)

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -391,8 +391,9 @@ func (c *consensusRuntime) FSM() error {
 		"endOfSprint", isEndOfSprint,
 	)
 
+	c.lock.Lock()
 	c.fsm = ff
-
+	c.lock.Unlock()
 	return nil
 }
 
@@ -996,6 +997,8 @@ func (c *consensusRuntime) IsValidBlock(proposal []byte) bool {
 }
 
 func (c *consensusRuntime) IsValidSender(msg *proto.Message) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	err := c.fsm.ValidateSender(msg)
 	if err != nil {
 		c.logger.Error("invalid sender", "error", err)
@@ -1007,6 +1010,8 @@ func (c *consensusRuntime) IsValidSender(msg *proto.Message) bool {
 }
 
 func (c *consensusRuntime) IsProposer(id []byte, height, round uint64) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	nextProposer, err := c.fsm.validators.CalcProposer(round)
 	if err != nil {
 		c.logger.Error("cannot calculate proposer", "error", err)
@@ -1113,6 +1118,8 @@ func (c *consensusRuntime) HasQuorum(
 	messages []*proto.Message,
 	msgType proto.MessageType,
 ) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	// extract the addresses of all the signers of the messages
 	ppIncluded := false
 	signers := make(map[types.Address]struct{}, len(messages))

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -998,8 +998,8 @@ func (c *consensusRuntime) IsValidBlock(proposal []byte) bool {
 }
 
 func (c *consensusRuntime) IsValidSender(msg *proto.Message) bool {
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 
 	err := c.fsm.ValidateSender(msg)
 	if err != nil {
@@ -1012,8 +1012,8 @@ func (c *consensusRuntime) IsValidSender(msg *proto.Message) bool {
 }
 
 func (c *consensusRuntime) IsProposer(id []byte, height, round uint64) bool {
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 
 	nextProposer, err := c.fsm.validators.CalcProposer(round)
 	if err != nil {
@@ -1121,8 +1121,8 @@ func (c *consensusRuntime) HasQuorum(
 	messages []*proto.Message,
 	msgType proto.MessageType,
 ) bool {
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	// extract the addresses of all the signers of the messages
 	ppIncluded := false
 	signers := make(map[types.Address]struct{}, len(messages))

--- a/consensus/polybft/validator_set.go
+++ b/consensus/polybft/validator_set.go
@@ -501,7 +501,7 @@ func (v *validatorSet) Copy() *validatorSet {
 func validatorListCopy(valList []*ValidatorAccount) []*ValidatorAccount {
 	valCopy := make([]*ValidatorAccount, len(valList))
 	for i, val := range valList {
-		valCopy[i] = NewValidator(val.Metadata, val.ProposerPriority)
+		valCopy[i] = NewValidator(val.Metadata.Copy(), val.ProposerPriority)
 	}
 
 	return valCopy

--- a/consensus/polybft/validator_set_test.go
+++ b/consensus/polybft/validator_set_test.go
@@ -408,8 +408,11 @@ func TestValidatorSetTotalVotingPowerErrorOnOverflow(t *testing.T) {
 func TestUpdatesForNewValidatorSet(t *testing.T) {
 	t.Parallel()
 
-	v1 := &ValidatorMetadata{Address: types.Address{0x1}, VotingPower: 100}
-	v2 := &ValidatorMetadata{Address: types.Address{0x2}, VotingPower: 100}
+	keys, err := bls.CreateRandomBlsKeys(2)
+	require.NoError(t, err)
+
+	v1 := &ValidatorMetadata{Address: types.Address{0x1}, BlsKey: keys[0].PublicKey(), VotingPower: 100}
+	v2 := &ValidatorMetadata{Address: types.Address{0x2}, BlsKey: keys[1].PublicKey(), VotingPower: 100}
 	accountSet := []*ValidatorMetadata{v1, v2}
 	valSet, err := NewValidatorSet(accountSet, hclog.NewNullLogger())
 	require.NoError(t, err)


### PR DESCRIPTION
# Description

Lock is added to prevent data race in hasQuorum method.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
