### PR TITLE
Fix uptime total blocks calculation

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -33,6 +33,8 @@ var (
 	errNotAValidator = errors.New("node is not a validator")
 	// errQuorumNotReached represents "quorum not reached for commitment message" error message
 	errQuorumNotReached = errors.New("quorum not reached for commitment message")
+	// errEpochToSmall is error message denoting that epoch doesn't contain enough blocks
+	errEpochTooSmal = errors.New("epoch size not large enough to calculate uptime")
 )
 
 // txPoolInterface is an abstraction of transaction pool
@@ -733,7 +735,7 @@ func (c *consensusRuntime) calculateUptime(currentBlock *types.Header, epoch *ep
 		// this means that epoch size must at least be 3 blocks,
 		// since we are not calculating uptime for lastBlockInEpoch and lastBlockInEpoch-1
 		// they will be included in the uptime calculation of next epoch
-		return nil, errors.New("epoch size not large enough to calculate uptime")
+		return nil, errEpochTooSmal
 	}
 
 	calculateUptimeForBlock := func(header *types.Header, validators AccountSet) error {

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -34,7 +34,7 @@ var (
 	// errQuorumNotReached represents "quorum not reached for commitment message" error message
 	errQuorumNotReached = errors.New("quorum not reached for commitment message")
 	// errEpochToSmall is error message denoting that epoch doesn't contain enough blocks
-	errEpochTooSmal = errors.New("epoch size not large enough to calculate uptime")
+	errEpochTooSmall = errors.New("epoch size not large enough to calculate uptime")
 )
 
 // txPoolInterface is an abstraction of transaction pool
@@ -735,7 +735,7 @@ func (c *consensusRuntime) calculateUptime(currentBlock *types.Header, epoch *ep
 		// this means that epoch size must at least be 3 blocks,
 		// since we are not calculating uptime for lastBlockInEpoch and lastBlockInEpoch-1
 		// they will be included in the uptime calculation of next epoch
-		return nil, errEpochTooSmal
+		return nil, errEpochTooSmall
 	}
 
 	calculateUptimeForBlock := func(header *types.Header, validators AccountSet) error {

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1531,9 +1531,12 @@ func TestConsensusRuntime_calculateUptime_SecondEpoch(t *testing.T) {
 
 	guardedData, err := consensusRuntime.getGuardedData()
 	require.NoError(t, err)
-	uptime, err := consensusRuntime.calculateUptime(guardedData.lastBuiltBlock, guardedData.epoch)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, uptime)
+	epochInfo, err := consensusRuntime.calculateUptime(guardedData.lastBuiltBlock, guardedData.epoch)
+	require.NoError(t, err)
+	require.NotEmpty(t, epochInfo)
+	require.Equal(t, config.PolyBFTConfig.EpochSize, epochInfo.Uptime.TotalBlocks)
+	require.Equal(t, uint64(1), epochInfo.Epoch.StartBlock)
+	require.Equal(t, uint64(10), epochInfo.Epoch.EndBlock)
 
 	blockchainMock.AssertExpectations(t)
 	polybftBackendMock.AssertExpectations(t)

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1481,7 +1481,7 @@ func TestConsensusRuntime_calculateUptime_EpochSizeToSmall(t *testing.T) {
 	}
 
 	epochInfo, err := consensusRuntime.calculateUptime(consensusRuntime.lastBuiltBlock, consensusRuntime.epoch)
-	require.ErrorIs(t, err, errEpochTooSmal)
+	require.ErrorIs(t, err, errEpochTooSmall)
 	require.Nil(t, epochInfo)
 }
 

--- a/consensus/polybft/state_transaction.go
+++ b/consensus/polybft/state_transaction.go
@@ -335,7 +335,7 @@ type Epoch struct {
 type Uptime struct {
 	EpochID     uint64            `abi:"epochId"`
 	UptimeData  []ValidatorUptime `abi:"uptimeData"`
-	TotalUptime uint64            `abi:"totalBlocks"`
+	TotalBlocks uint64            `abi:"totalBlocks"`
 }
 
 func (u *Uptime) addValidatorUptime(address types.Address, count uint64) {
@@ -343,7 +343,6 @@ func (u *Uptime) addValidatorUptime(address types.Address, count uint64) {
 		u.UptimeData = []ValidatorUptime{}
 	}
 
-	u.TotalUptime += count
 	u.UptimeData = append(u.UptimeData, ValidatorUptime{
 		Address: address,
 		Count:   count,


### PR DESCRIPTION
# Description

Validator rewards are being calculated using this formula:

```solidity
uint256 totalStake = (validator.stake + _validators.getDelegationPool(uptimeData.validator).supply)
uint256 validatorReward = (reward * totalStake * uptimeData.signedBlocks) / (activeStake * uptime.totalBlocks);
```
However there is an issue on the client side, as uptime total blocks is calculated as sum of how many blocks was signed by each validator during the epoch, instead of just denoting for how many blocks uptime information is being submitted. Therefore reward calculation is not giving expected results.

Fix consists of providing total blocks for uptime calculation, instead of aggregating number of signatures for each block in given epoch.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
