### PR TITLE
Changing skip_push flag to auto for latest tag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -129,4 +129,4 @@ docker_manifests:
     image_templates:
       - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
       - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
-    skip_push: false
+    skip_push: auto


### PR DESCRIPTION
# Description

As discussed, updating GoReleaser to skip pushing `latest` tag if prereleasing. 