### PR TITLE
BuildProofs for missed commitments

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -535,16 +535,7 @@ func (c *consensusRuntime) GenerateExitProof(exitID, epoch, checkpointBlock uint
 
 // GetStateSyncProof returns the proof for the state sync
 func (c *consensusRuntime) GetStateSyncProof(stateSyncID uint64) (*types.StateSyncProof, error) {
-	proof, err := c.state.getStateSyncProof(stateSyncID)
-	if err != nil {
-		return nil, fmt.Errorf("cannot get state sync proof for StateSync id %d: %w", stateSyncID, err)
-	}
-
-	if proof == nil {
-		return nil, fmt.Errorf("cannot find state sync proof containing StateSync id %d", stateSyncID)
-	}
-
-	return proof, nil
+	return c.stateSyncManager.GetStateSyncProof(stateSyncID)
 }
 
 // setIsActiveValidator updates the activeValidatorFlag field

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -577,7 +577,15 @@ func (s *State) getCommitmentForStateSync(stateSyncID uint64) (*CommitmentMessag
 			return errNoCommitmentForStateSync
 		}
 
-		return json.Unmarshal(v, &commitment)
+		if err := json.Unmarshal(v, &commitment); err != nil {
+			return err
+		}
+
+		if !commitment.ContainsStateSync(stateSyncID) {
+			return errNoCommitmentForStateSync
+		}
+
+		return nil
 	})
 
 	return commitment, err

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -406,9 +406,12 @@ func (s *stateSyncManager) GetStateSyncProof(stateSyncID uint64) (*types.StateSy
 		}
 
 		proof, err = s.state.getStateSyncProof(stateSyncID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get state sync proof for StateSync id %d: %w", stateSyncID, err)
+		}
 	}
 
-	return proof, err
+	return proof, nil
 }
 
 // buildProofs builds state sync proofs for the submitted commitment and saves them in boltDb for later execution

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -33,6 +33,7 @@ type StateSyncManager interface {
 	Init() error
 	Close()
 	Commitment() (*CommitmentMessageSigned, error)
+	GetStateSyncProof(stateSyncID uint64) (*types.StateSyncProof, error)
 	PostBlock(req *PostBlockRequest) error
 	PostEpoch(req *PostEpochRequest) error
 }
@@ -47,6 +48,9 @@ func (n *dummyStateSyncManager) Close()                                        {
 func (n *dummyStateSyncManager) Commitment() (*CommitmentMessageSigned, error) { return nil, nil }
 func (n *dummyStateSyncManager) PostBlock(req *PostBlockRequest) error         { return nil }
 func (n *dummyStateSyncManager) PostEpoch(req *PostEpochRequest) error         { return nil }
+func (n *dummyStateSyncManager) GetStateSyncProof(stateSyncID uint64) (*types.StateSyncProof, error) {
+	return nil, nil
+}
 
 // stateSyncConfig holds the configuration data of state sync manager
 type stateSyncConfig struct {
@@ -381,6 +385,32 @@ func (s *stateSyncManager) PostBlock(req *PostBlockRequest) error {
 	return nil
 }
 
+// GetStateSyncProof returns the proof for the state sync
+func (s *stateSyncManager) GetStateSyncProof(stateSyncID uint64) (*types.StateSyncProof, error) {
+	proof, err := s.state.getStateSyncProof(stateSyncID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get state sync proof for StateSync id %d: %w", stateSyncID, err)
+	}
+
+	if proof == nil {
+		// check if we might've missed a commitment. if it is so, we didn't build proofs for it while syncing
+		// if we are all synced up, commitment will be saved through PostBlock, but we wont have proofs,
+		// so we will build them now and save them to db so that we have proofs for missed commitment
+		commitment, err := s.state.getCommitmentForStateSync(stateSyncID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot find commitment for StateSync id %d: %w", stateSyncID, err)
+		}
+
+		if err := s.buildProofs(commitment.Message); err != nil {
+			return nil, fmt.Errorf("cannot build proofs for commitment for StateSync id %d: %w", stateSyncID, err)
+		}
+
+		proof, err = s.state.getStateSyncProof(stateSyncID)
+	}
+
+	return proof, err
+}
+
 // buildProofs builds state sync proofs for the submitted commitment and saves them in boltDb for later execution
 func (s *stateSyncManager) buildProofs(commitmentMsg *CommitmentMessage) error {
 	s.logger.Debug(
@@ -391,7 +421,7 @@ func (s *stateSyncManager) buildProofs(commitmentMsg *CommitmentMessage) error {
 
 	events, err := s.state.getStateSyncEventsForCommitment(commitmentMsg.FromIndex, commitmentMsg.ToIndex)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get state sync events for commitment to build proofs. Error: %w", err)
 	}
 
 	tree, err := createMerkleTree(events)
@@ -475,7 +505,7 @@ func (s *stateSyncManager) buildCommitment() error {
 	}
 
 	// gossip message
-	s.Multicast(&TransportMessage{
+	s.multicast(&TransportMessage{
 		Hash:        hashBytes,
 		Signature:   signature,
 		NodeID:      s.config.key.String(),
@@ -493,8 +523,8 @@ func (s *stateSyncManager) buildCommitment() error {
 	return nil
 }
 
-// Multicast publishes given message to the rest of the network
-func (s *stateSyncManager) Multicast(msg interface{}) {
+// multicast publishes given message to the rest of the network
+func (s *stateSyncManager) multicast(msg interface{}) {
 	data, err := json.Marshal(msg)
 	if err != nil {
 		s.logger.Warn("failed to marshal bridge message", "err", err)

--- a/consensus/polybft/state_transaction.go
+++ b/consensus/polybft/state_transaction.go
@@ -139,6 +139,11 @@ type CommitmentMessageSigned struct {
 	PublicKeys   [][]byte
 }
 
+// ContainsStateSync checks if commitment contains given state sync event
+func (cm *CommitmentMessageSigned) ContainsStateSync(stateSyncID uint64) bool {
+	return cm.Message.FromIndex <= stateSyncID && cm.Message.ToIndex >= stateSyncID
+}
+
 // EncodeAbi contains logic for encoding arbitrary data into ABI format
 func (cm *CommitmentMessageSigned) EncodeAbi() ([]byte, error) {
 	commitment := map[string]interface{}{


### PR DESCRIPTION
# Description

When a node was offline (or out of sync) for some time, it can miss on some commitments that might have happened in the meantime.

Since `syncer` is calling the `OnBlockInserted` callback in `consensus_runtime` for each block, the `state_sync_manager` will extract all the commitments that happened in those blocks, and save them to `boltDb`.
In the meantime, in parallel, `event_tracker` will get all the `stateSync` events that the node missed while out of sync, and save them to `boltDb` as well.

But, this process does not build the `state sync proofs` for the commitments that happened while the node was out of sync.

That is why, through this PR, when a user (or relayer) calls `GetStateSyncProof` `RPC` function, `state_sync_manager` will first check if it has a proof built for given `state sync event`. If it does have it, it will simply return it.
If it does not have it, it probably means, we were out of sync, and we need to build those proofs, so it will get the `commitment` from `db` (which was extracted from blocks while syncing), and build the proofs for it and save them in `db`.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually