### PR TITLE
Fix segmentation fault panic on `ValidateSender`

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -1028,18 +1028,34 @@ func (c *consensusRuntime) IsValidBlock(proposal []byte) bool {
 }
 
 func (c *consensusRuntime) IsValidSender(msg *proto.Message) bool {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	msgNoSig, err := msg.PayloadNoSig()
+	if err != nil {
+		c.logger.Error("IsValidSender failed", "error", err)
 
-	// IsValidSender is called whenever a message is received from the peer.
-	// Since it is triggered from a separate go routine, it can happen that fsm instance is not yet initialized.
-	if c.fsm == nil {
 		return false
 	}
 
-	err := c.fsm.ValidateSender(msg)
+	// recover ECDSA address
+	signerAddress, err := wallet.RecoverAddressFromSignature(msg.Signature, msgNoSig)
 	if err != nil {
-		c.logger.Error("invalid sender", "error", err)
+		c.logger.Error("IsValidSender failed", "error", fmt.Errorf("failed to recover address from message: %w", err))
+
+		return false
+	}
+
+	// verify that message signature and sender address match
+	if !bytes.Equal(msg.From, signerAddress.Bytes()) {
+		c.logger.Error("IsValidSender failed", "error",
+			fmt.Errorf("signer address %s doesn't match From field", signerAddress.String()))
+
+		return false
+	}
+
+	epoch := c.getEpoch()
+	// verify the sender is in the active validator set
+	if !epoch.Validators.ContainsAddress(signerAddress) {
+		c.logger.Error("IsValidSender failed", "error",
+			fmt.Errorf("signer address %s is not included in validator set", signerAddress.String()))
 
 		return false
 	}

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -1032,6 +1032,8 @@ func (c *consensusRuntime) IsValidSender(msg *proto.Message) bool {
 	defer c.lock.RUnlock()
 
 	if c.fsm == nil {
+		c.logger.Warn("unable to validate IBFT message sender, because FSM is not initialized")
+
 		return false
 	}
 

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -1031,6 +1031,12 @@ func (c *consensusRuntime) IsValidSender(msg *proto.Message) bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
+	// IsValidSender is called whenever a message is received from the peer.
+	// Since it is triggered from a separate go routine, it can happen that fsm instance is not yet initialized.
+	if c.fsm == nil {
+		return false
+	}
+
 	err := c.fsm.ValidateSender(msg)
 	if err != nil {
 		c.logger.Error("invalid sender", "error", err)

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1917,6 +1917,7 @@ func TestConsensusRuntime_IsValidSender(t *testing.T) {
 	msg, err := sender.Key().SignEcdsaMessage(&proto.Message{
 		From: sender.Address().Bytes(),
 	})
+
 	require.NoError(t, err)
 
 	assert.True(t, runtime.IsValidSender(msg))

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1911,14 +1911,16 @@ func TestConsensusRuntime_IsValidSender(t *testing.T) {
 		proposerCalculator: NewProposerCalculatorFromSnapshot(snapshot, config, hclog.NewNullLogger()),
 	}
 
-	require.NoError(t, runtime.FSM())
-
 	sender := validatorAccounts.getValidator("A")
 	msg, err := sender.Key().SignEcdsaMessage(&proto.Message{
 		From: sender.Address().Bytes(),
 	})
-
 	require.NoError(t, err)
+
+	// IsValidSender should return false in case FSM isn't (yet) initialized
+	require.False(t, runtime.IsValidSender(msg))
+
+	require.NoError(t, runtime.FSM())
 
 	assert.True(t, runtime.IsValidSender(msg))
 	blockchainMock.AssertExpectations(t)

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -577,7 +577,7 @@ func TestConsensusRuntime_FSM_NotEndOfEpoch_NotEndOfSprint(t *testing.T) {
 	assert.Equal(t, lastBlock.Number, runtime.fsm.parent.Number)
 
 	address := types.Address(runtime.config.Key.Address())
-	assert.True(t, runtime.fsm.ValidatorSet().Accounts().ContainsAddress(address))
+	assert.True(t, runtime.fsm.ValidatorSet().Includes(address))
 
 	assert.NotNil(t, runtime.fsm.blockBuilder)
 	assert.NotNil(t, runtime.fsm.backend)

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -577,7 +577,7 @@ func TestConsensusRuntime_FSM_NotEndOfEpoch_NotEndOfSprint(t *testing.T) {
 	assert.Equal(t, lastBlock.Number, runtime.fsm.parent.Number)
 
 	address := types.Address(runtime.config.Key.Address())
-	assert.True(t, runtime.fsm.ValidatorSet().Includes(address))
+	assert.True(t, runtime.fsm.ValidatorSet().Accounts().ContainsAddress(address))
 
 	assert.NotNil(t, runtime.fsm.blockBuilder)
 	assert.NotNil(t, runtime.fsm.backend)
@@ -1911,16 +1911,13 @@ func TestConsensusRuntime_IsValidSender(t *testing.T) {
 		proposerCalculator: NewProposerCalculatorFromSnapshot(snapshot, config, hclog.NewNullLogger()),
 	}
 
+	require.NoError(t, runtime.FSM())
+
 	sender := validatorAccounts.getValidator("A")
 	msg, err := sender.Key().SignEcdsaMessage(&proto.Message{
 		From: sender.Address().Bytes(),
 	})
 	require.NoError(t, err)
-
-	// IsValidSender should return false in case FSM isn't (yet) initialized
-	require.False(t, runtime.IsValidSender(msg))
-
-	require.NoError(t, runtime.FSM())
 
 	assert.True(t, runtime.IsValidSender(msg))
 	blockchainMock.AssertExpectations(t)

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -1,7 +1,6 @@
 package polybft
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"math/big"
@@ -9,10 +8,8 @@ import (
 	"time"
 
 	"github.com/0xPolygon/go-ibft/messages"
-	"github.com/0xPolygon/go-ibft/messages/proto"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/state"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -319,31 +316,6 @@ func (f *fsm) Validate(proposal []byte) error {
 	}
 
 	f.logger.Debug("[FSM Validate]", "txs", len(block.Transactions), "signed hash", checkpointHash)
-
-	return nil
-}
-
-// ValidateSender validates sender address and signature
-func (f *fsm) ValidateSender(msg *proto.Message) error {
-	msgNoSig, err := msg.PayloadNoSig()
-	if err != nil {
-		return err
-	}
-
-	signerAddress, err := wallet.RecoverAddressFromSignature(msg.Signature, msgNoSig)
-	if err != nil {
-		return fmt.Errorf("failed to ecrecover message: %w", err)
-	}
-
-	// verify the signature came from the sender
-	if !bytes.Equal(msg.From, signerAddress.Bytes()) {
-		return fmt.Errorf("signer address %s doesn't match From field", signerAddress.String())
-	}
-
-	// verify the sender is in the active validator set
-	if !f.validators.Includes(signerAddress) {
-		return fmt.Errorf("signer address %s is not included in validator set", signerAddress.String())
-	}
 
 	return nil
 }

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -202,6 +202,10 @@ func (p *Polybft) Initialize() error {
 
 	p.ibft = newIBFTConsensusWrapper(p.logger, p.runtime, p)
 
+	if err = p.subscribeToIbftTopic(); err != nil {
+		return fmt.Errorf("IBFT topic subscription failed: %w", err)
+	}
+
 	return nil
 }
 

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -202,10 +202,6 @@ func (p *Polybft) Initialize() error {
 
 	p.ibft = newIBFTConsensusWrapper(p.logger, p.runtime, p)
 
-	if err = p.subscribeToIbftTopic(); err != nil {
-		return fmt.Errorf("topic subscription failed: %w", err)
-	}
-
 	return nil
 }
 
@@ -231,7 +227,7 @@ func (p *Polybft) Start() error {
 		}
 	}()
 
-	// start pbft process
+	// start consensus runtime
 	if err := p.startRuntime(); err != nil {
 		return fmt.Errorf("consensus runtime start failed: %w", err)
 	}

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -275,12 +275,12 @@ func (p *Polybft) startRuntime() error {
 		}
 	}
 
-	go p.startPbftProcess()
+	go p.startConsensusProtocol()
 
 	return nil
 }
 
-func (p *Polybft) startPbftProcess() {
+func (p *Polybft) startConsensusProtocol() {
 	// wait to have at least n peers connected. The 2 is just an initial heuristic value
 	// Most likely we will parametrize this in the future.
 	if !p.waitForNPeers() {

--- a/consensus/polybft/transport.go
+++ b/consensus/polybft/transport.go
@@ -66,7 +66,6 @@ func (c *consensusRuntime) subscribeToBridgeTopic(topic *network.Topic) error {
 // subscribeToIbftTopic subscribes to ibft topic
 func (p *Polybft) subscribeToIbftTopic() error {
 	return p.consensusTopic.Subscribe(func(obj interface{}, _ peer.ID) {
-		// this check is from ibft impl
 		if !p.runtime.isActiveValidator() {
 			return
 		}

--- a/consensus/polybft/validator_set.go
+++ b/consensus/polybft/validator_set.go
@@ -10,6 +10,7 @@ import (
 
 // ValidatorSet interface of the current validator set
 type ValidatorSet interface {
+	// Includes check if given address is among the current validator set
 	Includes(address types.Address) bool
 
 	// Len returns the size of the validator set

--- a/consensus/polybft/wallet/key.go
+++ b/consensus/polybft/wallet/key.go
@@ -51,11 +51,11 @@ func (k *Key) SignEcdsaMessage(msg *proto.Message) (*proto.Message, error) {
 	return msg, nil
 }
 
-// recoverAddressFromSignature recovers signer address from the given digest and signature
+// RecoverAddressFromSignature recovers signer address from the given digest and signature
 func RecoverAddressFromSignature(sig, msg []byte) (types.Address, error) {
 	pub, err := crypto.RecoverPubkey(sig, msg)
 	if err != nil {
-		return types.Address{}, fmt.Errorf("cannot recover addrese from signature: %w", err)
+		return types.Address{}, fmt.Errorf("cannot recover address from signature: %w", err)
 	}
 
 	return crypto.PubKeyToAddress(pub), nil


### PR DESCRIPTION
# Description
This PR fixes segmentation fault in case IBFT message arrives before `FSM` is being initialized, which can happen as IBFT messages delivery and initialization of `FSM` object happen in a separate go routines.

Image below explains what are the execution paths for initialization of `FSM` object vs IBFT message delivery in order to get better understanding of the problem itself.
![image](https://user-images.githubusercontent.com/93934272/208053663-eb86244c-4749-48db-9da8-2e8f72a4a6b0.png)

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

