### PR TITLE
Detect empty proposal on IsValidProposalHash and BuildPrePrepareMessage

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -1031,6 +1031,12 @@ func (c *consensusRuntime) IsProposer(id []byte, height, round uint64) bool {
 }
 
 func (c *consensusRuntime) IsValidProposalHash(proposal, hash []byte) bool {
+	if len(proposal) == 0 {
+		c.logger.Error("proposal hash is not valid because proposal is empty")
+
+		return false
+	}
+
 	block := types.Block{}
 	if err := block.UnmarshalRLP(proposal); err != nil {
 		c.logger.Error("unable to unmarshal proposal", "error", err)
@@ -1166,6 +1172,12 @@ func (c *consensusRuntime) BuildPrePrepareMessage(
 	certificate *proto.RoundChangeCertificate,
 	view *proto.View,
 ) *proto.Message {
+	if len(proposal) == 0 {
+		c.logger.Error("can not build pre-prepare message, since proposal is empty")
+
+		return nil
+	}
+
 	block := types.Block{}
 	if err := block.UnmarshalRLP(proposal); err != nil {
 		c.logger.Error(fmt.Sprintf("cannot unmarshal RLP: %s", err))

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -2113,6 +2113,22 @@ func TestConsensusRuntime_BuildCommitMessage(t *testing.T) {
 	assert.Equal(t, signedMsg, runtime.BuildCommitMessage(proposalHash, view))
 }
 
+func TestConsensusRuntime_BuildPrePrepareMessage_EmptyProposal(t *testing.T) {
+	t.Parallel()
+
+	runtime := &consensusRuntime{logger: hclog.NewNullLogger()}
+
+	assert.Nil(t, runtime.BuildPrePrepareMessage(nil, &proto.RoundChangeCertificate{}, &proto.View{Height: 1, Round: 0}))
+}
+
+func TestConsensusRuntime_IsValidProposalHash_EmptyProposal(t *testing.T) {
+	t.Parallel()
+
+	runtime := &consensusRuntime{logger: hclog.NewNullLogger()}
+
+	assert.False(t, runtime.IsValidProposalHash(nil, []byte("hash")))
+}
+
 func TestConsensusRuntime_BuildPrepareMessage(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# Description

Since `Backend` interface in `go-ibft` for `BuildProposal`, `IsValidProposalHash` and `BuildPrePrepareMessage` functions does not have an error as one of the return values, if a proposal is `nil` (an error occurred in `BuildProposal`), when unmarshalling the empty proposal on `IsValidProposalHash` and `BuildPrePrepareMessage`, a misleading error occurs, saying that it can not parse an empty string. This is misleading when debugging, so a check is added to see if the proposal is empty in the `backend` (in `IsValidProposalHash` and `BuildPrePrepareMessage` functions), and if it is, it will log a more appropriate message.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually
