### PR TITLE
Return FullBlock from syncer

### DIFF
--- a/archive/restore.go
+++ b/archive/restore.go
@@ -23,7 +23,7 @@ type blockchainInterface interface {
 	GetBlockByNumber(uint64, bool) (*types.Block, bool)
 	GetHashByNumber(uint64) types.Hash
 	WriteBlock(*types.Block, string) error
-	VerifyFinalizedBlock(*types.Block) error
+	VerifyFinalizedBlock(*types.Block) (*types.FullBlock, error)
 }
 
 // RestoreChain reads blocks from the archive and write to the chain
@@ -78,7 +78,7 @@ func importBlocks(chain blockchainInterface, blockStream *blockStream, progressi
 	nextBlock := firstBlock
 
 	for {
-		if err := chain.VerifyFinalizedBlock(nextBlock); err != nil {
+		if _, err := chain.VerifyFinalizedBlock(nextBlock); err != nil {
 			return err
 		}
 

--- a/archive/restore_test.go
+++ b/archive/restore_test.go
@@ -55,8 +55,8 @@ func (m *mockChain) WriteBlock(block *types.Block, _ string) error {
 	return nil
 }
 
-func (m *mockChain) VerifyFinalizedBlock(block *types.Block) error {
-	return nil
+func (m *mockChain) VerifyFinalizedBlock(block *types.Block) (*types.FullBlock, error) {
+	return &types.FullBlock{Block: block}, nil
 }
 
 func (m *mockChain) SubscribeEvents() blockchain.Subscription {

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -885,27 +885,6 @@ func (b *Blockchain) executeBlockTransactions(block *types.Block) (*BlockResult,
 func (b *Blockchain) WriteFullBlock(fblock *types.FullBlock, source string) error {
 	block := fblock.Block
 
-	return b.writeBlockInternal(block, source,
-		func(b *types.Block) ([]*types.Receipt, error) {
-			// Provide the block receipts
-			return fblock.Receipts, nil
-		})
-}
-
-// WriteBlock writes a single block to the local blockchain.
-// It doesn't do any kind of verification, only commits the block to the DB
-func (b *Blockchain) WriteBlock(block *types.Block, source string) error {
-	return b.writeBlockInternal(block, source,
-		func(block *types.Block) ([]*types.Receipt, error) {
-			// Calculate block receipts
-			return b.extractBlockReceipts(block)
-		})
-}
-
-// writeBlockInternal writes a single block to the local blockchain.
-// It doesn't do any kind of verification, only commits the block to the DB
-func (b *Blockchain) writeBlockInternal(block *types.Block, source string,
-	receiptsProvider func(*types.Block) ([]*types.Receipt, error)) error {
 	b.writeLock.Lock()
 	defer b.writeLock.Unlock()
 
@@ -917,7 +896,64 @@ func (b *Blockchain) writeBlockInternal(block *types.Block, source string,
 
 	header := block.Header
 
-	// Write transactions
+	if err := b.writeBody(block); err != nil {
+		return err
+	}
+
+	// Write the header to the chain
+	evnt := &Event{Source: source}
+	if err := b.writeHeaderImpl(evnt, header); err != nil {
+		return err
+	}
+
+	// write the receipts, do it only after the header has been written.
+	// Otherwise, a client might ask for a header once the receipt is valid,
+	// but before it is written into the storage
+	if err := b.db.WriteReceipts(block.Hash(), fblock.Receipts); err != nil {
+		return err
+	}
+
+	// update snapshot
+	if err := b.consensus.ProcessHeaders([]*types.Header{header}); err != nil {
+		return err
+	}
+
+	b.dispatchEvent(evnt)
+
+	// Update the average gas price
+	b.updateGasPriceAvgWithBlock(block)
+
+	logArgs := []interface{}{
+		"number", header.Number,
+		"txs", len(block.Transactions),
+		"hash", header.Hash,
+		"parent", header.ParentHash,
+	}
+
+	if prevHeader, ok := b.GetHeaderByNumber(header.Number - 1); ok {
+		diff := header.Timestamp - prevHeader.Timestamp
+		logArgs = append(logArgs, "generation_time_in_seconds", diff)
+	}
+
+	b.logger.Info("new block", logArgs...)
+
+	return nil
+}
+
+// WriteBlock writes a single block to the local blockchain.
+// It doesn't do any kind of verification, only commits the block to the DB
+func (b *Blockchain) WriteBlock(block *types.Block, source string) error {
+	b.writeLock.Lock()
+	defer b.writeLock.Unlock()
+
+	if block.Number() <= b.Header().Number {
+		b.logger.Info("block already inserted", "block", block.Number(), "source", source)
+
+		return nil
+	}
+
+	header := block.Header
+
 	if err := b.writeBody(block); err != nil {
 		return err
 	}
@@ -929,19 +965,19 @@ func (b *Blockchain) writeBlockInternal(block *types.Block, source string,
 	}
 
 	// Fetch the block receipts
-	receipts, err := receiptsProvider(block)
-	if err != nil {
-		return err
+	blockReceipts, receiptsErr := b.extractBlockReceipts(block)
+	if receiptsErr != nil {
+		return receiptsErr
 	}
 
-	// Write the receipts, do it only after the header has been written.
+	// write the receipts, do it only after the header has been written.
 	// Otherwise, a client might ask for a header once the receipt is valid,
 	// but before it is written into the storage
-	if err := b.db.WriteReceipts(block.Hash(), receipts); err != nil {
+	if err := b.db.WriteReceipts(block.Hash(), blockReceipts); err != nil {
 		return err
 	}
 
-	// Update snapshot
+	// update snapshot
 	if err := b.consensus.ProcessHeaders([]*types.Header{header}); err != nil {
 		return err
 	}

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -902,6 +902,15 @@ func (b *Blockchain) WriteFullBlock(fblock *types.FullBlock, source string) erro
 		return err
 	}
 
+	if fblock.Receipts == nil { // Fetch the block receipts from cache if not already set
+		blockReceipts, receiptsErr := b.extractBlockReceipts(block)
+		if receiptsErr != nil {
+			return receiptsErr
+		}
+
+		fblock.Receipts = blockReceipts
+	}
+
 	// write the receipts, do it only after the header has been written.
 	// Otherwise, a client might ask for a header once the receipt is valid,
 	// but before it is written into the storage

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -1202,7 +1202,8 @@ func TestBlockchain_VerifyBlockBody(t *testing.T) {
 			},
 		}
 
-		assert.ErrorIs(t, blockchain.verifyBlockBody(block), ErrInvalidSha3Uncles)
+		_, err = blockchain.verifyBlockBody(block)
+		assert.ErrorIs(t, err, ErrInvalidSha3Uncles)
 	})
 
 	t.Run("Invalid Transactions root", func(t *testing.T) {
@@ -1219,7 +1220,8 @@ func TestBlockchain_VerifyBlockBody(t *testing.T) {
 			},
 		}
 
-		assert.ErrorIs(t, blockchain.verifyBlockBody(block), ErrInvalidTxRoot)
+		_, err = blockchain.verifyBlockBody(block)
+		assert.ErrorIs(t, err, ErrInvalidTxRoot)
 	})
 
 	t.Run("Invalid execution result - missing parent", func(t *testing.T) {
@@ -1246,7 +1248,8 @@ func TestBlockchain_VerifyBlockBody(t *testing.T) {
 			},
 		}
 
-		assert.ErrorIs(t, blockchain.verifyBlockBody(block), ErrParentNotFound)
+		_, err = blockchain.verifyBlockBody(block)
+		assert.ErrorIs(t, err, ErrParentNotFound)
 	})
 
 	t.Run("Invalid execution result - unable to fetch block creator", func(t *testing.T) {
@@ -1285,7 +1288,8 @@ func TestBlockchain_VerifyBlockBody(t *testing.T) {
 			},
 		}
 
-		assert.ErrorIs(t, blockchain.verifyBlockBody(block), errBlockCreatorNotFound)
+		_, err = blockchain.verifyBlockBody(block)
+		assert.ErrorIs(t, err, errBlockCreatorNotFound)
 	})
 
 	t.Run("Invalid execution result - unable to execute transactions", func(t *testing.T) {
@@ -1327,6 +1331,7 @@ func TestBlockchain_VerifyBlockBody(t *testing.T) {
 			},
 		}
 
-		assert.ErrorIs(t, blockchain.verifyBlockBody(block), errUnableToExecute)
+		_, err = blockchain.verifyBlockBody(block)
+		assert.ErrorIs(t, err, errUnableToExecute)
 	})
 }

--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -197,7 +197,7 @@ func (d *Dev) writeNewBlock(parent *types.Header) error {
 		Receipts: transition.Receipts(),
 	})
 
