### PR TITLE
EVM-338 fix race condition on account initialization

### DIFF
--- a/txpool/account.go
+++ b/txpool/account.go
@@ -19,20 +19,15 @@ type accountsMap struct {
 
 // Intializes an account for the given address.
 func (m *accountsMap) initOnce(addr types.Address, nonce uint64) *account {
-	a, _ := m.LoadOrStore(addr, &account{})
+	a, _ := m.LoadOrStore(addr, &account{
+		enqueued:    newAccountQueue(),
+		promoted:    newAccountQueue(),
+		maxEnqueued: m.maxEnqueuedLimit,
+		nextNonce:   nonce,
+	})
 	newAccount := a.(*account) //nolint:forcetypeassert
 	// run only once
 	newAccount.init.Do(func() {
-		// create queues
-		newAccount.enqueued = newAccountQueue()
-		newAccount.promoted = newAccountQueue()
-
-		//	set the limit for enqueued txs
-		newAccount.maxEnqueued = m.maxEnqueuedLimit
-
-		// set the nonce
-		newAccount.setNonce(nonce)
-
 		// update global count
 		atomic.AddUint64(&m.count, 1)
 	})


### PR DESCRIPTION
# Description

When a new account sent multiple transactions at the same time, a possible race condition was occurring as follows (using 2 threads example):

1. thread-1 stores an empty account inside `accountsMap`
2. thread-2 checks whether account with address exists, and sees that it does, so it continues without creating an account itself
3. thread-2 continues it's execution thinking account is valid, and calls a function on one of its fields, which causes a nil dereference exception since thread-1 did not set the account's fields yet

This fix carries the field initialization into the store phase. Since `LoadOrStore` function is already thread-safe, there won't be a state where an invalid account exists inside the `accountMap`. And even if multiple threads try to create an account, it is OK since `LoadOrStore` only allows storing once, and `account.init.Do` is executed only once and is thread safe as well.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually
