### PR TITLE
Add osusergo build tag to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,6 +47,7 @@ builds:
       -s -w -linkmode external -extldflags "-static" -X 'github.com/0xPolygon/polygon-edge/versioning.Version=v{{ .Version }}'
     tags:
       - netgo
+      - osusergo
 
   - id: linux-arm64
     main: ./main.go
@@ -63,6 +64,7 @@ builds:
       -s -w -linkmode external -extldflags "-static" -X 'github.com/0xPolygon/polygon-edge/versioning.Version=v{{ .Version }}'
     tags:
       - netgo
+      - osusergo
 
 archives:
   -

--- a/blockchain/storage/keyvalue.go
+++ b/blockchain/storage/keyvalue.go
@@ -221,23 +221,6 @@ func (s *KeyValueStorage) ReadBody(hash types.Hash) (*types.Body, error) {
 	return body, err
 }
 
-// SNAPSHOTS //
-
-// WriteSnapshot writes the snapshot to the DB
-func (s *KeyValueStorage) WriteSnapshot(hash types.Hash, blob []byte) error {
-	return s.set(SNAPSHOTS, hash.Bytes(), blob)
-}
-
-// ReadSnapshot reads the snapshot from the DB
-func (s *KeyValueStorage) ReadSnapshot(hash types.Hash) ([]byte, bool) {
-	data, ok := s.get(SNAPSHOTS, hash.Bytes())
-	if !ok {
-		return []byte{}, false
-	}
-
-	return data, true
-}
-
 // RECEIPTS //
 
 // WriteReceipts writes the receipts

--- a/blockchain/storage/storage.go
+++ b/blockchain/storage/storage.go
@@ -31,9 +31,6 @@ type Storage interface {
 	WriteBody(hash types.Hash, body *types.Body) error
 	ReadBody(hash types.Hash) (*types.Body, error)
 
-	WriteSnapshot(hash types.Hash, blob []byte) error
-	ReadSnapshot(hash types.Hash) ([]byte, bool)
-
 	WriteReceipts(hash types.Hash, receipts []*types.Receipt) error
 	ReadReceipts(hash types.Hash) ([]*types.Receipt, error)
 

--- a/blockchain/storage/testing.go
+++ b/blockchain/storage/testing.go
@@ -487,8 +487,6 @@ type MockStorage struct {
 	writeCanonicalHeaderFn writeCanonicalHeaderDelegate
 	writeBodyFn            writeBodyDelegate
 	readBodyFn             readBodyDelegate
-	writeSnapshotFn        writeSnapshotDelegate
-	readSnapshotFn         readSnapshotDelegate
 	writeReceiptsFn        writeReceiptsDelegate
 	readReceiptsFn         readReceiptsDelegate
 	writeTxLookupFn        writeTxLookupDelegate
@@ -678,30 +676,6 @@ func (m *MockStorage) ReadBody(hash types.Hash) (*types.Body, error) {
 
 func (m *MockStorage) HookReadBody(fn readBodyDelegate) {
 	m.readBodyFn = fn
-}
-
-func (m *MockStorage) WriteSnapshot(hash types.Hash, blob []byte) error {
-	if m.writeSnapshotFn != nil {
-		return m.writeSnapshotFn(hash, blob)
-	}
-
-	return nil
-}
-
-func (m *MockStorage) HookWriteSnapshot(fn writeSnapshotDelegate) {
-	m.writeSnapshotFn = fn
-}
-
-func (m *MockStorage) ReadSnapshot(hash types.Hash) ([]byte, bool) {
-	if m.readSnapshotFn != nil {
-		return m.readSnapshotFn(hash)
-	}
-
-	return []byte{}, true
-}
-
-func (m *MockStorage) HookReadSnapshot(fn readSnapshotDelegate) {
-	m.readSnapshotFn = fn
 }
 
 func (m *MockStorage) WriteReceipts(hash types.Hash, receipts []*types.Receipt) error {


### PR DESCRIPTION
# Description

Updating GoReleaser manifest to build with `osusergo` tag  to address https://github.com/0xPolygon/polygon-edge/issues/1008.

Also porting in https://github.com/0xPolygon/polygon-edge/pull/1032/commits/384ffa238da7bf45d9c4af88b274c081da6ecfb2 to align with `v0.6.1` tag.