### PR TITLE
Tracer should only fetch the currently active stack.

### DIFF
--- a/state/runtime/tracer/structtracer/tracer.go
+++ b/state/runtime/tracer/structtracer/tracer.go
@@ -143,7 +143,7 @@ func (t *StructTracer) CaptureState(
 
 	t.captureMemory(memory)
 
-	t.captureStack(stack)
+	t.captureStack(stack, sp)
 
 	t.captureStorage(
 		stack,
@@ -169,14 +169,19 @@ func (t *StructTracer) captureMemory(
 
 func (t *StructTracer) captureStack(
 	stack []*big.Int,
+	sp int,
 ) {
 	if !t.Config.EnableStack {
 		return
 	}
 
-	t.currentStack = make([]*big.Int, len(stack))
+	t.currentStack = make([]*big.Int, sp)
 
 	for i, v := range stack {
+		if i >= sp {
+			break
+		}
+
 		t.currentStack[i] = new(big.Int).Set(v)
 	}
 }


### PR DESCRIPTION
# Description

The stack in the EVM runtime is larger than the currently usable stack, which is controlled with the `sp` variable - due to performance optimizations.

As a part of this PR, tracer will only capture the currently usable stack.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Execute `0x6080604001` bytecode in the EVM, the tracer should report:

- [0x80] , [0x40, 0x80], [0xE0]

previously it was:

- [0x80], [0x40, 0x80], [0xE0, 0x40]