### PR TITLE
RLP Marshal/Unmarshal update field in `ValidatorSetDelta`

### DIFF
--- a/consensus/polybft/extra.go
+++ b/consensus/polybft/extra.go
@@ -242,17 +242,9 @@ func (d *ValidatorSetDelta) UnmarshalRLPWith(v *fastrlp.Value) error {
 			return fmt.Errorf("array expected for added validators")
 		}
 
-		if len(validatorsRaw) != 0 {
-			d.Added = make(AccountSet, len(validatorsRaw))
-
-			for i, validatorRaw := range validatorsRaw {
-				acc := &ValidatorMetadata{}
-				if err = acc.UnmarshalRLPWith(validatorRaw); err != nil {
-					return err
-				}
-
-				d.Added[i] = acc
-			}
+		d.Added, err = unmarshalValidators(validatorsRaw)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -263,17 +255,9 @@ func (d *ValidatorSetDelta) UnmarshalRLPWith(v *fastrlp.Value) error {
 			return fmt.Errorf("array expected for updated validators")
 		}
 
-		if len(validatorsRaw) != 0 {
-			d.Updated = make(AccountSet, len(validatorsRaw))
-
-			for i, validatorRaw := range validatorsRaw {
-				acc := &ValidatorMetadata{}
-				if err = acc.UnmarshalRLPWith(validatorRaw); err != nil {
-					return err
-				}
-
-				d.Updated[i] = acc
-			}
+		d.Updated, err = unmarshalValidators(validatorsRaw)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -288,6 +272,26 @@ func (d *ValidatorSetDelta) UnmarshalRLPWith(v *fastrlp.Value) error {
 	}
 
 	return nil
+}
+
+// unmarshalValidators unmarshals RLP encoded validators and returns AccountSet instance
+func unmarshalValidators(validatorsRaw []*fastrlp.Value) (AccountSet, error) {
+	if len(validatorsRaw) == 0 {
+		return nil, nil
+	}
+
+	validators := make(AccountSet, len(validatorsRaw))
+
+	for i, validatorRaw := range validatorsRaw {
+		acc := &ValidatorMetadata{}
+		if err := acc.UnmarshalRLPWith(validatorRaw); err != nil {
+			return nil, err
+		}
+
+		validators[i] = acc
+	}
+
+	return validators, nil
 }
 
 // IsEmpty returns indication whether delta is empty (namely added, updated slices and removed bitmap are empty)

--- a/consensus/polybft/extra_test.go
+++ b/consensus/polybft/extra_test.go
@@ -603,6 +603,32 @@ func TestValidatorSetDelta_UnmarshalRLPWith_NegativeCases(t *testing.T) {
 		delta := &ValidatorSetDelta{}
 		require.ErrorContains(t, delta.UnmarshalRLPWith(deltaMarshalled), "value is not of type bytes")
 	})
+
+	t.Run("Incorrect RLP value type for Updated field", func(t *testing.T) {
+		t.Parallel()
+
+		ar := &fastrlp.Arena{}
+		deltaMarshalled := ar.NewArray()
+		deltaMarshalled.Set(ar.NewArray())
+		deltaMarshalled.Set(ar.NewBytes([]byte{0x33}))
+		deltaMarshalled.Set(ar.NewNull())
+		delta := &ValidatorSetDelta{}
+		require.ErrorContains(t, delta.UnmarshalRLPWith(deltaMarshalled), "array expected for updated validators")
+	})
+
+	t.Run("Incorrect RLP value type for ValidatorMetadata in Updated field", func(t *testing.T) {
+		t.Parallel()
+
+		ar := &fastrlp.Arena{}
+		deltaMarshalled := ar.NewArray()
+		updatedArray := ar.NewArray()
+		updatedArray.Set(ar.NewNull())
+		deltaMarshalled.Set(ar.NewArray())
+		deltaMarshalled.Set(updatedArray)
+		deltaMarshalled.Set(ar.NewNull())
+		delta := &ValidatorSetDelta{}
+		require.ErrorContains(t, delta.UnmarshalRLPWith(deltaMarshalled), "value is not of type array")
+	})
 }
 
 func Test_GetIbftExtraClean_Fail(t *testing.T) {


### PR DESCRIPTION
# Description

This PR adds header extra data marshal and unmarshal logic for `ValidatorSetDelta.Updated` field.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Header extra data contains additional field from validator set delta, which contains updated validators.

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually