### PR TITLE
IBFT extra unmarshalRLP error

### DIFF
--- a/consensus/ibft/consensus_backend.go
+++ b/consensus/ibft/consensus_backend.go
@@ -77,10 +77,20 @@ func (i *backendIBFT) InsertBlock(
 	// This is a safety net to help us narrow down and also recover before
 	// writing the block
 	if err := i.ValidateExtraDataFormat(newBlock.Header); err != nil {
+
+		//Format committed seals to make them more readable
+		committedSealsStr := make([]string, len(committedSealsMap))
+		for i, seal := range committedSeals {
+			committedSealsStr[i] = fmt.Sprintf("{signer=%v signature=%v}",
+				hex.EncodeToHex(seal.Signer),
+				hex.EncodeToHex(seal.Signature))
+		}
+
 		i.logger.Error("cannot write block: corrupted extra data",
 			"err", err,
-			"\n\tbefore", hex.EncodeToHex(extraDataBackup),
-			"\n\tafter", hex.EncodeToHex(header.ExtraData))
+			"before", hex.EncodeToHex(extraDataBackup),
+			"after", hex.EncodeToHex(header.ExtraData),
+			"committedSeals", committedSealsStr)
 
 		return
 	}

--- a/consensus/ibft/consensus_backend.go
+++ b/consensus/ibft/consensus_backend.go
@@ -77,7 +77,6 @@ func (i *backendIBFT) InsertBlock(
 	// This is a safety net to help us narrow down and also recover before
 	// writing the block
 	if err := i.ValidateExtraDataFormat(newBlock.Header); err != nil {
-
 		//Format committed seals to make them more readable
 		committedSealsStr := make([]string, len(committedSealsMap))
 		for i, seal := range committedSeals {

--- a/consensus/ibft/consensus_backend.go
+++ b/consensus/ibft/consensus_backend.go
@@ -9,6 +9,7 @@ import (
 	"github.com/0xPolygon/go-ibft/messages"
 	"github.com/0xPolygon/polygon-edge/consensus"
 	"github.com/0xPolygon/polygon-edge/consensus/ibft/signer"
+	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/state"
 	"github.com/0xPolygon/polygon-edge/types"
 )
@@ -56,10 +57,30 @@ func (i *backendIBFT) InsertBlock(
 		committedSealsMap[types.BytesToAddress(cm.Signer)] = cm.Signature
 	}
 
+	// Copy extra data for debugging purposes
+	extraDataOriginal := newBlock.Header.ExtraData
+	extraDataBackup := make([]byte, len(extraDataOriginal))
+	copy(extraDataBackup, extraDataOriginal)
+
 	// Push the committed seals to the header
 	header, err := i.currentSigner.WriteCommittedSeals(newBlock.Header, committedSealsMap)
 	if err != nil {
 		i.logger.Error("cannot write committed seals", "err", err)
+
+		return
+	}
+
+	// WriteCommittedSeals alters the extra data before writing the block
+	// It doesn't handle errors while pushing changes which can result in
+	// corrupted extra data.
+	// We don't know exact circumstance of the unmarshalRLP error
+	// This is a safety net to help us narrow down and also recover before
+	// writing the block
+	if err := i.ValidateExtraDataFormat(newBlock.Header); err != nil {
+		i.logger.Error("cannot write block: corrupted extra data",
+			"err", err,
+			"\n\tbefore", hex.EncodeToHex(extraDataBackup),
+			"\n\tafter", hex.EncodeToHex(header.ExtraData))
 
 		return
 	}

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -634,6 +634,10 @@ func (i *backendIBFT) ValidateExtraDataFormat(header *types.Header) error {
 		header.Number,
 	)
 
+	if err != nil {
+		return err
+	}
+
 	_, err = blockSigner.GetIBFTExtra(header)
 
 	return err

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -635,5 +635,6 @@ func (i *backendIBFT) ValidateExtraDataFormat(header *types.Header) error {
 	)
 
 	_, err = blockSigner.GetIBFTExtra(header)
+
 	return err
 }

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -626,3 +626,14 @@ func verifyProposerSeal(
 
 	return nil
 }
+
+// ValidateExtraDataFormat Verifies that extra data can be unmarshaled
+func (i *backendIBFT) ValidateExtraDataFormat(header *types.Header) error {
+	blockSigner, _, _, err := getModulesFromForkManager(
+		i.forkManager,
+		header.Number,
+	)
+
+	_, err = blockSigner.GetIBFTExtra(header)
+	return err
+}


### PR DESCRIPTION
# Description

Customers faced an [issue](https://github.com/0xPolygon/polygon-edge/issues/845)
The issue is non existent in versions prior to 0.6.x and is present in all 0.6.x

Upon further inspection notice three things:
- The snapshot is invalid (its missing a new validator that should have been included based on genesis)
- UnmarshalRLP on extra data error when trying to insert a block
- UnmarshalRLP on extra data error when trying to sync snapshot

I haven't been able to pinpoint the exact cause of the issue. This fix can help the code recover **prior** to `i.blockchain.WriteBlock` so it discards it instead of writing and syncs with other valid node.
This doesn't **fix** the code. It **mitigates** the issue. Motivation is not to alter the code if we are not yet sure the exact nature of the corruption.

Assumptions:
- It happens upon insertion of the block
- It happens when packing committed seals
- Write block catches the error after already writing the header
- Updating the snapshot after restart repeats this issue by trying to unmarshal corrupted header

To locate the issue we searched for new code that is introduced when inserting the block. Also it is important to note that while doing the consensus mechanism the code checks for the validity of extra data. So the next natural conclusion would be that something happens after the consensus in the finalisation.

This is a piece of code which alters the extra data and also doesn't handle errors when packing it in.
`header, err := i.currentSigner.WriteCommittedSeals(newBlock.Header, committedSealsMap)`
Unsuccessfully trying to replicate the corruption by forcing return of error, discards the possibility of the fault happening because of the return of the error but rather because of the faulty alteration in the `packFn`

The potentially corrupted extra data is then written into storage, but then tried to be unmarshaled when its too late in `b.consensus.ProcessHeaders([]*types.Header{header})` when updating the snapshot.

To mitigate the issue I introduced a safety net. It tries to unmarshal the extra data after alteration and before write. This way we force the node to drop the block in the early phase of insert and make it fall back to sync but still managing to log out the before and after hex. 

I chose to log these particular values because we know it is still valid before alteration. So it can be unmarshaled. Every piece of data that is needed to pack committed seals is within original extra data so we can replicate the steps locally. The corrupted hex is logged out so we can see if we are dealing with empty array or corrupted rlp.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually
