### PR TITLE
Only setup telemetry if `prometheusAddr` is set

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -140,11 +140,12 @@ func NewServer(config *Config) (*Server, error) {
 		return nil, fmt.Errorf("failed to create data directories: %w", err)
 	}
 
-	if err := m.setupTelemetry(); err != nil {
-		return nil, err
-	}
-
 	if config.Telemetry.PrometheusAddr != nil {
+		// Only setup telemetry if `PrometheusAddr` has been configured.
+		if err := m.setupTelemetry(); err != nil {
+			return nil, err
+		}
+
 		m.prometheusServer = m.startPrometheusServer(config.Telemetry.PrometheusAddr)
 	}
 


### PR DESCRIPTION
Prometheus metric collector registration fails if performed multiple times with the same configuration. This can happen if multiple server instances are started within the same process, which is sometimes useful in e2e test cases.

# Description

This change will only call `setupTelemetry()` if prometheus address has been configured.

Prometheus metric collector registrations fail if performed multiple times. This can happen if multiple server instances are started within the same process, which is sometimes useful in e2e test cases.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
