### PR TITLE
Adding osuergo build tag to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,6 +47,7 @@ builds:
       -s -w -linkmode external -extldflags "-static" -X 'github.com/0xPolygon/polygon-edge/versioning.Version=v{{ .Version }}'
     tags:
       - netgo
+      - osusergo
 
   - id: linux-arm64
     main: ./main.go
@@ -63,6 +64,7 @@ builds:
       -s -w -linkmode external -extldflags "-static" -X 'github.com/0xPolygon/polygon-edge/versioning.Version=v{{ .Version }}'
     tags:
       - netgo
+      - osusergo
 
 archives:
   -


### PR DESCRIPTION
# Description

Updating GoReleaser manifest to build with `osusergo` tag  to address https://github.com/0xPolygon/polygon-edge/issues/1008.