### PR TITLE
Skip loading json metadata from file for broken file

### DIFF
--- a/consensus/ibft/fork/storewrapper.go
+++ b/consensus/ibft/fork/storewrapper.go
@@ -1,6 +1,8 @@
 package fork
 
 import (
+	"encoding/json"
+	"errors"
 	"path/filepath"
 
 	"github.com/0xPolygon/polygon-edge/consensus/ibft/signer"
@@ -10,6 +12,17 @@ import (
 	"github.com/0xPolygon/polygon-edge/validators/store/snapshot"
 	"github.com/hashicorp/go-hclog"
 )
+
+// isJSONSyntaxError returns bool indicating the giving error is json.SyntaxError or not
+func isJSONSyntaxError(err error) bool {
+	var expected *json.SyntaxError
+
+	if err == nil {
+		return false
+	}
+
+	return errors.As(err, &expected)
+}
 
 // SnapshotValidatorStoreWrapper is a wrapper of store.SnapshotValidatorStore
 // in order to add initialization and closer process with side effect
@@ -51,13 +64,26 @@ func NewSnapshotValidatorStoreWrapper(
 	dirPath string,
 	epochSize uint64,
 ) (*SnapshotValidatorStoreWrapper, error) {
-	snapshotMeta, err := loadSnapshotMetadata(filepath.Join(dirPath, snapshotMetadataFilename))
-	if err != nil {
+	var (
+		snapshotMetadataPath = filepath.Join(dirPath, snapshotMetadataFilename)
+		snapshotsPath        = filepath.Join(dirPath, snapshotSnapshotsFilename)
+	)
+
+	snapshotMeta, err := loadSnapshotMetadata(snapshotMetadataPath)
+	if isJSONSyntaxError(err) {
+		logger.Warn("Snapshot metadata file is broken, recover metadata from local chain", "filepath", snapshotMetadataPath)
+
+		snapshotMeta = nil
+	} else if err != nil {
 		return nil, err
 	}
 
-	snapshots, err := loadSnapshots(filepath.Join(dirPath, snapshotSnapshotsFilename))
-	if err != nil {
+	snapshots, err := loadSnapshots(snapshotsPath)
+	if isJSONSyntaxError(err) {
+		logger.Warn("Snapshots file is broken, recover snapshots from local chain", "filepath", snapshotsPath)
+
+		snapshots = nil
+	} else if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
# Description

As reported in https://github.com/0xPolygon/polygon-edge/issues/824, json file of snapshots and metadata will be broken very rarely. Basically this issue happens when saving json, which is done in `Close()` of consensus module, was interrupted by panic from other modules' closings. This PR will not fix this issue and will work on another PR. But this PR adds a tolerance against such problem in loading json file. If json file is broken, consensus stops using the data from json file and recover data from local chain as it does in case of missing json file.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
