### PR TITLE
Add appropriate prefixes to the Edge metrics

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -28,6 +28,9 @@ const (
 	KeyEpochSize     = "epochSize"
 
 	ibftProto = "/ibft/0.2"
+
+	// consensusMetrics is a prefix used for consensus-related metrics
+	consensusMetrics = "consensus"
 )
 
 var (
@@ -294,7 +297,7 @@ func (i *backendIBFT) startConsensus() {
 		}
 
 		// Update the No.of validator metric
-		metrics.SetGauge([]string{"validators"}, float32(i.currentValidators.Len()))
+		metrics.SetGauge([]string{consensusMetrics, "validators"}, float32(i.currentValidators.Len()))
 
 		isValidator = i.isActiveValidator()
 
@@ -336,11 +339,11 @@ func (i *backendIBFT) updateMetrics(block *types.Block) {
 
 	// Update the block interval metric
 	if block.Number() > 1 {
-		metrics.SetGauge([]string{"block_interval"}, float32(headerTime.Sub(parentTime).Seconds()))
+		metrics.SetGauge([]string{consensusMetrics, "block_interval"}, float32(headerTime.Sub(parentTime).Seconds()))
 	}
 
 	// Update the Number of transactions in the block metric
-	metrics.SetGauge([]string{"num_txs"}, float32(len(block.Body().Transactions)))
+	metrics.SetGauge([]string{consensusMetrics, "num_txs"}, float32(len(block.Body().Transactions)))
 }
 
 // verifyHeaderImpl verifies fields including Extra

--- a/network/server.go
+++ b/network/server.go
@@ -38,6 +38,9 @@ const (
 	// we should have enough capacity of the queue
 	// because when queue is full, validation is throttled and new messages are dropped.
 	validateBufferSize = 1024
+
+	// networkMetrics is a prefix used for network-related metrics
+	networkMetrics = "network"
 )
 
 const (
@@ -514,7 +517,7 @@ func (s *Server) removePeerInfo(peerID peer.ID) *PeerConnInfo {
 		}
 	}
 
-	metrics.SetGauge([]string{"peers"}, float32(len(s.peers)))
+	metrics.SetGauge([]string{networkMetrics, "peers"}, float32(len(s.peers)))
 
 	return connectionInfo
 }
@@ -769,10 +772,12 @@ func (s *Server) SubscribeCh(ctx context.Context) (<-chan *peerEvent.PeerEvent, 
 func (s *Server) updateConnCountMetrics(direction network.Direction) {
 	switch direction {
 	case network.DirInbound:
-		metrics.SetGauge([]string{"inbound_connections_count"}, float32(s.connectionCounts.GetInboundConnCount()))
+		metrics.SetGauge([]string{networkMetrics, "inbound_connections_count"},
+			float32(s.connectionCounts.GetInboundConnCount()))
 
 	case network.DirOutbound:
-		metrics.SetGauge([]string{"outbound_connections_count"}, float32(s.connectionCounts.GetOutboundConnCount()))
+		metrics.SetGauge([]string{networkMetrics, "outbound_connections_count"},
+			float32(s.connectionCounts.GetOutboundConnCount()))
 	}
 }
 
@@ -780,11 +785,11 @@ func (s *Server) updateConnCountMetrics(direction network.Direction) {
 func (s *Server) updatePendingConnCountMetrics(direction network.Direction) {
 	switch direction {
 	case network.DirInbound:
-		metrics.SetGauge([]string{"pending_inbound_connections_count"},
+		metrics.SetGauge([]string{networkMetrics, "pending_inbound_connections_count"},
 			float32(s.connectionCounts.GetPendingInboundConnCount()))
 
 	case network.DirOutbound:
-		metrics.SetGauge([]string{"pending_outbound_connections_count"},
+		metrics.SetGauge([]string{networkMetrics, "pending_outbound_connections_count"},
 			float32(s.connectionCounts.GetPendingOutboundConnCount()))
 	}
 }

--- a/network/server_identity.go
+++ b/network/server_identity.go
@@ -82,7 +82,7 @@ func (s *Server) addPeerInfo(id peer.ID, direction network.Direction) bool {
 	s.updateBootnodeConnCount(id, 1)
 
 	// Update the metric stats
-	metrics.SetGauge([]string{"peers"}, float32(len(s.peers)))
+	metrics.SetGauge([]string{networkMetrics, "peers"}, float32(len(s.peers)))
 
 	return false
 }

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -33,6 +33,9 @@ const (
 	maxAccountSkips = uint64(10)
 
 	pruningCooldown = 5000 * time.Millisecond
+
+	// txPoolMetrics is a prefix used for txpool-related metrics
+	txPoolMetrics = "txpool"
 )
 
 // errors
@@ -274,7 +277,7 @@ func NewTxPool(
 
 func (p *TxPool) updatePending(i int64) {
 	newPending := atomic.AddInt64(&p.pending, i)
-	metrics.SetGauge([]string{"pending_transactions"}, float32(newPending))
+	metrics.SetGauge([]string{txPoolMetrics, "pending_transactions"}, float32(newPending))
 }
 
 // Start runs the pool's main loop in the background.


### PR DESCRIPTION
# Description

This PR accommodates prefixes to the existing Edge metrics in order to categorize and align them with the documentation: https://wiki.polygon.technology/docs/edge/configuration/prometheus-metrics/.

Existing metrics fall into 3 categories: consensus, network and tx pool.


# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Datadog dashboards need to be changed in order to include renamed metrics.

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually