### PR TITLE
Create a full block object during polybft

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -874,6 +874,68 @@ func (b *Blockchain) executeBlockTransactions(block *types.Block) (*BlockResult,
 	}, nil
 }
 
+// WriteFullBlock writes a single block to the local blockchain.
+// It doesn't do any kind of verification, only commits the block to the DB
+// This function is a copy of WriteBlock but with a full block which does not
+// require to compute again the Receipts.
+func (b *Blockchain) WriteFullBlock(fblock *types.FullBlock, source string) error {
+	block := fblock.Block
+
+	b.writeLock.Lock()
+	defer b.writeLock.Unlock()
+
+	if block.Number() <= b.Header().Number {
+		b.logger.Info("block already inserted", "block", block.Number(), "source", source)
+
+		return nil
+	}
+
+	header := block.Header
+
+	if err := b.writeBody(block); err != nil {
+		return err
+	}
+
+	// Write the header to the chain
+	evnt := &Event{Source: source}
+	if err := b.writeHeaderImpl(evnt, header); err != nil {
+		return err
+	}
+
+	// write the receipts, do it only after the header has been written.
+	// Otherwise, a client might ask for a header once the receipt is valid,
+	// but before it is written into the storage
+	if err := b.db.WriteReceipts(block.Hash(), fblock.Receipts); err != nil {
+		return err
+	}
+
+	// update snapshot
+	if err := b.consensus.ProcessHeaders([]*types.Header{header}); err != nil {
+		return err
+	}
+
+	b.dispatchEvent(evnt)
+
+	// Update the average gas price
+	b.updateGasPriceAvgWithBlock(block)
+
+	logArgs := []interface{}{
+		"number", header.Number,
+		"txs", len(block.Transactions),
+		"hash", header.Hash,
+		"parent", header.ParentHash,
+	}
+
+	if prevHeader, ok := b.GetHeaderByNumber(header.Number - 1); ok {
+		diff := header.Timestamp - prevHeader.Timestamp
+		logArgs = append(logArgs, "generation_time_in_seconds", diff)
+	}
+
+	b.logger.Info("new block", logArgs...)
+
+	return nil
+}
+
 // WriteBlock writes a single block to the local blockchain.
 // It doesn't do any kind of verification, only commits the block to the DB
 func (b *Blockchain) WriteBlock(block *types.Block, source string) error {

--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -117,7 +117,7 @@ func (b *BlockBuilder) Block() *types.Block {
 }
 
 // Build creates the state and the final block
-func (b *BlockBuilder) Build(handler func(h *types.Header)) (*StateBlock, error) {
+func (b *BlockBuilder) Build(handler func(h *types.Header)) (*types.FullBlock, error) {
 	if handler != nil {
 		handler(b.header)
 	}
@@ -134,10 +134,9 @@ func (b *BlockBuilder) Build(handler func(h *types.Header)) (*StateBlock, error)
 
 	b.block.Header.ComputeHash()
 
-	return &StateBlock{
+	return &types.FullBlock{
 		Block:    b.block,
 		Receipts: b.state.Receipts(),
-		State:    b.state,
 	}, nil
 }
 
@@ -224,11 +223,4 @@ func (b *BlockBuilder) writeTxPoolTransaction(tx *types.Transaction) (bool, erro
 // GetState returns Transition reference
 func (b *BlockBuilder) GetState() *state.Transition {
 	return b.state
-}
-
-// StateBlock is a block with the full state it modifies
-type StateBlock struct {
-	Block    *types.Block
-	Receipts []*types.Receipt
-	State    *state.Transition
 }

--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -33,7 +33,7 @@ type blockchainBackend interface {
 		txPool txPoolInterface, blockTime time.Duration, logger hclog.Logger) (blockBuilder, error)
 
 	// ProcessBlock builds a final block from given 'block' on top of 'parent'.
-	ProcessBlock(parent *types.Header, block *types.Block) (*StateBlock, error)
+	ProcessBlock(parent *types.Header, block *types.Block) (*types.FullBlock, error)
 
 	// GetStateProviderForBlock returns a reference to make queries to the state at 'block'.
 	GetStateProviderForBlock(block *types.Header) (contract.Provider, error)
@@ -78,7 +78,7 @@ func (p *blockchainWrapper) CommitBlock(block *types.FullBlock) error {
 }
 
 // ProcessBlock builds a final block from given 'block' on top of 'parent'
-func (p *blockchainWrapper) ProcessBlock(parent *types.Header, block *types.Block) (*StateBlock, error) {
+func (p *blockchainWrapper) ProcessBlock(parent *types.Header, block *types.Block) (*types.FullBlock, error) {
 	// TODO: Call validate block in polybft
 	header := block.Header.Copy()
 
@@ -107,10 +107,9 @@ func (p *blockchainWrapper) ProcessBlock(parent *types.Header, block *types.Bloc
 		Receipts: transition.Receipts(),
 	})
 
-	return &StateBlock{
+	return &types.FullBlock{
 		Block:    builtBlock,
 		Receipts: transition.Receipts(),
-		State:    transition,
 	}, nil
 }
 

--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -26,7 +26,7 @@ type blockchainBackend interface {
 	CurrentHeader() *types.Header
 
 	// CommitBlock commits a block to the chain.
-	CommitBlock(block *types.Block) ([]*types.Receipt, error)
+	CommitBlock(block *types.FullBlock) error
 
 	// NewBlockBuilder is a factory method that returns a block builder on top of 'parent'.
 	NewBlockBuilder(parent *types.Header, coinbase types.Address,
@@ -69,13 +69,12 @@ func (p *blockchainWrapper) CurrentHeader() *types.Header {
 }
 
 // CommitBlock commits a block to the chain
-func (p *blockchainWrapper) CommitBlock(block *types.Block) ([]*types.Receipt, error) {
-	err := p.blockchain.WriteBlock(block, consensusSource)
-	if err != nil {
-		return nil, err
+func (p *blockchainWrapper) CommitBlock(block *types.FullBlock) error {
+	if err := p.blockchain.WriteFullBlock(block, consensusSource); err != nil {
+		return err
 	}
 
-	return p.blockchain.GetCachedReceipts(block.Hash())
+	return nil
 }
 
 // ProcessBlock builds a final block from given 'block' on top of 'parent'

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/0xPolygon/go-ibft/messages"
 	"github.com/0xPolygon/go-ibft/messages/proto"
@@ -995,12 +994,6 @@ func (c *consensusRuntime) getCommitmentToRegister(epoch *epochMetadata,
 }
 
 func (c *consensusRuntime) IsValidBlock(proposal []byte) bool {
-	now := time.Now()
-	fmt.Println("=> IsValidBlock")
-	defer func() {
-		fmt.Println("<= IsValidBlock", time.Since(now))
-	}()
-
 	if err := c.fsm.Validate(proposal); err != nil {
 		c.logger.Error("failed to validate proposal", "error", err)
 
@@ -1081,12 +1074,6 @@ func (c *consensusRuntime) IsValidCommittedSeal(proposalHash []byte, committedSe
 }
 
 func (c *consensusRuntime) BuildProposal(view *proto.View) []byte {
-	now := time.Now()
-	fmt.Println("=> BUILD PROPOSAL")
-	defer func() {
-		fmt.Println("<= BUILD PROPOSAL", time.Since(now))
-	}()
-
 	lastBuiltBlock, _ := c.getLastBuiltBlockAndEpoch()
 
 	if lastBuiltBlock.Number+1 != view.Height {
@@ -1108,12 +1095,6 @@ func (c *consensusRuntime) BuildProposal(view *proto.View) []byte {
 
 // InsertBlock inserts a proposal with the specified committed seals
 func (c *consensusRuntime) InsertBlock(proposal []byte, committedSeals []*messages.CommittedSeal) {
-	now := time.Now()
-	fmt.Println("=> InsertBlock")
-	defer func() {
-		fmt.Println("<= InsertBlock", time.Since(now))
-	}()
-
 	fsm := c.fsm
 
 	block, err := fsm.Insert(proposal, committedSeals)

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/0xPolygon/go-ibft/messages"
 	"github.com/0xPolygon/go-ibft/messages/proto"
@@ -994,6 +995,12 @@ func (c *consensusRuntime) getCommitmentToRegister(epoch *epochMetadata,
 }
 
 func (c *consensusRuntime) IsValidBlock(proposal []byte) bool {
+	now := time.Now()
+	fmt.Println("=> IsValidBlock")
+	defer func() {
+		fmt.Println("<= IsValidBlock", time.Since(now))
+	}()
+
 	if err := c.fsm.Validate(proposal); err != nil {
 		c.logger.Error("failed to validate proposal", "error", err)
 
@@ -1074,6 +1081,12 @@ func (c *consensusRuntime) IsValidCommittedSeal(proposalHash []byte, committedSe
 }
 
 func (c *consensusRuntime) BuildProposal(view *proto.View) []byte {
+	now := time.Now()
+	fmt.Println("=> BUILD PROPOSAL")
+	defer func() {
+		fmt.Println("<= BUILD PROPOSAL", time.Since(now))
+	}()
+
 	lastBuiltBlock, _ := c.getLastBuiltBlockAndEpoch()
 
 	if lastBuiltBlock.Number+1 != view.Height {
@@ -1095,6 +1108,12 @@ func (c *consensusRuntime) BuildProposal(view *proto.View) []byte {
 
 // InsertBlock inserts a proposal with the specified committed seals
 func (c *consensusRuntime) InsertBlock(proposal []byte, committedSeals []*messages.CommittedSeal) {
+	now := time.Now()
+	fmt.Println("=> InsertBlock")
+	defer func() {
+		fmt.Println("<= InsertBlock", time.Since(now))
+	}()
+
 	fsm := c.fsm
 
 	block, err := fsm.Insert(proposal, committedSeals)

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -138,9 +138,6 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 		headerTime = time.Now()
 	}
 
-	fmt.Println("-- build block --")
-	fmt.Println(parentTime, f.config.BlockTime, headerTime)
-
 	currentValidatorsHash, err := f.validators.Accounts().Hash()
 	if err != nil {
 		return nil, err

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -23,7 +23,7 @@ type blockBuilder interface {
 	Reset() error
 	WriteTx(*types.Transaction) error
 	Fill()
-	Build(func(h *types.Header)) (*StateBlock, error)
+	Build(func(h *types.Header)) (*types.FullBlock, error)
 	GetState() *state.Transition
 	Receipts() []*types.Receipt
 }
@@ -81,7 +81,7 @@ type fsm struct {
 	logger hcf.Logger
 
 	// target is the block being computed
-	target *StateBlock
+	target *types.FullBlock
 }
 
 // BuildProposal builds a proposal for the current round (used if proposer)

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -79,6 +79,9 @@ type fsm struct {
 
 	// logger instance
 	logger hcf.Logger
+
+	// target is the block being computed
+	target *StateBlock
 }
 
 // BuildProposal builds a proposal for the current round (used if proposer)
@@ -135,6 +138,9 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 		headerTime = time.Now()
 	}
 
+	fmt.Println("-- build block --")
+	fmt.Println(parentTime, f.config.BlockTime, headerTime)
+
 	currentValidatorsHash, err := f.validators.Accounts().Hash()
 	if err != nil {
 		return nil, err
@@ -181,6 +187,8 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 	f.logger.Debug("[FSM Build Proposal]",
 		"txs", len(stateBlock.Block.Transactions),
 		"hash", checkpointHash.String())
+
+	f.target = stateBlock
 
 	return stateBlock.Block.MarshalRLP(), nil
 }
@@ -306,7 +314,8 @@ func (f *fsm) Validate(proposal []byte) error {
 		return err
 	}
 
-	if _, err = f.backend.ProcessBlock(f.parent, &block); err != nil {
+	stateBlock, err := f.backend.ProcessBlock(f.parent, &block)
+	if err != nil {
 		return err
 	}
 
@@ -316,6 +325,8 @@ func (f *fsm) Validate(proposal []byte) error {
 	}
 
 	f.logger.Debug("[FSM Validate]", "txs", len(block.Transactions), "signed hash", checkpointHash)
+
+	f.target = stateBlock
 
 	return nil
 }
@@ -442,10 +453,8 @@ func (f *fsm) VerifyStateTransactions(transactions []*types.Transaction) error {
 
 // Insert inserts the sealed proposal
 func (f *fsm) Insert(proposal []byte, committedSeals []*messages.CommittedSeal) (*types.Block, error) {
-	newBlock := &types.Block{}
-	if err := newBlock.UnmarshalRLP(proposal); err != nil {
-		return nil, fmt.Errorf("cannot unmarshal proposal: %w", err)
-	}
+	newBlock := f.target.Block
+	receipts := f.target.Receipts
 
 	// In this function we should try to return little to no errors since
 	// at this point everything we have to do is just commit something that
@@ -496,8 +505,7 @@ func (f *fsm) Insert(proposal []byte, committedSeals []*messages.CommittedSeal) 
 	// Write extar data to header
 	newBlock.Header.ExtraData = append(make([]byte, ExtraVanity), extra.MarshalRLPTo(nil)...)
 
-	receipts, err := f.backend.CommitBlock(newBlock)
-	if err != nil {
+	if err := f.backend.CommitBlock(&types.FullBlock{Block: newBlock, Receipts: receipts}); err != nil {
 		return nil, err
 	}
 

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -168,14 +168,15 @@ func TestFSM_BuildProposal_WithExitEvents(t *testing.T) {
 		}}
 	}
 
+	stateBlock.Receipts = receipts
+
 	blockchainMock := new(blockchainMock)
-	blockchainMock.On("CommitBlock", mock.Anything).Return(receipts, nil).Once()
+	blockchainMock.On("CommitBlock", mock.Anything).Return(nil).Once()
 
 	mBlockBuilder := new(blockBuilderMock)
 	mBlockBuilder.On("Build", mock.Anything).Return(stateBlock).Once()
 	mBlockBuilder.On("Fill").Once()
 	mBlockBuilder.On("Receipts", mock.Anything).Return(receipts).Once()
-	stateBlock.Receipts = receipts
 
 	fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: blockchainMock,
 		validators: validators.toValidatorSetWithError(t), checkpointBackend: runtime, logger: hclog.NewNullLogger(),
@@ -953,7 +954,7 @@ func TestFSM_Validate_TimestampOlder(t *testing.T) {
 			Timestamp:  blockTime,
 			ExtraData:  parent.ExtraData,
 		}
-		stateBlock := &StateBlock{Block: consensus.BuildBlock(consensus.BuildBlockParams{Header: header})}
+		stateBlock := &types.FullBlock{Block: consensus.BuildBlock(consensus.BuildBlockParams{Header: header})}
 		fsm := &fsm{parent: parent, config: &PolyBFTConfig{}, backend: &blockchainMock{},
 			validators: validators.toValidatorSetWithError(t), logger: hclog.NewNullLogger()}
 
@@ -989,7 +990,7 @@ func TestFSM_Validate_IncorrectMixHash(t *testing.T) {
 		ExtraData:  parent.ExtraData,
 	}
 
-	buildBlock := &StateBlock{Block: consensus.BuildBlock(consensus.BuildBlockParams{Header: header})}
+	buildBlock := &types.FullBlock{Block: consensus.BuildBlock(consensus.BuildBlockParams{Header: header})}
 
 	fsm := &fsm{
 		parent:     parent,
@@ -1027,15 +1028,15 @@ func TestFSM_Insert_Good(t *testing.T) {
 		Header: &types.Header{Number: parentBlockNumber + 1, ParentHash: parent.Hash, ExtraData: extraBlock},
 	})
 
-	buildBlock := &StateBlock{Block: finalBlock}
+	buildBlock := &types.FullBlock{Block: finalBlock}
 	mBlockBuilder := newBlockBuilderMock(buildBlock)
 	mBackendMock := &blockchainMock{}
 	mBackendMock.On("CommitBlock", mock.MatchedBy(func(i interface{}) bool {
-		stateBlock, ok := i.(*types.Block)
+		stateBlock, ok := i.(*types.FullBlock)
 		require.True(t, ok)
 
-		return stateBlock.Number() == buildBlock.Block.Number() && stateBlock.Hash() == buildBlock.Block.Hash()
-	})).Return([]*types.Receipt(nil), error(nil)).Once()
+		return stateBlock.Block.Number() == buildBlock.Block.Number() && stateBlock.Block.Hash() == buildBlock.Block.Hash()
+	})).Return(error(nil)).Once()
 
 	validatorSet, err := NewValidatorSet(validatorsMetadata[0:len(validatorsMetadata)-1], hclog.NewNullLogger())
 	require.NoError(t, err)
@@ -1062,6 +1063,8 @@ func TestFSM_Insert_Good(t *testing.T) {
 	}
 
 	proposal := buildBlock.Block.MarshalRLP()
+
+	fsm.target = buildBlock
 
 	block, err := fsm.Insert(proposal, commitedSeals)
 
@@ -1091,7 +1094,7 @@ func TestFSM_Insert_InvalidNode(t *testing.T) {
 			Header: &types.Header{Number: parentBlockNumber + 1, ParentHash: parent.Hash, ExtraData: extraBlock},
 		})
 
-	buildBlock := &StateBlock{Block: finalBlock}
+	buildBlock := &types.FullBlock{Block: finalBlock, Receipts: []*types.Receipt{}}
 	mBlockBuilder := newBlockBuilderMock(buildBlock)
 
 	validatorSet, err := NewValidatorSet(validatorsMetadata[0:len(validatorsMetadata)-1], hclog.NewNullLogger())
@@ -1121,6 +1124,8 @@ func TestFSM_Insert_InvalidNode(t *testing.T) {
 		{Signer: validatorB.Address().Bytes(), Signature: sigB},
 		{Signer: nonValidatorAccount.Address().Bytes(), Signature: nonValidatorSignature}, // this one should fail
 	}
+
+	fsm.target = buildBlock
 
 	_, err = fsm.Insert(proposal, commitedSeals)
 	assert.ErrorContains(t, err, "invalid node id")
@@ -1602,7 +1607,7 @@ func TestFSM_Validate_FailToVerifySignatures(t *testing.T) {
 	polybftBackendMock.AssertExpectations(t)
 }
 
-func createDummyStateBlock(blockNumber uint64, parentHash types.Hash, extraData []byte) *StateBlock {
+func createDummyStateBlock(blockNumber uint64, parentHash types.Hash, extraData []byte) *types.FullBlock {
 	finalBlock := consensus.BuildBlock(consensus.BuildBlockParams{
 		Header: &types.Header{
 			Number:     blockNumber,
@@ -1612,7 +1617,7 @@ func createDummyStateBlock(blockNumber uint64, parentHash types.Hash, extraData 
 		},
 	})
 
-	return &StateBlock{Block: finalBlock}
+	return &types.FullBlock{Block: finalBlock}
 }
 
 func createTestExtra(
@@ -1679,7 +1684,7 @@ func createTestCommitment(t *testing.T, accounts []*wallet.Account) *CommitmentM
 	}
 }
 
-func newBlockBuilderMock(stateBlock *StateBlock) *blockBuilderMock {
+func newBlockBuilderMock(stateBlock *types.FullBlock) *blockBuilderMock {
 	mBlockBuilder := new(blockBuilderMock)
 	mBlockBuilder.On("Build", mock.Anything).Return(stateBlock).Once()
 	mBlockBuilder.On("Fill", mock.Anything).Once()

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -35,10 +35,10 @@ func (m *blockchainMock) CurrentHeader() *types.Header {
 	return args.Get(0).(*types.Header) //nolint:forcetypeassert
 }
 
-func (m *blockchainMock) CommitBlock(block *types.Block) ([]*types.Receipt, error) {
+func (m *blockchainMock) CommitBlock(block *types.FullBlock) error {
 	args := m.Called(block)
 
-	return args.Get(0).([]*types.Receipt), args.Error(1) //nolint:forcetypeassert
+	return args.Error(0) //nolint:forcetypeassert
 }
 
 func (m *blockchainMock) NewBlockBuilder(parent *types.Header, coinbase types.Address,

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -38,7 +38,7 @@ func (m *blockchainMock) CurrentHeader() *types.Header {
 func (m *blockchainMock) CommitBlock(block *types.FullBlock) error {
 	args := m.Called(block)
 
-	return args.Error(0) //nolint:forcetypeassert
+	return args.Error(0)
 }
 
 func (m *blockchainMock) NewBlockBuilder(parent *types.Header, coinbase types.Address,
@@ -48,10 +48,10 @@ func (m *blockchainMock) NewBlockBuilder(parent *types.Header, coinbase types.Ad
 	return args.Get(0).(blockBuilder), args.Error(1) //nolint:forcetypeassert
 }
 
-func (m *blockchainMock) ProcessBlock(parent *types.Header, block *types.Block) (*StateBlock, error) {
+func (m *blockchainMock) ProcessBlock(parent *types.Header, block *types.Block) (*types.FullBlock, error) {
 	args := m.Called(parent, block)
 
-	return args.Get(0).(*StateBlock), args.Error(1) //nolint:forcetypeassert
+	return args.Get(0).(*types.FullBlock), args.Error(1) //nolint:forcetypeassert
 }
 
 func (m *blockchainMock) GetStateProviderForBlock(block *types.Header) (contract.Provider, error) {
@@ -176,9 +176,9 @@ func (m *blockBuilderMock) Receipts() []*types.Receipt {
 	return args.Get(0).([]*types.Receipt) //nolint:forcetypeassert
 }
 
-func (m *blockBuilderMock) Build(handler func(*types.Header)) (*StateBlock, error) {
+func (m *blockBuilderMock) Build(handler func(*types.Header)) (*types.FullBlock, error) {
 	args := m.Called(handler)
-	builtBlock := args.Get(0).(*StateBlock) //nolint:forcetypeassert
+	builtBlock := args.Get(0).(*types.FullBlock) //nolint:forcetypeassert
 
 	handler(builtBlock.Block.Header)
 

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -345,6 +345,8 @@ func (p *Polybft) startPbftProcess() {
 			sequenceCh, stopSequence = p.ibft.runSequence(latestHeader.Number + 1)
 		}
 
+		now := time.Now()
+
 		select {
 		case <-syncerBlockCh:
 			if isValidator {
@@ -359,6 +361,8 @@ func (p *Polybft) startPbftProcess() {
 
 			return
 		}
+
+		p.logger.Debug("time to run the sequence", "seconds", time.Since(now))
 	}
 }
 

--- a/types/header.go
+++ b/types/header.go
@@ -91,6 +91,11 @@ type Body struct {
 	Uncles       []*Header
 }
 
+type FullBlock struct {
+	Block    *Block
+	Receipts []*Receipt
+}
+
 type Block struct {
 	Header       *Header
 	Transactions []*Transaction


### PR DESCRIPTION
# Description

This PR introduces the concept of `FullBlock`. A `FullBlock` is a `Block` object including its `Receipts`. Before, there was a bug because `polybft` and `blockchain` would only communicate over `Block` objects. However, at some point over that coordination, the `Receipt` objects would be needed it and the Block was being re-executed again.

The important nuance of the PR is that inside the `fsm` we keep the target `FullBlock` block that is going to be inserted and that it was processed either during `BlockProposal` or `Validate`. If not, and we rely on the `proposal []byte` from `go-ibft` (which only includes `Block`) we would have to do extra tricks (like caching receipts in `blockchain`) to ensure we do no recompute `Receipts` and `From` addresses from the transactions.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
