### PR TITLE
Multiple state sync commitments per epoch

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -247,6 +247,11 @@ func (c *consensusRuntime) OnBlockInserted(block *types.Block) {
 		err   error
 	)
 
+	// handle commitment and proofs creation
+	if err := c.stateSyncManager.PostBlock(&PostBlockRequest{Block: block}); err != nil {
+		c.logger.Error("failed to post block state sync", "err", err)
+	}
+
 	// TODO - this condition will need to be changed to recognize that either slashing happened
 	// or epoch reached its fixed size
 	if c.isFixedSizeOfEpochMet(block.Header.Number, c.epoch) {
@@ -254,11 +259,6 @@ func (c *consensusRuntime) OnBlockInserted(block *types.Block) {
 			c.logger.Error("failed to restart epoch after block inserted", "error", err)
 
 			return
-		}
-	} else {
-		// handle commitment and proofs creation
-		if err := c.stateSyncManager.PostBlock(&PostBlockRequest{Block: block}); err != nil {
-			c.logger.Error("failed to post block state sync", "err", err)
 		}
 	}
 

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -254,7 +254,7 @@ func (c *consensusRuntime) OnBlockInserted(block *types.Block) {
 
 	// TODO - this condition will need to be changed to recognize that either slashing happened
 	// or epoch reached its fixed size
-	if c.isFixedSizeOfEpochMet(block.Header.Number, c.epoch) {
+	if c.isFixedSizeOfEpochMet(block.Header.Number, epoch) {
 		if epoch, err = c.restartEpoch(block.Header); err != nil {
 			c.logger.Error("failed to restart epoch after block inserted", "error", err)
 

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	eventsBufferSize   = 10
+	maxCommitmentSize  = 10
 	stateFileName      = "consensusState.db"
 	uptimeLookbackSize = 2 // number of blocks to calculate uptime from the previous epoch
 )
@@ -178,11 +178,12 @@ func (c *consensusRuntime) initStateSyncManager(logger hcf.Logger) error {
 			logger,
 			c.config.State,
 			&stateSyncConfig{
-				key:             c.config.Key,
-				stateSenderAddr: c.config.PolyBFTConfig.Bridge.BridgeAddr,
-				jsonrpcAddr:     c.config.PolyBFTConfig.Bridge.JSONRPCEndpoint,
-				dataDir:         c.config.DataDir,
-				topic:           c.config.bridgeTopic,
+				key:               c.config.Key,
+				stateSenderAddr:   c.config.PolyBFTConfig.Bridge.BridgeAddr,
+				jsonrpcAddr:       c.config.PolyBFTConfig.Bridge.JSONRPCEndpoint,
+				dataDir:           c.config.DataDir,
+				topic:             c.config.bridgeTopic,
+				maxCommitmentSize: maxCommitmentSize,
 			},
 		)
 

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -182,19 +182,17 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 func (f *fsm) stateTransactions() []*types.Transaction {
 	var txns []*types.Transaction
 
-	if f.isEndOfEpoch {
-		if f.proposerCommitmentToRegister != nil {
-			// add register commitment transaction
-			inputData, err := f.proposerCommitmentToRegister.EncodeAbi()
-			if err != nil {
-				f.logger.Error("StateTransactions failed to encode input data for state sync commitment registration", "Error", err)
+	if f.proposerCommitmentToRegister != nil {
+		// add register commitment transaction
+		inputData, err := f.proposerCommitmentToRegister.EncodeAbi()
+		if err != nil {
+			f.logger.Error("StateTransactions failed to encode input data for state sync commitment registration", "Error", err)
 
-				return nil
-			}
-
-			txns = append(txns,
-				createStateTransactionWithData(f.config.StateReceiverAddr, inputData))
+			return nil
 		}
+
+		txns = append(txns,
+			createStateTransactionWithData(f.config.StateReceiverAddr, inputData))
 	}
 
 	f.logger.Debug("Apply state transaction", "num", len(txns))

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -443,10 +443,7 @@ func (s *State) insertStateSyncEvent(event *types.StateSyncEvent) error {
 }
 
 // getStateSyncEventsForCommitment returns state sync events for commitment
-// based on the getAll flag, the function will try to get all events in range, and if it fails,
-// it will either return an error, or return all the events it can without returning an error
-func (s *State) getStateSyncEventsForCommitment(fromIndex, toIndex uint64,
-	getAll bool) ([]*types.StateSyncEvent, error) {
+func (s *State) getStateSyncEventsForCommitment(fromIndex, toIndex uint64) ([]*types.StateSyncEvent, error) {
 	var events []*types.StateSyncEvent
 
 	err := s.db.View(func(tx *bolt.Tx) error {
@@ -454,11 +451,7 @@ func (s *State) getStateSyncEventsForCommitment(fromIndex, toIndex uint64,
 		for i := fromIndex; i <= toIndex; i++ {
 			v := bucket.Get(itob(i))
 			if v == nil {
-				if getAll {
-					return errNotEnoughStateSyncs
-				}
-
-				return nil
+				return errNotEnoughStateSyncs
 			}
 
 			var event *types.StateSyncEvent

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -449,17 +449,16 @@ func (s *State) getStateSyncEventsForCommitment(fromIndex, toIndex uint64,
 	getAll bool) ([]*types.StateSyncEvent, error) {
 	var events []*types.StateSyncEvent
 
-	var notEnoughEventsErr error
-	if getAll {
-		notEnoughEventsErr = errNotEnoughStateSyncs
-	}
-
 	err := s.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(syncStateEventsBucket)
 		for i := fromIndex; i <= toIndex; i++ {
 			v := bucket.Get(itob(i))
 			if v == nil {
-				return notEnoughEventsErr
+				if getAll {
+					return errNotEnoughStateSyncs
+				}
+
+				return nil
 			}
 
 			var event *types.StateSyncEvent

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -72,7 +72,7 @@ type stateSyncManager struct {
 	// per epoch fields
 	lock               sync.RWMutex
 	pendingCommitments []*Commitment
-	validatorSet       *validatorSet
+	validatorSet       ValidatorSet
 	epoch              uint64
 	nextCommittedIndex uint64
 }
@@ -86,10 +86,9 @@ type topic interface {
 // NewStateSyncManager creates a new instance of state sync manager
 func NewStateSyncManager(logger hclog.Logger, state *State, config *stateSyncConfig) (*stateSyncManager, error) {
 	s := &stateSyncManager{
-		logger: logger.Named("state-sync"),
+		logger: logger.Named("state-sync-manager"),
 		state:  state,
 		config: config,
-		lock:   sync.RWMutex{},
 	}
 
 	return s, nil
@@ -218,7 +217,7 @@ func (s *stateSyncManager) AddLog(eventLog *ethgo.Log) {
 	}
 
 	if err := s.buildCommitment(); err != nil {
-		s.logger.Error("could not build a commitment on arrival of new state sync", "err", err)
+		s.logger.Error("could not build a commitment on arrival of new state sync", "err", err, "stateSyncID", event.ID)
 	}
 }
 

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -229,6 +229,8 @@ func (s *stateSyncManager) Commitment() (*CommitmentMessageSigned, error) {
 
 	var largestCommitment *CommitmentMessageSigned
 
+	s.logger.Info("Getting commitment to submit...", "pendingCommitments", len(s.pendingCommitments))
+
 	// we start from the end, since last pending commitment is the largest one
 	for i := len(s.pendingCommitments) - 1; i >= 0; i-- {
 		commitment := s.pendingCommitments[i]
@@ -255,7 +257,11 @@ func (s *stateSyncManager) Commitment() (*CommitmentMessageSigned, error) {
 			AggSignature: aggregatedSignature,
 			PublicKeys:   publicKeys,
 		}
+
+		break
 	}
+
+	s.logger.Info("Getting commitment to submit finished.", "isNil", largestCommitment == nil)
 
 	return largestCommitment, nil
 }

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -23,9 +23,8 @@ import (
 )
 
 const (
-	// maximum number of stateSyncEvents that a commitment can have
-	maxCommitmentSize = 10
 	// minimum number of stateSyncEvents that a commitment can have
+	// minimum number is 2 because smart contract expects that the merkle tree has at least two leafs
 	minCommitmentSize = 2
 )
 
@@ -51,11 +50,12 @@ func (n *dummyStateSyncManager) PostEpoch(req *PostEpochRequest) error         {
 
 // stateSyncConfig holds the configuration data of state sync manager
 type stateSyncConfig struct {
-	stateSenderAddr types.Address
-	jsonrpcAddr     string
-	dataDir         string
-	topic           topic
-	key             *wallet.Key
+	stateSenderAddr   types.Address
+	jsonrpcAddr       string
+	dataDir           string
+	topic             topic
+	key               *wallet.Key
+	maxCommitmentSize uint64
 }
 
 var _ StateSyncManager = (*stateSyncManager)(nil)
@@ -443,7 +443,8 @@ func (s *stateSyncManager) buildCommitment() error {
 	epoch := s.epoch
 	fromIndex := s.nextCommittedIndex
 
-	stateSyncEvents, err := s.state.getStateSyncEventsForCommitment(fromIndex, fromIndex+maxCommitmentSize-1, false)
+	stateSyncEvents, err := s.state.getStateSyncEventsForCommitment(fromIndex,
+		fromIndex+s.config.maxCommitmentSize-1, false)
 	if err != nil {
 		return fmt.Errorf("failed to get state sync events for commitment. Error: %w", err)
 	}

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// minimum number of stateSyncEvents that a commitment can have
-	// minimum number is 2 because smart contract expects that the merkle tree has at least two leafs
+	// (minimum number is 2 because smart contract expects that the merkle tree has at least two leaves)
 	minCommitmentSize = 2
 )
 

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -350,6 +350,8 @@ func (s *stateSyncManager) PostEpoch(req *PostEpochRequest) error {
 	// build a new commitment at the end of the epoch
 	nextCommittedIndex, err := req.SystemState.GetNextCommittedIndex()
 	if err != nil {
+		s.lock.Unlock()
+
 		return err
 	}
 

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -23,10 +23,10 @@ import (
 )
 
 const (
-	// number of stateSyncEvents to be processed before a commitment message can be created and gossiped
-	stateSyncCommitmentSize = 10
-	minCommitmentSize       = 2
-	maxCommitmentSize       = 10
+	// maximum number of stateSyncEvents that a commitment can have
+	maxCommitmentSize = 10
+	// minimum number of stateSyncEvents that a commitment can have
+	minCommitmentSize = 2
 )
 
 // StateSyncManager is an interface that defines functions for state sync workflow

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -405,7 +405,7 @@ func (s *stateSyncManager) buildProofs(commitmentMsg *CommitmentMessage) error {
 		"toIndex", commitmentMsg.ToIndex,
 	)
 
-	events, err := s.state.getStateSyncEventsForCommitment(commitmentMsg.FromIndex, commitmentMsg.ToIndex, true)
+	events, err := s.state.getStateSyncEventsForCommitment(commitmentMsg.FromIndex, commitmentMsg.ToIndex)
 	if err != nil {
 		return err
 	}
@@ -444,8 +444,8 @@ func (s *stateSyncManager) buildCommitment() error {
 	fromIndex := s.nextCommittedIndex
 
 	stateSyncEvents, err := s.state.getStateSyncEventsForCommitment(fromIndex,
-		fromIndex+s.config.maxCommitmentSize-1, false)
-	if err != nil {
+		fromIndex+s.config.maxCommitmentSize-1)
+	if err != nil && !errors.Is(err, errNotEnoughStateSyncs) {
 		return fmt.Errorf("failed to get state sync events for commitment. Error: %w", err)
 	}
 

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -283,7 +283,7 @@ func TestStateSyncerManager_AddLog_BuildCommitments(t *testing.T) {
 
 	s.AddLog(goodLog)
 
-	stateSyncs, err = s.state.getStateSyncEventsForCommitment(0, 0, true)
+	stateSyncs, err = s.state.getStateSyncEventsForCommitment(0, 0)
 	require.NoError(t, err)
 	require.Len(t, stateSyncs, 1)
 	require.Len(t, s.pendingCommitments, 0)
@@ -350,7 +350,7 @@ func TestStateSyncerManager_EventTracker_Sync(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	events, err := s.state.getStateSyncEventsForCommitment(0, 9, true)
+	events, err := s.state.getStateSyncEventsForCommitment(0, 9)
 	require.NoError(t, err)
 	require.Len(t, events, 10)
 }

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -29,11 +29,12 @@ func newTestStateSyncManager(t *testing.T, key *testValidator) *stateSyncManager
 
 	s, err := NewStateSyncManager(hclog.NewNullLogger(), state,
 		&stateSyncConfig{
-			stateSenderAddr: types.Address{},
-			jsonrpcAddr:     "",
-			dataDir:         tmpDir,
-			topic:           topic,
-			key:             key.Key(),
+			stateSenderAddr:   types.Address{},
+			jsonrpcAddr:       "",
+			dataDir:           tmpDir,
+			topic:             topic,
+			key:               key.Key(),
+			maxCommitmentSize: maxCommitmentSize,
 		})
 
 	require.NoError(t, err)

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -50,32 +50,32 @@ func TestStateSyncManager_PostEpoch_BuildCommitment(t *testing.T) {
 	s := newTestStateSyncManager(t, vals.getValidator("0"))
 
 	// there are no state syncs
-	commitment, err := s.buildCommitment(0, 0)
-	require.NoError(t, err)
-	require.Nil(t, commitment)
+	require.NoError(t, s.buildCommitment())
+	require.Nil(t, s.pendingCommitments)
 
-	stateSyncs10 := generateStateSyncEvents(t, 20, 0)
+	stateSyncs10 := generateStateSyncEvents(t, 10, 0)
 
-	// add 5 state syncs starting in index 0, it will not generate a commitment
+	// add 5 state syncs starting in index 0, it will generate one smaller commitment
 	for i := 0; i < 5; i++ {
 		require.NoError(t, s.state.insertStateSyncEvent(stateSyncs10[i]))
 	}
 
-	commitment, err = s.buildCommitment(0, 0)
-	require.NoError(t, err)
-	require.Nil(t, commitment)
+	require.NoError(t, s.buildCommitment())
+	require.Len(t, s.pendingCommitments, 1)
+	require.Equal(t, uint64(0), s.pendingCommitments[0].FromIndex)
+	require.Equal(t, uint64(4), s.pendingCommitments[0].ToIndex)
+	require.Equal(t, uint64(0), s.pendingCommitments[0].Epoch)
 
-	// add the next 5 state syncs, at that point
+	// add the next 5 state syncs, at that point, so that it generates a larger commitment
 	for i := 5; i < 10; i++ {
 		require.NoError(t, s.state.insertStateSyncEvent(stateSyncs10[i]))
 	}
 
-	commitment, err = s.buildCommitment(0, 0)
-	require.NoError(t, err)
-
-	require.Equal(t, commitment.Epoch, uint64(0))
-	require.Equal(t, commitment.FromIndex, uint64(0))
-	require.Equal(t, commitment.ToIndex, uint64(9))
+	require.NoError(t, s.buildCommitment())
+	require.Len(t, s.pendingCommitments, 2)
+	require.Equal(t, uint64(0), s.pendingCommitments[1].FromIndex)
+	require.Equal(t, uint64(9), s.pendingCommitments[1].ToIndex)
+	require.Equal(t, uint64(0), s.pendingCommitments[1].Epoch)
 
 	// the message was sent
 	require.NotNil(t, s.config.topic.(*mockTopic).consume()) //nolint
@@ -181,11 +181,11 @@ func TestStateSyncManager_BuildCommitment(t *testing.T) {
 	tree, err := NewMerkleTree([][]byte{{0x1}})
 	require.NoError(t, err)
 
-	s.commitment = &Commitment{
-		MerkleTree: tree,
+	s.pendingCommitments = []*Commitment{
+		{MerkleTree: tree},
 	}
 
-	hash, err := s.commitment.Hash()
+	hash, err := s.pendingCommitments[0].Hash()
 	require.NoError(t, err)
 
 	msg := newMockMsg().WithHash(hash.Bytes())
@@ -217,15 +217,13 @@ func TestStateSyncerManager_BuildProofs(t *testing.T) {
 		require.NoError(t, s.state.insertStateSyncEvent(evnt))
 	}
 
-	commitment, err := s.buildCommitment(0, 0)
-	require.NoError(t, err)
-
-	s.commitment = commitment
+	require.NoError(t, s.buildCommitment())
+	require.Len(t, s.pendingCommitments, 1)
 
 	mockMsg := &CommitmentMessageSigned{
 		Message: &CommitmentMessage{
-			FromIndex: commitment.FromIndex,
-			ToIndex:   commitment.ToIndex,
+			FromIndex: s.pendingCommitments[0].FromIndex,
+			ToIndex:   s.pendingCommitments[0].ToIndex,
 		},
 	}
 
@@ -239,6 +237,7 @@ func TestStateSyncerManager_BuildProofs(t *testing.T) {
 			Transactions: []*types.Transaction{tx},
 		},
 	}
+
 	require.NoError(t, s.PostBlock(req))
 
 	for i := uint64(0); i < 10; i++ {
@@ -248,7 +247,7 @@ func TestStateSyncerManager_BuildProofs(t *testing.T) {
 	}
 }
 
-func TestStateSyncerManager_EventTracker_AddLog(t *testing.T) {
+func TestStateSyncerManager_AddLog_BuildCommitments(t *testing.T) {
 	vals := newTestValidators(5)
 
 	s := newTestStateSyncManager(t, vals.getValidator("0"))
@@ -274,7 +273,7 @@ func TestStateSyncerManager_EventTracker_AddLog(t *testing.T) {
 	goodLog := &ethgo.Log{
 		Topics: []ethgo.Hash{
 			stateTransferEventABI.ID(),
-			ethgo.BytesToHash([]byte{0x1}), // state sync index 1
+			ethgo.BytesToHash([]byte{0x0}), // state sync index 0
 			ethgo.ZeroHash,
 			ethgo.ZeroHash,
 		},
@@ -283,9 +282,32 @@ func TestStateSyncerManager_EventTracker_AddLog(t *testing.T) {
 
 	s.AddLog(goodLog)
 
-	stateSyncs, err = s.state.getStateSyncEventsForCommitment(1, 1)
+	stateSyncs, err = s.state.getStateSyncEventsForCommitment(0, 0, true)
 	require.NoError(t, err)
 	require.Len(t, stateSyncs, 1)
+	require.Len(t, s.pendingCommitments, 0)
+
+	// add one more log to have a minimum commitment
+	goodLog2 := goodLog.Copy()
+	goodLog2.Topics[1] = ethgo.BytesToHash([]byte{0x1}) // state sync index 1
+	s.AddLog(goodLog2)
+
+	require.Len(t, s.pendingCommitments, 1)
+	require.Equal(t, uint64(0), s.pendingCommitments[0].FromIndex)
+	require.Equal(t, uint64(1), s.pendingCommitments[0].ToIndex)
+
+	// add two more logs to have larger commitments
+	goodLog3 := goodLog.Copy()
+	goodLog3.Topics[1] = ethgo.BytesToHash([]byte{0x2}) // state sync index 2
+	s.AddLog(goodLog3)
+
+	goodLog4 := goodLog.Copy()
+	goodLog4.Topics[1] = ethgo.BytesToHash([]byte{0x3}) // state sync index 3
+	s.AddLog(goodLog4)
+
+	require.Len(t, s.pendingCommitments, 3)
+	require.Equal(t, uint64(0), s.pendingCommitments[2].FromIndex)
+	require.Equal(t, uint64(3), s.pendingCommitments[2].ToIndex)
 }
 
 func TestStateSyncerManager_EventTracker_Sync(t *testing.T) {
@@ -327,7 +349,7 @@ func TestStateSyncerManager_EventTracker_Sync(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	events, err := s.state.getStateSyncEventsForCommitment(0, 9)
+	events, err := s.state.getStateSyncEventsForCommitment(0, 9, true)
 	require.NoError(t, err)
 	require.Len(t, events, 10)
 }

--- a/consensus/polybft/state_test.go
+++ b/consensus/polybft/state_test.go
@@ -276,14 +276,14 @@ func TestState_getStateSyncEventsForCommitment_NotEnoughEvents(t *testing.T) {
 
 	state := newTestState(t)
 
-	for i := 0; i < stateSyncCommitmentSize-2; i++ {
+	for i := 0; i < maxCommitmentSize-2; i++ {
 		assert.NoError(t, state.insertStateSyncEvent(&types.StateSyncEvent{
 			ID:   uint64(i),
 			Data: []byte{1, 2},
 		}))
 	}
 
-	_, err := state.getStateSyncEventsForCommitment(0, stateSyncCommitmentSize-1, true)
+	_, err := state.getStateSyncEventsForCommitment(0, maxCommitmentSize-1, true)
 	assert.ErrorIs(t, err, errNotEnoughStateSyncs)
 }
 
@@ -292,7 +292,7 @@ func TestState_getStateSyncEventsForCommitment(t *testing.T) {
 
 	state := newTestState(t)
 
-	for i := 0; i < stateSyncCommitmentSize; i++ {
+	for i := 0; i < maxCommitmentSize; i++ {
 		assert.NoError(t, state.insertStateSyncEvent(&types.StateSyncEvent{
 			ID:   uint64(i),
 			Data: []byte{1, 2},
@@ -302,32 +302,32 @@ func TestState_getStateSyncEventsForCommitment(t *testing.T) {
 	t.Run("Return all - forced. Enough events", func(t *testing.T) {
 		t.Parallel()
 
-		events, err := state.getStateSyncEventsForCommitment(0, stateSyncCommitmentSize-1, true)
+		events, err := state.getStateSyncEventsForCommitment(0, maxCommitmentSize-1, true)
 		require.NoError(t, err)
-		require.Equal(t, stateSyncCommitmentSize, len(events))
+		require.Equal(t, maxCommitmentSize, len(events))
 	})
 
 	t.Run("Return all - forced. Not enough events", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := state.getStateSyncEventsForCommitment(0, stateSyncCommitmentSize+1, true)
+		_, err := state.getStateSyncEventsForCommitment(0, maxCommitmentSize+1, true)
 		require.ErrorIs(t, err, errNotEnoughStateSyncs)
 	})
 
 	t.Run("Return all you can. Enough events", func(t *testing.T) {
 		t.Parallel()
 
-		events, err := state.getStateSyncEventsForCommitment(0, stateSyncCommitmentSize-1, false)
+		events, err := state.getStateSyncEventsForCommitment(0, maxCommitmentSize-1, false)
 		assert.NoError(t, err)
-		assert.Equal(t, stateSyncCommitmentSize, len(events))
+		assert.Equal(t, maxCommitmentSize, len(events))
 	})
 
 	t.Run("Return all you can. Not enough events", func(t *testing.T) {
 		t.Parallel()
 
-		events, err := state.getStateSyncEventsForCommitment(0, stateSyncCommitmentSize+1, false)
+		events, err := state.getStateSyncEventsForCommitment(0, maxCommitmentSize+1, false)
 		assert.NoError(t, err)
-		assert.Equal(t, stateSyncCommitmentSize, len(events))
+		assert.Equal(t, maxCommitmentSize, len(events))
 	})
 }
 
@@ -528,7 +528,7 @@ func insertTestCommitments(t *testing.T, state *State, epoch, numberOfCommitment
 	t.Helper()
 
 	for i := uint64(0); i <= numberOfCommitments; i++ {
-		commitment, err := createTestCommitmentMessage(i * stateSyncCommitmentSize)
+		commitment, err := createTestCommitmentMessage(i * maxCommitmentSize)
 		require.NoError(t, err)
 		require.NoError(t, state.insertCommitmentMessage(commitment))
 	}
@@ -572,7 +572,7 @@ func createTestCommitmentMessage(fromIndex uint64) (*CommitmentMessageSigned, er
 	msg := &CommitmentMessage{
 		MerkleRootHash: tree.Hash(),
 		FromIndex:      fromIndex,
-		ToIndex:        fromIndex + stateSyncCommitmentSize - 1,
+		ToIndex:        fromIndex + maxCommitmentSize - 1,
 	}
 
 	return &CommitmentMessageSigned{

--- a/consensus/polybft/state_test.go
+++ b/consensus/polybft/state_test.go
@@ -283,7 +283,7 @@ func TestState_getStateSyncEventsForCommitment_NotEnoughEvents(t *testing.T) {
 		}))
 	}
 
-	_, err := state.getStateSyncEventsForCommitment(0, maxCommitmentSize-1, true)
+	_, err := state.getStateSyncEventsForCommitment(0, maxCommitmentSize-1)
 	assert.ErrorIs(t, err, errNotEnoughStateSyncs)
 }
 
@@ -302,7 +302,7 @@ func TestState_getStateSyncEventsForCommitment(t *testing.T) {
 	t.Run("Return all - forced. Enough events", func(t *testing.T) {
 		t.Parallel()
 
-		events, err := state.getStateSyncEventsForCommitment(0, maxCommitmentSize-1, true)
+		events, err := state.getStateSyncEventsForCommitment(0, maxCommitmentSize-1)
 		require.NoError(t, err)
 		require.Equal(t, maxCommitmentSize, len(events))
 	})
@@ -310,14 +310,14 @@ func TestState_getStateSyncEventsForCommitment(t *testing.T) {
 	t.Run("Return all - forced. Not enough events", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := state.getStateSyncEventsForCommitment(0, maxCommitmentSize+1, true)
+		_, err := state.getStateSyncEventsForCommitment(0, maxCommitmentSize+1)
 		require.ErrorIs(t, err, errNotEnoughStateSyncs)
 	})
 
 	t.Run("Return all you can. Enough events", func(t *testing.T) {
 		t.Parallel()
 
-		events, err := state.getStateSyncEventsForCommitment(0, maxCommitmentSize-1, false)
+		events, err := state.getStateSyncEventsForCommitment(0, maxCommitmentSize-1)
 		assert.NoError(t, err)
 		assert.Equal(t, maxCommitmentSize, len(events))
 	})
@@ -325,8 +325,8 @@ func TestState_getStateSyncEventsForCommitment(t *testing.T) {
 	t.Run("Return all you can. Not enough events", func(t *testing.T) {
 		t.Parallel()
 
-		events, err := state.getStateSyncEventsForCommitment(0, maxCommitmentSize+1, false)
-		assert.NoError(t, err)
+		events, err := state.getStateSyncEventsForCommitment(0, maxCommitmentSize+1)
+		assert.ErrorIs(t, err, errNotEnoughStateSyncs)
 		assert.Equal(t, maxCommitmentSize, len(events))
 	})
 }

--- a/e2e-polybft/bridge_test.go
+++ b/e2e-polybft/bridge_test.go
@@ -7,9 +7,7 @@ import (
 	"io"
 	"math/big"
 	"net/http"
-	"os"
 	"path"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -33,20 +31,6 @@ import (
 	"github.com/umbracle/ethgo/jsonrpc"
 	ethgow "github.com/umbracle/ethgo/wallet"
 )
-
-func init() {
-	wd, err := os.Getwd()
-	if err != nil {
-		return
-	}
-
-	parent := filepath.Dir(wd)
-	wd = filepath.Join(parent, "/artifacts/polygon-edge")
-	os.Setenv("EDGE_BINARY", wd)
-	os.Setenv("E2E_TESTS", "true")
-	os.Setenv("E2E_LOGS", "true")
-	os.Setenv("E2E_LOG_LEVEL", "debug")
-}
 
 var (
 	stateSyncResultEvent = abi.MustNewEvent(`event StateSyncResult(
@@ -146,7 +130,7 @@ func TestE2E_Bridge_MainWorkflow(t *testing.T) {
 	)
 
 	// wait for a few more sprints
-	require.NoError(t, cluster.WaitForBlock(30, 2*time.Minute))
+	require.NoError(t, cluster.WaitForBlock(20, 2*time.Minute))
 
 	client := cluster.Servers[0].JSONRPC()
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithClient(client))

--- a/e2e-polybft/bridge_test.go
+++ b/e2e-polybft/bridge_test.go
@@ -7,7 +7,10 @@ import (
 	"io"
 	"math/big"
 	"net/http"
+	"os"
 	"path"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -30,6 +33,20 @@ import (
 	"github.com/umbracle/ethgo/jsonrpc"
 	ethgow "github.com/umbracle/ethgo/wallet"
 )
+
+func init() {
+	wd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+
+	parent := filepath.Dir(wd)
+	wd = filepath.Join(parent, "/artifacts/polygon-edge")
+	os.Setenv("EDGE_BINARY", wd)
+	os.Setenv("E2E_TESTS", "true")
+	os.Setenv("E2E_LOGS", "true")
+	os.Setenv("E2E_LOG_LEVEL", "debug")
+}
 
 var (
 	stateSyncResultEvent = abi.MustNewEvent(`event StateSyncResult(
@@ -137,6 +154,101 @@ func TestE2E_Bridge_MainWorkflow(t *testing.T) {
 
 	// commitments should've been stored
 	// execute the state syncs
+	for i := 0; i < num; i++ {
+		executeStateSync(t, client, txRelayer, accounts[i], fmt.Sprintf("%x", i+1))
+	}
+
+	// the transactions are mined and there should be a success events
+	id := stateSyncResultEvent.ID()
+	filter := &ethgo.LogFilter{
+		Topics: [][]*ethgo.Hash{
+			{&id},
+		},
+	}
+
+	filter.SetFromUint64(0)
+	filter.SetToUint64(100)
+
+	logs, err := cluster.Servers[0].JSONRPC().Eth().GetLogs(filter)
+	require.NoError(t, err)
+
+	// Assert that all state syncs are executed successfully
+	checkLogs(t, logs, num)
+}
+
+func TestE2E_Bridge_MultipleCommitmentsPerEpoch(t *testing.T) {
+	const num = 10
+
+	var (
+		accounts         = make([]ethgo.Key, num)
+		wallets, amounts [num]string
+		premine          [num]types.Address
+	)
+
+	for i := 0; i < num; i++ {
+		accounts[i], _ = ethgow.GenerateKey()
+		premine[i] = types.Address(accounts[i].Address())
+		wallets[i] = premine[i].String()
+		amounts[i] = fmt.Sprintf("%d", 100)
+	}
+
+	cluster := framework.NewTestCluster(t, 5, framework.WithBridge(), framework.WithPremine(premine[:]...), framework.WithEpochSize(30))
+	defer cluster.Stop()
+
+	// wait for a couple of blocks
+	require.NoError(t, cluster.WaitForBlock(2, 1*time.Minute))
+
+	// send two transactions to the bridge so that we have a minimal commitment
+	require.NoError(
+		t,
+		cluster.EmitTransfer(
+			contracts.NativeTokenContract.String(),
+			strings.Join(wallets[:2], ","),
+			strings.Join(amounts[:2], ","),
+		),
+	)
+
+	// wait for a few more sprints
+	require.NoError(t, cluster.WaitForBlock(10, 2*time.Minute))
+
+	client := cluster.Servers[0].JSONRPC()
+	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithClient(client))
+	require.NoError(t, err)
+
+	lastCommittedIDMethod := polybft.SidechainBridgeFunctionsABI.GetMethod("lastCommittedId")
+	encode, err := lastCommittedIDMethod.Encode([]interface{}{})
+	require.NoError(t, err)
+
+	// check that we submitted the minimal commitment to smart contract
+	result, err := txRelayer.Call(accounts[0].Address(), ethgo.Address(contracts.StateReceiverContract), encode)
+	require.NoError(t, err)
+
+	lastCommittedID, err := strconv.ParseUint(result, 0, 64)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), lastCommittedID)
+
+	// send some more transactions to the bridge to build another commitment in epoch
+	require.NoError(
+		t,
+		cluster.EmitTransfer(
+			contracts.NativeTokenContract.String(),
+			strings.Join(wallets[2:], ","),
+			strings.Join(amounts[2:], ","),
+		),
+	)
+
+	// wait for a few more sprints
+	require.NoError(t, cluster.WaitForBlock(25, 2*time.Minute))
+
+	// check that the second (larger commitment) was also submitted in epoch
+	result, err = txRelayer.Call(accounts[0].Address(), ethgo.Address(contracts.StateReceiverContract), encode)
+	require.NoError(t, err)
+
+	lastCommittedID, err = strconv.ParseUint(result, 0, 64)
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), lastCommittedID)
+
+	// execute all state syncs in submitted commitments
 	for i := 0; i < num; i++ {
 		executeStateSync(t, client, txRelayer, accounts[i], fmt.Sprintf("%x", i+1))
 	}

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -78,7 +78,6 @@ type TestClusterConfig struct {
 	Binary            string
 	ValidatorSetSize  uint64
 	EpochSize         int
-	SprintSize        int
 	EpochReward       int
 
 	logsDirOnce sync.Once
@@ -188,12 +187,6 @@ func WithEpochSize(epochSize int) ClusterOption {
 	}
 }
 
-func WithSprintSize(sprintSize int) ClusterOption {
-	return func(h *TestClusterConfig) {
-		h.SprintSize = sprintSize
-	}
-}
-
 func WithEpochReward(epochReward int) ClusterOption {
 	return func(h *TestClusterConfig) {
 		h.EpochReward = epochReward
@@ -299,7 +292,6 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 			"--block-gas-limit", strconv.FormatUint(cluster.Config.BlockGasLimit, 10),
 			"--epoch-size", strconv.Itoa(cluster.Config.EpochSize),
 			"--epoch-reward", strconv.Itoa(cluster.Config.EpochReward),
-			"--sprint-size", strconv.Itoa(cluster.Config.SprintSize),
 			"--premine", "0x0000000000000000000000000000000000000000",
 		}
 

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -78,6 +78,7 @@ type TestClusterConfig struct {
 	Binary            string
 	ValidatorSetSize  uint64
 	EpochSize         int
+	SprintSize        int
 	EpochReward       int
 
 	logsDirOnce sync.Once
@@ -180,9 +181,16 @@ func WithBootnodeCount(cnt int) ClusterOption {
 		h.BootnodeCount = cnt
 	}
 }
+
 func WithEpochSize(epochSize int) ClusterOption {
 	return func(h *TestClusterConfig) {
 		h.EpochSize = epochSize
+	}
+}
+
+func WithSprintSize(sprintSize int) ClusterOption {
+	return func(h *TestClusterConfig) {
+		h.SprintSize = sprintSize
 	}
 }
 
@@ -291,6 +299,7 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 			"--block-gas-limit", strconv.FormatUint(cluster.Config.BlockGasLimit, 10),
 			"--epoch-size", strconv.Itoa(cluster.Config.EpochSize),
 			"--epoch-reward", strconv.Itoa(cluster.Config.EpochReward),
+			"--sprint-size", strconv.Itoa(cluster.Config.SprintSize),
 			"--premine", "0x0000000000000000000000000000000000000000",
 		}
 


### PR DESCRIPTION
# Description

Implemented multiple commitments per epoch feature, as per RFC-178. Wrote appropriate UTs, and a `e2e` test (`TestE2E_Bridge_MultipleCommitmentsPerEpoch`).

Process of building commitments is as follows:

1. Using the event tracker, listen for state sync events, and store them in db.
2. At the beginning of an epoch, check if we have enough events to build a commitment (minimum size of commitment at least, which is 2 events).
    a. If we have, build a commitment, sign it, and gossip a vote.
    b. If we do not have enough state sync events, wait until we have enough.
3. If we gossiped a commitment which did not have a full size (10 events), on every state sync event that was received in the meantime, create a new commitment (with number of events of the old gossiped commitment, plus the new state syncs), sign it and gossip it.
4. At every sprint block, check which of the gossiped commitments have quorum of votes, find the largest commitment that has quorum, and submit it.
5. Once the block is finalized, check it to see if any was submit commitment transaction occurred.
     a. If there is, create a merkle tree, build state sync proofs, and save them to `boltDb`. Also, discard any cached commitment, 
    since a new one will be built in the next block.
     b. If there isn’t, wait until some proposer submits the largest commitment with quorum.
6. Once the epoch ends, and a new epoch is started, discard any pending commitments (that were built in the previous epoch, and are waiting for quorum of messages), since the validator set changes (we need to rebuild the last pending checkpoint in the new epoch).

![commitmentsBuild](https://user-images.githubusercontent.com/100121253/209815111-db79d69d-d4f9-416a-a93c-a8a0642149c0.jpg)

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually