### PR TITLE
[FIX] Exposed Prometheus API in local docker environment

### DIFF
--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -19,6 +19,6 @@ COPY --from=builder /polygon-edge/polygon-edge ./
 COPY ./docker/local/polygon-edge.sh ./
 
 # Expose json-rpc, libp2p and grpc ports
-EXPOSE 8545 9632 1478
+EXPOSE 8545 9632 1478 5001
 
 ENTRYPOINT ["./polygon-edge.sh"]

--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -22,13 +22,14 @@ services:
     build:
       context: ../../
       dockerfile: docker/local/Dockerfile
-    command: ["server", "--data-dir", "/data", "--chain", "/genesis/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--seal"]
+    command: ["server", "--data-dir", "/data", "--chain", "/genesis/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--prometheus", "0.0.0.0:5001", "--seal"]
     depends_on:
       init:
         condition: service_completed_successfully
     ports:
       - '10000:9632'
       - '10002:8545'
+      - '10003:5001'
     volumes:
       - node-1:/data
       - genesis:/genesis
@@ -40,13 +41,14 @@ services:
     build:
       context: ../../
       dockerfile: docker/local/Dockerfile
-    command: ["server", "--data-dir", "/data", "--chain", "/genesis/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--seal"]
+    command: ["server", "--data-dir", "/data", "--chain", "/genesis/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--prometheus", "0.0.0.0:5001", "--seal"]
     depends_on:
       init:
         condition: service_completed_successfully
     ports:
       - '20000:9632'
       - '20002:8545'
+      - '20003:5001'
     volumes:
       - node-2:/data
       - genesis:/genesis
@@ -58,13 +60,14 @@ services:
     build:
       context: ../../
       dockerfile: docker/local/Dockerfile
-    command: ["server", "--data-dir", "/data", "--chain", "/genesis/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--seal"]
+    command: ["server", "--data-dir", "/data", "--chain", "/genesis/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--prometheus", "0.0.0.0:5001", "--seal"]
     depends_on:
       init:
         condition: service_completed_successfully
     ports:
       - '30000:9632'
       - '30002:8545'
+      - '30003:5001'
     volumes:
       - node-3:/data
       - genesis:/genesis
@@ -76,13 +79,14 @@ services:
     build:
       context: ../../
       dockerfile: docker/local/Dockerfile
-    command: ["server", "--data-dir", "/data", "--chain", "/genesis/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--seal"]
+    command: ["server", "--data-dir", "/data", "--chain", "/genesis/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--prometheus", "0.0.0.0:5001", "--seal"]
     depends_on:
       init:
         condition: service_completed_successfully
     ports:
       - '40000:9632'
       - '40002:8545'
+      - '40003:5001'
     volumes:
       - node-4:/data
       - genesis:/genesis


### PR DESCRIPTION
# Description

This PR exposes Prometheus API when running a local docker environment using `make`

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Run `make run-local` from branch root folder.    
After the chain is running, you should be able to see Prometheus metrics in the web browser via ports `10003`, `20003`, `30003` and `40003` on `localhost` 

