### PR TITLE
Simplify docker-compose build process

### DIFF
--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: ../../
       dockerfile: docker/local/Dockerfile
+    image: local/polygon-edge
+    container_name: polygon-edge-bootstrapper
     command: [ "init", "${EDGE_CONSENSUS:-ibft}" ]
     volumes:
       - data:/data
@@ -14,9 +16,8 @@ services:
 
   ## RUN NODES
   node-1:
-    build:
-      context: ../../
-      dockerfile: docker/local/Dockerfile
+    image: local/polygon-edge
+    container_name: polygon-edge-validator-1
     command: ["server", "--data-dir", "/data/data-1", "--chain", "/data/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--prometheus", "0.0.0.0:5001", "--seal"]
     depends_on:
       init:
@@ -32,9 +33,8 @@ services:
     restart: on-failure
 
   node-2:
-    build:
-      context: ../../
-      dockerfile: docker/local/Dockerfile
+    image: local/polygon-edge
+    container_name: polygon-edge-validator-2
     command: ["server", "--data-dir", "/data/data-2", "--chain", "/data/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--prometheus", "0.0.0.0:5001", "--seal"]
     depends_on:
       init:
@@ -50,9 +50,8 @@ services:
     restart: on-failure
 
   node-3:
-    build:
-      context: ../../
-      dockerfile: docker/local/Dockerfile
+    image: local/polygon-edge
+    container_name: polygon-edge-validator-3
     command: ["server", "--data-dir", "/data/data-3", "--chain", "/data/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--prometheus", "0.0.0.0:5001", "--seal"]
     depends_on:
       init:
@@ -68,9 +67,8 @@ services:
     restart: on-failure
 
   node-4:
-    build:
-      context: ../../
-      dockerfile: docker/local/Dockerfile
+    image: local/polygon-edge
+    container_name: polygon-edge-validator-4
     command: ["server", "--data-dir", "/data/data-4", "--chain", "/data/genesis.json", "--grpc-address", "0.0.0.0:9632", "--libp2p", "0.0.0.0:1478", "--jsonrpc", "0.0.0.0:8545", "--prometheus", "0.0.0.0:5001", "--seal"]
     depends_on:
       init:


### PR DESCRIPTION
# Description

This PR simplifies the build process for `docker-compose`. 
The `local/polygon-edge` container is being built only once for the `bootstrapper` node, and that container is than used for all the nodes.   
Added custom node names to easily differentiate `polygon-edge` nodes.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests
Run `scripts/cluster polybft --docker`  (or `scripts/cluster ibft --docker`) and check how many docker images are being created.
It should be only one `local/polygon-edge`.     
To cleanup everything, run `scripts/cluster polybft --docker destroy` or `scripts/cluster ibft --docker destroy`

# Additional comments

FIXES EDGE-1020
