### PR TITLE
Bundle build fix

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -586,9 +586,7 @@ func (c *consensusRuntime) buildBundles(commitment *Commitment, commitmentMsg *C
 
 	var bundleProofs []*BundleProof
 
-	startBundleIdx := commitmentMsg.GetBundleIdxFromStateSyncEventIdx(stateSyncExecutionIndex)
-
-	for idx := startBundleIdx; idx < commitmentMsg.BundlesCount(); idx++ {
+	for idx := uint64(0); idx < commitmentMsg.BundlesCount(); idx++ {
 		p := commitment.MerkleTree.GenerateProof(idx, 0)
 		events, err := c.getStateSyncEventsForBundle(commitmentMsg.GetFirstStateSyncIndexFromBundleIndex(idx),
 			commitmentMsg.BundleSize)


### PR DESCRIPTION
# Description

Since our bundle size is now 1, `buildBundles` function had an issue with building bundles for submitted commitments, where the start bundle index was not calculated correctly.

Bundles for a newly submitted commitment should always start from 0.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually
