### PR TITLE
Fix eth_sendRawTransaction from uninitialized address

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -331,6 +331,10 @@ func (t *txpoolHub) GetBalance(root types.Hash, addr types.Address) (*big.Int, e
 	account, err := getAccountImpl(t.state, root, addr)
 
 	if err != nil {
+		if err == jsonrpc.ErrStateNotFound {
+			return big.NewInt(0), nil
+		}
+
 		return big.NewInt(0), err
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -331,7 +331,7 @@ func (t *txpoolHub) GetBalance(root types.Hash, addr types.Address) (*big.Int, e
 	account, err := getAccountImpl(t.state, root, addr)
 
 	if err != nil {
-		if err == jsonrpc.ErrStateNotFound {
+		if errors.Is(err, jsonrpc.ErrStateNotFound) {
 			return big.NewInt(0), nil
 		}
 


### PR DESCRIPTION
# Description

Fixed the way account state fetch error is handled in txPoolHub

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

pandoras-box