### PR TITLE
EVM-362 Provide ExitRootHash to fsm without need for checkpointBackend

### DIFF
--- a/consensus/polybft/checkpoint_manager_test.go
+++ b/consensus/polybft/checkpoint_manager_test.go
@@ -339,6 +339,39 @@ func TestCheckpointManager_PostBlock(t *testing.T) {
 	})
 }
 
+func TestCheckpointManager_BuildEventRoot(t *testing.T) {
+	t.Parallel()
+
+	const (
+		numOfBlocks         = 10
+		numOfEventsPerBlock = 2
+	)
+
+	state := newTestState(t)
+	checkpointManager := &checkpointManager{state: state}
+
+	encodedEvents := setupExitEventsForProofVerification(t, state, numOfBlocks, numOfEventsPerBlock)
+
+	t.Run("Get exit event root hash", func(t *testing.T) {
+		t.Parallel()
+
+		tree, err := NewMerkleTree(encodedEvents)
+		require.NoError(t, err)
+
+		hash, err := checkpointManager.BuildEventRoot(1)
+		require.NoError(t, err)
+		require.Equal(t, tree.Hash(), hash)
+	})
+
+	t.Run("Get exit event root hash - no events", func(t *testing.T) {
+		t.Parallel()
+
+		hash, err := checkpointManager.BuildEventRoot(2)
+		require.NoError(t, err)
+		require.Equal(t, types.Hash{}, hash)
+	})
+}
+
 func TestPerformExit(t *testing.T) {
 	t.Parallel()
 

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -348,9 +348,10 @@ func TestConsensusRuntime_FSM_NotEndOfEpoch_NotEndOfSprint(t *testing.T) {
 			Validators:        validators.getPublicIdentities(),
 			FirstBlockInEpoch: 1,
 		},
-		lastBuiltBlock:   lastBlock,
-		state:            newTestState(t),
-		stateSyncManager: &dummyStateSyncManager{},
+		lastBuiltBlock:    lastBlock,
+		state:             newTestState(t),
+		stateSyncManager:  &dummyStateSyncManager{},
+		checkpointManager: &dummyCheckpointManager{},
 	}
 
 	err := runtime.FSM()
@@ -418,6 +419,7 @@ func TestConsensusRuntime_FSM_EndOfEpoch_BuildUptime(t *testing.T) {
 		config:             config,
 		lastBuiltBlock:     lastBuiltBlock,
 		stateSyncManager:   &dummyStateSyncManager{},
+		checkpointManager:  &dummyCheckpointManager{},
 	}
 
 	err := runtime.FSM()
@@ -606,41 +608,6 @@ func TestConsensusRuntime_validateVote_VoteSentFromUnknownValidator(t *testing.T
 		fmt.Sprintf("message is received from sender %s, which is not in current validator set", vote.From))
 }
 
-func TestConsensusRuntime_getExitEventRootHash(t *testing.T) {
-	t.Parallel()
-
-	const (
-		numOfBlocks         = 10
-		numOfEventsPerBlock = 2
-	)
-
-	state := newTestState(t)
-	runtime := &consensusRuntime{
-		state: state,
-	}
-
-	encodedEvents := setupExitEventsForProofVerification(t, state, numOfBlocks, numOfEventsPerBlock)
-
-	t.Run("Get exit event root hash", func(t *testing.T) {
-		t.Parallel()
-
-		tree, err := NewMerkleTree(encodedEvents)
-		require.NoError(t, err)
-
-		hash, err := runtime.BuildEventRoot(1)
-		require.NoError(t, err)
-		require.Equal(t, tree.Hash(), hash)
-	})
-
-	t.Run("Get exit event root hash - no events", func(t *testing.T) {
-		t.Parallel()
-
-		hash, err := runtime.BuildEventRoot(2)
-		require.NoError(t, err)
-		require.Equal(t, types.Hash{}, hash)
-	})
-}
-
 func TestConsensusRuntime_GenerateExitProof(t *testing.T) {
 	t.Parallel()
 
@@ -723,6 +690,7 @@ func TestConsensusRuntime_IsValidSender(t *testing.T) {
 		logger:             hclog.NewNullLogger(),
 		proposerCalculator: NewProposerCalculatorFromSnapshot(snapshot, config, hclog.NewNullLogger()),
 		stateSyncManager:   &dummyStateSyncManager{},
+		checkpointManager:  &dummyCheckpointManager{},
 	}
 
 	require.NoError(t, runtime.FSM())
@@ -925,6 +893,7 @@ func TestConsensusRuntime_HasQuorum(t *testing.T) {
 		logger:             hclog.NewNullLogger(),
 		proposerCalculator: NewProposerCalculatorFromSnapshot(snapshot, config, hclog.NewNullLogger()),
 		stateSyncManager:   &dummyStateSyncManager{},
+		checkpointManager:  &dummyCheckpointManager{},
 	}
 
 	require.NoError(t, runtime.FSM())

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -274,24 +274,6 @@ func (t *transportMock) Multicast(msg interface{}) {
 	_ = t.Called(msg)
 }
 
-var _ checkpointBackend = (*checkpointBackendMock)(nil)
-
-type checkpointBackendMock struct {
-	mock.Mock
-}
-
-func (c *checkpointBackendMock) BuildEventRoot(epoch uint64) (types.Hash, error) {
-	args := c.Called()
-
-	return args.Get(0).(types.Hash), args.Error(1) //nolint:forcetypeassert
-}
-
-func (c *checkpointBackendMock) InsertExitEvents(exitEvents []*ExitEvent) error {
-	c.Called()
-
-	return nil
-}
-
 type testValidators struct {
 	validators map[string]*testValidator
 }


### PR DESCRIPTION
# Description

This PR removes the `checkpointBackend` interface, and provides the `exitRootHash` to `fsm` on `fsm` creation. Also, moved the creating of `exit tree` and `exitRootHash` to `checkpointManager`.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually