### PR TITLE
EVM-356 Update checkpoint out of fsm

### DIFF
--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -261,15 +261,8 @@ func (c *checkpointManager) isCheckpointBlock(blockNumber uint64) bool {
 // PostBlock is called on every insert of finalized block (either from consensus or syncer)
 // It will read any exit event that happened in block and insert it to state boltDb
 func (c *checkpointManager) PostBlock(req *PostBlockRequest) error {
-	epoch := req.Epoch
-	if req.IsEpochEndingBlock {
-		// exit events that happened in epoch ending blocks,
-		// should be added to the tree of the next epoch
-		epoch++
-	}
-
 	// commit exit events only when we finalize a block
-	events, err := getExitEventsFromReceipts(epoch, req.FullBlock.Block.Number(), req.FullBlock.Receipts)
+	events, err := getExitEventsFromReceipts(req.Epoch, req.FullBlock.Block.Number(), req.FullBlock.Receipts)
 	if err != nil {
 		return err
 	}
@@ -281,6 +274,14 @@ func (c *checkpointManager) PostBlock(req *PostBlockRequest) error {
 	}
 
 	return nil
+}
+
+// PostEpoch notifies the checkpoint manager that an epoch has changed,
+// so that it can discard any previous epoch commitments, and build a new one (since validator set changed)
+func (c *checkpointManager) PostEpoch(req *PostEpochRequest) error {
+	// update any exit events that happened in the last block of previous epoch and move them to the current one
+	// this is done to make sure we know they are finalized properly
+	return c.state.updateExitEvents(req.FirstBlockOfEpoch-1, req.NewEpochID-1, req.NewEpochID)
 }
 
 // getExitEventsFromReceipts parses logs from receipts to find exit events

--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -3,9 +3,11 @@ package polybft
 import (
 	"fmt"
 	"math/big"
+	"sort"
 	"strconv"
 
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
+	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 	metrics "github.com/armon/go-metrics"
@@ -47,16 +49,19 @@ type checkpointManager struct {
 	checkpointsOffset uint64
 	// checkpointManagerAddr is address of CheckpointManager smart contract
 	checkpointManagerAddr types.Address
-	// latestCheckpointID represents last checkpointed block number
+	// latestCheckpointID represents last checkpoint block number
 	latestCheckpointID uint64
 	// logger instance
 	logger hclog.Logger
+	// state boltDb instance
+	state *State
 }
 
 // newCheckpointManager creates a new instance of checkpointManager
 func newCheckpointManager(key ethgo.Key, checkpointOffset uint64,
 	checkpointManagerSC types.Address, txRelayer txrelayer.TxRelayer,
-	blockchain blockchainBackend, backend polybftBackend, logger hclog.Logger) *checkpointManager {
+	blockchain blockchainBackend, backend polybftBackend, logger hclog.Logger,
+	state *State) *checkpointManager {
 	return &checkpointManager{
 		key:                   key,
 		blockchain:            blockchain,
@@ -65,6 +70,7 @@ func newCheckpointManager(key ethgo.Key, checkpointOffset uint64,
 		checkpointsOffset:     checkpointOffset,
 		checkpointManagerAddr: checkpointManagerSC,
 		logger:                logger,
+		state:                 state,
 	}
 }
 
@@ -247,7 +253,68 @@ func (c *checkpointManager) abiEncodeCheckpointBlock(blockNumber uint64, blockHa
 }
 
 // isCheckpointBlock returns true for blocks in the middle of the epoch
-// which are offseted by predefined count of blocks
+// which are offset by predefined count of blocks
 func (c *checkpointManager) isCheckpointBlock(blockNumber uint64) bool {
 	return blockNumber == c.latestCheckpointID+c.checkpointsOffset
+}
+
+// PostBlock is called on every insert of finalized block (either from consensus or syncer)
+// It will read any exit event that happened in block and insert it to state boltDb
+func (c *checkpointManager) PostBlock(req *PostBlockRequest) error {
+	epoch := req.Epoch
+	if req.IsEpochEndingBlock {
+		// exit events that happened in epoch ending blocks,
+		// should be added to the tree of the next epoch
+		epoch++
+	}
+
+	// commit exit events only when we finalize a block
+	events, err := getExitEventsFromReceipts(epoch, req.FullBlock.Block.Number(), req.FullBlock.Receipts)
+	if err != nil {
+		return err
+	}
+
+	if len(events) > 0 {
+		if err := c.state.insertExitEvents(events); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getExitEventsFromReceipts parses logs from receipts to find exit events
+func getExitEventsFromReceipts(epoch, block uint64, receipts []*types.Receipt) ([]*ExitEvent, error) {
+	events := make([]*ExitEvent, 0)
+
+	for i := 0; i < len(receipts); i++ {
+		if len(receipts[i].Logs) == 0 {
+			continue
+		}
+
+		for _, log := range receipts[i].Logs {
+			if log.Address != contracts.L2StateSenderContract {
+				continue
+			}
+
+			event, err := decodeExitEvent(convertLog(log), epoch, block)
+			if err != nil {
+				return nil, err
+			}
+
+			if event == nil {
+				// valid case, not an exit event
+				continue
+			}
+
+			events = append(events, event)
+		}
+	}
+
+	// enforce sequential order
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].ID < events[j].ID
+	})
+
+	return events, nil
 }

--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -277,7 +277,7 @@ func (c *checkpointManager) PostBlock(req *PostBlockRequest) error {
 }
 
 // PostEpoch notifies the checkpoint manager that an epoch has changed,
-// so that it can discard any previous epoch commitments, and build a new one (since validator set changed)
+// so that it can update any exit events that happened in the epoch ending block of the previous epoch
 func (c *checkpointManager) PostEpoch(req *PostEpochRequest) error {
 	// update any exit events that happened in the last block of previous epoch and move them to the current one
 	// this is done to make sure we know they are finalized properly

--- a/consensus/polybft/checkpoint_manager_test.go
+++ b/consensus/polybft/checkpoint_manager_test.go
@@ -295,31 +295,15 @@ func TestCheckpointManager_PostBlock(t *testing.T) {
 	checkpointManager := newCheckpointManager(wallet.NewEcdsaSigner(createTestKey(t)), 5, types.ZeroAddress,
 		nil, nil, nil, hclog.NewNullLogger(), state)
 
-	t.Run("PostBlock - not epoch ending block", func(t *testing.T) {
-		req.IsEpochEndingBlock = false
-		require.NoError(t, checkpointManager.PostBlock(req))
+	require.NoError(t, checkpointManager.PostBlock(req))
 
-		exitEvents, err := state.getExitEvents(epoch, func(exitEvent *ExitEvent) bool {
-			return exitEvent.BlockNumber == block
-		})
-
-		require.NoError(t, err)
-		require.Len(t, exitEvents, numOfReceipts)
-		require.Equal(t, uint64(epoch), exitEvents[0].EpochNumber)
+	exitEvents, err := state.getExitEvents(epoch, func(exitEvent *ExitEvent) bool {
+		return exitEvent.BlockNumber == block
 	})
 
-	t.Run("PostBlock - epoch ending block (exit events are saved to the next epoch)", func(t *testing.T) {
-		req.IsEpochEndingBlock = true
-		require.NoError(t, checkpointManager.PostBlock(req))
-
-		exitEvents, err := state.getExitEvents(epoch+1, func(exitEvent *ExitEvent) bool {
-			return exitEvent.BlockNumber == block
-		})
-
-		require.NoError(t, err)
-		require.Len(t, exitEvents, numOfReceipts)
-		require.Equal(t, uint64(epoch+1), exitEvents[0].EpochNumber)
-	})
+	require.NoError(t, err)
+	require.Len(t, exitEvents, numOfReceipts)
+	require.Equal(t, uint64(epoch), exitEvents[0].EpochNumber)
 }
 
 func TestPerformExit(t *testing.T) {

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -421,6 +421,10 @@ func (c *consensusRuntime) restartEpoch(header *types.Header) (*epochMetadata, e
 		return nil, err
 	}
 
+	if err := c.checkpointManager.PostEpoch(reqObj); err != nil {
+		return nil, err
+	}
+
 	return &epochMetadata{
 		Number:            epochNumber,
 		Validators:        validatorSet,

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -763,7 +763,7 @@ func (c *consensusRuntime) InsertBlock(proposal []byte, committedSeals []*messag
 			}
 		}(fullBlock.Block.Header, fsm.epochNumber)
 
-		c.checkpointManager.SetLatestCheckpointID(fullBlock.Block.Number())
+		c.checkpointManager.SetLastSentBlock(fullBlock.Block.Number())
 	}
 
 	c.OnBlockInserted(fullBlock)

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -106,7 +106,7 @@ type consensusRuntime struct {
 	activeValidatorFlag uint32
 
 	// checkpointManager represents abstraction for checkpoint submission
-	checkpointManager *checkpointManager
+	checkpointManager CheckpointManager
 
 	// proposerCalculator is the object which manipulates with ProposerSnapshot
 	proposerCalculator *ProposerCalculator
@@ -137,22 +137,8 @@ func newConsensusRuntime(log hcf.Logger, config *runtimeConfig) (*consensusRunti
 		return nil, err
 	}
 
-	if runtime.IsBridgeEnabled() {
-		// enable checkpoint manager
-		txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(config.PolyBFTConfig.Bridge.JSONRPCEndpoint))
-		if err != nil {
-			return nil, err
-		}
-
-		runtime.checkpointManager = newCheckpointManager(
-			wallet.NewEcdsaSigner(config.Key),
-			defaultCheckpointsOffset,
-			config.PolyBFTConfig.Bridge.CheckpointAddr,
-			txRelayer,
-			config.blockchain,
-			config.polybftBackend,
-			log.Named("checkpoint_manager"),
-			runtime.state)
+	if err := runtime.initCheckpointManager(log); err != nil {
+		return nil, err
 	}
 
 	// we need to call restart epoch on runtime to initialize epoch state
@@ -196,6 +182,32 @@ func (c *consensusRuntime) initStateSyncManager(logger hcf.Logger) error {
 	}
 
 	return c.stateSyncManager.Init()
+}
+
+// initCheckpointManager initializes checkpoint manager
+// if bridge is not enabled, then a dummy checkpoint manager will be used
+func (c *consensusRuntime) initCheckpointManager(logger hcf.Logger) error {
+	if c.IsBridgeEnabled() {
+		// enable checkpoint manager
+		txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(c.config.PolyBFTConfig.Bridge.JSONRPCEndpoint))
+		if err != nil {
+			return err
+		}
+
+		c.checkpointManager = newCheckpointManager(
+			wallet.NewEcdsaSigner(c.config.Key),
+			defaultCheckpointsOffset,
+			c.config.PolyBFTConfig.Bridge.CheckpointAddr,
+			txRelayer,
+			c.config.blockchain,
+			c.config.polybftBackend,
+			logger.Named("checkpoint_manager"),
+			c.state)
+	} else {
+		c.checkpointManager = &dummyCheckpointManager{}
+	}
+
+	return nil
 }
 
 // getGuardedData returns last build block, proposer snapshot and current epochMetadata in a thread-safe manner.
@@ -743,20 +755,18 @@ func (c *consensusRuntime) InsertBlock(proposal []byte, committedSeals []*messag
 		return
 	}
 
-	if c.IsBridgeEnabled() {
-		if (fsm.isEndOfEpoch || c.checkpointManager.isCheckpointBlock(fullBlock.Block.Header.Number)) &&
-			bytes.Equal(c.config.Key.Address().Bytes(), fullBlock.Block.Header.Miner) {
-			go func(header types.Header, epochNumber uint64) {
-				if err := c.checkpointManager.submitCheckpoint(header, fsm.isEndOfEpoch); err != nil {
-					c.logger.Warn("failed to submit checkpoint",
-						"checkpoint block", header.Number,
-						"epoch number", epochNumber,
-						"error", err)
-				}
-			}(*fullBlock.Block.Header, fsm.epochNumber)
+	if c.checkpointManager.IsCheckpointBlock(fullBlock.Block.Header.Number, fsm.isEndOfEpoch) &&
+		bytes.Equal(c.config.Key.Address().Bytes(), fullBlock.Block.Header.Miner) {
+		go func(header *types.Header, epochNumber uint64) {
+			if err := c.checkpointManager.SubmitCheckpoint(header, fsm.isEndOfEpoch); err != nil {
+				c.logger.Warn("failed to submit checkpoint",
+					"checkpoint block", header.Number,
+					"epoch number", epochNumber,
+					"error", err)
+			}
+		}(fullBlock.Block.Header, fsm.epochNumber)
 
-			c.checkpointManager.latestCheckpointID = fullBlock.Block.Number()
-		}
+		c.checkpointManager.SetLatestCheckpointID(fullBlock.Block.Number())
 	}
 
 	c.OnBlockInserted(fullBlock)

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -224,8 +224,9 @@ func TestConsensusRuntime_OnBlockInserted_EndOfEpoch(t *testing.T) {
 			Number:            currentEpochNumber,
 			FirstBlockInEpoch: header.Number - epochSize + 1,
 		},
-		lastBuiltBlock:   &types.Header{Number: header.Number - 1},
-		stateSyncManager: &dummyStateSyncManager{},
+		lastBuiltBlock:    &types.Header{Number: header.Number - 1},
+		stateSyncManager:  &dummyStateSyncManager{},
+		checkpointManager: &checkpointManager{state: config.State},
 	}
 	runtime.OnBlockInserted(&types.FullBlock{Block: builtBlock})
 

--- a/consensus/polybft/handlers.go
+++ b/consensus/polybft/handlers.go
@@ -1,0 +1,25 @@
+package polybft
+
+import "github.com/0xPolygon/polygon-edge/types"
+
+type PostBlockRequest struct {
+	// FullBlock is a reference of the executed block
+	FullBlock *types.FullBlock
+	// Epoch is the epoch number of the executed block
+	Epoch uint64
+}
+
+type PostEpochRequest struct {
+	// NewEpochID is the id of the new epoch
+	NewEpochID uint64
+
+	// FirstBlockOfEpoch is the number of the epoch beginning block
+	FirstBlockOfEpoch uint64
+
+	// SystemState is the state of the governance smart contracts
+	// after this block
+	SystemState SystemState
+
+	// ValidatorSet is the validator set for the new epoch
+	ValidatorSet *validatorSet
+}

--- a/consensus/polybft/handlers.go
+++ b/consensus/polybft/handlers.go
@@ -7,6 +7,8 @@ type PostBlockRequest struct {
 	FullBlock *types.FullBlock
 	// Epoch is the epoch number of the executed block
 	Epoch uint64
+	// IsEpochEndingBlock indicates if this was the last block of given epoch
+	IsEpochEndingBlock bool
 }
 
 type PostEpochRequest struct {

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -398,83 +398,34 @@ func (s *State) getExitEventsForProof(epoch, checkpointBlock uint64) ([]*ExitEve
 	})
 }
 
-// updateExitEvents updates the exit events that happened in given block and old epoch to the provided new epoch
-// that means their key in db changes, so we have to remove the old event and reinsert the new one
-func (s *State) updateExitEvents(blockNumber, oldEpoch, newEpoch uint64) error {
-	return s.db.Update(func(tx *bolt.Tx) error {
-		exitEvents, err := getExitEvents(tx, oldEpoch, func(exitEvent *ExitEvent) bool {
-			return exitEvent.BlockNumber == blockNumber
-		})
-
-		if err != nil {
-			return err
-		}
-
-		bucket := tx.Bucket(exitEventsBucket)
-
-		for _, e := range exitEvents {
-			oldKey := bytes.Join([][]byte{itob(e.EpochNumber),
-				itob(e.ID), itob(e.BlockNumber)}, nil)
-
-			if err := bucket.Delete(oldKey); err != nil {
-				// remove old event
-				return err
-			}
-
-			e.EpochNumber = newEpoch
-			if err := insertExitEventToBucket(bucket, e); err != nil {
-				// insert updated event because its key changed
-				return err
-			}
-		}
-
-		return nil
-	})
-}
-
 // getExitEvents returns exit events for given epoch and provided filter
 func (s *State) getExitEvents(epoch uint64, filter func(exitEvent *ExitEvent) bool) ([]*ExitEvent, error) {
-	var (
-		exitEvents []*ExitEvent
-		err        error
-	)
+	var events []*ExitEvent
 
-	err = s.db.View(func(tx *bolt.Tx) error {
-		exitEvents, err = getExitEvents(tx, epoch, filter)
+	err := s.db.View(func(tx *bolt.Tx) error {
+		c := tx.Bucket(exitEventsBucket).Cursor()
+		prefix := itob(epoch)
 
-		if err != nil {
-			return err
+		for k, v := c.Seek(prefix); bytes.HasPrefix(k, prefix); k, v = c.Next() {
+			var event *ExitEvent
+			if err := json.Unmarshal(v, &event); err != nil {
+				return err
+			}
+
+			if filter(event) {
+				events = append(events, event)
+			}
 		}
 
 		return nil
 	})
-
-	return exitEvents, err
-}
-
-func getExitEvents(tx *bolt.Tx, epoch uint64, filter func(exitEvent *ExitEvent) bool) ([]*ExitEvent, error) {
-	c := tx.Bucket(exitEventsBucket).Cursor()
-	prefix := itob(epoch)
-
-	var events []*ExitEvent
-
-	for k, v := c.Seek(prefix); bytes.HasPrefix(k, prefix); k, v = c.Next() {
-		var event *ExitEvent
-		if err := json.Unmarshal(v, &event); err != nil {
-			return nil, err
-		}
-
-		if filter(event) {
-			events = append(events, event)
-		}
-	}
 
 	// enforce sequential order
 	sort.Slice(events, func(i, j int) bool {
 		return events[i].ID < events[j].ID
 	})
 
-	return events, nil
+	return events, err
 }
 
 // insertStateSyncEvent inserts a new state sync event to state event bucket in db

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -434,21 +434,22 @@ func (s *State) updateExitEvents(blockNumber, oldEpoch, newEpoch uint64) error {
 
 // getExitEvents returns exit events for given epoch and provided filter
 func (s *State) getExitEvents(epoch uint64, filter func(exitEvent *ExitEvent) bool) ([]*ExitEvent, error) {
-	var events []*ExitEvent
+	var (
+		exitEvents []*ExitEvent
+		err        error
+	)
 
-	err := s.db.View(func(tx *bolt.Tx) error {
-		exitEvents, err := getExitEvents(tx, epoch, filter)
+	err = s.db.View(func(tx *bolt.Tx) error {
+		exitEvents, err = getExitEvents(tx, epoch, filter)
 
 		if err != nil {
 			return err
 		}
 
-		events = exitEvents
-
 		return nil
 	})
 
-	return events, err
+	return exitEvents, err
 }
 
 func getExitEvents(tx *bolt.Tx, epoch uint64, filter func(exitEvent *ExitEvent) bool) ([]*ExitEvent, error) {

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -330,6 +330,11 @@ func (s *State) list() ([]*types.StateSyncEvent, error) {
 
 // insertExitEvents inserts a slice of exit events to exit event bucket in bolt db
 func (s *State) insertExitEvents(exitEvents []*ExitEvent) error {
+	if len(exitEvents) == 0 {
+		// small optimization
+		return nil
+	}
+
 	return s.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(exitEventsBucket)
 		for i := 0; i < len(exitEvents); i++ {

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -325,18 +325,6 @@ func (s *stateSyncManager) getAggSignatureForCommitmentMessage(commitment *Commi
 	return result, publicKeys, nil
 }
 
-type PostEpochRequest struct {
-	// NewEpochID is the id of the new epoch
-	NewEpochID uint64
-
-	// SystemState is the state of the governance smart contracts
-	// after this block
-	SystemState SystemState
-
-	// ValidatorSet is the validator set for the new epoch
-	ValidatorSet *validatorSet
-}
-
 // PostEpoch notifies the state sync manager that an epoch has changed,
 // so that it can discard any previous epoch commitments, and build a new one (since validator set changed)
 func (s *stateSyncManager) PostEpoch(req *PostEpochRequest) error {
@@ -359,15 +347,6 @@ func (s *stateSyncManager) PostEpoch(req *PostEpochRequest) error {
 	s.lock.Unlock()
 
 	return s.buildCommitment()
-}
-
-type PostBlockRequest struct {
-	// FullBlock is a reference of the executed block
-	FullBlock *types.FullBlock
-	// Epoch is the epoch number of the executed block
-	Epoch uint64
-	// IsEpochEndingBlock indicates if this is the last block in epoch
-	IsEpochEndingBlock bool
 }
 
 // PostBlock notifies state sync manager that a block was finalized,

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -362,14 +362,18 @@ func (s *stateSyncManager) PostEpoch(req *PostEpochRequest) error {
 }
 
 type PostBlockRequest struct {
-	// Block is a reference of the executed block
-	Block *types.Block
+	// FullBlock is a reference of the executed block
+	FullBlock *types.FullBlock
+	// Epoch is the epoch number of the executed block
+	Epoch uint64
+	// IsEpochEndingBlock indicates if this is the last block in epoch
+	IsEpochEndingBlock bool
 }
 
 // PostBlock notifies state sync manager that a block was finalized,
 // so that it can build state sync proofs if a block has a commitment submission transaction
 func (s *stateSyncManager) PostBlock(req *PostBlockRequest) error {
-	commitment, err := getCommitmentMessageSignedTx(req.Block.Transactions)
+	commitment, err := getCommitmentMessageSignedTx(req.FullBlock.Block.Transactions)
 	if err != nil {
 		return err
 	}

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -234,8 +234,10 @@ func TestStateSyncerManager_BuildProofs(t *testing.T) {
 	tx := createStateTransactionWithData(types.Address{}, txData)
 
 	req := &PostBlockRequest{
-		Block: &types.Block{
-			Transactions: []*types.Transaction{tx},
+		FullBlock: &types.FullBlock{
+			Block: &types.Block{
+				Transactions: []*types.Transaction{tx},
+			},
 		},
 	}
 

--- a/consensus/polybft/state_test.go
+++ b/consensus/polybft/state_test.go
@@ -505,46 +505,6 @@ func TestState_getProposerSnapshot_writeProposerSnapshot(t *testing.T) {
 	require.Equal(t, newSnapshot, snap)
 }
 
-func TestState_updateExitEvents(t *testing.T) {
-	t.Parallel()
-
-	const (
-		oldEpoch            = 1
-		newEpoch            = 2
-		numOfBlocksPerEpoch = 5
-		numOfExitsPerBlock  = 5
-	)
-
-	state := newTestState(t)
-
-	insertTestExitEvents(t, state, 1, numOfBlocksPerEpoch, numOfExitsPerBlock)
-
-	exitEvents, err := state.getExitEvents(oldEpoch, func(exitEvent *ExitEvent) bool {
-		return exitEvent.BlockNumber == 5
-	})
-
-	require.NoError(t, err)
-	require.Len(t, exitEvents, numOfExitsPerBlock)
-	require.Equal(t, uint64(oldEpoch), exitEvents[0].EpochNumber)
-
-	require.NoError(t, state.updateExitEvents(5, oldEpoch, newEpoch))
-
-	exitEvents, err = state.getExitEvents(oldEpoch, func(exitEvent *ExitEvent) bool {
-		return exitEvent.BlockNumber == 5
-	})
-
-	require.NoError(t, err)
-	require.Empty(t, exitEvents, 0)
-
-	exitEvents, err = state.getExitEvents(newEpoch, func(exitEvent *ExitEvent) bool {
-		return exitEvent.BlockNumber == 5
-	})
-
-	require.NoError(t, err)
-	require.Len(t, exitEvents, numOfExitsPerBlock)
-	require.Equal(t, uint64(newEpoch), exitEvents[0].EpochNumber)
-}
-
 func insertTestExitEvents(t *testing.T, state *State,
 	numOfEpochs, numOfBlocksPerEpoch, numOfEventsPerBlock int) {
 	t.Helper()

--- a/consensus/polybft/state_test.go
+++ b/consensus/polybft/state_test.go
@@ -505,6 +505,46 @@ func TestState_getProposerSnapshot_writeProposerSnapshot(t *testing.T) {
 	require.Equal(t, newSnapshot, snap)
 }
 
+func TestState_updateExitEvents(t *testing.T) {
+	t.Parallel()
+
+	const (
+		oldEpoch            = 1
+		newEpoch            = 2
+		numOfBlocksPerEpoch = 5
+		numOfExitsPerBlock  = 5
+	)
+
+	state := newTestState(t)
+
+	insertTestExitEvents(t, state, 1, numOfBlocksPerEpoch, numOfExitsPerBlock)
+
+	exitEvents, err := state.getExitEvents(oldEpoch, func(exitEvent *ExitEvent) bool {
+		return exitEvent.BlockNumber == 5
+	})
+
+	require.NoError(t, err)
+	require.Len(t, exitEvents, numOfExitsPerBlock)
+	require.Equal(t, uint64(oldEpoch), exitEvents[0].EpochNumber)
+
+	require.NoError(t, state.updateExitEvents(5, oldEpoch, newEpoch))
+
+	exitEvents, err = state.getExitEvents(oldEpoch, func(exitEvent *ExitEvent) bool {
+		return exitEvent.BlockNumber == 5
+	})
+
+	require.NoError(t, err)
+	require.Empty(t, exitEvents, 0)
+
+	exitEvents, err = state.getExitEvents(newEpoch, func(exitEvent *ExitEvent) bool {
+		return exitEvent.BlockNumber == 5
+	})
+
+	require.NoError(t, err)
+	require.Len(t, exitEvents, numOfExitsPerBlock)
+	require.Equal(t, uint64(newEpoch), exitEvents[0].EpochNumber)
+}
+
 func insertTestExitEvents(t *testing.T, state *State,
 	numOfEpochs, numOfBlocksPerEpoch, numOfEventsPerBlock int) {
 	t.Helper()


### PR DESCRIPTION
# Description

Moved the `exitEvent` handling from `fsm` to `OnBlockInserted` callback in `consensusRuntime`.

In `OnBlockInserted` `checkpointManager` will handle new exit events that happened in the newly finalized block inside the `PostBlock` function. This will insert all the exit events from the given block to `boltDb`.

If the block is epoch ending block, in the `PostEpoch` function, `checkpointManager` will update the exit events to point to the next epoch (as per RFC-30). This is only done for the exit events that happened in the epoch ending blocks, since we can not ensure that they were finalized, and to prevent malicious attacks (exits).

**Importan note**: This PR solves the issue where exit events were not gotten from the blocks gotten from `syncer`. This way we will not miss any exit events that happened if node was down or not synced with network for a given amount of time.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually