### PR TITLE
Validator unstake e2e test

### DIFF
--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math/big"
 	"sort"
 	"time"
 
@@ -216,6 +215,13 @@ func (p *genesisParams) deployContracts() (map[types.Address]*chain.GenesisAccou
 
 	allocations := make(map[types.Address]*chain.GenesisAccount, len(genesisContracts))
 
+	val := command.DefaultPremineBalance
+
+	contractBalance, err := types.ParseUint256orHex(&val)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, contract := range genesisContracts {
 		artifact, err := artifact.ReadArtifact(p.smartContractsRootPath, contract.relativePath, contract.name)
 		if err != nil {
@@ -223,7 +229,7 @@ func (p *genesisParams) deployContracts() (map[types.Address]*chain.GenesisAccou
 		}
 
 		allocations[contract.address] = &chain.GenesisAccount{
-			Balance: big.NewInt(0),
+			Balance: contractBalance,
 			Code:    artifact.DeployedBytecode,
 		}
 	}

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -227,19 +227,14 @@ func (p *genesisParams) deployContracts(totalStake *big.Int) (map[types.Address]
 			return nil, err
 		}
 
-		// ChildValidatorSet must have funds pre-allocated, because of withdrawal workflow
-		if contract.name == "ChildValidatorSet" {
-			allocations[contract.address] = &chain.GenesisAccount{
-				Balance: totalStake,
-				Code:    artifact.DeployedBytecode,
-			}
-		} else {
-			allocations[contract.address] = &chain.GenesisAccount{
-				Balance: big.NewInt(0),
-				Code:    artifact.DeployedBytecode,
-			}
+		allocations[contract.address] = &chain.GenesisAccount{
+			Balance: big.NewInt(0),
+			Code:    artifact.DeployedBytecode,
 		}
 	}
+
+	// ChildValidatorSet must have funds pre-allocated, because of withdrawal workflow
+	allocations[contracts.ValidatorSetContract].Balance = totalStake
 
 	return allocations, nil
 }

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -99,8 +99,9 @@ func (p *genesisParams) generatePolyBftChainConfig() error {
 		premineInfos[i] = premineInfo
 		validatorPreminesMap[premineInfo.address] = i
 
+		// TODO: @Stefan-Ethernal change this to Stake when https://github.com/0xPolygon/polygon-edge/pull/1137 gets merged
 		// increment total stake
-		totalStake.Add(totalStake, validator.Stake)
+		totalStake.Add(totalStake, validator.Balance)
 	}
 
 	// deploy genesis contracts

--- a/command/sidechain/helper.go
+++ b/command/sidechain/helper.go
@@ -28,6 +28,8 @@ const (
 var (
 	getDelegatorRewardMethod, _ = abi.NewMethod(
 		"getDelegatorReward(address validator, address delegator) returns (uint256)")
+	getValidatorRewardMethod, _ = abi.NewMethod(
+		"getValidatorReward(address validator) returns (uint256)")
 )
 
 func CheckIfDirectoryExist(dir string) error {
@@ -105,4 +107,26 @@ func GetDelegatorReward(validatorAddr ethgo.Address, delegatorAddr ethgo.Address
 	}
 
 	return delegatorReward, nil
+}
+
+// GetDelegatorReward queries delegator reward for given validator address
+func GetValidatorReward(validatorAddr ethgo.Address, txRelayer txrelayer.TxRelayer) (*big.Int, error) {
+	input, err := getValidatorRewardMethod.Encode([]interface{}{validatorAddr})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode input parameters for getDelegatorReward fn: %w", err)
+	}
+
+	response, err := txRelayer.Call(ethgo.Address(contracts.SystemCaller),
+		ethgo.Address(contracts.ValidatorSetContract), input)
+	if err != nil {
+		return nil, err
+	}
+
+	validatorReward, err := types.ParseUint256orHex(&response)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode hex response, %w", err)
+	}
+
+	return validatorReward, nil
 }

--- a/command/sidechain/helper.go
+++ b/command/sidechain/helper.go
@@ -28,8 +28,6 @@ const (
 var (
 	getDelegatorRewardMethod, _ = abi.NewMethod(
 		"getDelegatorReward(address validator, address delegator) returns (uint256)")
-	getValidatorRewardMethod, _ = abi.NewMethod(
-		"getValidatorReward(address validator) returns (uint256)")
 )
 
 func CheckIfDirectoryExist(dir string) error {
@@ -107,26 +105,4 @@ func GetDelegatorReward(validatorAddr ethgo.Address, delegatorAddr ethgo.Address
 	}
 
 	return delegatorReward, nil
-}
-
-// GetDelegatorReward queries delegator reward for given validator address
-func GetValidatorReward(validatorAddr ethgo.Address, txRelayer txrelayer.TxRelayer) (*big.Int, error) {
-	input, err := getValidatorRewardMethod.Encode([]interface{}{validatorAddr})
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode input parameters for getDelegatorReward fn: %w", err)
-	}
-
-	response, err := txRelayer.Call(ethgo.Address(contracts.SystemCaller),
-		ethgo.Address(contracts.ValidatorSetContract), input)
-	if err != nil {
-		return nil, err
-	}
-
-	validatorReward, err := types.ParseUint256orHex(&response)
-	if err != nil {
-		return nil, fmt.Errorf("unable to decode hex response, %w", err)
-	}
-
-	return validatorReward, nil
 }

--- a/e2e-polybft/bridge_test.go
+++ b/e2e-polybft/bridge_test.go
@@ -495,12 +495,6 @@ func ABITransaction(relayer txrelayer.TxRelayer, key ethgo.Key, artifact *artifa
 	}, key)
 }
 
-type validatorInfo struct {
-	address    ethgo.Address
-	rewards    *big.Int
-	totalStake *big.Int
-}
-
 func TestE2E_Bridge_ChangeVotingPower(t *testing.T) {
 	const (
 		finalBlockNumber   = 20

--- a/e2e-polybft/consensus_test.go
+++ b/e2e-polybft/consensus_test.go
@@ -374,11 +374,10 @@ func TestE2E_Consensus_Validator_Unstake(t *testing.T) {
 	err = cluster.Bridge.WaitUntil(time.Second, 10*time.Second, func() (bool, error) {
 		rootchainValidators, err = getRootchainValidators(l1Relayer, checkpointManagerAddr, rootchainSender)
 		if err != nil {
-			return false, err
+			return true, err
 		}
 
-		// execute until number of validators is different than 5 (namely it becomes 4)
-		return len(rootchainValidators) == 5, nil
+		return len(rootchainValidators) == 4, nil
 	})
 	require.NoError(t, err)
 	require.Equal(t, 4, len(rootchainValidators))

--- a/e2e-polybft/framework/test-server.go
+++ b/e2e-polybft/framework/test-server.go
@@ -165,6 +165,20 @@ func (t *TestServer) Stake(amount uint64) error {
 	return runCommand(t.clusterConfig.Binary, args, t.clusterConfig.GetStdout("stake"))
 }
 
+// Unstake unstakes given amount from validator account encapsulated by given server instance
+func (t *TestServer) Unstake(amount uint64) error {
+	args := []string{
+		"polybft",
+		"unstake",
+		"--account", t.config.DataDir,
+		"--jsonrpc", t.JSONRPCAddr(),
+		"--amount", strconv.FormatUint(amount, 10),
+		"--self",
+	}
+
+	return runCommand(t.clusterConfig.Binary, args, t.clusterConfig.GetStdout("stake"))
+}
+
 // RegisterValidator is a wrapper function which registers new validator with given balance and stake
 func (t *TestServer) RegisterValidator(secrets string, balance string, stake string) error {
 	args := []string{

--- a/e2e-polybft/helpers_test.go
+++ b/e2e-polybft/helpers_test.go
@@ -2,7 +2,9 @@ package e2e
 
 import (
 	"errors"
+	"math/big"
 
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -25,4 +27,67 @@ func (s *e2eStateProvider) Call(contractAddr ethgo.Address, input []byte, opts *
 
 func (s *e2eStateProvider) Txn(ethgo.Address, ethgo.Key, []byte) (contract.Txn, error) {
 	return nil, errors.New("send txn is not supported")
+}
+
+type validatorInfo struct {
+	address    ethgo.Address
+	rewards    *big.Int
+	totalStake *big.Int
+}
+
+// getRootchainValidators queries rootchain validator set
+func getRootchainValidators(relayer txrelayer.TxRelayer, checkpointManagerAddr, sender ethgo.Address) ([]*validatorInfo, error) {
+	getValidatorCount := func() (uint64, error) {
+		validatorCountRaw, err := ABICall(relayer, contractsapi.CheckpointManager,
+			checkpointManagerAddr, sender, "currentValidatorSetLength")
+		if err != nil {
+			return 0, err
+		}
+
+		actualValidatorCount, err := types.ParseUint64orHex(&validatorCountRaw)
+		if err != nil {
+			return 0, err
+		}
+
+		return actualValidatorCount, nil
+	}
+
+	numberOfValidators, err := getValidatorCount()
+	if err != nil {
+		return nil, err
+	}
+
+	currentValidatorSetMethod := contractsapi.CheckpointManager.Abi.GetMethod("currentValidatorSet")
+	validators := make([]*validatorInfo, numberOfValidators)
+
+	for i := 0; i < int(numberOfValidators); i++ {
+		validatorRaw, err := ABICall(relayer, contractsapi.CheckpointManager,
+			checkpointManagerAddr, sender, "currentValidatorSet", i)
+		if err != nil {
+			return nil, err
+		}
+
+		validatorSetRaw, err := hex.DecodeString(validatorRaw[2:])
+		if err != nil {
+			return nil, err
+		}
+
+		decodedResults, err := currentValidatorSetMethod.Outputs.Decode(validatorSetRaw)
+		if err != nil {
+			return nil, err
+		}
+
+		results, ok := decodedResults.(map[string]interface{})
+		if !ok {
+			return nil, errors.New("failed to decode validator")
+		}
+
+		//nolint:forcetypeassert
+		validators[i] = &validatorInfo{
+			address:    results["_address"].(ethgo.Address),
+			totalStake: results["votingPower"].(*big.Int),
+		}
+	}
+
+	return validators, nil
 }

--- a/e2e-polybft/helpers_test.go
+++ b/e2e-polybft/helpers_test.go
@@ -37,30 +37,21 @@ type validatorInfo struct {
 
 // getRootchainValidators queries rootchain validator set
 func getRootchainValidators(relayer txrelayer.TxRelayer, checkpointManagerAddr, sender ethgo.Address) ([]*validatorInfo, error) {
-	getValidatorCount := func() (uint64, error) {
-		validatorCountRaw, err := ABICall(relayer, contractsapi.CheckpointManager,
-			checkpointManagerAddr, sender, "currentValidatorSetLength")
-		if err != nil {
-			return 0, err
-		}
-
-		actualValidatorCount, err := types.ParseUint64orHex(&validatorCountRaw)
-		if err != nil {
-			return 0, err
-		}
-
-		return actualValidatorCount, nil
+	validatorsCountRaw, err := ABICall(relayer, contractsapi.CheckpointManager,
+		checkpointManagerAddr, sender, "currentValidatorSetLength")
+	if err != nil {
+		return nil, err
 	}
 
-	numberOfValidators, err := getValidatorCount()
+	validatorsCount, err := types.ParseUint64orHex(&validatorsCountRaw)
 	if err != nil {
 		return nil, err
 	}
 
 	currentValidatorSetMethod := contractsapi.CheckpointManager.Abi.GetMethod("currentValidatorSet")
-	validators := make([]*validatorInfo, numberOfValidators)
+	validators := make([]*validatorInfo, validatorsCount)
 
-	for i := 0; i < int(numberOfValidators); i++ {
+	for i := 0; i < int(validatorsCount); i++ {
 		validatorRaw, err := ABICall(relayer, contractsapi.CheckpointManager,
 			checkpointManagerAddr, sender, "currentValidatorSet", i)
 		if err != nil {


### PR DESCRIPTION
# Description

PR introduces validator unstake workflow e2e test.

**Note**: we needed to premine contracts with some balance, in order to be able to execute withdrawal from `ChildValidatorSet` ([CVSWithdrawal](https://github.com/0xPolygon/core-contracts/blob/dev/contracts/child/modules/CVSWithdrawal.sol#L23) module to be precise).


# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
