### PR TITLE
Add `stake` flag to manifest command

### DIFF
--- a/command/default.go
+++ b/command/default.go
@@ -1,6 +1,9 @@
 package command
 
-import "github.com/0xPolygon/polygon-edge/server"
+import (
+	"github.com/0xPolygon/polygon-edge/server"
+	"github.com/umbracle/ethgo"
+)
 
 const (
 	DefaultGenesisFileName = "genesis.json"
@@ -22,4 +25,8 @@ const (
 // compatibility with running clients
 const (
 	GRPCAddressFlagLEGACY = "grpc"
+)
+
+var (
+	DefaultStake = ethgo.Ether(1e6)
 )

--- a/command/default.go
+++ b/command/default.go
@@ -9,10 +9,14 @@ const (
 	DefaultGenesisFileName = "genesis.json"
 	DefaultChainName       = "polygon-edge"
 	DefaultChainID         = 100
-	DefaultPremineBalance  = "0xD3C21BCECCEDA1000000" // 1 million units of native network currency
 	DefaultConsensus       = server.PolyBFTConsensus
 	DefaultGenesisGasUsed  = 458752  // 0x70000
 	DefaultGenesisGasLimit = 5242880 // 0x500000
+)
+
+var (
+	DefaultStake          = ethgo.Ether(1e6)
+	DefaultPremineBalance = ethgo.Ether(1e6)
 )
 
 const (
@@ -25,8 +29,4 @@ const (
 // compatibility with running clients
 const (
 	GRPCAddressFlagLEGACY = "grpc"
-)
-
-var (
-	DefaultStake = ethgo.Ether(1e6)
 )

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -60,7 +60,7 @@ func setFlags(cmd *cobra.Command) {
 		premineFlag,
 		[]string{},
 		fmt.Sprintf(
-			"the premined accounts and balances (format: <address>:<balance>). Default premined balance: %s",
+			"the premined accounts and balances (format: <address>:<balance>). Default premined balance: %d",
 			command.DefaultPremineBalance,
 		),
 	)

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -349,7 +349,7 @@ func (p *genesisParams) initGenesisConfig() error {
 		}
 
 		chainConfig.Genesis.Alloc[premineInfo.Address] = &chain.GenesisAccount{
-			Balance: premineInfo.Balance,
+			Balance: premineInfo.Amount,
 		}
 	}
 

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -161,7 +161,7 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 	// premine non-validator accounts
 	for _, premine := range premineInfos {
 		allocs[premine.Address] = &chain.GenesisAccount{
-			Balance: premine.Balance,
+			Balance: premine.Amount,
 		}
 	}
 

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -117,9 +117,8 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 		// populate premine info for validator accounts
 		genesisValidators[validator.Address] = struct{}{}
 
-		// TODO: @Stefan-Ethernal change this to Stake when https://github.com/0xPolygon/polygon-edge/pull/1137 gets merged
 		// increment total stake
-		totalStake.Add(totalStake, validator.Balance)
+		totalStake.Add(totalStake, validator.Stake)
 	}
 
 	// deploy genesis contracts

--- a/command/genesis/utils.go
+++ b/command/genesis/utils.go
@@ -64,10 +64,10 @@ func verifyGenesisExistence(genesisPath string) *GenesisGenError {
 
 type PremineInfo struct {
 	Address types.Address
-	Balance *big.Int
+	Amount  *big.Int
 }
 
-// ParsePremineInfo parses provided premine information and returns premine address and premine balance
+// ParsePremineInfo parses provided premine information and returns premine address and amount
 func ParsePremineInfo(premineInfoRaw string) (*PremineInfo, error) {
 	var (
 		address types.Address
@@ -87,7 +87,7 @@ func ParsePremineInfo(premineInfoRaw string) (*PremineInfo, error) {
 		return nil, fmt.Errorf("failed to parse amount %s: %w", val, err)
 	}
 
-	return &PremineInfo{Address: address, Balance: amount}, nil
+	return &PremineInfo{Address: address, Amount: amount}, nil
 }
 
 // parseTrackerStartBlocks parses provided event tracker start blocks configuration.

--- a/command/genesis/utils.go
+++ b/command/genesis/utils.go
@@ -71,20 +71,23 @@ type PremineInfo struct {
 func ParsePremineInfo(premineInfoRaw string) (*PremineInfo, error) {
 	var (
 		address types.Address
-		val     = command.DefaultPremineBalance
+		amount  = command.DefaultPremineBalance
+		err     error
 	)
 
 	if delimiterIdx := strings.Index(premineInfoRaw, ":"); delimiterIdx != -1 {
 		// <addr>:<balance>
-		address, val = types.StringToAddress(premineInfoRaw[:delimiterIdx]), premineInfoRaw[delimiterIdx+1:]
+		valueRaw := premineInfoRaw[delimiterIdx+1:]
+
+		amount, err = types.ParseUint256orHex(&valueRaw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse amount %s: %w", valueRaw, err)
+		}
+
+		address = types.StringToAddress(premineInfoRaw[:delimiterIdx])
 	} else {
 		// <addr>
 		address = types.StringToAddress(premineInfoRaw)
-	}
-
-	amount, err := types.ParseUint256orHex(&val)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse amount %s: %w", val, err)
 	}
 
 	return &PremineInfo{Address: address, Amount: amount}, nil

--- a/command/polybftmanifest/manifest_init.go
+++ b/command/polybftmanifest/manifest_init.go
@@ -89,7 +89,7 @@ func setFlags(cmd *cobra.Command) {
 		premineValidatorsFlag,
 		[]string{},
 		fmt.Sprintf(
-			"the premined validators and balances (format: <address>[:<balance>]). Default premined balance: %s",
+			"the premined validators and balances (format: <address>[:<balance>]). Default premined balance: %d",
 			command.DefaultPremineBalance,
 		),
 	)
@@ -178,14 +178,6 @@ func (p *manifestInitParams) getValidatorAccounts() ([]*polybft.Validator, error
 		stakeMap[stakeInfo.Address] = stakeInfo
 	}
 
-	// parse default validators' balance
-	defaultBalanceRaw := command.DefaultPremineBalance
-
-	defaultBalance, err := types.ParseUint256orHex(&defaultBalanceRaw)
-	if err != nil {
-		return nil, fmt.Errorf("provided invalid premine validators balance: %s", defaultBalanceRaw)
-	}
-
 	if len(p.validators) > 0 {
 		validators := make([]*polybft.Validator, len(p.validators))
 		for i, validator := range p.validators {
@@ -220,7 +212,7 @@ func (p *manifestInitParams) getValidatorAccounts() ([]*polybft.Validator, error
 				Address:      addr,
 				BlsKey:       trimmedBLSKey,
 				BlsSignature: parts[3],
-				Balance:      getPremineAmount(addr, premineMap, defaultBalance),
+				Balance:      getPremineAmount(addr, premineMap, command.DefaultPremineBalance),
 				Stake:        getPremineAmount(addr, stakeMap, command.DefaultStake),
 			}
 		}
@@ -239,7 +231,7 @@ func (p *manifestInitParams) getValidatorAccounts() ([]*polybft.Validator, error
 	}
 
 	for _, v := range validators {
-		v.Balance = getPremineAmount(v.Address, premineMap, defaultBalance)
+		v.Balance = getPremineAmount(v.Address, premineMap, command.DefaultPremineBalance)
 		v.Stake = getPremineAmount(v.Address, stakeMap, command.DefaultStake)
 	}
 

--- a/command/rootchain/initcontracts/init_contracts.go
+++ b/command/rootchain/initcontracts/init_contracts.go
@@ -222,7 +222,7 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 		// fund account
 		deployerAddress := deployerKey.Address()
 
-		txn := &ethgo.Transaction{To: &deployerAddress, Value: ethgo.Ether(1e6)}
+		txn := &ethgo.Transaction{To: &deployerAddress, Value: command.DefaultPremineBalance}
 		if _, err := txRelayer.SendTransactionLocal(txn); err != nil {
 			return err
 		}

--- a/command/rootchain/initcontracts/init_contracts.go
+++ b/command/rootchain/initcontracts/init_contracts.go
@@ -463,7 +463,7 @@ func validatorSetToABISlice(o command.OutputFormatter,
 		accSet[i] = &polybft.ValidatorMetadata{
 			Address:     validator.Address,
 			BlsKey:      blsKey,
-			VotingPower: new(big.Int).Set(validator.Balance),
+			VotingPower: new(big.Int).Set(validator.Stake),
 		}
 	}
 

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -426,6 +426,7 @@ func (v *testValidator) paramsValidator() *Validator {
 		Address: v.Address(),
 		BlsKey:  hex.EncodeToString(bls),
 		Balance: big.NewInt(1000),
+		Stake:   big.NewInt(1000),
 	}
 }
 

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -106,9 +106,10 @@ func (v *Validator) MarshalJSON() ([]byte, error) {
 }
 
 func (v *Validator) UnmarshalJSON(data []byte) error {
-	var raw validatorRaw
-
-	var err error
+	var (
+		raw validatorRaw
+		err error
+	)
 
 	if err = json.Unmarshal(data, &raw); err != nil {
 		return err

--- a/consensus/polybft/sc_integration_test.go
+++ b/consensus/polybft/sc_integration_test.go
@@ -254,6 +254,7 @@ func TestIntegration_CommitEpoch(t *testing.T) {
 			initValidators[i] = &Validator{
 				Address:      validator.Address,
 				Balance:      validator.VotingPower,
+				Stake:        validator.VotingPower,
 				BlsKey:       hex.EncodeToString(validator.BlsKey.Marshal()),
 				BlsSignature: hex.EncodeToString(signatureBytes),
 			}

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -331,6 +331,7 @@ func TestE2E_Consensus_Delegation_Undelegation(t *testing.T) {
 		framework.WithSecretsCallback(func(addresses []types.Address, config *framework.TestClusterConfig) {
 			for _, a := range addresses {
 				config.PremineValidators = append(config.PremineValidators, fmt.Sprintf("%s:%s", a, premineBalance))
+				config.StakeAmounts = append(config.StakeAmounts, fmt.Sprintf("%s:%s", a, premineBalance))
 			}
 		}),
 	)
@@ -442,6 +443,7 @@ func TestE2E_Consensus_Validator_Unstake(t *testing.T) {
 		framework.WithSecretsCallback(func(addresses []types.Address, config *framework.TestClusterConfig) {
 			for _, a := range addresses {
 				config.PremineValidators = append(config.PremineValidators, fmt.Sprintf("%s:%d", a, premineAmount))
+				config.StakeAmounts = append(config.StakeAmounts, fmt.Sprintf("%s:%d", a, premineAmount))
 			}
 		}),
 	)

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -72,7 +72,8 @@ type TestClusterConfig struct {
 
 	Name              string
 	Premine           []string // address[:amount]
-	PremineValidators []string // address:[amount]
+	PremineValidators []string // address[:amount]
+	StakeAmount       string
 	HasBridge         bool
 	BootnodeCount     int
 	NonValidatorCount int
@@ -178,6 +179,12 @@ func WithPremine(addresses ...types.Address) ClusterOption {
 func WithSecretsCallback(fn func([]types.Address, *TestClusterConfig)) ClusterOption {
 	return func(h *TestClusterConfig) {
 		h.SecretsCallback = fn
+	}
+}
+
+func WithValidatorsStake(stakeAmount string) ClusterOption {
+	return func(h *TestClusterConfig) {
+		h.StakeAmount = stakeAmount
 	}
 }
 
@@ -317,6 +324,10 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 	// premine validators
 	for _, premineValidator := range cluster.Config.PremineValidators {
 		args = append(args, "--premine-validators", premineValidator)
+	}
+
+	if cluster.Config.StakeAmount != "" {
+		args = append(args, "--stake", cluster.Config.StakeAmount)
 	}
 
 	// run manifest file creation

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -73,7 +73,7 @@ type TestClusterConfig struct {
 	Name              string
 	Premine           []string // address[:amount]
 	PremineValidators []string // address[:amount]
-	StakeAmount       string
+	StakeAmounts      []string // address[:amount]
 	HasBridge         bool
 	BootnodeCount     int
 	NonValidatorCount int
@@ -182,12 +182,6 @@ func WithSecretsCallback(fn func([]types.Address, *TestClusterConfig)) ClusterOp
 	}
 }
 
-func WithValidatorsStake(stakeAmount string) ClusterOption {
-	return func(h *TestClusterConfig) {
-		h.StakeAmount = stakeAmount
-	}
-}
-
 func WithBridge() ClusterOption {
 	return func(h *TestClusterConfig) {
 		h.HasBridge = true
@@ -273,6 +267,7 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 		EpochReward:       1,
 		BlockGasLimit:     1e7, // 10M
 		PremineValidators: []string{},
+		StakeAmounts:      []string{},
 	}
 
 	if config.ValidatorPrefix == "" {
@@ -326,8 +321,8 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 		args = append(args, "--premine-validators", premineValidator)
 	}
 
-	if cluster.Config.StakeAmount != "" {
-		args = append(args, "--stake", cluster.Config.StakeAmount)
+	for _, validatorStake := range cluster.Config.StakeAmounts {
+		args = append(args, "--stake", validatorStake)
 	}
 
 	// run manifest file creation


### PR DESCRIPTION
# Description

This PR introduces `stake` flag to the manifest command. This flag enables specifying genesis validators' stake. Prior to this PR, validators' balances were used as stake amount staked. 

If a stake flag is not provided, then the stake defaults to 1M tokens (the same as with the pre-mine balance).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes
Introduced `stake` field as part of `InitialValidatorSet` in the genesis specification.

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
