### PR TITLE
Initialize `closeCh` in `stateSyncManager`

### DIFF
--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -86,9 +86,10 @@ type topic interface {
 // NewStateSyncManager creates a new instance of state sync manager
 func NewStateSyncManager(logger hclog.Logger, state *State, config *stateSyncConfig) (*stateSyncManager, error) {
 	s := &stateSyncManager{
-		logger: logger.Named("state-sync-manager"),
-		state:  state,
-		config: config,
+		logger:  logger.Named("state-sync-manager"),
+		state:   state,
+		config:  config,
+		closeCh: make(chan struct{}),
 	}
 
 	return s, nil

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -355,6 +355,13 @@ func TestStateSyncerManager_EventTracker_Sync(t *testing.T) {
 	require.Len(t, events, 10)
 }
 
+func TestStateSyncManager_Close_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	mgr := newTestStateSyncManager(t, newTestValidator("A", 100))
+	require.NotPanics(t, func() { mgr.Close() })
+}
+
 type mockTopic struct {
 	published proto.Message
 }

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -355,7 +355,7 @@ func TestStateSyncerManager_EventTracker_Sync(t *testing.T) {
 	require.Len(t, events, 10)
 }
 
-func TestStateSyncManager_Close_NoPanic(t *testing.T) {
+func TestStateSyncManager_Close(t *testing.T) {
 	t.Parallel()
 
 	mgr := newTestStateSyncManager(t, newTestValidator("A", 100))

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer_test.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/umbracle/ethgo"
 	"github.com/umbracle/ethgo/wallet"
 )
@@ -106,4 +108,15 @@ func Test_sanitizeRPCEndpoint(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStateSyncRelayer_Stop(t *testing.T) {
+	t.Parallel()
+
+	key, err := wallet.GenerateKey()
+	require.NoError(t, err)
+
+	r := NewRelayer("test-chain-1", "http://127.0.0.1:8545", ethgo.Address(contracts.StateReceiverContract), hclog.NewNullLogger(), key)
+
+	require.NotPanics(t, func() { r.Stop() })
 }


### PR DESCRIPTION
# Description

In #1080, it is missed to initialize `closeCh` in `stateSyncManger`. This PR fixes that issue.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
