### PR TITLE
EVM-338 & EVM-340 fix race condition on account initialization

### DIFF
--- a/txpool/account.go
+++ b/txpool/account.go
@@ -19,20 +19,15 @@ type accountsMap struct {
 
 // Intializes an account for the given address.
 func (m *accountsMap) initOnce(addr types.Address, nonce uint64) *account {
-	a, _ := m.LoadOrStore(addr, &account{})
+	a, _ := m.LoadOrStore(addr, &account{
+		enqueued:    newAccountQueue(),
+		promoted:    newAccountQueue(),
+		maxEnqueued: m.maxEnqueuedLimit,
+		nextNonce:   nonce,
+	})
 	newAccount := a.(*account) //nolint:forcetypeassert
 	// run only once
 	newAccount.init.Do(func() {
-		// create queues
-		newAccount.enqueued = newAccountQueue()
-		newAccount.promoted = newAccountQueue()
-
-		//	set the limit for enqueued txs
-		newAccount.maxEnqueued = m.maxEnqueuedLimit
-
-		// set the nonce
-		newAccount.setNonce(nonce)
-
 		// update global count
 		atomic.AddUint64(&m.count, 1)
 	})

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math/big"
+	"sync"
 	"testing"
 	"time"
 
@@ -2727,5 +2728,74 @@ func TestSetSealing(t *testing.T) {
 				pool.getSealing(),
 			)
 		})
+	}
+}
+
+func TestBatchTx_SingleAccount(t *testing.T) {
+	t.Parallel()
+
+	_, addr := tests.GenerateKeyAndAddr(t)
+
+	pool, err := newTestPool()
+	assert.NoError(t, err)
+
+	pool.SetSigner(&mockSigner{})
+
+	// start event handler goroutines
+	pool.Start()
+	defer pool.Close()
+
+	// subscribe to ennewTxqueue and promote events
+	subscription := pool.eventManager.subscribe([]proto.EventType{proto.EventType_ENQUEUED, proto.EventType_PROMOTED})
+	defer pool.eventManager.cancelSubscription(subscription.subscriptionID)
+
+	txHashMap := map[types.Hash]struct{}{}
+	// mutex for txHashMap
+	mux := &sync.RWMutex{}
+
+	// run max number of addTx in parallel
+	for i := 0; i < int(defaultMaxAccountEnqueued); i++ {
+		go func(i uint64) {
+			tx := newTx(addr, i, 1)
+
+			tx.ComputeHash()
+
+			// add transaction hash to map
+			mux.Lock()
+			txHashMap[tx.Hash] = struct{}{}
+			mux.Unlock()
+
+			// submit transaction to pool
+			pool.addTx(local, tx)
+		}(uint64(i))
+	}
+
+	enqueuedCount := 0
+	promotedCount := 0
+
+	// wait for all the submitted transactions to be promoted
+	for {
+		ev := <-subscription.subscriptionChannel
+
+		// check if valid transaction hash
+		mux.Lock()
+		_, hashExists := txHashMap[types.StringToHash(ev.TxHash)]
+		mux.Unlock()
+
+		assert.True(t, hashExists)
+
+		// increment corresponding event type's count
+		if ev.Type == proto.EventType_ENQUEUED {
+			enqueuedCount++
+		} else if ev.Type == proto.EventType_PROMOTED {
+			promotedCount++
+		}
+
+		if enqueuedCount == int(defaultMaxAccountEnqueued) && promotedCount == int(defaultMaxAccountEnqueued) {
+			assert.Equal(t, defaultMaxAccountEnqueued, pool.Length())
+
+			// all transactions are promoted
+			break
+		}
 	}
 }

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -2745,7 +2745,7 @@ func TestBatchTx_SingleAccount(t *testing.T) {
 	pool.Start()
 	defer pool.Close()
 
-	// subscribe to ennewTxqueue and promote events
+	// subscribe to enqueue and promote events
 	subscription := pool.eventManager.subscribe([]proto.EventType{proto.EventType_ENQUEUED, proto.EventType_PROMOTED})
 	defer pool.eventManager.cancelSubscription(subscription.subscriptionID)
 
@@ -2753,7 +2753,7 @@ func TestBatchTx_SingleAccount(t *testing.T) {
 	// mutex for txHashMap
 	mux := &sync.RWMutex{}
 
-	// run max number of addTx in parallel
+	// run max number of addTx concurrently
 	for i := 0; i < int(defaultMaxAccountEnqueued); i++ {
 		go func(i uint64) {
 			tx := newTx(addr, i, 1)
@@ -2792,6 +2792,7 @@ func TestBatchTx_SingleAccount(t *testing.T) {
 		}
 
 		if enqueuedCount == int(defaultMaxAccountEnqueued) && promotedCount == int(defaultMaxAccountEnqueued) {
+			// compare local tracker to pool internal
 			assert.Equal(t, defaultMaxAccountEnqueued, pool.Length())
 
 			// all transactions are promoted


### PR DESCRIPTION
# Description

When a new account sent multiple transactions at the same time, a possible race condition was occurring as follows (using 2 threads example):

- thread-1 stores an empty account inside accountsMap
- thread-2 checks whether account with address exists, and sees that it does, so it continues without creating an account itself
- thread-2 continues it's execution thinking account is valid, and calls a function on one of its fields, which causes a nil dereference exception since thread-1 did not set the account's fields yet

This fix carries the field initialization into the store phase. Since LoadOrStore function is already thread-safe, there won't be a state where an invalid account exists inside the accountMap. And even if multiple threads try to create an account, it is OK since LoadOrStore only allows storing once, and account.init.Do is executed only once and is thread safe as well.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

## Manual Testing

I ran the test which is added in this PR multiple times (more than 50) in both debug mode and with `go test`. Debug mode is done with breakpoints around the lines where data race occurs. 

## Additional Comments

Since this is a data race bug, it is relatively hard to fully encapsulate this case in a unit test. I believe the best that can be done is to send batch of transactions from single account in parallel with the hope of encountering this specific case, which seems pretty high-likely according to the testing I did manually. I added such test to PR.

One weird behavior I observed was that when I run the test in the unchanged version with `go test`, it's always success. Same goes for testing in debug mode with no breakpoints. But when I debug the test with breakpoints around the lines which data race occurs, it almost always fails.

This could be expected to some extent since breakpoints changes behavior and might cause priority changes on threads. But it is weird that I literally got error 0 times when I did it with `go test` and got error 99% of the time when I did it in debug mode with breakpoints.

PS: I ran `go clean -testcache` after every `go test` as well.

For clarification, I also tested with the updated version, everything worked fine with all above mentioned cases.