### PR TITLE
Remove unused checkpoint fields from `epochMetadata`

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -64,15 +64,6 @@ type epochMetadata struct {
 	// Number is the number of the epoch
 	Number uint64
 
-	// LastCheckpoint is the last epoch that was checkpointed, for now it is epoch-1.
-	LastCheckpoint uint64
-
-	// CheckpointProposer is the validator that has to send the checkpoint, assume it is static for now.
-	CheckpointProposer string
-
-	// Blocks is the list of blocks that we have to checkpoint in rootchain
-	Blocks []*types.Block
-
 	// Validators is the set of validators for the epoch
 	Validators AccountSet
 
@@ -457,10 +448,8 @@ func (c *consensusRuntime) restartEpoch(header *types.Header) error {
 	}
 
 	epoch := &epochMetadata{
-		Number:         epochNumber,
-		LastCheckpoint: 0,
-		Blocks:         []*types.Block{},
-		Validators:     validatorSet,
+		Number:     epochNumber,
+		Validators: validatorSet,
 	}
 
 	if err := c.state.cleanEpochsFromDB(); err != nil {


### PR DESCRIPTION
# Description

There are a couple of unused fields in the `epochMetadata`, which were originally meant to be used by checkpointing mechanism. However they turned out to be redundant, therefore can be safely removed.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
