### PR TITLE
Fix invalid docker compose deployment

### DIFF
--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -8,11 +8,7 @@ services:
       dockerfile: docker/local/Dockerfile
     command: ["init"]
     volumes:
-      - node-1:/polygon-edge/data-1
-      - node-2:/polygon-edge/data-2
-      - node-3:/polygon-edge/data-3
-      - node-4:/polygon-edge/data-4
-      - genesis:/genesis
+      - data:/data
     networks:
       - polygon-edge-docker
   
@@ -22,7 +18,7 @@ services:
     build:
       context: ../../
       dockerfile: docker/local/Dockerfile
-    command: ["server", "--data-dir", "/data", "--chain", "/genesis/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--prometheus", "0.0.0.0:5001", "--seal"]
+    command: ["server", "--data-dir", "/data/data-1", "--chain", "/data/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--prometheus", "0.0.0.0:5001", "--seal"]
     depends_on:
       init:
         condition: service_completed_successfully
@@ -31,8 +27,7 @@ services:
       - '10002:8545'
       - '10003:5001'
     volumes:
-      - node-1:/data
-      - genesis:/genesis
+      - data:/data
     networks:
       - polygon-edge-docker
     restart: on-failure
@@ -41,7 +36,7 @@ services:
     build:
       context: ../../
       dockerfile: docker/local/Dockerfile
-    command: ["server", "--data-dir", "/data", "--chain", "/genesis/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--prometheus", "0.0.0.0:5001", "--seal"]
+    command: ["server", "--data-dir", "/data/data-2", "--chain", "/data/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--prometheus", "0.0.0.0:5001", "--seal"]
     depends_on:
       init:
         condition: service_completed_successfully
@@ -50,8 +45,7 @@ services:
       - '20002:8545'
       - '20003:5001'
     volumes:
-      - node-2:/data
-      - genesis:/genesis
+      - data:/data
     networks:
       - polygon-edge-docker
     restart: on-failure
@@ -60,7 +54,7 @@ services:
     build:
       context: ../../
       dockerfile: docker/local/Dockerfile
-    command: ["server", "--data-dir", "/data", "--chain", "/genesis/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--prometheus", "0.0.0.0:5001", "--seal"]
+    command: ["server", "--data-dir", "/data/data-3", "--chain", "/data/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--prometheus", "0.0.0.0:5001", "--seal"]
     depends_on:
       init:
         condition: service_completed_successfully
@@ -69,8 +63,7 @@ services:
       - '30002:8545'
       - '30003:5001'
     volumes:
-      - node-3:/data
-      - genesis:/genesis
+      - data:/data
     networks:
       - polygon-edge-docker
     restart: on-failure
@@ -79,7 +72,7 @@ services:
     build:
       context: ../../
       dockerfile: docker/local/Dockerfile
-    command: ["server", "--data-dir", "/data", "--chain", "/genesis/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--prometheus", "0.0.0.0:5001", "--seal"]
+    command: ["server", "--data-dir", "/data/data-4", "--chain", "/data/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--prometheus", "0.0.0.0:5001", "--seal"]
     depends_on:
       init:
         condition: service_completed_successfully
@@ -88,8 +81,7 @@ services:
       - '40002:8545'
       - '40003:5001'
     volumes:
-      - node-4:/data
-      - genesis:/genesis
+      - data:/data
     networks:
       - polygon-edge-docker
     restart: on-failure
@@ -100,8 +92,5 @@ networks:
     name: polygon-edge-docker
 
 volumes:
-  node-1:
-  node-2:
-  node-3:
-  node-4:
+  data:
   genesis:

--- a/docker/local/polygon-edge.sh
+++ b/docker/local/polygon-edge.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-POLYGON_EDGE_BIN=./polygon-edge
-GENESIS_PATH=/genesis/genesis.json
+POLYGON_EDGE_BIN=/polygon-edge/polygon-edge
+GENESIS_PATH=/data/genesis.json
 
 case "$1" in
 
@@ -12,11 +12,11 @@ case "$1" in
           echo "Secrets have already been generated."
       else
           echo "Generating secrets..."
-          secrets=$("$POLYGON_EDGE_BIN" secrets init --num 4 --data-dir data- --json)
+          secrets=$("$POLYGON_EDGE_BIN" secrets init --num 4 --data-dir /data/data- --json)
           echo "Secrets have been successfully generated"
 
           echo "Generating genesis file..."
-          "$POLYGON_EDGE_BIN" genesis \
+          cd /data && "$POLYGON_EDGE_BIN" genesis \
             --dir "$GENESIS_PATH" \
             --consensus ibft \
             --ibft-validators-prefix-path data- \


### PR DESCRIPTION
# Description
This PR fixes faulty `docker-compose` deployment for `ibft` consensus on current `develop` branch.    
Also, reworked `docker` scripts to be more in line with `v3-parity` branch, as it will be easier to resolve conflicts.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Run `make run-local` or `docker-compose -f ./docker/local/docker-compose.yml up -d --build` from repo root and the chain should be deployed in a local docker environment.      
To destroy everything, run `docker-compose -f ./docker/local/docker-compose.yml down -v`

Fixes #1094