### PR TITLE
Fix gasCost field in return of debug trace

### DIFF
--- a/jsonrpc/debug_endpoint.go
+++ b/jsonrpc/debug_endpoint.go
@@ -19,6 +19,8 @@ var (
 	ErrExecutionTimeout = errors.New("execution timeout")
 	// ErrTraceGenesisBlock is an error returned when tracing genesis block which can't be traced
 	ErrTraceGenesisBlock = errors.New("genesis is not traceable")
+	// ErrNoConfig is an error returns when config is empty
+	ErrNoConfig = errors.New("missing config object")
 )
 
 type debugBlockchainStore interface {
@@ -134,11 +136,11 @@ func (d *Debug) TraceTransaction(
 	}
 
 	tracer, cancel, err := newTracer(config)
-	defer cancel()
-
 	if err != nil {
 		return nil, err
 	}
+
+	defer cancel()
 
 	return d.store.TraceTxn(block, tx.Hash, tracer)
 }
@@ -201,6 +203,10 @@ func newTracer(config *TraceConfig) (
 		timeout = defaultTraceTimeout
 		err     error
 	)
+
+	if config == nil {
+		return nil, nil, ErrNoConfig
+	}
 
 	if config.Timeout != nil {
 		if timeout, err = time.ParseDuration(*config.Timeout); err != nil {

--- a/jsonrpc/debug_endpoint_test.go
+++ b/jsonrpc/debug_endpoint_test.go
@@ -709,6 +709,16 @@ func Test_newTracer(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("should return error if arg is nil", func(t *testing.T) {
+		t.Parallel()
+
+		tracer, cancel, err := newTracer(nil)
+
+		assert.Nil(t, tracer)
+		assert.Nil(t, cancel)
+		assert.ErrorIs(t, ErrNoConfig, err)
+	})
+
 	t.Run("GetResult should return errExecutionTimeout if timeout happens", func(t *testing.T) {
 		t.Parallel()
 

--- a/state/runtime/evm/evm_test.go
+++ b/state/runtime/evm/evm_test.go
@@ -324,7 +324,7 @@ func TestRunWithTracer(t *testing.T) {
 						"ip":              uint64(0),
 						"opcode":          opCodeToString[POP],
 						"availableGas":    uint64(5000),
-						"cost":            uint64(0),
+						"cost":            uint64(2),
 						"lastReturnData":  []byte{},
 						"depth":           1,
 						"err":             errStackUnderflow,

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -224,7 +224,7 @@ func (c *state) Run() ([]byte, error) {
 
 	for !c.stop {
 		op, ok = c.CurrentOpCode()
-		gasCopy := c.gas
+		gasCopy, ipCopy := c.gas, uint64(c.ip)
 
 		c.captureState(int(op))
 
@@ -258,10 +258,10 @@ func (c *state) Run() ([]byte, error) {
 			break
 		}
 
-		c.captureSuccessfulExecution(op.String(), gasCopy, gasCopy-c.gas)
-
 		// execute the instruction
 		inst.inst(c)
+
+		c.captureSuccessfulExecution(op.String(), ipCopy, gasCopy, gasCopy-c.gas)
 
 		// check if stack size exceeds the max size
 		if c.sp > stackSize {
@@ -402,6 +402,7 @@ func (c *state) captureState(opCode int) {
 
 func (c *state) captureSuccessfulExecution(
 	opCode string,
+	ip uint64,
 	gas uint64,
 	consumedGas uint64,
 ) {
@@ -413,7 +414,7 @@ func (c *state) captureSuccessfulExecution(
 
 	tracer.ExecuteState(
 		c.msg.Address,
-		uint64(c.ip),
+		ip,
 		opCode,
 		gas,
 		consumedGas,


### PR DESCRIPTION
# Description

Fix wrong `gasCost` field in return value of debug tracing. Previously this value indicated the total consumed gas after the execution of operation but the expected value is the used gas for the execution of the operation. This PR fixes this issue and adds nil check for config argument in debug tracing API.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
