### PR TITLE
Epikichi/edge 992 disable cgo in the goreleaser manifest

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,8 +14,7 @@ builds:
     goarch:
       - amd64
     env:
-      - CC=o64-clang
-      - CXX=o64-clang++
+      - CGO_ENABLED=0
     ldflags:
       -s -w -X 'github.com/0xPolygon/polygon-edge/versioning.Version=v{{ .Version }}'
 
@@ -27,8 +26,7 @@ builds:
     goarch:
       - arm64
     env:
-      - CC=oa64-clang
-      - CXX=oa64-clang++
+      - CGO_ENABLED=0
     ldflags:
       -s -w -X 'github.com/0xPolygon/polygon-edge/versioning.Version=v{{ .Version }}'
 
@@ -40,11 +38,10 @@ builds:
     goarch:
       - amd64
     env:
-      - CC=gcc
-      - CXX=g++
+      - CGO_ENABLED=0
     ldflags:
       # We need to build a static binary because we are building in a glibc based system and running in a musl container
-      -s -w -linkmode external -extldflags "-static" -X 'github.com/0xPolygon/polygon-edge/versioning.Version=v{{ .Version }}'
+      -s -w -X 'github.com/0xPolygon/polygon-edge/versioning.Version=v{{ .Version }}'
     tags:
       - netgo
 
@@ -56,11 +53,10 @@ builds:
     goarch:
       - arm64
     env:
-      - CC=aarch64-linux-gnu-gcc
-      - CXX=aarch64-linux-gnu-g++
+      - CGO_ENABLED=0
     ldflags:
       # We need to build a static binary because we are building in a glibc based system and running in a musl container
-      -s -w -linkmode external -extldflags "-static" -X 'github.com/0xPolygon/polygon-edge/versioning.Version=v{{ .Version }}'
+      -s -w -X 'github.com/0xPolygon/polygon-edge/versioning.Version=v{{ .Version }}'
     tags:
       - netgo
 

--- a/blockchain/storage/keyvalue.go
+++ b/blockchain/storage/keyvalue.go
@@ -221,23 +221,6 @@ func (s *KeyValueStorage) ReadBody(hash types.Hash) (*types.Body, error) {
 	return body, err
 }
 
-// SNAPSHOTS //
-
-// WriteSnapshot writes the snapshot to the DB
-func (s *KeyValueStorage) WriteSnapshot(hash types.Hash, blob []byte) error {
-	return s.set(SNAPSHOTS, hash.Bytes(), blob)
-}
-
-// ReadSnapshot reads the snapshot from the DB
-func (s *KeyValueStorage) ReadSnapshot(hash types.Hash) ([]byte, bool) {
-	data, ok := s.get(SNAPSHOTS, hash.Bytes())
-	if !ok {
-		return []byte{}, false
-	}
-
-	return data, true
-}
-
 // RECEIPTS //
 
 // WriteReceipts writes the receipts

--- a/blockchain/storage/storage.go
+++ b/blockchain/storage/storage.go
@@ -31,9 +31,6 @@ type Storage interface {
 	WriteBody(hash types.Hash, body *types.Body) error
 	ReadBody(hash types.Hash) (*types.Body, error)
 
-	WriteSnapshot(hash types.Hash, blob []byte) error
-	ReadSnapshot(hash types.Hash) ([]byte, bool)
-
 	WriteReceipts(hash types.Hash, receipts []*types.Receipt) error
 	ReadReceipts(hash types.Hash) ([]*types.Receipt, error)
 

--- a/blockchain/storage/testing.go
+++ b/blockchain/storage/testing.go
@@ -487,8 +487,6 @@ type MockStorage struct {
 	writeCanonicalHeaderFn writeCanonicalHeaderDelegate
 	writeBodyFn            writeBodyDelegate
 	readBodyFn             readBodyDelegate
-	writeSnapshotFn        writeSnapshotDelegate
-	readSnapshotFn         readSnapshotDelegate
 	writeReceiptsFn        writeReceiptsDelegate
 	readReceiptsFn         readReceiptsDelegate
 	writeTxLookupFn        writeTxLookupDelegate
@@ -678,30 +676,6 @@ func (m *MockStorage) ReadBody(hash types.Hash) (*types.Body, error) {
 
 func (m *MockStorage) HookReadBody(fn readBodyDelegate) {
 	m.readBodyFn = fn
-}
-
-func (m *MockStorage) WriteSnapshot(hash types.Hash, blob []byte) error {
-	if m.writeSnapshotFn != nil {
-		return m.writeSnapshotFn(hash, blob)
-	}
-
-	return nil
-}
-
-func (m *MockStorage) HookWriteSnapshot(fn writeSnapshotDelegate) {
-	m.writeSnapshotFn = fn
-}
-
-func (m *MockStorage) ReadSnapshot(hash types.Hash) ([]byte, bool) {
-	if m.readSnapshotFn != nil {
-		return m.readSnapshotFn(hash)
-	}
-
-	return []byte{}, true
-}
-
-func (m *MockStorage) HookReadSnapshot(fn readSnapshotDelegate) {
-	m.readSnapshotFn = fn
 }
 
 func (m *MockStorage) WriteReceipts(hash types.Hash, receipts []*types.Receipt) error {


### PR DESCRIPTION
# Description

Disabling CGO to use native go bindings. Also fastforwarding the branch to include https://github.com/0xPolygon/polygon-edge/commit/384ffa238da7bf45d9c4af88b274c081da6ecfb2 to reflect `v0.6.1` tag. 