### PR TITLE
Fix loop closure violations in unit tests

### DIFF
--- a/consensus/polybft/extra_test.go
+++ b/consensus/polybft/extra_test.go
@@ -369,46 +369,47 @@ func TestExtra_CreateValidatorSetDelta_Cases(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
+		localCase := c
+		t.Run(localCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			vals := newTestValidatorsWithAliases([]string{})
 
-			for _, name := range c.oldSet {
+			for _, name := range localCase.oldSet {
 				vals.create(name, 1)
 			}
-			for _, name := range c.newSet {
+			for _, name := range localCase.newSet {
 				vals.create(name, 1)
 			}
 
-			oldValidatorSet := vals.getPublicIdentities(c.oldSet...)
+			oldValidatorSet := vals.getPublicIdentities(localCase.oldSet...)
 			// update voting power to random value
 			maxVotingPower := big.NewInt(100)
-			for _, name := range c.updated {
+			for _, name := range localCase.updated {
 				v := vals.getValidator(name)
 				vp, err := rand.Int(rand.Reader, maxVotingPower)
 				require.NoError(t, err)
 				v.votingPower = vp.Uint64()
 			}
-			newValidatorSet := vals.getPublicIdentities(c.newSet...)
+			newValidatorSet := vals.getPublicIdentities(localCase.newSet...)
 
 			delta, err := createValidatorSetDelta(oldValidatorSet, newValidatorSet)
 			require.NoError(t, err)
 
 			// added validators
-			require.Len(t, delta.Added, len(c.added))
-			for i, name := range c.added {
+			require.Len(t, delta.Added, len(localCase.added))
+			for i, name := range localCase.added {
 				require.Equal(t, delta.Added[i].Address, vals.getValidator(name).Address())
 			}
 
 			// removed validators
-			for _, i := range c.removed {
+			for _, i := range localCase.removed {
 				require.True(t, delta.Removed.IsSet(i))
 			}
 
 			// updated validators
-			require.Len(t, delta.Updated, len(c.updated))
-			for i, name := range c.updated {
+			require.Len(t, delta.Updated, len(localCase.updated))
+			for i, name := range localCase.updated {
 				require.Equal(t, delta.Updated[i].Address, vals.getValidator(name).Address())
 			}
 		})

--- a/consensus/polybft/extra_test.go
+++ b/consensus/polybft/extra_test.go
@@ -385,16 +385,12 @@ func TestExtra_CreateValidatorSetDelta_Cases(t *testing.T) {
 			oldValidatorSet := vals.getPublicIdentities(localCase.oldSet...)
 			// update voting power to random value
 			maxVotingPower := big.NewInt(100)
-			var newVotingPower uint64
 			for _, name := range localCase.updated {
 				v := vals.getValidator(name)
+				vp, err := rand.Int(rand.Reader, maxVotingPower)
+				require.NoError(t, err)
 				// make sure generated voting power is different than the original one
-				for v.votingPower == newVotingPower {
-					vp, err := rand.Int(rand.Reader, maxVotingPower)
-					require.NoError(t, err)
-					newVotingPower = vp.Uint64()
-				}
-				v.votingPower = newVotingPower
+				v.votingPower += v.votingPower + vp.Uint64() + 1
 			}
 			newValidatorSet := vals.getPublicIdentities(localCase.newSet...)
 

--- a/consensus/polybft/extra_test.go
+++ b/consensus/polybft/extra_test.go
@@ -369,48 +369,48 @@ func TestExtra_CreateValidatorSetDelta_Cases(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		localCase := c
-		t.Run(localCase.name, func(t *testing.T) {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
 			vals := newTestValidatorsWithAliases([]string{})
 
-			for _, name := range localCase.oldSet {
+			for _, name := range c.oldSet {
 				vals.create(name, 1)
 			}
-			for _, name := range localCase.newSet {
+			for _, name := range c.newSet {
 				vals.create(name, 1)
 			}
 
-			oldValidatorSet := vals.getPublicIdentities(localCase.oldSet...)
+			oldValidatorSet := vals.getPublicIdentities(c.oldSet...)
 			// update voting power to random value
 			maxVotingPower := big.NewInt(100)
-			for _, name := range localCase.updated {
+			for _, name := range c.updated {
 				v := vals.getValidator(name)
 				vp, err := rand.Int(rand.Reader, maxVotingPower)
 				require.NoError(t, err)
 				// make sure generated voting power is different than the original one
 				v.votingPower += v.votingPower + vp.Uint64() + 1
 			}
-			newValidatorSet := vals.getPublicIdentities(localCase.newSet...)
+			newValidatorSet := vals.getPublicIdentities(c.newSet...)
 
 			delta, err := createValidatorSetDelta(oldValidatorSet, newValidatorSet)
 			require.NoError(t, err)
 
 			// added validators
-			require.Len(t, delta.Added, len(localCase.added))
-			for i, name := range localCase.added {
+			require.Len(t, delta.Added, len(c.added))
+			for i, name := range c.added {
 				require.Equal(t, delta.Added[i].Address, vals.getValidator(name).Address())
 			}
 
 			// removed validators
-			for _, i := range localCase.removed {
+			for _, i := range c.removed {
 				require.True(t, delta.Removed.IsSet(i))
 			}
 
 			// updated validators
-			require.Len(t, delta.Updated, len(localCase.updated))
-			for i, name := range localCase.updated {
+			require.Len(t, delta.Updated, len(c.updated))
+			for i, name := range c.updated {
 				require.Equal(t, delta.Updated[i].Address, vals.getValidator(name).Address())
 			}
 		})

--- a/consensus/polybft/extra_test.go
+++ b/consensus/polybft/extra_test.go
@@ -390,7 +390,7 @@ func TestExtra_CreateValidatorSetDelta_Cases(t *testing.T) {
 				vp, err := rand.Int(rand.Reader, maxVotingPower)
 				require.NoError(t, err)
 				// make sure generated voting power is different than the original one
-				v.votingPower += v.votingPower + vp.Uint64() + 1
+				v.votingPower += vp.Uint64() + 1
 			}
 			newValidatorSet := vals.getPublicIdentities(c.newSet...)
 

--- a/consensus/polybft/extra_test.go
+++ b/consensus/polybft/extra_test.go
@@ -385,11 +385,16 @@ func TestExtra_CreateValidatorSetDelta_Cases(t *testing.T) {
 			oldValidatorSet := vals.getPublicIdentities(localCase.oldSet...)
 			// update voting power to random value
 			maxVotingPower := big.NewInt(100)
+			var newVotingPower uint64
 			for _, name := range localCase.updated {
 				v := vals.getValidator(name)
-				vp, err := rand.Int(rand.Reader, maxVotingPower)
-				require.NoError(t, err)
-				v.votingPower = vp.Uint64()
+				// make sure generated voting power is different than the original one
+				for v.votingPower == newVotingPower {
+					vp, err := rand.Int(rand.Reader, maxVotingPower)
+					require.NoError(t, err)
+					newVotingPower = vp.Uint64()
+				}
+				v.votingPower = newVotingPower
 			}
 			newValidatorSet := vals.getPublicIdentities(localCase.newSet...)
 

--- a/consensus/polybft/system_state_test.go
+++ b/consensus/polybft/system_state_test.go
@@ -285,14 +285,14 @@ func Test_buildLogsFromReceipts(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		localTest := tt
-		t.Run(localTest.name, func(t *testing.T) {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
 			assert.EqualValuesf(t,
-				localTest.want,
-				buildLogsFromReceipts(localTest.args.entry, localTest.args.header),
-				"buildLogsFromReceipts(%v, %v)", localTest.args.entry, localTest.args.header,
+				tt.want,
+				buildLogsFromReceipts(tt.args.entry, tt.args.header),
+				"buildLogsFromReceipts(%v, %v)", tt.args.entry, tt.args.header,
 			)
 		})
 	}

--- a/consensus/polybft/system_state_test.go
+++ b/consensus/polybft/system_state_test.go
@@ -285,13 +285,14 @@ func Test_buildLogsFromReceipts(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		localTest := tt
+		t.Run(localTest.name, func(t *testing.T) {
 			t.Parallel()
 
 			assert.EqualValuesf(t,
-				tt.want,
-				buildLogsFromReceipts(tt.args.entry, tt.args.header),
-				"buildLogsFromReceipts(%v, %v)", tt.args.entry, tt.args.header,
+				localTest.want,
+				buildLogsFromReceipts(localTest.args.entry, localTest.args.header),
+				"buildLogsFromReceipts(%v, %v)", localTest.args.entry, localTest.args.header,
 			)
 		})
 	}


### PR DESCRIPTION
# Description

This PR fixes:
- loop closure violations in polybft unit tests and 
- makes `TestExtra_CreateValidatorSetDelta_Cases` runs deterministically (by fixing randomization of voting power updates)

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
