### PR TITLE
Removing `GenesisTarget` and adding the `NodeID` field to `Validator` struct

### DIFF
--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -2,7 +2,6 @@ package genesis
 
 import (
 	"bytes"
-	"encoding/hex"
 	"fmt"
 	"math/big"
 	"path"
@@ -17,7 +16,6 @@ import (
 	rootchain "github.com/0xPolygon/polygon-edge/command/rootchain/helper"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
-	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/server"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -45,72 +43,29 @@ const (
 )
 
 func (p *genesisParams) generatePolyBFTConfig() (*chain.Chain, error) {
-	validatorsInfo, err := ReadValidatorsByRegexp(path.Dir(p.genesisPath), p.polyBftValidatorPrefixPath)
+	// set initial validator set
+	genesisValidators, err := p.getGenesisValidators()
 	if err != nil {
 		return nil, err
 	}
 
+	// deploy genesis contracts
 	allocs, err := p.deployContracts()
 	if err != nil {
 		return nil, err
 	}
 
-	// use 1st account as governance address
-	governanceAccount := validatorsInfo[0].Account
-	polyBftConfig := &polybft.PolyBFTConfig{
-		BlockTime:         p.blockTime,
-		EpochSize:         p.epochSize,
-		SprintSize:        p.sprintSize,
-		ValidatorSetSize:  p.validatorSetSize,
-		ValidatorSetAddr:  contracts.ValidatorSetContract,
-		StateReceiverAddr: contracts.StateReceiverContract,
-		Governance:        types.Address(governanceAccount.Ecdsa.Address()),
-	}
-
-	if p.bridgeEnabled {
-		ip, err := rootchain.ReadRootchainIP()
-		if err != nil {
-			return nil, err
-		}
-
-		polyBftConfig.Bridge = &polybft.BridgeConfig{
-			BridgeAddr:      rootchain.StateSenderAddress,
-			CheckpointAddr:  rootchain.CheckpointManagerAddress,
-			JSONRPCEndpoint: ip,
-		}
-	}
-
-	chainConfig := &chain.Chain{
-		Name: p.name,
-		Params: &chain.Params{
-			ChainID: int(p.chainID),
-			Forks:   chain.AllForksEnabled,
-			Engine: map[string]interface{}{
-				string(server.PolyBFTConsensus): polyBftConfig,
-			},
-		},
-		Bootnodes: p.bootnodes,
-	}
-
-	// set generic validators as bootnodes if needed
-	if len(p.bootnodes) == 0 {
-		for i, validator := range validatorsInfo {
-			bnode := fmt.Sprintf("/ip4/%s/tcp/%d/p2p/%s", "127.0.0.1", bootnodePortStart+i, validator.NodeID)
-			chainConfig.Bootnodes = append(chainConfig.Bootnodes, bnode)
-		}
-	}
-
+	// premine accounts with some tokens
 	var (
 		validatorPreminesMap map[types.Address]int
 		premineInfos         []*premineInfo
 	)
 
 	if p.premineValidators != "" {
-		validatorPreminesMap = make(map[types.Address]int, len(validatorsInfo))
+		validatorPreminesMap = make(map[types.Address]int, len(genesisValidators))
 
-		for i, vi := range validatorsInfo {
-			premineInfo, err := parsePremineInfo(fmt.Sprintf("%s:%s",
-				vi.Account.Ecdsa.Address().String(), p.premineValidators))
+		for i, vi := range genesisValidators {
+			premineInfo, err := parsePremineInfo(fmt.Sprintf("%s:%s", vi.Address, p.premineValidators))
 			if err != nil {
 				return nil, err
 			}
@@ -138,20 +93,64 @@ func (p *genesisParams) generatePolyBFTConfig() (*chain.Chain, error) {
 	// premine accounts
 	fillPremineMap(allocs, premineInfos)
 
-	// set initial validator set
-	genesisValidators, err := p.getGenesisValidators(validatorsInfo, allocs)
-	if err != nil {
-		return nil, err
+	// populate genesis validators balances
+	for _, validator := range genesisValidators {
+		balance, err := chain.GetGenesisAccountBalance(validator.Address, allocs)
+		if err != nil {
+			return nil, err
+		}
+
+		validator.Balance = balance
+	}
+
+	polyBftConfig := &polybft.PolyBFTConfig{
+		BlockTime:         p.blockTime,
+		EpochSize:         p.epochSize,
+		SprintSize:        p.sprintSize,
+		ValidatorSetSize:  p.validatorSetSize,
+		ValidatorSetAddr:  contracts.ValidatorSetContract,
+		StateReceiverAddr: contracts.StateReceiverContract,
+		// use 1st account as governance address
+		Governance: genesisValidators[0].Address,
+	}
+
+	// populate bridge configuration
+	if p.bridgeEnabled {
+		ip, err := rootchain.ReadRootchainIP()
+		if err != nil {
+			return nil, err
+		}
+
+		polyBftConfig.Bridge = &polybft.BridgeConfig{
+			BridgeAddr:      rootchain.StateSenderAddress,
+			CheckpointAddr:  rootchain.CheckpointManagerAddress,
+			JSONRPCEndpoint: ip,
+		}
+	}
+
+	chainConfig := &chain.Chain{
+		Name: p.name,
+		Params: &chain.Params{
+			ChainID: int(p.chainID),
+			Forks:   chain.AllForksEnabled,
+			Engine: map[string]interface{}{
+				string(server.PolyBFTConsensus): polyBftConfig,
+			},
+		},
+		Bootnodes: p.bootnodes,
+	}
+
+	// set generic validators as bootnodes if needed
+	if len(p.bootnodes) == 0 {
+		for i, validator := range genesisValidators {
+			bootNode := fmt.Sprintf("/ip4/%s/tcp/%d/p2p/%s", "127.0.0.1", bootnodePortStart+i, validator.NodeID)
+			chainConfig.Bootnodes = append(chainConfig.Bootnodes, bootNode)
+		}
 	}
 
 	polyBftConfig.InitialValidatorSet = genesisValidators
 
-	pubKeys := make([]*bls.PublicKey, len(validatorsInfo))
-	for i, validatorInfo := range validatorsInfo {
-		pubKeys[i] = validatorInfo.Account.Bls.PublicKey()
-	}
-
-	genesisExtraData, err := generateExtraDataPolyBft(genesisValidators, pubKeys)
+	genesisExtraData, err := generateExtraDataPolyBft(genesisValidators)
 	if err != nil {
 		return nil, err
 	}
@@ -169,49 +168,40 @@ func (p *genesisParams) generatePolyBFTConfig() (*chain.Chain, error) {
 	return chainConfig, nil
 }
 
-func (p *genesisParams) getGenesisValidators(validators []GenesisTarget,
-	allocs map[types.Address]*chain.GenesisAccount) ([]*polybft.Validator, error) {
-	result := make([]*polybft.Validator, 0)
-
+func (p *genesisParams) getGenesisValidators() ([]*polybft.Validator, error) {
 	if len(p.validators) > 0 {
-		for _, validator := range p.validators {
+		validators := make([]*polybft.Validator, len(p.validators))
+		for i, validator := range p.validators {
 			parts := strings.Split(validator, ":")
-			if len(parts) != 2 || len(parts[0]) != 32 || len(parts[1]) < 2 {
-				continue
+
+			if len(parts) != 3 {
+				return nil, fmt.Errorf("expected 3 parts provided in the following format <nodeId:address:blsKey>, but got %d",
+					len(parts))
 			}
 
-			addr := types.StringToAddress(parts[0])
-
-			balance, err := chain.GetGenesisAccountBalance(addr, allocs)
-			if err != nil {
-				return nil, err
+			if len(parts[0]) != 53 {
+				return nil, fmt.Errorf("invalid node id: %s", parts[0])
 			}
 
-			result = append(result, &polybft.Validator{
-				Address: addr,
-				BlsKey:  parts[1],
-				Balance: balance,
-			})
+			if len(parts[1]) != 42 {
+				return nil, fmt.Errorf("invalid address: %s", parts[1])
+			}
+
+			if len(parts[2]) < 2 {
+				return nil, fmt.Errorf("invalid bls key: %s", parts[2])
+			}
+
+			validators[i] = &polybft.Validator{
+				NodeID:  parts[0],
+				Address: types.StringToAddress(parts[1]),
+				BlsKey:  parts[2],
+			}
 		}
-	} else {
-		for _, validator := range validators {
-			pubKeyMarshalled := validator.Account.Bls.PublicKey().Marshal()
-			addr := types.Address(validator.Account.Ecdsa.Address())
 
-			balance, err := chain.GetGenesisAccountBalance(addr, allocs)
-			if err != nil {
-				return nil, err
-			}
-
-			result = append(result, &polybft.Validator{
-				Address: addr,
-				BlsKey:  hex.EncodeToString(pubKeyMarshalled),
-				Balance: balance,
-			})
-		}
+		return validators, nil
 	}
 
-	return result, nil
+	return ReadValidatorsByRegexp(path.Dir(p.genesisPath), p.polyBftValidatorPrefixPath)
 }
 
 func (p *genesisParams) generatePolyBftGenesis() error {
@@ -279,20 +269,21 @@ func (p *genesisParams) deployContracts() (map[types.Address]*chain.GenesisAccou
 }
 
 // generateExtraDataPolyBft populates Extra with specific fields required for polybft consensus protocol
-func generateExtraDataPolyBft(validators []*polybft.Validator, publicKeys []*bls.PublicKey) ([]byte, error) {
-	if len(validators) != len(publicKeys) {
-		return nil, fmt.Errorf("expected same length for genesis validators and BLS public keys")
-	}
-
+func generateExtraDataPolyBft(validators []*polybft.Validator) ([]byte, error) {
 	delta := &polybft.ValidatorSetDelta{
 		Added:   make(polybft.AccountSet, len(validators)),
 		Removed: bitmap.Bitmap{},
 	}
 
 	for i, validator := range validators {
+		blsKey, err := validator.UnmarshallBLSPublicKey()
+		if err != nil {
+			return nil, err
+		}
+
 		delta.Added[i] = &polybft.ValidatorMetadata{
 			Address:     validator.Address,
-			BlsKey:      publicKeys[i],
+			BlsKey:      blsKey,
 			VotingPower: chain.ConvertWeiToTokensAmount(validator.Balance).Uint64(),
 		}
 	}

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -75,18 +75,16 @@ func (p *genesisParams) generatePolyBFTConfig() (*chain.Chain, error) {
 		}
 	}
 
-	if len(p.premine) > 0 {
-		for _, premine := range p.premine {
-			premineInfo, err := parsePremineInfo(premine)
-			if err != nil {
-				return nil, err
-			}
+	for _, premine := range p.premine {
+		premineInfo, err := parsePremineInfo(premine)
+		if err != nil {
+			return nil, err
+		}
 
-			if i, ok := validatorPreminesMap[premineInfo.address]; ok {
-				premineInfos[i] = premineInfo
-			} else {
-				premineInfos = append(premineInfos, premineInfo)
-			}
+		if i, ok := validatorPreminesMap[premineInfo.address]; ok {
+			premineInfos[i] = premineInfo
+		} else {
+			premineInfos = append(premineInfos, premineInfo)
 		}
 	}
 

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -276,7 +276,7 @@ func generateExtraDataPolyBft(validators []*polybft.Validator) ([]byte, error) {
 	}
 
 	for i, validator := range validators {
-		blsKey, err := validator.UnmarshallBLSPublicKey()
+		blsKey, err := validator.UnmarshalBLSPublicKey()
 		if err != nil {
 			return nil, err
 		}

--- a/command/genesis/utils.go
+++ b/command/genesis/utils.go
@@ -1,6 +1,7 @@
 package genesis
 
 import (
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/command"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/secrets"
 	"github.com/0xPolygon/polygon-edge/secrets/helper"
@@ -96,12 +98,7 @@ func parsePremineInfo(premineInfoRaw string) (*premineInfo, error) {
 	return &premineInfo{address: address, balance: amount}, nil
 }
 
-type GenesisTarget struct {
-	Account *wallet.Account
-	NodeID  string
-}
-
-func ReadValidatorsByRegexp(dir, prefix string) ([]GenesisTarget, error) {
+func ReadValidatorsByRegexp(dir, prefix string) ([]*polybft.Validator, error) {
 	if dir == "" {
 		dir = "."
 	}
@@ -132,9 +129,9 @@ func ReadValidatorsByRegexp(dir, prefix string) ([]GenesisTarget, error) {
 		return num1 < num2
 	})
 
-	validators := make([]GenesisTarget, 0, len(files))
+	validators := make([]*polybft.Validator, len(files))
 
-	for _, file := range files {
+	for i, file := range files {
 		path := filepath.Join(dir, file.Name())
 
 		account, nodeID, err := getSecrets(path)
@@ -142,8 +139,12 @@ func ReadValidatorsByRegexp(dir, prefix string) ([]GenesisTarget, error) {
 			return nil, err
 		}
 
-		target := GenesisTarget{Account: account, NodeID: nodeID}
-		validators = append(validators, target)
+		validator := &polybft.Validator{
+			Address: types.Address(account.Ecdsa.Address()),
+			BlsKey:  hex.EncodeToString(account.Bls.PublicKey().Marshal()),
+			NodeID:  nodeID,
+		}
+		validators[i] = validator
 	}
 
 	return validators, nil

--- a/command/rootchain/initcontracts/init_contracts.go
+++ b/command/rootchain/initcontracts/init_contracts.go
@@ -274,7 +274,7 @@ func validatorSetToABISlice(allocs map[types.Address]*chain.GenesisAccount) ([]m
 			return nil, err
 		}
 
-		blsKey, err := validatorInfo.UnmarshallBLSPublicKey()
+		blsKey, err := validatorInfo.UnmarshalBLSPublicKey()
 		if err != nil {
 			return nil, err
 		}

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -1,10 +1,12 @@
 package polybft
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"math/big"
 	"time"
 
+	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
@@ -44,6 +46,7 @@ type Validator struct {
 	Address types.Address `json:"address"`
 	BlsKey  string        `json:"blsKey"`
 	Balance *big.Int      `json:"balance"`
+	NodeID  string        `json:"-"`
 }
 
 type validatorRaw struct {
@@ -77,6 +80,16 @@ func (v *Validator) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+// UnmarshalBLSPublicKey unmarshals the hex encoded BLS public key
+func (v *Validator) UnmarshalBLSPublicKey() (*bls.PublicKey, error) {
+	decoded, err := hex.DecodeString(v.BlsKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return bls.UnmarshalPublicKey(decoded)
 }
 
 // DebugConfig is a struct used for test configuration in init genesis

--- a/e2e-polybft/bridge_test.go
+++ b/e2e-polybft/bridge_test.go
@@ -155,7 +155,7 @@ func TestE2E_Bridge_MainWorkflow(t *testing.T) {
 	)
 
 	// wait for a few more sprints
-	require.NoError(t, cluster.WaitForBlock(25, 1*time.Minute))
+	require.NoError(t, cluster.WaitForBlock(30, 2*time.Minute))
 
 	// commitments should've been stored
 	// execute the state sysncs

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -258,7 +258,7 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 
 		// premine all the validators by default
 		for _, validator := range validators {
-			args = append(args, "--premine", validator.Account.Ecdsa.Address().String())
+			args = append(args, "--premine", validator.Address.String())
 		}
 
 		if cluster.Config.BootnodeCount > 0 {


### PR DESCRIPTION
# Description

* Refactored generatePolyBFTConfig to use the new struct and simplify the code and take into account validators passed from params

* Add NodeID as a field needed for validators passed from params

Co-authored-by: Stefan Negovanović <Stefan-Ethernal@users.noreply.github.com>

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Tested with local files and CLI params
