### PR TITLE
EVM-353 Different voting power property based test

### DIFF
--- a/e2e-polybft/consensus_test.go
+++ b/e2e-polybft/consensus_test.go
@@ -126,7 +126,8 @@ func TestE2E_Consensus_RegisterValidator(t *testing.T) {
 		&e2eStateProvider{txRelayer: txRelayer})
 
 	// create new account
-	require.NoError(t, cluster.InitSecrets(newValidatorSecrets, 1))
+	_, err = cluster.InitSecrets(newValidatorSecrets, 1)
+	require.NoError(t, err)
 
 	// assert that account is created
 	validatorSecrets, err := genesis.GetValidatorKeyFiles(cluster.Config.TmpDir, cluster.Config.ValidatorPrefix)
@@ -215,7 +216,9 @@ func TestE2E_Consensus_Delegation_Undelegation(t *testing.T) {
 	defer cluster.Stop()
 
 	// init delegator account
-	require.NoError(t, cluster.InitSecrets(delegatorSecrets, 1))
+	_, err = cluster.InitSecrets(delegatorSecrets, 1)
+	require.NoError(t, err)
+
 	srv := cluster.Servers[0]
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(srv.JSONRPCAddr()))

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -63,7 +64,7 @@ type TestClusterConfig struct {
 	t *testing.T
 
 	Name              string
-	Premine           []types.Address
+	Premine           []string // address[:amount]
 	PremineValidators string
 	HasBridge         bool
 	BootnodeCount     int
@@ -79,6 +80,7 @@ type TestClusterConfig struct {
 	ValidatorSetSize  uint64
 	EpochSize         int
 	EpochReward       int
+	SecretsCallback   func([]types.Address, *TestClusterConfig)
 
 	logsDirOnce sync.Once
 }
@@ -87,7 +89,7 @@ func (c *TestClusterConfig) Dir(name string) string {
 	return filepath.Join(c.TmpDir, name)
 }
 
-func (c *TestClusterConfig) GetStdout(name string) io.Writer {
+func (c *TestClusterConfig) GetStdout(name string, custom ...io.Writer) io.Writer {
 	writers := []io.Writer{}
 
 	if c.WithLogs {
@@ -112,6 +114,10 @@ func (c *TestClusterConfig) GetStdout(name string) io.Writer {
 
 	if c.WithStdout {
 		writers = append(writers, os.Stdout)
+	}
+
+	if len(custom) > 0 {
+		writers = append(writers, custom...)
 	}
 
 	if len(writers) == 0 {
@@ -147,13 +153,21 @@ type ClusterOption func(*TestClusterConfig)
 
 func WithPremine(addresses ...types.Address) ClusterOption {
 	return func(h *TestClusterConfig) {
-		h.Premine = append(h.Premine, addresses...)
+		for _, a := range addresses {
+			h.Premine = append(h.Premine, a.String())
+		}
 	}
 }
 
 func WithPremineValidators(premineBalance string) ClusterOption {
 	return func(h *TestClusterConfig) {
 		h.PremineValidators = premineBalance
+	}
+}
+
+func WithSecretsCallback(fn func([]types.Address, *TestClusterConfig)) ClusterOption {
+	return func(h *TestClusterConfig) {
+		h.SecretsCallback = fn
 	}
 }
 
@@ -247,8 +261,12 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 
 	{
 		// run init accounts
-		err = cluster.InitSecrets(cluster.Config.ValidatorPrefix, validatorsCount)
+		addresses, err := cluster.InitSecrets(cluster.Config.ValidatorPrefix, validatorsCount)
 		require.NoError(t, err)
+
+		if cluster.Config.SecretsCallback != nil {
+			cluster.Config.SecretsCallback(addresses, cluster.Config)
+		}
 	}
 
 	manifestPath := path.Join(tmpDir, "manifest.json")
@@ -296,8 +314,8 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 		}
 
 		if len(cluster.Config.Premine) != 0 {
-			for _, addr := range cluster.Config.Premine {
-				args = append(args, "--premine", addr.String())
+			for _, premine := range cluster.Config.Premine {
+				args = append(args, "--premine", premine)
 			}
 		}
 
@@ -526,12 +544,27 @@ func runCommand(binary string, args []string, stdout io.Writer) error {
 
 // InitSecrets initializes account(s) secrets with given prefix.
 // (secrets are being stored in the temp directory created by given e2e test execution)
-func (c *TestCluster) InitSecrets(prefix string, count int) error {
+func (c *TestCluster) InitSecrets(prefix string, count int) ([]types.Address, error) {
+	var b bytes.Buffer
+
 	args := []string{
 		"polybft-secrets",
 		"--data-dir", path.Join(c.Config.TmpDir, prefix),
 		"--num", strconv.Itoa(count),
 	}
+	stdOut := c.Config.GetStdout("polybft-secrets", &b)
 
-	return runCommand(c.Config.Binary, args, c.Config.GetStdout("polybft-secrets"))
+	if err := runCommand(c.Config.Binary, args, stdOut); err != nil {
+		return nil, err
+	}
+
+	re := regexp.MustCompile("\\(address\\) = 0x([a-fA-F0-9]+)")
+	parsed := re.FindAllStringSubmatch(b.String(), -1)
+	result := make([]types.Address, len(parsed))
+
+	for i, v := range parsed {
+		result[i] = types.StringToAddress(v[1])
+	}
+
+	return result, nil
 }

--- a/e2e-polybft/property_test.go
+++ b/e2e-polybft/property_test.go
@@ -3,6 +3,8 @@ package e2e
 import (
 	"fmt"
 	"math"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,7 +13,14 @@ import (
 	"pgregory.net/rapid"
 )
 
+// property based tests enabled
+const envPropertyBaseTestEnabled = "E2E_PROPERTY_TESTS"
+
 func TestProperty_DifferentVotingPower(t *testing.T) {
+	if strings.ToLower(os.Getenv(envPropertyBaseTestEnabled)) != "true" {
+		t.Skip("Property based tests are disabled.")
+	}
+
 	t.Parallel()
 
 	const (
@@ -21,7 +30,7 @@ func TestProperty_DifferentVotingPower(t *testing.T) {
 
 	rapid.Check(t, func(tt *rapid.T) {
 		var (
-			numNodes  = rapid.Uint64Range(4, 30).Draw(tt, "number of cluster nodes")
+			numNodes  = rapid.Uint64Range(4, 8).Draw(tt, "number of cluster nodes")
 			epochSize = rapid.OneOf(rapid.Just(4), rapid.Just(10)).Draw(tt, "Size of epoch")
 			numBlocks = rapid.Uint64Range(2, 5).Draw(tt, "number of blocks the cluster should mine")
 		)

--- a/e2e-polybft/property_test.go
+++ b/e2e-polybft/property_test.go
@@ -3,8 +3,6 @@ package e2e
 import (
 	"fmt"
 	"math"
-	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -13,14 +11,7 @@ import (
 	"pgregory.net/rapid"
 )
 
-// property based tests enabled
-const envPropertyBaseTestEnabled = "E2E_PROPERTY_TESTS"
-
 func TestProperty_DifferentVotingPower(t *testing.T) {
-	if strings.ToLower(os.Getenv(envPropertyBaseTestEnabled)) != "true" {
-		t.Skip("Property based tests are disabled.")
-	}
-
 	t.Parallel()
 
 	const (
@@ -31,7 +22,7 @@ func TestProperty_DifferentVotingPower(t *testing.T) {
 	rapid.Check(t, func(tt *rapid.T) {
 		var (
 			numNodes  = rapid.Uint64Range(4, 8).Draw(tt, "number of cluster nodes")
-			epochSize = rapid.OneOf(rapid.Just(4), rapid.Just(10)).Draw(tt, "Size of epoch")
+			epochSize = rapid.OneOf(rapid.Just(4), rapid.Just(10)).Draw(tt, "epoch size")
 			numBlocks = rapid.Uint64Range(2, 5).Draw(tt, "number of blocks the cluster should mine")
 		)
 
@@ -44,6 +35,7 @@ func TestProperty_DifferentVotingPower(t *testing.T) {
 
 		cluster := framework.NewTestCluster(t, int(numNodes),
 			framework.WithEpochSize(epochSize),
+			framework.WithPropertyBaseTests(true),
 			framework.WithSecretsCallback(func(adresses []types.Address, config *framework.TestClusterConfig) {
 				for i, a := range adresses {
 					config.Premine = append(config.Premine, fmt.Sprintf("%s:%d", a, premine[i]))

--- a/e2e-polybft/rapid_test.go
+++ b/e2e-polybft/rapid_test.go
@@ -1,0 +1,49 @@
+package e2e
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/0xPolygon/polygon-edge/e2e-polybft/framework"
+	"github.com/0xPolygon/polygon-edge/types"
+	"pgregory.net/rapid"
+)
+
+func TestProperty_DifferentVotingPower(t *testing.T) {
+	t.Parallel()
+
+	const (
+		blockTime  = time.Second * 6
+		maxPremine = math.MaxUint64
+	)
+
+	rapid.Check(t, func(tt *rapid.T) {
+		var (
+			numNodes  = rapid.Uint64Range(4, 30).Draw(tt, "number of cluster nodes")
+			epochSize = rapid.IntRange(5, 20).Draw(tt, "Size of epoch")
+			numBlocks = rapid.Uint64Range(2, 40).Draw(tt, "number of block the cluster should mine")
+		)
+
+		premine := make([]uint64, numNodes)
+
+		// premined amount will determine validator's stake and in the end voting power
+		for i := range premine {
+			premine[i] = rapid.Uint64Range(1, maxPremine).Draw(tt, fmt.Sprintf("stake for node %d", i+1))
+		}
+
+		cluster := framework.NewTestCluster(t, int(numNodes),
+			framework.WithEpochSize(epochSize),
+			framework.WithSecretsCallback(func(adresses []types.Address, config *framework.TestClusterConfig) {
+				for i, a := range adresses {
+					config.Premine = append(config.Premine, fmt.Sprintf("%s:%d", a, premine[i]))
+				}
+			}),
+			framework.WithNonValidators(2), framework.WithValidatorSnapshot(5))
+		defer cluster.Stop()
+
+		// wait for single epoch to process withdrawal
+		cluster.WaitForBlock(numBlocks, blockTime*time.Duration(numBlocks))
+	})
+}

--- a/e2e-polybft/rapid_test.go
+++ b/e2e-polybft/rapid_test.go
@@ -22,13 +22,13 @@ func TestProperty_DifferentVotingPower(t *testing.T) {
 	rapid.Check(t, func(tt *rapid.T) {
 		var (
 			numNodes  = rapid.Uint64Range(4, 30).Draw(tt, "number of cluster nodes")
-			epochSize = rapid.IntRange(5, 20).Draw(tt, "Size of epoch")
-			numBlocks = rapid.Uint64Range(2, 40).Draw(tt, "number of block the cluster should mine")
+			epochSize = rapid.OneOf(rapid.Just(4), rapid.Just(10)).Draw(tt, "Size of epoch")
+			numBlocks = rapid.Uint64Range(2, 5).Draw(tt, "number of blocks the cluster should mine")
 		)
 
 		premine := make([]uint64, numNodes)
 
-		// premined amount will determine validator's stake and in the end voting power
+		// premined amount will determine validator's stake and therefore voting power
 		for i := range premine {
 			premine[i] = rapid.Uint64Range(1, maxPremine).Draw(tt, fmt.Sprintf("stake for node %d", i+1))
 		}
@@ -39,8 +39,7 @@ func TestProperty_DifferentVotingPower(t *testing.T) {
 				for i, a := range adresses {
 					config.Premine = append(config.Premine, fmt.Sprintf("%s:%d", a, premine[i]))
 				}
-			}),
-			framework.WithNonValidators(2), framework.WithValidatorSnapshot(5))
+			}))
 		defer cluster.Stop()
 
 		// wait for single epoch to process withdrawal

--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/kilic/bn254 v0.0.0-20201116081810-790649bc68fe
 	golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.43.1
+	pgregory.net/rapid v0.5.5
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1227,7 +1227,8 @@ inet.af/netaddr v0.0.0-20220617031823-097006376321 h1:B4dC8ySKTQXasnjDTMsoCMf1sQ
 inet.af/netaddr v0.0.0-20220617031823-097006376321/go.mod h1:OIezDfdzOgFhuw4HuWapWq2e9l0H9tK4F1j+ETRtF3k=
 lukechampine.com/blake3 v1.1.7 h1:GgRMhmdsuK8+ii6UZFDL8Nb+VyMwadAgcJyfYHxG6n0=
 lukechampine.com/blake3 v1.1.7/go.mod h1:tkKEOtDkNtklkXtLNEOGNq5tcV90tJiA1vAA12R78LA=
-pgregory.net/rapid v0.5.3 h1:163N50IHFqr1phZens4FQOdPgfJscR7a562mjQqeo4M=
+pgregory.net/rapid v0.5.5 h1:jkgx1TjbQPD/feRoK+S/mXw9e1uj6WilpHrXJowi6oA=
+pgregory.net/rapid v0.5.5/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=


### PR DESCRIPTION
# Description

We need a property based test that allows us to check that we can create different cluster with different voting power.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually

# Additional comments

In order to run the test `env` variable `export E2E_PROPERTY_TESTS=true` must be set
