### PR TITLE
EVM-360 Invalid state root error on v0.7.1-alpha2

### DIFF
--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/consensus"
-	"github.com/0xPolygon/polygon-edge/consensus/ibft/signer"
 	"github.com/0xPolygon/polygon-edge/state"
 	"github.com/0xPolygon/polygon-edge/txpool"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -24,9 +23,6 @@ type BlockBuilderParams struct {
 	// Coinbase that is signing the block
 	Coinbase types.Address
 
-	// Vanity extra for the block
-	Extra []byte
-
 	// GasLimit is the gas limit for the block
 	GasLimit uint64
 
@@ -40,25 +36,14 @@ type BlockBuilderParams struct {
 	TxPool txPoolInterface
 }
 
-func NewBlockBuilder(params *BlockBuilderParams) (*BlockBuilder, error) {
-	// extra can only be 32 size max. it is better to trim that to return
-	// an error that we have to propagate. It should be up to higher level
-	// code to error if the extra supplied by the user is too big.
-	if len(params.Extra) > signer.IstanbulExtraVanity {
-		params.Extra = params.Extra[:signer.IstanbulExtraVanity]
-	}
-
-	if params.Extra == nil {
-		params.Extra = make([]byte, 0)
-	}
-
+func NewBlockBuilder(params *BlockBuilderParams) *BlockBuilder {
 	builder := &BlockBuilder{
 		params: params,
 	}
 
 	builder.Reset()
 
-	return builder, nil
+	return builder
 }
 
 var _ blockBuilder = &BlockBuilder{}
@@ -88,7 +73,6 @@ func (b *BlockBuilder) Reset() {
 		Number:       b.params.Parent.Number + 1,
 		Miner:        b.params.Coinbase[:],
 		Difficulty:   1,
-		ExtraData:    b.params.Extra,
 		StateRoot:    types.EmptyRootHash, // this avoids needing state for now
 		TxRoot:       types.EmptyRootHash,
 		ReceiptsRoot: types.EmptyRootHash, // this avoids needing state for now

--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -62,7 +62,7 @@ type BlockBuilder struct {
 }
 
 // Init initializes block builder before adding transactions and actual block building
-func (b *BlockBuilder) Init() error {
+func (b *BlockBuilder) Reset() error {
 	// set the timestamp
 	parentTime := time.Unix(int64(b.params.Parent.Timestamp), 0)
 	headerTime := parentTime.Add(b.params.BlockTime)

--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -160,7 +160,7 @@ func (p *blockchainWrapper) NewBlockBuilder(
 		GasLimit:  gasLimit,
 		TxPool:    txPool,
 		Logger:    logger,
-	})
+	}), nil
 }
 
 // GetSystemState is an implementation of blockchainBackend interface

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -18,7 +18,6 @@ import (
 )
 
 type blockBuilder interface {
-	Reset()
 	Init() error
 	WriteTx(*types.Transaction) error
 	Fill()

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -18,7 +18,7 @@ import (
 )
 
 type blockBuilder interface {
-	Init() error
+	Reset() error
 	WriteTx(*types.Transaction) error
 	Fill()
 	Build(func(h *types.Header)) (*types.FullBlock, error)
@@ -87,7 +87,7 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 	// for non-epoch ending blocks, currentValidatorsHash is the same as the nextValidatorsHash
 	nextValidators := f.validators.Accounts()
 
-	if err := f.blockBuilder.Init(); err != nil {
+	if err := f.blockBuilder.Reset(); err != nil {
 		return nil, fmt.Errorf("failed to initialize block builder: %w", err)
 	}
 

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -289,7 +289,7 @@ func TestFSM_BuildProposal_EpochEndingBlock_FailedToCommitStateTx(t *testing.T) 
 
 	mBlockBuilder := new(blockBuilderMock)
 	mBlockBuilder.On("WriteTx", mock.Anything).Return(errors.New("error")).Once()
-	mBlockBuilder.On("Init").Return(error(nil)).Once()
+	mBlockBuilder.On("Reset").Return(error(nil)).Once()
 
 	validatorSet := NewValidatorSet(validators.getPublicIdentities(), hclog.NewNullLogger())
 
@@ -397,7 +397,7 @@ func TestFSM_BuildProposal_NonEpochEndingBlock_ValidatorsDeltaEmpty(t *testing.T
 	blockBuilderMock := &blockBuilderMock{}
 	blockBuilderMock.On("Build", mock.Anything).Return(stateBlock).Once()
 	blockBuilderMock.On("Fill").Once()
-	blockBuilderMock.On("Init").Return(error(nil)).Once()
+	blockBuilderMock.On("Reset").Return(error(nil)).Once()
 
 	systemStateMock := new(systemStateMock)
 
@@ -437,7 +437,7 @@ func TestFSM_BuildProposal_EpochEndingBlock_FailToCreateValidatorsDelta(t *testi
 	blockBuilderMock := new(blockBuilderMock)
 	blockBuilderMock.On("WriteTx", mock.Anything).Return(error(nil)).Once()
 	blockBuilderMock.On("GetState").Return(transition).Once()
-	blockBuilderMock.On("Init").Return(error(nil)).Once()
+	blockBuilderMock.On("Reset").Return(error(nil)).Once()
 
 	systemStateMock := new(systemStateMock)
 	systemStateMock.On("GetValidatorSet").Return(nil, errors.New("failed to get validators set")).Once()
@@ -1351,7 +1351,7 @@ func newBlockBuilderMock(stateBlock *types.FullBlock) *blockBuilderMock {
 	mBlockBuilder := new(blockBuilderMock)
 	mBlockBuilder.On("Build", mock.Anything).Return(stateBlock).Once()
 	mBlockBuilder.On("Fill", mock.Anything).Once()
-	mBlockBuilder.On("Init", mock.Anything).Return(error(nil)).Once()
+	mBlockBuilder.On("Reset", mock.Anything).Return(error(nil)).Once()
 
 	return mBlockBuilder
 }

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -289,6 +289,7 @@ func TestFSM_BuildProposal_EpochEndingBlock_FailedToCommitStateTx(t *testing.T) 
 
 	mBlockBuilder := new(blockBuilderMock)
 	mBlockBuilder.On("WriteTx", mock.Anything).Return(errors.New("error")).Once()
+	mBlockBuilder.On("Init").Return(error(nil)).Once()
 
 	validatorSet := NewValidatorSet(validators.getPublicIdentities(), hclog.NewNullLogger())
 
@@ -396,6 +397,7 @@ func TestFSM_BuildProposal_NonEpochEndingBlock_ValidatorsDeltaEmpty(t *testing.T
 	blockBuilderMock := &blockBuilderMock{}
 	blockBuilderMock.On("Build", mock.Anything).Return(stateBlock).Once()
 	blockBuilderMock.On("Fill").Once()
+	blockBuilderMock.On("Init").Return(error(nil)).Once()
 
 	systemStateMock := new(systemStateMock)
 
@@ -435,6 +437,7 @@ func TestFSM_BuildProposal_EpochEndingBlock_FailToCreateValidatorsDelta(t *testi
 	blockBuilderMock := new(blockBuilderMock)
 	blockBuilderMock.On("WriteTx", mock.Anything).Return(error(nil)).Once()
 	blockBuilderMock.On("GetState").Return(transition).Once()
+	blockBuilderMock.On("Init").Return(error(nil)).Once()
 
 	systemStateMock := new(systemStateMock)
 	systemStateMock.On("GetValidatorSet").Return(nil, errors.New("failed to get validators set")).Once()
@@ -1348,6 +1351,7 @@ func newBlockBuilderMock(stateBlock *types.FullBlock) *blockBuilderMock {
 	mBlockBuilder := new(blockBuilderMock)
 	mBlockBuilder.On("Build", mock.Anything).Return(stateBlock).Once()
 	mBlockBuilder.On("Fill", mock.Anything).Once()
+	mBlockBuilder.On("Init", mock.Anything).Return(error(nil)).Once()
 
 	return mBlockBuilder
 }

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -153,10 +153,6 @@ type blockBuilderMock struct {
 	mock.Mock
 }
 
-func (m *blockBuilderMock) Reset() {
-	_ = m.Called()
-}
-
 func (m *blockBuilderMock) Init() error {
 	args := m.Called()
 	if len(args) == 0 {

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -153,7 +153,7 @@ type blockBuilderMock struct {
 	mock.Mock
 }
 
-func (m *blockBuilderMock) Init() error {
+func (m *blockBuilderMock) Reset() error {
 	args := m.Called()
 	if len(args) == 0 {
 		return nil

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -153,10 +153,17 @@ type blockBuilderMock struct {
 	mock.Mock
 }
 
-func (m *blockBuilderMock) Reset() error {
+func (m *blockBuilderMock) Reset() {
 	_ = m.Called()
+}
 
-	return nil
+func (m *blockBuilderMock) Init() error {
+	args := m.Called()
+	if len(args) == 0 {
+		return nil
+	}
+
+	return args.Error(0)
 }
 
 func (m *blockBuilderMock) WriteTx(tx *types.Transaction) error {


### PR DESCRIPTION
# Description

In block builder, header timestamp was not set and transition was created with timestamp 0 before any tx writing.
Because of that opcode `TIMESTAMP = 0x42` (`opTimstamp`) returned different results when tx is executed while building and verifying proposal

The solution is to change `block builder` `Reset` to include timestamp for current block and to call `Reset` each time before proposal is created and not just once when we are creating `fsm`.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

