### PR TITLE
EVM-370 Added insecure flag for local store. 

### DIFF
--- a/command/secrets/init/params.go
+++ b/command/secrets/init/params.go
@@ -9,26 +9,29 @@ import (
 )
 
 const (
-	dataDirFlag = "data-dir"
-	configFlag  = "config"
-	ecdsaFlag   = "ecdsa"
-	blsFlag     = "bls"
-	networkFlag = "network"
-	numFlag     = "num"
+	dataDirFlag        = "data-dir"
+	configFlag         = "config"
+	ecdsaFlag          = "ecdsa"
+	blsFlag            = "bls"
+	networkFlag        = "network"
+	numFlag            = "num"
+	insecureLocalStore = "insecure"
 )
 
 var (
-	errInvalidConfig   = errors.New("invalid secrets configuration")
-	errInvalidParams   = errors.New("no config file or data directory passed in")
-	errUnsupportedType = errors.New("unsupported secrets manager")
+	errInvalidConfig                  = errors.New("invalid secrets configuration")
+	errInvalidParams                  = errors.New("no config file or data directory passed in")
+	errUnsupportedType                = errors.New("unsupported secrets manager")
+	errSecureLocalStoreNotImplemented = errors.New("secure local store not yet implemented")
 )
 
 type initParams struct {
-	dataDir          string
-	configPath       string
-	generatesECDSA   bool
-	generatesBLS     bool
-	generatesNetwork bool
+	dataDir            string
+	configPath         string
+	generatesECDSA     bool
+	generatesBLS       bool
+	generatesNetwork   bool
+	insecureLocalStore bool
 
 	secretsManager secrets.SecretsManager
 	secretsConfig  *secrets.SecretsManagerConfig
@@ -89,6 +92,12 @@ func (ip *initParams) parseConfig() error {
 }
 
 func (ip *initParams) initLocalSecretsManager() error {
+	if !ip.insecureLocalStore {
+		//TODO: implement encryption mechanism for local secrets manager
+		return errSecureLocalStoreNotImplemented
+	}
+
+	// setup local secrets manager
 	local, err := helper.SetupLocalSecretsManager(ip.dataDir)
 	if err != nil {
 		return err
@@ -145,6 +154,8 @@ func (ip *initParams) getResult() (command.CommandResult, error) {
 	if res.NodeID, err = helper.LoadNodeID(ip.secretsManager); err != nil {
 		return nil, err
 	}
+
+	res.Insecure = ip.insecureLocalStore
 
 	return res, nil
 }

--- a/command/secrets/init/params.go
+++ b/command/secrets/init/params.go
@@ -96,9 +96,9 @@ func (ip *initParams) parseConfig() error {
 
 func (ip *initParams) initLocalSecretsManager() error {
 	if !ip.insecureLocalStore {
-		//storing secrets on a local file system should only be allowed with --insecure flag
-		//to raise awareness that it should be only used in development/testing
-		//production environment should use one of the supported secrets managers
+		//Storing secrets on a local file system should only be allowed with --insecure flag,
+		//to raise awareness that it should be only used in development/testing environments.
+		//Production setups should use one of the supported secrets managers
 		return errSecureLocalStoreNotImplemented
 	}
 

--- a/command/secrets/init/params.go
+++ b/command/secrets/init/params.go
@@ -9,13 +9,13 @@ import (
 )
 
 const (
-	dataDirFlag        = "data-dir"
-	configFlag         = "config"
-	ecdsaFlag          = "ecdsa"
-	blsFlag            = "bls"
-	networkFlag        = "network"
-	numFlag            = "num"
-	insecureLocalStore = "insecure"
+	dataDirFlag            = "data-dir"
+	configFlag             = "config"
+	ecdsaFlag              = "ecdsa"
+	blsFlag                = "bls"
+	networkFlag            = "network"
+	numFlag                = "num"
+	insecureLocalStoreFlag = "insecure"
 )
 
 var (

--- a/command/secrets/init/params.go
+++ b/command/secrets/init/params.go
@@ -22,7 +22,10 @@ var (
 	errInvalidConfig                  = errors.New("invalid secrets configuration")
 	errInvalidParams                  = errors.New("no config file or data directory passed in")
 	errUnsupportedType                = errors.New("unsupported secrets manager")
-	errSecureLocalStoreNotImplemented = errors.New("secure local store not yet implemented")
+	errSecureLocalStoreNotImplemented = errors.New(
+		"use a secrets backend, or supply an --insecure flag " +
+			"to store the private keys locally on the filesystem, " +
+			"avoid doing so in production")
 )
 
 type initParams struct {
@@ -93,7 +96,9 @@ func (ip *initParams) parseConfig() error {
 
 func (ip *initParams) initLocalSecretsManager() error {
 	if !ip.insecureLocalStore {
-		//TODO: implement encryption mechanism for local secrets manager
+		//storing secrets on a local file system should only be allowed with --insecure flag
+		//to raise awareness that it should be only used in development/testing
+		//production environment should use one of the supported secrets managers
 		return errSecureLocalStoreNotImplemented
 	}
 

--- a/command/secrets/init/result.go
+++ b/command/secrets/init/result.go
@@ -26,6 +26,7 @@ type SecretsInitResult struct {
 	Address   types.Address `json:"address"`
 	BLSPubkey string        `json:"bls_pubkey"`
 	NodeID    string        `json:"node_id"`
+	Insecure  bool          `json:"insecure"`
 }
 
 func (r *SecretsInitResult) GetOutput() string {
@@ -46,6 +47,10 @@ func (r *SecretsInitResult) GetOutput() string {
 	}
 
 	vals = append(vals, fmt.Sprintf("Node ID|%s", r.NodeID))
+
+	if r.Insecure {
+		buffer.WriteString("\n[WARNING: INSECURE LOCAL SECRETS - SHOULD NOT BE RUN IN PRODUCTION]\n")
+	}
 
 	buffer.WriteString("\n[SECRETS INIT]\n")
 	buffer.WriteString(helper.FormatKV(vals))

--- a/command/secrets/init/secrets_init.go
+++ b/command/secrets/init/secrets_init.go
@@ -87,7 +87,7 @@ func setFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(
 		&basicParams.insecureLocalStore,
-		insecureLocalStore,
+		insecureLocalStoreFlag,
 		false,
 		"the flag indicating should the secrets stored on the local storage be encrypted",
 	)

--- a/command/secrets/init/secrets_init.go
+++ b/command/secrets/init/secrets_init.go
@@ -84,6 +84,13 @@ func setFlags(cmd *cobra.Command) {
 		true,
 		"the flag indicating whether new BLS key is created",
 	)
+
+	cmd.Flags().BoolVar(
+		&basicParams.insecureLocalStore,
+		insecureLocalStore,
+		false,
+		"the flag indicating should the secrets stored on the local storage be encrypted",
+	)
 }
 
 func runPreRun(_ *cobra.Command, _ []string) error {
@@ -131,10 +138,11 @@ func newParamsList(params initParams, num int) []initParams {
 	paramsList := make([]initParams, num)
 	for i := 1; i <= num; i++ {
 		paramsList[i-1] = initParams{
-			dataDir:          fmt.Sprintf("%s%d", params.dataDir, i),
-			generatesECDSA:   params.generatesECDSA,
-			generatesBLS:     params.generatesBLS,
-			generatesNetwork: params.generatesNetwork,
+			dataDir:            fmt.Sprintf("%s%d", params.dataDir, i),
+			generatesECDSA:     params.generatesECDSA,
+			generatesBLS:       params.generatesBLS,
+			generatesNetwork:   params.generatesNetwork,
+			insecureLocalStore: params.insecureLocalStore,
 		}
 	}
 

--- a/command/secrets/output/result.go
+++ b/command/secrets/output/result.go
@@ -7,19 +7,19 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/helper"
 )
 
-// SecretsOutputAllResults for default output case
+// SecretsOutputAllResult for default output case
 type SecretsOutputAllResult struct {
 	Address   string `json:"address"`
 	BLSPubkey string `json:"bls"`
 	NodeID    string `json:"node_id"`
 }
 
-// SecretsOutputNodeIDResults for `--node` output case
+// SecretsOutputNodeIDResult for `--node` output case
 type SecretsOutputNodeIDResult struct {
 	NodeID string `json:"node_id"`
 }
 
-// SecretsOutputBLSResults for `--bls` output case
+// SecretsOutputBLSResult for `--bls` output case
 type SecretsOutputBLSResult struct {
 	BLSPubkey string `json:"bls"`
 }

--- a/docker/local/polygon-edge.sh
+++ b/docker/local/polygon-edge.sh
@@ -12,7 +12,7 @@ case "$1" in
           echo "Secrets have already been generated."
       else
           echo "Generating secrets..."
-          secrets=$("$POLYGON_EDGE_BIN" secrets init --num 4 --data-dir /data/data- --json)
+          secrets=$("$POLYGON_EDGE_BIN" secrets init --num 4 --data-dir /data/data- --insecure --json)
           echo "Secrets have been successfully generated"
 
           echo "Generating genesis file..."


### PR DESCRIPTION
# Description

When initializing the chain and using a local storage, private keys are stored as a plaintext format by default, in a local folder the operator has defined during the `init` stage.    

This PR adds the `--insecure` flag as mandatory in order to store private keys unencrypted.    
If the operator tries to run `secrets init` command without `--insecure` flag, the error `use a secrets backend, or supply an --insecure flag...` will be presented.    
When `--insecure` flag is used for storing the secrets locally, the following warning will be presented:  
`[WARNING: INSECURE LOCAL SECRETS - SHOULD NOT BE RUN IN PRODUCTION]`    
as storing secrets using this method, presents a high security risk and should not be used in production environments.


# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Run `secrets init --data-dir <folder>` - it should fail with an error `use a secrets backend, or supply an --insecure flag...`.     
Run `secrets init --data-dir <folder> --insecure` - it should succeed with a warning `[WARNING: INSECURE LOCAL SECRETS - SHOULD NOT BE RUN IN PRODUCTION]`


# Additional comments

Fixes EVM-370
Fixes EDGE-1024