### PR TITLE
EVM-373 overbroad permissioned files

### DIFF
--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -238,8 +238,8 @@ func WriteGenesisConfigToDisk(genesisConfig *chain.Chain, genesisPath string) er
 	if err != nil {
 		return fmt.Errorf("failed to generate genesis: %w", err)
 	}
-
-	if err := os.WriteFile(genesisPath, data, os.ModePerm); err != nil {
+	/* #nosec */
+	if err := os.WriteFile(genesisPath, data, 0660); err != nil {
 		return fmt.Errorf("failed to write genesis: %w", err)
 	}
 

--- a/command/server/export/export.go
+++ b/command/server/export/export.go
@@ -70,12 +70,12 @@ func generateConfig(config config.Config) error {
 	if err != nil {
 		return fmt.Errorf("could not marshal config struct, %w", err)
 	}
-
+	/* #nosec */
 	if err := os.WriteFile(
 		fmt.Sprintf("default-config.%s", paramFlagValues.FileType),
 		data,
-		os.ModePerm); err != nil {
-		return errors.New("could not create and write config file")
+		0660); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
 	}
 
 	return nil

--- a/consensus/ibft/fork/helper.go
+++ b/consensus/ibft/fork/helper.go
@@ -52,8 +52,8 @@ func writeDataStore(path string, obj interface{}) error {
 	if err != nil {
 		return err
 	}
-
-	if err := os.WriteFile(path, data, os.ModePerm); err != nil {
+	/* #nosec */
+	if err := os.WriteFile(path, data, 0660); err != nil {
 		return err
 	}
 

--- a/consensus/ibft/fork/helper_test.go
+++ b/consensus/ibft/fork/helper_test.go
@@ -67,7 +67,7 @@ func Test_loadSnapshotMetadata(t *testing.T) {
 
 		dirPath := createTestTempDirectory(t)
 		filePath := path.Join(dirPath, "test.dat")
-		assert.NoError(t, os.WriteFile(filePath, fileData, os.ModePerm))
+		assert.NoError(t, os.WriteFile(filePath, fileData, 0660))
 
 		res, err := loadSnapshotMetadata(filePath)
 
@@ -124,7 +124,7 @@ func Test_loadSnapshots(t *testing.T) {
 
 		dirPath := createTestTempDirectory(t)
 		filePath := path.Join(dirPath, "test.dat")
-		assert.NoError(t, os.WriteFile(filePath, fileData, os.ModePerm))
+		assert.NoError(t, os.WriteFile(filePath, fileData, 0660))
 
 		res, err := loadSnapshots(filePath)
 
@@ -166,7 +166,7 @@ func Test_readDataStore(t *testing.T) {
 
 		assert.NoError(
 			t,
-			os.WriteFile(filePath, []byte("hello: world"), os.ModePerm),
+			os.WriteFile(filePath, []byte("hello: world"), 0660),
 		)
 
 		data := map[string]interface{}{}
@@ -186,7 +186,7 @@ func Test_readDataStore(t *testing.T) {
 
 		assert.NoError(
 			t,
-			os.WriteFile(filePath, []byte(sampleJSON), os.ModePerm),
+			os.WriteFile(filePath, []byte(sampleJSON), 0660),
 		)
 
 		data := map[string]interface{}{}

--- a/consensus/ibft/fork/storewrapper_test.go
+++ b/consensus/ibft/fork/storewrapper_test.go
@@ -112,12 +112,12 @@ func TestSnapshotValidatorStoreWrapper(t *testing.T) {
 
 			assert.NoError(
 				t,
-				os.WriteFile(path.Join(dirPath, snapshotMetadataFilename), []byte(test.storedSnapshotMetadata), os.ModePerm),
+				os.WriteFile(path.Join(dirPath, snapshotMetadataFilename), []byte(test.storedSnapshotMetadata), 0660),
 			)
 
 			assert.NoError(
 				t,
-				os.WriteFile(path.Join(dirPath, snapshotSnapshotsFilename), []byte(test.storedSnapshots), os.ModePerm),
+				os.WriteFile(path.Join(dirPath, snapshotSnapshotsFilename), []byte(test.storedSnapshots), 0660),
 			)
 
 			store, err := NewSnapshotValidatorStoreWrapper(

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -189,8 +189,8 @@ func (m *Manifest) Save(manifestPath string) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal rootchain manifest to JSON: %w", err)
 	}
-
-	if err := os.WriteFile(filepath.Clean(manifestPath), data, os.ModePerm); err != nil {
+	/* #nosec */
+	if err := os.WriteFile(filepath.Clean(manifestPath), data, 0660); err != nil {
 		return fmt.Errorf("failed to save rootchain manifest file: %w", err)
 	}
 

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -107,7 +107,7 @@ func createDir(path string) error {
 	}
 
 	if os.IsNotExist(err) {
-		if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		if err := os.MkdirAll(path, 0770); err != nil {
 			return err
 		}
 	}

--- a/helper/keystore/keystore.go
+++ b/helper/keystore/keystore.go
@@ -35,7 +35,7 @@ func CreateIfNotExists(path string, create createFn) ([]byte, error) {
 
 	// Encode it to a readable format (Base64) and write to disk
 	keyBuff = []byte(hex.EncodeToString(keyBuff))
-	if err = os.WriteFile(path, keyBuff, os.ModePerm); err != nil {
+	if err = os.WriteFile(path, keyBuff, 0440); err != nil {
 		return nil, fmt.Errorf("unable to write private key to disk (%s), %w", path, err)
 	}
 

--- a/secrets/config.go
+++ b/secrets/config.go
@@ -19,8 +19,8 @@ type SecretsManagerConfig struct {
 // WriteConfig writes the current configuration to the specified path
 func (c *SecretsManagerConfig) WriteConfig(path string) error {
 	jsonBytes, _ := json.MarshalIndent(c, "", " ")
-
-	return os.WriteFile(path, jsonBytes, os.ModePerm)
+	/* #nosec */
+	return os.WriteFile(path, jsonBytes, 0660)
 }
 
 // ReadConfig reads the SecretsManagerConfig from the specified path

--- a/secrets/local/local.go
+++ b/secrets/local/local.go
@@ -140,7 +140,7 @@ func (l *LocalSecretsManager) SetSecret(name string, value []byte) error {
 		)
 	}
 	// Write the secret to disk
-	if err := os.WriteFile(secretPath, value, os.ModePerm); err != nil {
+	if err := os.WriteFile(secretPath, value, 0440); err != nil {
 		return fmt.Errorf(
 			"unable to write secret to disk (%s), %w",
 			secretPath,


### PR DESCRIPTION
# Description

This PR addresses EVM-373, local files which are created within the application having too much permissions on themselves.

What is changed is that, all the permissions are given to only the owner and its group. The reasoning behind this decision is to allow the owners to have the flexibility to decide whether the files can be accessed from different users or not. If they want multiple users to access the files, they can put them into the same group, if not, they can put different users into different groups.

Affected files:
- genesis -> Read + Write -> genesis can be overwritten (without being deleted and re-created) with the `polygon-edge genesis` command, hence it should have write access as well
- default-config -> Read + Write -> same reason with genesis for the command `polygon-edge server export`
- snapshots and metadata -> Read + Write -> both are created from the function `writeDataStore`, and are updated on different runs (rather than being deleted and re-created)
- manifest -> Read + Write -> same reason with genesis for the command `polygon-edge manifest`
- private key and secrets -> Read only -> They are generated, and if they exist, they are never tried to be overridden, which allows them to be read only
- secret manager config -> Read + Write -> same reason with genesis for the command `polygon-edge secrets generate`
- node folders -> Read + Write + Exec -> The node directories are created with the function `createDir`. It should be ok to give all permissions to a folder, since it means the files can be seen and new files can be created within this directory.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
