### PR TITLE
RFC173 Checkpoint consensus issue

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -50,7 +50,7 @@ type txPoolInterface interface {
 // checkpointBackend is an interface providing functions for working with checkpoints and exit evens
 type checkpointBackend interface {
 	// BuildEventRoot generates an event root hash from exit events in given epoch
-	BuildEventRoot(epoch uint64, nonCommittedExitEvents []*ExitEvent) (types.Hash, error)
+	BuildEventRoot(epoch uint64) (types.Hash, error)
 	// InsertExitEvents inserts provided exit events to persistence storage
 	InsertExitEvents(exitEvents []*ExitEvent) error
 }
@@ -834,18 +834,17 @@ func (c *consensusRuntime) InsertExitEvents(exitEvents []*ExitEvent) error {
 }
 
 // BuildEventRoot is an implementation of checkpointBackend interface
-func (c *consensusRuntime) BuildEventRoot(epoch uint64, nonCommittedExitEvents []*ExitEvent) (types.Hash, error) {
+func (c *consensusRuntime) BuildEventRoot(epoch uint64) (types.Hash, error) {
 	exitEvents, err := c.state.getExitEventsByEpoch(epoch)
 	if err != nil {
 		return types.ZeroHash, err
 	}
 
-	allEvents := append(exitEvents, nonCommittedExitEvents...)
-	if len(allEvents) == 0 {
+	if len(exitEvents) == 0 {
 		return types.ZeroHash, nil
 	}
 
-	tree, err := createExitTree(allEvents)
+	tree, err := createExitTree(exitEvents)
 	if err != nil {
 		return types.ZeroHash, err
 	}

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1807,7 +1807,7 @@ func TestConsensusRuntime_getExitEventRootHash(t *testing.T) {
 		tree, err := NewMerkleTree(encodedEvents)
 		require.NoError(t, err)
 
-		hash, err := runtime.BuildEventRoot(1, nil)
+		hash, err := runtime.BuildEventRoot(1)
 		require.NoError(t, err)
 		require.Equal(t, tree.Hash(), hash)
 	})
@@ -1815,7 +1815,7 @@ func TestConsensusRuntime_getExitEventRootHash(t *testing.T) {
 	t.Run("Get exit event root hash - no events", func(t *testing.T) {
 		t.Parallel()
 
-		hash, err := runtime.BuildEventRoot(2, nil)
+		hash, err := runtime.BuildEventRoot(2)
 		require.NoError(t, err)
 		require.Equal(t, types.Hash{}, hash)
 	})

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -1403,7 +1403,7 @@ func TestFSM_InsertBlock_HasEpochEndingExitEvents(t *testing.T) {
 		return stateBlock.Block.Number() == buildBlock.Block.Number() && stateBlock.Block.Hash() == buildBlock.Block.Hash()
 	})).Return(error(nil)).Once()
 
-	validatorSet, err := NewValidatorSet(validatorsMetadata[0:len(validatorsMetadata)-1], hclog.NewNullLogger())
+	validatorSet, err := NewValidatorSet(validatorsMetadata, hclog.NewNullLogger())
 	require.NoError(t, err)
 
 	state := newTestState(t)

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -277,7 +277,7 @@ type checkpointBackendMock struct {
 	mock.Mock
 }
 
-func (c *checkpointBackendMock) BuildEventRoot(epoch uint64, nonCommittedExitEvents []*ExitEvent) (types.Hash, error) {
+func (c *checkpointBackendMock) BuildEventRoot(epoch uint64) (types.Hash, error) {
 	args := c.Called()
 
 	return args.Get(0).(types.Hash), args.Error(1) //nolint:forcetypeassert


### PR DESCRIPTION
# Description

Through this PR we removed the exit events that happened in the currently built block from the exit event root hash, because they are not finalized. This way we are mitigating the risk of a potential malicious exits added by a malicious proposer.

Now, exit events that happened in the currently built block (which can be a checkpoint block) are moved to the next checkpoint block (this way we are sure they are finalized and agreed upon by the validator consensus).

**Important note** here is that exit events that happened in the epoch ending block (which is a checkpoint block by default), will be moved to the exit root of the next epoch.

See the image below for an illustrated process:

![v3 checkpointing - Trie workflow_new](https://user-images.githubusercontent.com/100121253/208893546-eac30056-c757-4166-87e4-8e6e95bbb20e.jpg)

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually
