### PR TITLE
Implement `Stringer` interface in `AccountSet`

### DIFF
--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -508,16 +508,7 @@ func (f *fsm) getCurrentValidators(pendingBlockState *state.Transition) (Account
 	}
 
 	if f.logger.IsDebug() {
-		var buf bytes.Buffer
-		for i, validator := range newValidators {
-			buf.WriteString(fmt.Sprintf("Address:%s Voting power:%d", validator.Address, validator.VotingPower))
-
-			if i != len(newValidators)-1 {
-				buf.WriteString("\n")
-			}
-		}
-
-		f.logger.Debug("getCurrentValidators", "Validator set", buf.String())
+		f.logger.Debug("getCurrentValidators", "Validator set", newValidators.String())
 	}
 
 	return newValidators, nil

--- a/consensus/polybft/validator_metadata.go
+++ b/consensus/polybft/validator_metadata.go
@@ -1,6 +1,7 @@
 package polybft
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -116,12 +117,23 @@ func (v *ValidatorMetadata) UnmarshalRLPWith(val *fastrlp.Value) error {
 
 // fmt.Stringer implementation
 func (v *ValidatorMetadata) String() string {
-	return fmt.Sprintf("Address=%v; BLS Key=%v; Voting Power=%d",
-		v.Address.String(), hex.EncodeToString(v.BlsKey.Marshal()), v.VotingPower)
+	return fmt.Sprintf("Address=%v; Voting Power=%d; BLS Key=%v;",
+		v.Address.String(), v.VotingPower, hex.EncodeToString(v.BlsKey.Marshal()))
 }
 
 // AccountSet is a type alias for slice of ValidatorMetadata instances
 type AccountSet []*ValidatorMetadata
+
+// fmt.Stringer implementation
+func (as AccountSet) String() string {
+	var buf bytes.Buffer
+	for _, v := range as {
+		buf.WriteString(v.String())
+		buf.WriteString("\n")
+	}
+
+	return buf.String()
+}
 
 // GetAddresses aggregates addresses for given AccountSet
 func (as AccountSet) GetAddresses() []types.Address {

--- a/consensus/polybft/validator_metadata.go
+++ b/consensus/polybft/validator_metadata.go
@@ -1,13 +1,13 @@
 package polybft
 
 import (
-	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
 	"reflect"
+	"strings"
 
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/crypto"
@@ -126,13 +126,12 @@ type AccountSet []*ValidatorMetadata
 
 // fmt.Stringer implementation
 func (as AccountSet) String() string {
-	var buf bytes.Buffer
-	for _, v := range as {
-		buf.WriteString(v.String())
-		buf.WriteString("\n")
+	metadataString := make([]string, len(as))
+	for i, v := range as {
+		metadataString[i] = v.String()
 	}
 
-	return buf.String()
+	return strings.Join(metadataString, "\n")
 }
 
 // GetAddresses aggregates addresses for given AccountSet


### PR DESCRIPTION
# Description

This PR implements `fmt.Stringer` interface by the `AccountSet`, so that we have prettified logging output for validator accounts.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually