### PR TITLE
Immutable trie simplification

### DIFF
--- a/state/immutable-trie/snapshot.go
+++ b/state/immutable-trie/snapshot.go
@@ -1,6 +1,8 @@
 package itrie
 
 import (
+	"bytes"
+
 	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/state"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -15,6 +17,9 @@ type Snapshot struct {
 var emptyStateHash = types.StringToHash("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
 
 func (s *Snapshot) GetStorage(addr types.Address, root types.Hash, rawkey types.Hash) types.Hash {
+	s.state.m.Lock()
+	defer s.state.m.Unlock()
+
 	var (
 		err  error
 		trie *Trie
@@ -23,7 +28,7 @@ func (s *Snapshot) GetStorage(addr types.Address, root types.Hash, rawkey types.
 	if root == emptyStateHash {
 		trie = s.state.newTrie()
 	} else {
-		trie, err = s.state.NewTrieAt(root)
+		trie, err = s.state.newTrieAt(root)
 		if err != nil {
 			return types.Hash{}
 		}
@@ -52,6 +57,9 @@ func (s *Snapshot) GetStorage(addr types.Address, root types.Hash, rawkey types.
 }
 
 func (s *Snapshot) GetAccount(addr types.Address) (*state.Account, error) {
+	s.state.m.RLock()
+	defer s.state.m.RUnlock()
+
 	key := crypto.Keccak256(addr.Bytes())
 
 	data, ok := s.trie.Get(key)
@@ -68,11 +76,89 @@ func (s *Snapshot) GetAccount(addr types.Address) (*state.Account, error) {
 }
 
 func (s *Snapshot) GetCode(hash types.Hash) ([]byte, bool) {
+	s.state.m.RLock()
+	defer s.state.m.RUnlock()
+
 	return s.state.GetCode(hash)
 }
 
 func (s *Snapshot) Commit(objs []*state.Object) (state.Snapshot, []byte) {
-	trie, root := s.trie.Commit(objs)
+	s.state.m.Lock()
+	defer s.state.m.Unlock()
 
-	return &Snapshot{trie: trie, state: s.state}, root
+	batch := s.trie.storage.Batch()
+
+	tt := s.trie.Txn()
+	tt.batch = batch
+
+	arena := accountArenaPool.Get()
+	defer accountArenaPool.Put(arena)
+
+	ar1 := stateArenaPool.Get()
+	defer stateArenaPool.Put(ar1)
+
+	for _, obj := range objs {
+		if obj.Deleted {
+			tt.Delete(hashit(obj.Address.Bytes()))
+		} else {
+			account := state.Account{
+				Balance:  obj.Balance,
+				Nonce:    obj.Nonce,
+				CodeHash: obj.CodeHash.Bytes(),
+				Root:     obj.Root, // old root
+			}
+
+			if len(obj.Storage) != 0 {
+				trie, err := s.trie.state.newTrieAt(obj.Root)
+				if err != nil {
+					panic(err)
+				}
+
+				localTxn := trie.Txn()
+				localTxn.batch = batch
+
+				for _, entry := range obj.Storage {
+					k := hashit(entry.Key)
+					if entry.Deleted {
+						localTxn.Delete(k)
+					} else {
+						vv := ar1.NewBytes(bytes.TrimLeft(entry.Val, "\x00"))
+						localTxn.Insert(k, vv.MarshalTo(nil))
+					}
+				}
+
+				accountStateRoot, _ := localTxn.Hash()
+				accountStateTrie := localTxn.Commit()
+
+				// Add this to the cache
+				s.trie.state.AddState(types.BytesToHash(accountStateRoot), accountStateTrie)
+
+				account.Root = types.BytesToHash(accountStateRoot)
+			}
+
+			if obj.DirtyCode {
+				s.trie.state.SetCode(obj.CodeHash, obj.Code)
+			}
+
+			vv := account.MarshalWith(arena)
+			data := vv.MarshalTo(nil)
+
+			tt.Insert(hashit(obj.Address.Bytes()), data)
+			arena.Reset()
+		}
+	}
+
+	root, _ := tt.Hash()
+
+	nTrie := tt.Commit()
+
+	nTrie.state = s.trie.state
+	nTrie.storage = s.trie.storage
+
+	// Write all the entries to db
+	batch.Write()
+
+	s.trie.state.AddState(types.BytesToHash(root), nTrie)
+
+	return &Snapshot{trie: nTrie, state: s.state}, root
 }

--- a/state/immutable-trie/snapshot.go
+++ b/state/immutable-trie/snapshot.go
@@ -140,7 +140,6 @@ func (s *Snapshot) Commit(objs []*state.Object) (state.Snapshot, []byte) {
 
 	nTrie := tt.Commit()
 
-	// nTrie.state = s.trie.state
 	nTrie.storage = s.trie.storage
 
 	// Write all the entries to db

--- a/state/immutable-trie/state.go
+++ b/state/immutable-trie/state.go
@@ -39,10 +39,7 @@ func (s *State) NewSnapshotAt(root types.Hash) (state.Snapshot, error) {
 }
 
 func (s *State) newTrie() *Trie {
-	t := NewTrie()
-	t.storage = s.storage
-
-	return t
+	return NewTrie()
 }
 
 func (s *State) SetCode(hash types.Hash, code []byte) {
@@ -80,8 +77,7 @@ func (s *State) newTrieAt(root types.Hash) (*Trie, error) {
 	}
 
 	t := &Trie{
-		root:    n,
-		storage: s.storage,
+		root: n,
 	}
 
 	return t, nil

--- a/state/immutable-trie/trie.go
+++ b/state/immutable-trie/trie.go
@@ -91,7 +91,6 @@ func (f *FullNode) getEdge(idx byte) Node {
 }
 
 type Trie struct {
-	state   *State
 	root    Node
 	epoch   uint32
 	storage Storage

--- a/state/immutable-trie/trie.go
+++ b/state/immutable-trie/trie.go
@@ -156,7 +156,6 @@ func (t *Trie) hashRoot() []byte {
 }
 
 func (t *Trie) Txn() *Txn {
-	// FIXME: could we copy t.root, t.storage without putting the same refs to mutexes?
 	return &Txn{root: t.root, epoch: t.epoch + 1, storage: t.storage}
 }
 

--- a/types/buildroot/buildroot.go
+++ b/types/buildroot/buildroot.go
@@ -95,7 +95,7 @@ var numArenaPool fastrlp.ArenaPool
 
 func deriveSlow(num int, h func(indx int) []byte) []byte {
 	t := itrie.NewTrie()
-	txn := t.Txn()
+	txn := t.Txn(nil)
 
 	ar := numArenaPool.Get()
 	for i := 0; i < num; i++ {


### PR DESCRIPTION
# Description

Immutable trie simplification. Removes unused method and trie locking,  decouples snapshot, trie and state.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

