### PR TITLE
Modify snapshot calculation for dynamic epoch

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/0xPolygon/polygon-edge/blockchain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
@@ -770,7 +769,7 @@ func (c *consensusRuntime) calculateUptime(currentBlock *types.Header, epoch *ep
 			return nil, err
 		}
 
-		blockHeader, blockExtra, err = c.getBlockData(blockHeader.Number - 1)
+		blockHeader, blockExtra, err = getBlockData(blockHeader.Number-1, c.config.blockchain)
 	}
 
 	// calculate uptime for blocks from previous epoch that were not processed in previous uptime
@@ -786,7 +785,7 @@ func (c *consensusRuntime) calculateUptime(currentBlock *types.Header, epoch *ep
 				return nil, err
 			}
 
-			blockHeader, blockExtra, err = c.getBlockData(blockHeader.Number - 1)
+			blockHeader, blockExtra, err = getBlockData(blockHeader.Number-1, c.config.blockchain)
 		}
 	}
 
@@ -1325,7 +1324,7 @@ func (c *consensusRuntime) getFirstBlockOfEpoch(epochNumber uint64, latestHeader
 
 	for blockExtra.Checkpoint.EpochNumber == epoch {
 		firstBlockInEpoch = blockHeader.Number
-		blockHeader, blockExtra, err = c.getBlockData(blockHeader.Number - 1)
+		blockHeader, blockExtra, err = getBlockData(blockHeader.Number-1, c.config.blockchain)
 
 		if err != nil {
 			return 0, err
@@ -1333,21 +1332,6 @@ func (c *consensusRuntime) getFirstBlockOfEpoch(epochNumber uint64, latestHeader
 	}
 
 	return firstBlockInEpoch, nil
-}
-
-// getBlockData returns block header and extra
-func (c *consensusRuntime) getBlockData(blockNumber uint64) (*types.Header, *Extra, error) {
-	blockHeader, found := c.config.blockchain.GetHeaderByNumber(blockNumber)
-	if !found {
-		return nil, nil, blockchain.ErrNoBlock
-	}
-
-	blockExtra, err := GetIbftExtra(blockHeader.ExtraData)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return blockHeader, blockExtra, nil
 }
 
 // validateVote validates if the senders address is in active validator set

--- a/consensus/polybft/helpers_test.go
+++ b/consensus/polybft/helpers_test.go
@@ -5,13 +5,91 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/0xPolygon/polygon-edge/blockchain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/umbracle/ethgo"
 )
+
+func TestHelpers_isEpochEndingBlock_DeltaNotEmpty(t *testing.T) {
+	t.Parallel()
+
+	validators := newTestValidators(3).getPublicIdentities()
+	bitmap := bitmap.Bitmap{}
+	bitmap.Set(0)
+
+	delta := &ValidatorSetDelta{
+		Added:   validators[1:],
+		Removed: bitmap,
+	}
+
+	extra := &Extra{Validators: delta, Checkpoint: &CheckpointData{EpochNumber: 2}}
+	blockNumber := uint64(20)
+
+	isEndOfEpoch, err := isEpochEndingBlock(blockNumber, extra, new(blockchainMock))
+	require.NoError(t, err)
+	require.True(t, isEndOfEpoch)
+}
+
+func TestHelpers_isEpochEndingBlock_NoBlock(t *testing.T) {
+	t.Parallel()
+
+	blockchainMock := new(blockchainMock)
+	blockchainMock.On("GetHeaderByNumber", mock.Anything).Return(&types.Header{}, false)
+
+	extra := &Extra{Checkpoint: &CheckpointData{EpochNumber: 2}, Validators: &ValidatorSetDelta{}}
+	blockNumber := uint64(20)
+
+	isEndOfEpoch, err := isEpochEndingBlock(blockNumber, extra, blockchainMock)
+	require.ErrorIs(t, blockchain.ErrNoBlock, err)
+	require.False(t, isEndOfEpoch)
+}
+
+func TestHelpers_isEpochEndingBlock_EpochsNotTheSame(t *testing.T) {
+	t.Parallel()
+
+	blockchainMock := new(blockchainMock)
+
+	nextBlockExtra := &Extra{Checkpoint: &CheckpointData{EpochNumber: 3}, Validators: &ValidatorSetDelta{}}
+	nextBlock := &types.Header{
+		Number:    21,
+		ExtraData: append(make([]byte, ExtraVanity), nextBlockExtra.MarshalRLPTo(nil)...),
+	}
+
+	blockchainMock.On("GetHeaderByNumber", mock.Anything).Return(nextBlock, true)
+
+	extra := &Extra{Checkpoint: &CheckpointData{EpochNumber: 2}, Validators: &ValidatorSetDelta{}}
+	blockNumber := uint64(20)
+
+	isEndOfEpoch, err := isEpochEndingBlock(blockNumber, extra, blockchainMock)
+	require.NoError(t, err)
+	require.True(t, isEndOfEpoch)
+}
+
+func TestHelpers_isEpochEndingBlock_EpochsAreTheSame(t *testing.T) {
+	t.Parallel()
+
+	blockchainMock := new(blockchainMock)
+
+	nextBlockExtra := &Extra{Checkpoint: &CheckpointData{EpochNumber: 2}, Validators: &ValidatorSetDelta{}}
+	nextBlock := &types.Header{
+		Number:    16,
+		ExtraData: append(make([]byte, ExtraVanity), nextBlockExtra.MarshalRLPTo(nil)...),
+	}
+
+	blockchainMock.On("GetHeaderByNumber", mock.Anything).Return(nextBlock, true)
+
+	extra := &Extra{Checkpoint: &CheckpointData{EpochNumber: 2}, Validators: &ValidatorSetDelta{}}
+	blockNumber := uint64(15)
+
+	isEndOfEpoch, err := isEpochEndingBlock(blockNumber, extra, blockchainMock)
+	require.NoError(t, err)
+	require.False(t, isEndOfEpoch)
+}
 
 func createTestKey(t *testing.T) *wallet.Key {
 	t.Helper()

--- a/consensus/polybft/helpers_test.go
+++ b/consensus/polybft/helpers_test.go
@@ -5,91 +5,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/0xPolygon/polygon-edge/blockchain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/umbracle/ethgo"
 )
-
-func TestHelpers_isEpochEndingBlock_DeltaNotEmpty(t *testing.T) {
-	t.Parallel()
-
-	validators := newTestValidators(3).getPublicIdentities()
-	bitmap := bitmap.Bitmap{}
-	bitmap.Set(0)
-
-	delta := &ValidatorSetDelta{
-		Added:   validators[1:],
-		Removed: bitmap,
-	}
-
-	extra := &Extra{Validators: delta, Checkpoint: &CheckpointData{EpochNumber: 2}}
-	blockNumber := uint64(20)
-
-	isEndOfEpoch, err := isEpochEndingBlock(blockNumber, extra, new(blockchainMock))
-	require.NoError(t, err)
-	require.True(t, isEndOfEpoch)
-}
-
-func TestHelpers_isEpochEndingBlock_NoBlock(t *testing.T) {
-	t.Parallel()
-
-	blockchainMock := new(blockchainMock)
-	blockchainMock.On("GetHeaderByNumber", mock.Anything).Return(&types.Header{}, false)
-
-	extra := &Extra{Checkpoint: &CheckpointData{EpochNumber: 2}, Validators: &ValidatorSetDelta{}}
-	blockNumber := uint64(20)
-
-	isEndOfEpoch, err := isEpochEndingBlock(blockNumber, extra, blockchainMock)
-	require.ErrorIs(t, blockchain.ErrNoBlock, err)
-	require.False(t, isEndOfEpoch)
-}
-
-func TestHelpers_isEpochEndingBlock_EpochsNotTheSame(t *testing.T) {
-	t.Parallel()
-
-	blockchainMock := new(blockchainMock)
-
-	nextBlockExtra := &Extra{Checkpoint: &CheckpointData{EpochNumber: 3}, Validators: &ValidatorSetDelta{}}
-	nextBlock := &types.Header{
-		Number:    21,
-		ExtraData: append(make([]byte, ExtraVanity), nextBlockExtra.MarshalRLPTo(nil)...),
-	}
-
-	blockchainMock.On("GetHeaderByNumber", mock.Anything).Return(nextBlock, true)
-
-	extra := &Extra{Checkpoint: &CheckpointData{EpochNumber: 2}, Validators: &ValidatorSetDelta{}}
-	blockNumber := uint64(20)
-
-	isEndOfEpoch, err := isEpochEndingBlock(blockNumber, extra, blockchainMock)
-	require.NoError(t, err)
-	require.True(t, isEndOfEpoch)
-}
-
-func TestHelpers_isEpochEndingBlock_EpochsAreTheSame(t *testing.T) {
-	t.Parallel()
-
-	blockchainMock := new(blockchainMock)
-
-	nextBlockExtra := &Extra{Checkpoint: &CheckpointData{EpochNumber: 2}, Validators: &ValidatorSetDelta{}}
-	nextBlock := &types.Header{
-		Number:    16,
-		ExtraData: append(make([]byte, ExtraVanity), nextBlockExtra.MarshalRLPTo(nil)...),
-	}
-
-	blockchainMock.On("GetHeaderByNumber", mock.Anything).Return(nextBlock, true)
-
-	extra := &Extra{Checkpoint: &CheckpointData{EpochNumber: 2}, Validators: &ValidatorSetDelta{}}
-	blockNumber := uint64(15)
-
-	isEndOfEpoch, err := isEpochEndingBlock(blockNumber, extra, blockchainMock)
-	require.NoError(t, err)
-	require.False(t, isEndOfEpoch)
-}
 
 func createTestKey(t *testing.T) *wallet.Key {
 	t.Helper()

--- a/consensus/polybft/helpers_test.go
+++ b/consensus/polybft/helpers_test.go
@@ -79,9 +79,3 @@ func getEpochNumber(t *testing.T, blockNumber, epochSize uint64) uint64 {
 
 	return blockNumber/epochSize + 1
 }
-
-// isEndOfPeriod checks if an end of a period (either it be sprint or epoch)
-// is reached with the current block (the parent block of the current fsm iteration)
-func isEndOfPeriod(blockNumber, periodSize uint64) bool {
-	return blockNumber%periodSize == 0
-}

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -68,17 +68,22 @@ func (m *blockchainMock) GetStateProvider(transition *state.Transition) contract
 
 func (m *blockchainMock) GetHeaderByNumber(number uint64) (*types.Header, bool) {
 	args := m.Called(number)
-	header, ok := args.Get(0).(*types.Header)
 
-	if ok {
-		return header, true
-	}
+	if len(args) == 1 {
+		header, ok := args.Get(0).(*types.Header)
 
-	getHeaderCallback, ok := args.Get(0).(func(number uint64) *types.Header)
-	if ok {
-		h := getHeaderCallback(number)
+		if ok {
+			return header, true
+		}
 
-		return h, h != nil
+		getHeaderCallback, ok := args.Get(0).(func(number uint64) *types.Header)
+		if ok {
+			h := getHeaderCallback(number)
+
+			return h, h != nil
+		}
+	} else if len(args) == 2 {
+		return args.Get(0).(*types.Header), args.Get(1).(bool) //nolint:forcetypeassert
 	}
 
 	panic("Unsupported mock for GetHeaderByNumber")

--- a/consensus/polybft/polybft_test.go
+++ b/consensus/polybft/polybft_test.go
@@ -24,7 +24,11 @@ import (
 func TestPolybft_VerifyHeader(t *testing.T) {
 	t.Parallel()
 
-	const validatorSetSize = 6 // overall there are 6 validators
+	const (
+		allValidatorsSize = 6 // overall there are 6 validators
+		validatorSetSize  = 5 // only 5 validators are active at the time
+		fixedEpochSize    = uint64(10)
+	)
 
 	updateHeaderExtra := func(header *types.Header,
 		validators *ValidatorSetDelta,
@@ -57,13 +61,13 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 		return extra.Committed
 	}
 
-	// create all valdators
-	validators := newTestValidators(validatorSetSize)
+	// create all validators
+	validators := newTestValidators(allValidatorsSize)
 
 	// create configuration
 	polyBftConfig := PolyBFTConfig{
 		InitialValidatorSet: validators.getParamValidators(),
-		EpochSize:           10,
+		EpochSize:           fixedEpochSize,
 		SprintSize:          5,
 	}
 
@@ -88,12 +92,12 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 	headersMap.addHeader(genesisHeader)
 
 	// create headers from 1 to 9
-	for i := 1; i < int(polyBftConfig.EpochSize); i++ {
+	for i := uint64(1); i < polyBftConfig.EpochSize; i++ {
 		delta, err := createValidatorSetDelta(validatorSetParent, validatorSetParent)
 		require.NoError(t, err)
 
-		header := &types.Header{Number: uint64(i)}
-		updateHeaderExtra(header, delta, nil, nil, nil)
+		header := &types.Header{Number: i}
+		updateHeaderExtra(header, delta, nil, &CheckpointData{EpochNumber: 1}, nil)
 
 		// add headers from 1 to 9 to map (blockchain imitation)
 		headersMap.addHeader(header)
@@ -125,7 +129,7 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 		Number:    polyBftConfig.EpochSize,
 		Timestamp: uint64(time.Now().UnixMilli()),
 	}
-	parentCommitment := updateHeaderExtra(parentHeader, parentDelta, nil, nil, accountSetParent)
+	parentCommitment := updateHeaderExtra(parentHeader, parentDelta, nil, &CheckpointData{EpochNumber: 1}, accountSetParent)
 
 	// add parent header to map
 	headersMap.addHeader(parentHeader)
@@ -141,7 +145,7 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 		MixHash:    PolyBFTMixDigest,
 		Difficulty: 1,
 	}
-	updateHeaderExtra(currentHeader, currentDelta, nil, nil, nil)
+	updateHeaderExtra(currentHeader, currentDelta, nil, &CheckpointData{EpochNumber: 2}, nil)
 
 	currentHeader.Hash[0] = currentHeader.Hash[0] + 1
 	assert.ErrorContains(t, polybft.VerifyHeader(currentHeader), "invalid header hash")
@@ -156,16 +160,16 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 
 	assert.NoError(t, polybft.VerifyHeader(currentHeader))
 
-	// clean validator snapshot cache (reinstantiate it), submit invalid validator set for parnet signature and expect the following error
+	// clean validator snapshot cache (re-instantiate it), submit invalid validator set for parent signature and expect the following error
 	polybft.validatorsCache = newValidatorsSnapshotCache(hclog.NewNullLogger(), newTestState(t), blockchainMock)
-	assert.NoError(t, polybft.validatorsCache.storeSnapshot(parentHeader.Number-1, validatorSetCurrent)) // invalid valdator set is submitted
-	assert.NoError(t, polybft.validatorsCache.storeSnapshot(currentHeader.Number-1, validatorSetCurrent))
+	assert.NoError(t, polybft.validatorsCache.storeSnapshot(&validatorSnapshot{Epoch: 0, Snapshot: validatorSetCurrent})) // invalid validator set is submitted
+	assert.NoError(t, polybft.validatorsCache.storeSnapshot(&validatorSnapshot{Epoch: 1, Snapshot: validatorSetCurrent}))
 	assert.ErrorContains(t, polybft.VerifyHeader(currentHeader), "failed to verify signatures for parent of block")
 
 	// clean validators cache again and set valid snapshots
 	polybft.validatorsCache = newValidatorsSnapshotCache(hclog.NewNullLogger(), newTestState(t), blockchainMock)
-	assert.NoError(t, polybft.validatorsCache.storeSnapshot(parentHeader.Number-1, validatorSetParent))
-	assert.NoError(t, polybft.validatorsCache.storeSnapshot(currentHeader.Number-1, validatorSetCurrent))
+	assert.NoError(t, polybft.validatorsCache.storeSnapshot(&validatorSnapshot{Epoch: 0, Snapshot: validatorSetParent}))
+	assert.NoError(t, polybft.validatorsCache.storeSnapshot(&validatorSnapshot{Epoch: 1, Snapshot: validatorSetCurrent}))
 	assert.NoError(t, polybft.VerifyHeader(currentHeader))
 
 	// add current header to the blockchain (headersMap) and try validating again

--- a/consensus/polybft/proposer_calculator.go
+++ b/consensus/polybft/proposer_calculator.go
@@ -234,14 +234,9 @@ func (pc *ProposerCalculator) updatePerBlock(blockNumber uint64) error {
 		return fmt.Errorf("proposer calculator update wrong block=%d, height = %d", blockNumber, pc.snapshot.Height)
 	}
 
-	currentHeader, found := pc.config.blockchain.GetHeaderByNumber(blockNumber)
-	if !found {
-		return fmt.Errorf("cannot get header by number: %d", blockNumber)
-	}
-
-	extra, err := GetIbftExtra(currentHeader.ExtraData)
+	_, extra, err := getBlockData(blockNumber, pc.config.blockchain)
 	if err != nil {
-		return fmt.Errorf("cannot get ibft extra for block while updating proposer snapshot %d: %w", blockNumber, err)
+		return fmt.Errorf("cannot get block header and extra while updating proposer snapshot %d: %w", blockNumber, err)
 	}
 
 	var newValidatorSet AccountSet = nil
@@ -249,7 +244,7 @@ func (pc *ProposerCalculator) updatePerBlock(blockNumber uint64) error {
 	if extra.Validators != nil && !extra.Validators.IsEmpty() {
 		newValidatorSet, err = pc.config.polybftBackend.GetValidators(blockNumber, nil)
 		if err != nil {
-			return fmt.Errorf("cannot get ibft extra for block %d: %w", blockNumber, err)
+			return fmt.Errorf("cannot get validators for block %d: %w", blockNumber, err)
 		}
 	}
 

--- a/consensus/polybft/runtime_helpers.go
+++ b/consensus/polybft/runtime_helpers.go
@@ -1,0 +1,33 @@
+package polybft
+
+import (
+	"github.com/0xPolygon/polygon-edge/blockchain"
+	"github.com/0xPolygon/polygon-edge/types"
+)
+
+// isEndOfPeriod checks if an end of a period (either it be sprint or epoch)
+// is reached with the current block (the parent block of the current fsm iteration)
+func isEndOfPeriod(blockNumber, periodSize uint64) bool {
+	return blockNumber%periodSize == 0
+}
+
+// getQuorumSize returns result of division of given number by two,
+// but rounded to next integer value (similar to math.Ceil function).
+func getQuorumSize(validatorsCount int) int {
+	return (validatorsCount + 1) / 2
+}
+
+// getBlockData returns block header and extra
+func getBlockData(blockNumber uint64, blockchainBackend blockchainBackend) (*types.Header, *Extra, error) {
+	blockHeader, found := blockchainBackend.GetHeaderByNumber(blockNumber)
+	if !found {
+		return nil, nil, blockchain.ErrNoBlock
+	}
+
+	blockExtra, err := GetIbftExtra(blockHeader.ExtraData)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return blockHeader, blockExtra, nil
+}

--- a/consensus/polybft/runtime_helpers_test.go
+++ b/consensus/polybft/runtime_helpers_test.go
@@ -1,0 +1,87 @@
+package polybft
+
+import (
+	"testing"
+
+	"github.com/0xPolygon/polygon-edge/blockchain"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHelpers_isEpochEndingBlock_DeltaNotEmpty(t *testing.T) {
+	t.Parallel()
+
+	validators := newTestValidators(3).getPublicIdentities()
+	bitmap := bitmap.Bitmap{}
+	bitmap.Set(0)
+
+	delta := &ValidatorSetDelta{
+		Added:   validators[1:],
+		Removed: bitmap,
+	}
+
+	extra := &Extra{Validators: delta, Checkpoint: &CheckpointData{EpochNumber: 2}}
+	blockNumber := uint64(20)
+
+	isEndOfEpoch, err := isEpochEndingBlock(blockNumber, extra, new(blockchainMock))
+	require.NoError(t, err)
+	require.True(t, isEndOfEpoch)
+}
+
+func TestHelpers_isEpochEndingBlock_NoBlock(t *testing.T) {
+	t.Parallel()
+
+	blockchainMock := new(blockchainMock)
+	blockchainMock.On("GetHeaderByNumber", mock.Anything).Return(&types.Header{}, false)
+
+	extra := &Extra{Checkpoint: &CheckpointData{EpochNumber: 2}, Validators: &ValidatorSetDelta{}}
+	blockNumber := uint64(20)
+
+	isEndOfEpoch, err := isEpochEndingBlock(blockNumber, extra, blockchainMock)
+	require.ErrorIs(t, blockchain.ErrNoBlock, err)
+	require.False(t, isEndOfEpoch)
+}
+
+func TestHelpers_isEpochEndingBlock_EpochsNotTheSame(t *testing.T) {
+	t.Parallel()
+
+	blockchainMock := new(blockchainMock)
+
+	nextBlockExtra := &Extra{Checkpoint: &CheckpointData{EpochNumber: 3}, Validators: &ValidatorSetDelta{}}
+	nextBlock := &types.Header{
+		Number:    21,
+		ExtraData: append(make([]byte, ExtraVanity), nextBlockExtra.MarshalRLPTo(nil)...),
+	}
+
+	blockchainMock.On("GetHeaderByNumber", mock.Anything).Return(nextBlock, true)
+
+	extra := &Extra{Checkpoint: &CheckpointData{EpochNumber: 2}, Validators: &ValidatorSetDelta{}}
+	blockNumber := uint64(20)
+
+	isEndOfEpoch, err := isEpochEndingBlock(blockNumber, extra, blockchainMock)
+	require.NoError(t, err)
+	require.True(t, isEndOfEpoch)
+}
+
+func TestHelpers_isEpochEndingBlock_EpochsAreTheSame(t *testing.T) {
+	t.Parallel()
+
+	blockchainMock := new(blockchainMock)
+
+	nextBlockExtra := &Extra{Checkpoint: &CheckpointData{EpochNumber: 2}, Validators: &ValidatorSetDelta{}}
+	nextBlock := &types.Header{
+		Number:    16,
+		ExtraData: append(make([]byte, ExtraVanity), nextBlockExtra.MarshalRLPTo(nil)...),
+	}
+
+	blockchainMock.On("GetHeaderByNumber", mock.Anything).Return(nextBlock, true)
+
+	extra := &Extra{Checkpoint: &CheckpointData{EpochNumber: 2}, Validators: &ValidatorSetDelta{}}
+	blockNumber := uint64(15)
+
+	isEndOfEpoch, err := isEpochEndingBlock(blockNumber, extra, blockchainMock)
+	require.NoError(t, err)
+	require.False(t, isEndOfEpoch)
+}

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -290,8 +290,6 @@ func initMainDBBuckets(db *bolt.DB) error {
 	return err
 }
 
-const snapshotKeySeparator = "edge-snapshot-key-separator"
-
 // insertValidatorSnapshot inserts a validator snapshot for the given block to its bucket in db
 func (s *State) insertValidatorSnapshot(validatorSnapshot *validatorSnapshot) error {
 	return s.db.Update(func(tx *bolt.Tx) error {

--- a/consensus/polybft/validators_snapshot.go
+++ b/consensus/polybft/validators_snapshot.go
@@ -309,7 +309,7 @@ func (v *validatorsSnapshotCache) isEpochEndingBlock(blockNumber uint64, extra *
 			return true, nil
 		}
 
-		return false, nil
+		return false, err
 	}
 
 	return extra.Checkpoint.EpochNumber != nextBlockExtra.Checkpoint.EpochNumber, nil

--- a/consensus/polybft/validators_snapshot.go
+++ b/consensus/polybft/validators_snapshot.go
@@ -283,6 +283,8 @@ func (v *validatorsSnapshotCache) getLastCachedSnapshot(currentEpoch uint64) (*v
 		// return the one from db
 		if cachedSnapshot == nil || dbSnapshot.Epoch > cachedSnapshot.Epoch {
 			cachedSnapshot = dbSnapshot
+			// save it in cache as well, since it doesn't exist
+			v.snapshots[dbSnapshot.Epoch] = dbSnapshot.copy()
 		}
 	}
 

--- a/consensus/polybft/validators_snapshot_test.go
+++ b/consensus/polybft/validators_snapshot_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestValidatorsSnapshotCache_GetSnapshot_Build(t *testing.T) {
 	t.Parallel()
-	assertions := assert.New(t)
+	assertions := require.New(t)
 
 	const (
 		totalValidators  = 10
@@ -34,18 +34,11 @@ func TestValidatorsSnapshotCache_GetSnapshot_Build(t *testing.T) {
 	}
 
 	headersMap := &testHeadersMap{headersByNumber: make(map[uint64]*types.Header)}
-	createHeaders := func(fromBlock, toBlock uint64, oldValidators, newValidators AccountSet) {
-		headersMap.addHeader(createValidatorDeltaHeader(t, fromBlock, oldValidators, newValidators))
 
-		for i := fromBlock + 1; i <= toBlock; i++ {
-			headersMap.addHeader(createValidatorDeltaHeader(t, i, nil, nil))
-		}
-	}
-
-	createHeaders(0, epochSize-1, nil, allValidators[:validatorSetSize])
-	createHeaders(epochSize, 2*epochSize-1, allValidators[:validatorSetSize], allValidators[validatorSetSize:])
-	createHeaders(2*epochSize, 3*epochSize-1, allValidators[validatorSetSize:], oddValidators)
-	createHeaders(3*epochSize, 4*epochSize-1, oddValidators, evenValidators)
+	createHeaders(t, headersMap, 0, epochSize-1, 1, nil, allValidators[:validatorSetSize])
+	createHeaders(t, headersMap, epochSize, 2*epochSize-1, 2, allValidators[:validatorSetSize], allValidators[validatorSetSize:])
+	createHeaders(t, headersMap, 2*epochSize, 3*epochSize-1, 3, allValidators[validatorSetSize:], oddValidators)
+	createHeaders(t, headersMap, 3*epochSize, 4*epochSize-1, 4, oddValidators, evenValidators)
 
 	var cases = []struct {
 		blockNumber       uint64
@@ -106,34 +99,40 @@ func TestValidatorsSnapshotCache_GetSnapshot_FetchFromCache(t *testing.T) {
 	)
 
 	allValidators := newTestValidators(totalValidators).getPublicIdentities()
-	blockOneValidators := AccountSet{allValidators[0], allValidators[len(allValidators)-1]}
-	blockTwoValidators := allValidators[1 : len(allValidators)-2]
+	epochOneValidators := AccountSet{allValidators[0], allValidators[len(allValidators)-1]}
+	epochTwoValidators := allValidators[1 : len(allValidators)-2]
+
+	headersMap := &testHeadersMap{headersByNumber: make(map[uint64]*types.Header)}
+	createHeaders(t, headersMap, 0, 9, 1, nil, allValidators)
+	createHeaders(t, headersMap, 10, 19, 2, allValidators, epochOneValidators)
+	createHeaders(t, headersMap, 20, 29, 3, epochOneValidators, epochTwoValidators)
 
 	blockchainMock := new(blockchainMock)
+	blockchainMock.On("GetHeaderByNumber", mock.Anything).Return(headersMap.getHeader)
 
 	testValidatorsCache := &testValidatorsCache{
 		validatorsSnapshotCache: newValidatorsSnapshotCache(hclog.NewNullLogger(), newTestState(t), blockchainMock),
 	}
-	require.NoError(testValidatorsCache.storeSnapshot(10, blockOneValidators))
-	require.NoError(testValidatorsCache.storeSnapshot(20, blockTwoValidators))
+
+	require.NoError(testValidatorsCache.storeSnapshot(&validatorSnapshot{1, 10, epochOneValidators}))
+	require.NoError(testValidatorsCache.storeSnapshot(&validatorSnapshot{2, 20, epochTwoValidators}))
 
 	// Fetch snapshot from in memory cache
 	snapshot, err := testValidatorsCache.GetSnapshot(10, nil)
 	require.NoError(err)
-	require.Equal(blockOneValidators, snapshot)
+	require.Equal(epochOneValidators, snapshot)
 
 	// Invalidate in memory cache
-	testValidatorsCache.snapshots = make(map[uint64]AccountSet)
+	testValidatorsCache.snapshots = map[uint64]*validatorSnapshot{}
+	require.NoError(testValidatorsCache.state.removeAllValidatorSnapshots())
 	// Fetch snapshot from database
 	snapshot, err = testValidatorsCache.GetSnapshot(10, nil)
 	require.NoError(err)
-	require.Equal(blockOneValidators, snapshot)
+	require.Equal(epochOneValidators, snapshot)
 
 	snapshot, err = testValidatorsCache.GetSnapshot(20, nil)
 	require.NoError(err)
-	require.Equal(blockTwoValidators, snapshot)
-
-	blockchainMock.AssertNotCalled(t, "GetHeaderByNumber")
+	require.Equal(epochTwoValidators, snapshot)
 }
 
 func TestValidatorsSnapshotCache_Cleanup(t *testing.T) {
@@ -142,13 +141,14 @@ func TestValidatorsSnapshotCache_Cleanup(t *testing.T) {
 
 	blockchainMock := new(blockchainMock)
 	cache := &testValidatorsCache{
-		validatorsSnapshotCache: newValidatorsSnapshotCache(hclog.NewNullLogger(), newTestState(t), blockchainMock)}
+		validatorsSnapshotCache: newValidatorsSnapshotCache(hclog.NewNullLogger(), newTestState(t), blockchainMock),
+	}
 	snapshot := newTestValidators(3).getPublicIdentities()
-	maxBlock := uint64(0)
+	maxEpoch := uint64(0)
 
-	for i := 0; i < validatorSnapshotLimit; i++ {
-		require.NoError(cache.storeSnapshot(uint64(i), snapshot))
-		maxBlock++
+	for i := uint64(0); i < validatorSnapshotLimit; i++ {
+		require.NoError(cache.storeSnapshot(&validatorSnapshot{i, i * 10, snapshot}))
+		maxEpoch++
 	}
 
 	require.NoError(cache.cleanup())
@@ -156,25 +156,25 @@ func TestValidatorsSnapshotCache_Cleanup(t *testing.T) {
 	// assertions for remaining snapshots in the in memory cache
 	require.Len(cache.snapshots, numberOfSnapshotsToLeaveInMemory)
 
-	currentBlock := maxBlock
+	currentEpoch := maxEpoch
 
 	for i := 0; i < numberOfSnapshotsToLeaveInMemory; i++ {
-		currentBlock--
-		currentSnapshot, snapExists := cache.snapshots[currentBlock]
-		require.True(snapExists, fmt.Sprintf("failed to fetch in memory snapshot for block %d", currentBlock))
-		require.Equal(snapshot, currentSnapshot, fmt.Sprintf("snapshots for block %d are not equal", currentBlock))
+		currentEpoch--
+		currentSnapshot, snapExists := cache.snapshots[currentEpoch]
+		require.True(snapExists, fmt.Sprintf("failed to fetch in memory snapshot for epoch %d", currentEpoch))
+		require.Equal(snapshot, currentSnapshot.Snapshot, fmt.Sprintf("snapshots for epoch %d are not equal", currentEpoch))
 	}
 
 	// assertions for remaining snapshots in database
 	require.Equal(cache.state.validatorSnapshotsDBStats().KeyN, numberOfSnapshotsToLeaveInDB)
 
-	currentBlock = maxBlock
+	currentEpoch = maxEpoch
 
 	for i := 0; i < numberOfSnapshotsToLeaveInDB; i++ {
-		currentBlock--
-		currentSnapshot, err := cache.state.getValidatorSnapshot(currentBlock)
-		require.NoError(err, fmt.Sprintf("failed to fetch database snapshot for block %d", currentBlock))
-		require.Equal(snapshot, currentSnapshot, fmt.Sprintf("snapshots for block %d are not equal", currentBlock))
+		currentEpoch--
+		currentSnapshot, err := cache.state.getValidatorSnapshot(currentEpoch)
+		require.NoError(err, fmt.Sprintf("failed to fetch database snapshot for epoch %d", currentEpoch))
+		require.Equal(snapshot, currentSnapshot.Snapshot, fmt.Sprintf("snapshots for epoch %d are not equal", currentEpoch))
 	}
 }
 
@@ -190,8 +190,8 @@ func TestValidatorsSnapshotCache_ComputeSnapshot_UnknownBlock(t *testing.T) {
 
 	allValidators := newTestValidators(totalValidators).getPublicIdentities()
 	headersMap := &testHeadersMap{}
-	headersMap.addHeader(createValidatorDeltaHeader(t, 0, nil, allValidators[:validatorSetSize]))
-	headersMap.addHeader(createValidatorDeltaHeader(t, 1*epochSize, allValidators[:validatorSetSize], allValidators[validatorSetSize:]))
+	headersMap.addHeader(createValidatorDeltaHeader(t, 0, 0, nil, allValidators[:validatorSetSize]))
+	headersMap.addHeader(createValidatorDeltaHeader(t, 1*epochSize, 1, allValidators[:validatorSetSize], allValidators[validatorSetSize:]))
 
 	blockchainMock := new(blockchainMock)
 	blockchainMock.On("GetHeaderByNumber", mock.Anything).Return(headersMap.getHeader)
@@ -217,7 +217,7 @@ func TestValidatorsSnapshotCache_ComputeSnapshot_IncorrectExtra(t *testing.T) {
 
 	allValidators := newTestValidators(totalValidators).getPublicIdentities()
 	headersMap := &testHeadersMap{}
-	invalidHeader := createValidatorDeltaHeader(t, 1*epochSize, allValidators[:validatorSetSize], allValidators[validatorSetSize:])
+	invalidHeader := createValidatorDeltaHeader(t, 1*epochSize, 1, allValidators[:validatorSetSize], allValidators[validatorSetSize:])
 	invalidHeader.ExtraData = []byte{0x2, 0x7}
 	headersMap.addHeader(invalidHeader)
 
@@ -245,8 +245,8 @@ func TestValidatorsSnapshotCache_ComputeSnapshot_ApplyDeltaFail(t *testing.T) {
 
 	allValidators := newTestValidators(totalValidators).getPublicIdentities()
 	headersMap := &testHeadersMap{}
-	headersMap.addHeader(createValidatorDeltaHeader(t, 0, nil, allValidators[:validatorSetSize]))
-	headersMap.addHeader(createValidatorDeltaHeader(t, 1*epochSize, nil, allValidators[:validatorSetSize]))
+	headersMap.addHeader(createValidatorDeltaHeader(t, 0, 0, nil, allValidators[:validatorSetSize]))
+	headersMap.addHeader(createValidatorDeltaHeader(t, 1*epochSize, 1, nil, allValidators[:validatorSetSize]))
 
 	blockchainMock := new(blockchainMock)
 	blockchainMock.On("GetHeaderByNumber", mock.Anything).Return(headersMap.getHeader)
@@ -255,19 +255,30 @@ func TestValidatorsSnapshotCache_ComputeSnapshot_ApplyDeltaFail(t *testing.T) {
 		validatorsSnapshotCache: newValidatorsSnapshotCache(hclog.NewNullLogger(), newTestState(t), blockchainMock),
 	}
 
-	snapshot, err := testValidatorsCache.computeSnapshot(allValidators, 1*epochSize, nil)
+	snapshot, err := testValidatorsCache.computeSnapshot(&validatorSnapshot{0, 0, allValidators}, 1*epochSize, nil)
 	assertions.Nil(snapshot)
 	assertions.ErrorContains(err, "failed to apply delta to the validators snapshot, block#10")
 }
 
-func createValidatorDeltaHeader(t *testing.T, number uint64, oldValidatorSet, newValidatorSet AccountSet) *types.Header {
+func createHeaders(t *testing.T, headersMap *testHeadersMap,
+	fromBlock, toBlock, epoch uint64, oldValidators, newValidators AccountSet) {
+	t.Helper()
+
+	headersMap.addHeader(createValidatorDeltaHeader(t, fromBlock, epoch-1, oldValidators, newValidators))
+
+	for i := fromBlock + 1; i <= toBlock; i++ {
+		headersMap.addHeader(createValidatorDeltaHeader(t, i, epoch, nil, nil))
+	}
+}
+
+func createValidatorDeltaHeader(t *testing.T, blockNumber, epoch uint64, oldValidatorSet, newValidatorSet AccountSet) *types.Header {
 	t.Helper()
 
 	delta, _ := createValidatorSetDelta(oldValidatorSet, newValidatorSet)
-	extra := &Extra{Validators: delta}
+	extra := &Extra{Validators: delta, Checkpoint: &CheckpointData{EpochNumber: epoch}}
 
 	return &types.Header{
-		Number:    number,
+		Number:    blockNumber,
 		ExtraData: append(make([]byte, ExtraVanity), extra.MarshalRLPTo(nil)...),
 	}
 }
@@ -277,7 +288,7 @@ type testValidatorsCache struct {
 }
 
 func (c *testValidatorsCache) cleanValidatorsCache() error {
-	c.snapshots = make(map[uint64]AccountSet)
+	c.snapshots = make(map[uint64]*validatorSnapshot)
 
 	return c.state.removeAllValidatorSnapshots()
 }


### PR DESCRIPTION
# Description

Changed the validator snapshot storage back to storing it by epoch number, but added necessary changes to accommodate dynamic epoch size, mainly how we figure out which was the epoch ending block.

Added a helper function (`isEpochEndingBlock`) that checks if any arbitrary block is an epoch ending block, so that it can be used by different features (such as storing a validator snapshot, or  It is located in `runtime_helpers.go`. It checks two things to know if a block is an epoch ending block:
1. If the `validatorSetDelta` is not empty in the header `extra`, it means that epoch change happened on that block.
2. If there is a newer block than the block for which we are checking the epoch ending exists in blockchain, it checks if it has a different epoch number (in header `extra`). If it has, that block we are checking is the epoch ending block.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually