### PR TITLE
Exclude core-contracts from SonarQube checks

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=polygon-edge
 
 sonar.sources=.
-sonar.exclusions=**/*_test.go,**/vendor/**,**/*.py
+sonar.exclusions=**/*_test.go,**/vendor/**,**/*.py,**/core-contracts/**
  
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go


### PR DESCRIPTION
# Description

We don't want to check `core-contracts` repo from Edge

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
