### PR TITLE
Provide `epochSize` to the `ChildValidatorSet`

### DIFF
--- a/consensus/polybft/contracts_initializer.go
+++ b/consensus/polybft/contracts_initializer.go
@@ -15,16 +15,14 @@ import (
 
 const (
 	// safe numbers for the test
-	newEpochReward   = 1
-	newMinStake      = 1
-	newMinDelegation = 1
+	epochReward   = 1
+	minStake      = 1
+	minDelegation = 1
 )
 
 var (
-	initCallStaking, _ = abi.NewMethod("function initialize(" +
-		"uint256 newEpochReward," +
-		"uint256 newMinStake," +
-		"uint256 newMinDelegation," +
+	childValidatorSetInitializer, _ = abi.NewMethod("function initialize(" +
+		"tuple(uint256 epochReward, uint256 minStake, uint256 minDelegation, uint256 epochSize) initParams," +
 		"address[] validatorAddresses," +
 		"uint256[4][] validatorPubkeys," +
 		"uint256[] validatorStakes," +
@@ -32,7 +30,7 @@ var (
 		"uint256[2] newMessage," +
 		"address governance)")
 
-	initNativeTokenMethod, _ = abi.NewMethod("function initialize(" +
+	nativeTokenInitializer, _ = abi.NewMethod("function initialize(" +
 		"address predicate_," +
 		"string name_," +
 		"string symbol_)")
@@ -41,12 +39,12 @@ var (
 	nativeTokenSymbol = "MATIC"
 )
 
-func getInitChildValidatorSetInput(validators []*Validator, governanceAddr types.Address) ([]byte, error) {
-	validatorAddresses := make([]types.Address, len(validators))
-	validatorPubkeys := make([][4]*big.Int, len(validators))
-	validatorStakes := make([]*big.Int, len(validators))
+func getInitChildValidatorSetInput(polyBFTConfig PolyBFTConfig) ([]byte, error) {
+	validatorAddresses := make([]types.Address, len(polyBFTConfig.InitialValidatorSet))
+	validatorPubkeys := make([][4]*big.Int, len(polyBFTConfig.InitialValidatorSet))
+	validatorStakes := make([]*big.Int, len(polyBFTConfig.InitialValidatorSet))
 
-	for i, validator := range validators {
+	for i, validator := range polyBFTConfig.InitialValidatorSet {
 		blsKey, err := hex.DecodeString(validator.BlsKey)
 		if err != nil {
 			return nil, err
@@ -69,17 +67,22 @@ func getInitChildValidatorSetInput(validators []*Validator, governanceAddr types
 		return nil, err
 	}
 
-	input, err := initCallStaking.Encode([]interface{}{
-		big.NewInt(newEpochReward),
-		big.NewInt(newMinStake),
-		big.NewInt(newMinDelegation),
-		validatorAddresses,
-		validatorPubkeys,
-		validatorStakes,
-		contracts.BLSContract, // address of the deployed BLS contract
-		registerMessage,
-		governanceAddr,
-	})
+	params := map[string]interface{}{
+		"initParams": map[string]interface{}{
+			"epochReward":   epochReward,
+			"minStake":      minStake,
+			"minDelegation": minDelegation,
+			"epochSize":     polyBFTConfig.EpochSize,
+		},
+		"validatorAddresses": validatorAddresses,
+		"validatorPubkeys":   validatorPubkeys,
+		"validatorStakes":    validatorStakes,
+		"newBLS":             contracts.BLSContract, // address of the deployed BLS contract
+		"newMessage":         registerMessage,
+		"governance":         polyBFTConfig.Governance,
+	}
+
+	input, err := childValidatorSetInitializer.Encode(params)
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/polybft/contracts_initializer.go
+++ b/consensus/polybft/contracts_initializer.go
@@ -77,7 +77,7 @@ func getInitChildValidatorSetInput(polyBFTConfig PolyBFTConfig) ([]byte, error) 
 		"validatorAddresses": validatorAddresses,
 		"validatorPubkeys":   validatorPubkeys,
 		"validatorStakes":    validatorStakes,
-		"newBLS":             contracts.BLSContract, // address of the deployed BLS contract
+		"newBls":             contracts.BLSContract, // address of the deployed BLS contract
 		"newMessage":         registerMessage,
 		"governance":         polyBFTConfig.Governance,
 	}

--- a/consensus/polybft/contracts_initializer.go
+++ b/consensus/polybft/contracts_initializer.go
@@ -22,7 +22,7 @@ const (
 
 var (
 	childValidatorSetInitializer, _ = abi.NewMethod("function initialize(" +
-		"tuple(uint256 epochReward, uint256 minStake, uint256 minDelegation, uint256 epochSize) initParams," +
+		"tuple(uint256 epochReward, uint256 minStake, uint256 minDelegation, uint256 epochSize) init," +
 		"address[] validatorAddresses," +
 		"uint256[4][] validatorPubkeys," +
 		"uint256[] validatorStakes," +
@@ -68,11 +68,11 @@ func getInitChildValidatorSetInput(polyBFTConfig PolyBFTConfig) ([]byte, error) 
 	}
 
 	params := map[string]interface{}{
-		"initParams": map[string]interface{}{
-			"epochReward":   epochReward,
-			"minStake":      minStake,
-			"minDelegation": minDelegation,
-			"epochSize":     polyBFTConfig.EpochSize,
+		"init": map[string]interface{}{
+			"epochReward":   big.NewInt(epochReward),
+			"minStake":      big.NewInt(minStake),
+			"minDelegation": big.NewInt(minDelegation),
+			"epochSize":     new(big.Int).SetUint64(polyBFTConfig.EpochSize),
 		},
 		"validatorAddresses": validatorAddresses,
 		"validatorPubkeys":   validatorPubkeys,

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -112,19 +112,19 @@ type Polybft struct {
 
 func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *state.Transition) error {
 	return func(transition *state.Transition) error {
-		var pbftConfig PolyBFTConfig
+		var polyBFTConfig PolyBFTConfig
 
-		customConfigJSON, err := json.Marshal(config.Params.Engine[engineName])
+		consensusConfigJSON, err := json.Marshal(config.Params.Engine[engineName])
 		if err != nil {
 			return err
 		}
 
-		err = json.Unmarshal(customConfigJSON, &pbftConfig)
+		err = json.Unmarshal(consensusConfigJSON, &polyBFTConfig)
 		if err != nil {
 			return err
 		}
 		// Initialize child validator set
-		input, err := getInitChildValidatorSetInput(pbftConfig.InitialValidatorSet, pbftConfig.Governance)
+		input, err := getInitChildValidatorSetInput(polyBFTConfig)
 		if err != nil {
 			return err
 		}
@@ -133,7 +133,7 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 			return err
 		}
 
-		input, err = initNativeTokenMethod.Encode(
+		input, err = nativeTokenInitializer.Encode(
 			[]interface{}{helper.GetRootchainAdminAddr(), nativeTokenName, nativeTokenSymbol})
 		if err != nil {
 			return err


### PR DESCRIPTION
# Description

This PR initializes `ChildValidatorSet` smart contract with the epoch size from the genesis configuration. Doing so enables us to configure epoch sizes arbitrarily.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually