### PR TITLE
Invert logical condition in `WaitUntil` functions

### DIFF
--- a/e2e-polybft/bridge_test.go
+++ b/e2e-polybft/bridge_test.go
@@ -590,7 +590,6 @@ func TestE2E_Bridge_ChangeVotingPower(t *testing.T) {
 
 		t.Logf("Checkpoint block: %d\n", actualCheckpointBlock)
 
-		// waiting until condition is true (namely when block 20 gets checkpointed)
-		return actualCheckpointBlock >= finalBlockNumber, nil
+		return actualCheckpointBlock == finalBlockNumber, nil
 	}))
 }

--- a/e2e-polybft/bridge_test.go
+++ b/e2e-polybft/bridge_test.go
@@ -278,7 +278,7 @@ func TestE2E_CheckpointSubmission(t *testing.T) {
 
 		t.Logf("Checkpoint block: %d\n", actualCheckpointBlock)
 
-		return actualCheckpointBlock < expectedCheckpointBlock, nil
+		return actualCheckpointBlock == expectedCheckpointBlock, nil
 	}
 
 	// wait for a single epoch to be checkpointed
@@ -591,6 +591,6 @@ func TestE2E_Bridge_ChangeVotingPower(t *testing.T) {
 		t.Logf("Checkpoint block: %d\n", actualCheckpointBlock)
 
 		// waiting until condition is true (namely when block 20 gets checkpointed)
-		return actualCheckpointBlock < finalBlockNumber, nil
+		return actualCheckpointBlock >= finalBlockNumber, nil
 	}))
 }

--- a/e2e-polybft/framework/test-bridge.go
+++ b/e2e-polybft/framework/test-bridge.go
@@ -116,7 +116,7 @@ func (t *TestBridge) WaitUntil(pollFrequency, timeout time.Duration, handler fun
 			return err
 		}
 
-		if !isConditionMet {
+		if isConditionMet {
 			return nil
 		}
 	}

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -443,7 +443,7 @@ func (c *TestCluster) WaitUntil(dur time.Duration, handler func() bool) error {
 		case <-time.After(2 * time.Second):
 		}
 
-		if !handler() {
+		if handler() {
 			return nil
 		}
 	}
@@ -484,12 +484,13 @@ func (c *TestCluster) WaitForBlock(n uint64, timeout time.Duration) error {
 func (c *TestCluster) WaitForGeneric(dur time.Duration, fn func(*TestServer) bool) error {
 	return c.WaitUntil(dur, func() bool {
 		for _, srv := range c.Servers {
-			if srv.isRunning() && !fn(srv) { // if server is stopped - skip it
-				return true
+			// query only running servers
+			if srv.isRunning() && !fn(srv) {
+				return false
 			}
 		}
 
-		return false
+		return true
 	})
 }
 

--- a/e2e-polybft/txpool_test.go
+++ b/e2e-polybft/txpool_test.go
@@ -71,11 +71,11 @@ func TestE2E_TxPool_Transfer(t *testing.T) {
 			}
 			t.Logf("Balance %s %s", receiver, balance)
 			if balance.Uint64() != uint64(sendAmount) {
-				return true
+				return false
 			}
 		}
 
-		return false
+		return true
 	})
 	require.NoError(t, err)
 }
@@ -104,7 +104,7 @@ func TestE2E_TxPool_Transfer_Linear(t *testing.T) {
 				return true
 			}
 
-			return balance.Cmp(big.NewInt(0)) == 0
+			return balance.Cmp(big.NewInt(0)) > 0
 		})
 
 		return err


### PR DESCRIPTION
# Description

This PR inverts logical condition for `WaitUntil` function, since previous implementation expected false logical condition as `WaitUntil` function's exit criteria. However it is not as intuitive and practical as it should be, since we need to think about exit criteria and then negate it.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually