### PR TITLE
Add missing cluster stop invocations in e2e tests

### DIFF
--- a/e2e-polybft/bridge_test.go
+++ b/e2e-polybft/bridge_test.go
@@ -511,6 +511,7 @@ func TestE2E_Bridge_ChangeVotingPower(t *testing.T) {
 		framework.WithBridge(),
 		framework.WithEpochSize(5),
 		framework.WithEpochReward(1000))
+	defer cluster.Stop()
 
 	// load manifest file
 	manifest, err := polybft.LoadManifest(path.Join(cluster.Config.TmpDir, manifestFileName))

--- a/e2e-polybft/consensus_test.go
+++ b/e2e-polybft/consensus_test.go
@@ -114,6 +114,7 @@ func TestE2E_Consensus_RegisterValidator(t *testing.T) {
 		framework.WithEpochSize(5),
 		framework.WithEpochReward(1000),
 		framework.WithPremineValidators(premineBalance))
+	defer cluster.Stop()
 	srv := cluster.Servers[0]
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(srv.JSONRPCAddr()))
 	require.NoError(t, err)
@@ -209,6 +210,7 @@ func TestE2E_Consensus_Delegation_Undelegation(t *testing.T) {
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithEpochReward(100000),
 		framework.WithPremineValidators(premineBalance))
+	defer cluster.Stop()
 
 	// init delegator account
 	require.NoError(t, cluster.InitSecrets(delegatorSecrets, 1))


### PR DESCRIPTION
# Description

This PR adds missing cluster stop function invocations in a couple of e2e tests.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
