### PR TITLE
TestE2E_Bridge_L2toL1Exit to work with multiple users 

### DIFF
--- a/e2e-polybft/bridge_test.go
+++ b/e2e-polybft/bridge_test.go
@@ -413,7 +413,6 @@ func TestE2E_Bridge_L2toL1Exit(t *testing.T) {
 	for i := 0; i < userNumber; i++ {
 		exitID := uint64(i + 1) // because exit events start from ID = 1
 		proof, err = getExitProof(cluster.Servers[0].JSONRPCAddr(), exitID, checkpointEpoch, checkpointBlock)
-
 		require.NoError(t, err)
 
 		isProcessed, err := isExitEventProcessed(sidechainKeys[i], proof, checkpointBlock, stateSenderData, l1ExitTestAddr, exitHelperAddr, adminAddr, l1TxRelayer, exitID)

--- a/e2e-polybft/bridge_test.go
+++ b/e2e-polybft/bridge_test.go
@@ -490,7 +490,7 @@ func TestE2E_Bridge_L2toL1ExitMultiple(t *testing.T) {
 		eventData, err := contractsapi.L2StateSender.Abi.Events["L2StateSynced"].ParseLog(receipt.Logs[0])
 		require.NoError(t, err)
 
-		exitEventIds[j+(i-1)*userNumber] = eventData["id"].(*big.Int).Uint64()
+		exitEventIds[j+(i-1)*userNumber] = eventData["id"].(*big.Int).Uint64() //nolint:forcetypeassert
 	}
 
 	for i := 1; i <= roundNumber; i++ {

--- a/e2e-polybft/bridge_test.go
+++ b/e2e-polybft/bridge_test.go
@@ -446,7 +446,7 @@ func isExitEventProcessed(sidechainKey *ethgow.Key, proof types.ExitProof, check
 	}
 
 	if receipt.Status != uint64(types.ReceiptSuccess) {
-		return false, errors.New("Failed to get transaction")
+		return false, errors.New("transaction execution failed")
 	}
 
 	result, err := ABICall(l1TxRelayer, contractsapi.ExitHelper, exitHelperAddr, adminAddr, "processedExits", big.NewInt(int64(exitEventID)))


### PR DESCRIPTION
# Description
N users send an exit transaction. Need to check that all of them can be processed on L1 side(using only API). 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

