### PR TITLE
Use geth console fork as default with flag to disable

### DIFF
--- a/command/rootchain/server/params.go
+++ b/command/rootchain/server/params.go
@@ -2,8 +2,10 @@ package server
 
 const (
 	dataDirFlag = "data-dir"
+	noConsole   = "no-console"
 )
 
 type serverParams struct {
-	dataDir string
+	dataDir   string
+	noConsole bool
 }


### PR DESCRIPTION
# Description

This PR defaults the `rootchain server` to the `console` fork ([here](https://github.com/0xPolygon/go-ethereum/tree/feature/add-console-precompile)) and adds a flag to use the normal Geth client.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