-	if err := d.blockchain.VerifyFinalizedBlock(block); err != nil {
+	if _, err := d.blockchain.VerifyFinalizedBlock(block); err != nil {
 		return err
 	}
 

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -208,16 +208,16 @@ func (i *backendIBFT) Initialize() error {
 
 // sync runs the syncer in the background to receive blocks from advanced peers
 func (i *backendIBFT) startSyncing() {
-	callInsertBlockHook := func(block *types.Block) bool {
-		if err := i.currentHooks.PostInsertBlock(block); err != nil {
-			i.logger.Error("failed to call PostInsertBlock", "height", block.Header.Number, "error", err)
+	callInsertBlockHook := func(fullBlock *types.FullBlock) bool {
+		if err := i.currentHooks.PostInsertBlock(fullBlock.Block); err != nil {
+			i.logger.Error("failed to call PostInsertBlock", "height", fullBlock.Block.Header.Number, "error", err)
 		}
 
-		if err := i.updateCurrentModules(block.Number() + 1); err != nil {
-			i.logger.Error("failed to update sub modules", "height", block.Number()+1, "err", err)
+		if err := i.updateCurrentModules(fullBlock.Block.Number() + 1); err != nil {
+			i.logger.Error("failed to update sub modules", "height", fullBlock.Block.Number()+1, "err", err)
 		}
 
-		i.txpool.ResetWithHeaders(block.Header)
+		i.txpool.ResetWithHeaders(fullBlock.Block.Header)
 
 		return false
 	}

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -227,7 +227,7 @@ func TestConsensusRuntime_OnBlockInserted_EndOfEpoch(t *testing.T) {
 		lastBuiltBlock:   &types.Header{Number: header.Number - 1},
 		stateSyncManager: &dummyStateSyncManager{},
 	}
-	runtime.OnBlockInserted(builtBlock)
+	runtime.OnBlockInserted(&types.FullBlock{Block: builtBlock})
 
 	require.True(t, runtime.state.isEpochInserted(currentEpochNumber+1))
 	require.Equal(t, newEpochNumber, runtime.epoch.Number)
@@ -281,7 +281,7 @@ func TestConsensusRuntime_OnBlockInserted_MiddleOfEpoch(t *testing.T) {
 		logger:             hclog.NewNullLogger(),
 		proposerCalculator: NewProposerCalculatorFromSnapshot(snapshot, config, hclog.NewNullLogger()),
 	}
-	runtime.OnBlockInserted(builtBlock)
+	runtime.OnBlockInserted(&types.FullBlock{Block: builtBlock})
 
 	require.Equal(t, header.Number, runtime.lastBuiltBlock.Number)
 }

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -407,7 +407,7 @@ func (f *fsm) VerifyStateTransactions(transactions []*types.Transaction) error {
 
 // Insert inserts the sealed proposal
 func (f *fsm) Insert(proposal []byte, committedSeals []*messages.CommittedSeal) (*types.FullBlock, error) {
-	newBlock := &types.FullBlock{Block: f.target.Block, Receipts: f.target.Receipts}
+	newBlock := f.target
 
 	// In this function we should try to return little to no errors since
 	// at this point everything we have to do is just commit something that

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -175,11 +175,11 @@ func TestFSM_BuildProposal_WithExitEvents(t *testing.T) {
 
 	commitedSeals := []*messages.CommittedSeal{}
 
-	block, err := fsm.Insert(proposal, commitedSeals)
+	fullBlock, err := fsm.Insert(proposal, commitedSeals)
 
 	require.NoError(t, err)
-	require.Equal(t, parentBlockNumber+1, block.Number())
-	require.Equal(t, parent.Hash, block.ParentHash())
+	require.Equal(t, parentBlockNumber+1, fullBlock.Block.Number())
+	require.Equal(t, parent.Hash, fullBlock.Block.ParentHash())
 
 	events, err := runtime.state.getExitEventsByEpoch(epoch)
 	require.NoError(t, err)
@@ -992,11 +992,11 @@ func TestFSM_Insert_Good(t *testing.T) {
 
 	fsm.target = buildBlock
 
-	block, err := fsm.Insert(proposal, commitedSeals)
+	fullBlock, err := fsm.Insert(proposal, commitedSeals)
 
 	require.NoError(t, err)
 	mBackendMock.AssertExpectations(t)
-	assert.Equal(t, parentBlockNumber+1, block.Number())
+	assert.Equal(t, parentBlockNumber+1, fullBlock.Block.Number())
 }
 
 func TestFSM_Insert_InvalidNode(t *testing.T) {
@@ -1426,12 +1426,12 @@ func TestFSM_InsertBlock_HasEpochEndingExitEvents(t *testing.T) {
 
 	proposal := buildBlock.Block.MarshalRLP()
 
-	// insert block
-	block, err := fsm.Insert(proposal, commitedSeals)
+	// insert fullBlock
+	fullBlock, err := fsm.Insert(proposal, commitedSeals)
 
 	require.NoError(t, err)
 	mBackendMock.AssertExpectations(t)
-	assert.Equal(t, parentBlockNumber+1, block.Number())
+	assert.Equal(t, parentBlockNumber+1, fullBlock.Block.Number())
 
 	// check that exit event was not added in current epoch
 	_, err = state.getExitEvent(exitEventID, epoch)
@@ -1445,7 +1445,7 @@ func TestFSM_InsertBlock_HasEpochEndingExitEvents(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, epoch+1, exitEvent.EpochNumber)
 	require.Equal(t, exitEventID, exitEvent.ID)
-	require.Equal(t, block.Header.Number, exitEvent.BlockNumber)
+	require.Equal(t, fullBlock.Block.Header.Number, exitEvent.BlockNumber)
 
 	// check that the exit event is in exit event root for next epoch
 	exitRootHash, err := runtime.BuildEventRoot(epoch + 1)

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -559,7 +559,7 @@ func (tp *syncerMock) HasSyncPeer() bool {
 	return args[0].(bool) //nolint
 }
 
-func (tp *syncerMock) Sync(func(*types.Block) bool) error {
+func (tp *syncerMock) Sync(func(*types.FullBlock) bool) error {
 	args := tp.Called()
 
 	return args.Error(0)

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -223,7 +223,7 @@ func (p *Polybft) Start() error {
 
 	// start syncing
 	go func() {
-		blockHandler := func(b *types.Block) bool {
+		blockHandler := func(b *types.FullBlock) bool {
 			p.runtime.OnBlockInserted(b)
 
 			return false

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -238,11 +238,10 @@ func (s *syncer) bulkSyncWithPeer(peerID peer.ID, newBlockCallback func(*types.F
 				continue
 			}
 
-			if err := s.blockchain.VerifyFinalizedBlock(block); err != nil {
+			fullBlock, err := s.blockchain.VerifyFinalizedBlock(block)
+			if err != nil {
 				return lastReceivedNumber, false, fmt.Errorf("unable to verify block, %w", err)
 			}
-
-			fullBlock := &types.FullBlock{Block: block}
 
 			if err := s.blockchain.WriteFullBlock(fullBlock, syncerName); err != nil {
 				return lastReceivedNumber, false, fmt.Errorf("failed to write block while bulk syncing: %w", err)

--- a/syncer/types.go
+++ b/syncer/types.go
@@ -24,7 +24,7 @@ type Blockchain interface {
 	// GetBlockByNumber returns block by number
 	GetBlockByNumber(uint64, bool) (*types.Block, bool)
 	// VerifyFinalizedBlock verifies finalized block
-	VerifyFinalizedBlock(*types.Block) error
+	VerifyFinalizedBlock(block *types.Block) (*types.FullBlock, error)
 	// WriteBlock writes a given block to chain
 	WriteBlock(*types.Block, string) error
 	// WriteFullBlock writes a given block to chain and saves its receipts to cache

--- a/syncer/types.go
+++ b/syncer/types.go
@@ -27,6 +27,8 @@ type Blockchain interface {
 	VerifyFinalizedBlock(*types.Block) error
 	// WriteBlock writes a given block to chain
 	WriteBlock(*types.Block, string) error
+	// WriteFullBlock writes a given block to chain and saves its receipts to cache
+	WriteFullBlock(*types.FullBlock, string) error
 }
 
 type Network interface {
@@ -63,7 +65,7 @@ type Syncer interface {
 	// HasSyncPeer returns whether syncer has the peer syncer can sync with
 	HasSyncPeer() bool
 	// Sync starts routine to sync blocks
-	Sync(func(*types.Block) bool) error
+	Sync(func(*types.FullBlock) bool) error
 }
 
 type Progression interface {


### PR DESCRIPTION
# Description

This PR modifies the `OnBlockInserted` callback to `consensus engine` from `syncer` so that it returns a `types.FullBlock` (which contains transaction receipts as well, not just the block).

This is needed so that the `consensus engine` has all the necessary data for `bridge` to properly function, specifically exit workflow, since currently we are only extracting exit events when a block is inserted through consensus.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually