### PR TITLE
Checkpoint data validations

### DIFF
--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -38,7 +38,8 @@ type blockchainBackend interface {
 		txPool txPoolInterface, blockTime time.Duration, logger hclog.Logger) (blockBuilder, error)
 
 	// ProcessBlock builds a final block from given 'block' on top of 'parent'.
-	ProcessBlock(parent *types.Header, block *types.Block) (*types.FullBlock, error)
+	ProcessBlock(parent *types.Header, block *types.Block,
+		callback func(*state.Transition) error) (*types.FullBlock, error)
 
 	// GetStateProviderForBlock returns a reference to make queries to the state at 'block'.
 	GetStateProviderForBlock(block *types.Header) (contract.Provider, error)
@@ -83,7 +84,8 @@ func (p *blockchainWrapper) CommitBlock(block *types.FullBlock) error {
 }
 
 // ProcessBlock builds a final block from given 'block' on top of 'parent'
-func (p *blockchainWrapper) ProcessBlock(parent *types.Header, block *types.Block) (*types.FullBlock, error) {
+func (p *blockchainWrapper) ProcessBlock(parent *types.Header, block *types.Block,
+	callback func(*state.Transition) error) (*types.FullBlock, error) {
 	// TODO: Call validate block in polybft
 	header := block.Header.Copy()
 
@@ -96,6 +98,12 @@ func (p *blockchainWrapper) ProcessBlock(parent *types.Header, block *types.Bloc
 	for _, tx := range block.Transactions {
 		if err := transition.Write(tx); err != nil {
 			return nil, fmt.Errorf("process block tx error, tx = %v, err = %w", tx.Hash, err)
+		}
+	}
+
+	if callback != nil {
+		if err := callback(transition); err != nil {
+			return nil, err
 		}
 	}
 

--- a/consensus/polybft/extra.go
+++ b/consensus/polybft/extra.go
@@ -144,11 +144,7 @@ func (i *Extra) UnmarshalRLPWith(v *fastrlp.Value) error {
 
 // ValidateBasic contains extra data basic set of validations
 func (i *Extra) ValidateBasic(parentExtra *Extra) error {
-	if err := i.Checkpoint.ValidateBasic(parentExtra.Checkpoint); err != nil {
-		return err
-	}
-
-	return nil
+	return i.Checkpoint.ValidateBasic(parentExtra.Checkpoint)
 }
 
 // Validate contains extra data validation logic

--- a/consensus/polybft/extra.go
+++ b/consensus/polybft/extra.go
@@ -534,12 +534,11 @@ func (c *CheckpointData) Hash(chainID uint64, blockNumber uint64, blockHash type
 // ValidateBasic encapsulates basic validation logic for checkpoint data.
 // It only checks epoch numbers validity and whether validators hashes are non-empty.
 func (c *CheckpointData) ValidateBasic(parentCheckpoint *CheckpointData) error {
-	if c.EpochNumber != parentCheckpoint.EpochNumber {
-		if c.EpochNumber != parentCheckpoint.EpochNumber+1 {
-			// epoch-beginning block
-			// epoch number must be incremented by one compared to parent block's checkpoint
-			return fmt.Errorf("invalid epoch number for epoch-beginning block")
-		}
+	if c.EpochNumber != parentCheckpoint.EpochNumber &&
+		c.EpochNumber != parentCheckpoint.EpochNumber+1 {
+		// epoch-beginning block
+		// epoch number must be incremented by one compared to parent block's checkpoint
+		return fmt.Errorf("invalid epoch number for epoch-beginning block")
 	}
 
 	if c.CurrentValidatorsHash == types.ZeroHash {
@@ -581,12 +580,11 @@ func (c *CheckpointData) Validate(parentCheckpoint *CheckpointData,
 	}
 
 	// epoch ending blocks have validator set transitions
-	if !currentValidators.Equals(nextValidators) {
+	if !currentValidators.Equals(nextValidators) &&
+		c.EpochNumber != parentCheckpoint.EpochNumber {
 		// epoch ending blocks should have the same epoch number as parent block
 		// (as they belong to the same epoch)
-		if c.EpochNumber != parentCheckpoint.EpochNumber {
-			return fmt.Errorf("epoch number should not change for epoch-ending block")
-		}
+		return fmt.Errorf("epoch number should not change for epoch-ending block")
 	}
 
 	return nil

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -271,12 +271,13 @@ func (f *fsm) Validate(proposal []byte) error {
 		return err
 	}
 
-	if err := currentExtra.Validate(block.Header, parentExtra, currentValidators, nextValidators); err != nil {
+	if err := currentExtra.Validate(parentExtra, currentValidators, nextValidators); err != nil {
 		return err
 	}
 
 	// TODO: Validate validator set delta?
 
+	// TODO: Move signature validation logic to Extra
 	blockNumber := block.Number()
 	if blockNumber > 1 {
 		// verify parent signature

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -247,6 +247,10 @@ func (f *fsm) Validate(proposal []byte) error {
 		return err
 	}
 
+	if err := f.VerifyStateTransactions(block.Transactions); err != nil {
+		return err
+	}
+
 	currentValidators := f.validators.Accounts()
 	nextValidators := f.validators.Accounts()
 
@@ -265,10 +269,6 @@ func (f *fsm) Validate(proposal []byte) error {
 		if err != nil {
 			return err
 		}
-	}
-
-	if err := f.VerifyStateTransactions(block.Transactions); err != nil {
-		return err
 	}
 
 	if err := currentExtra.Validate(parentExtra, currentValidators, nextValidators); err != nil {

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -46,8 +46,8 @@ func (m *blockchainMock) NewBlockBuilder(parent *types.Header, coinbase types.Ad
 	return args.Get(0).(blockBuilder), args.Error(1) //nolint:forcetypeassert
 }
 
-func (m *blockchainMock) ProcessBlock(parent *types.Header, block *types.Block) (*types.FullBlock, error) {
-	args := m.Called(parent, block)
+func (m *blockchainMock) ProcessBlock(parent *types.Header, block *types.Block, callback func(*state.Transition) error) (*types.FullBlock, error) {
+	args := m.Called(parent, block, callback)
 
 	return args.Get(0).(*types.FullBlock), args.Error(1) //nolint:forcetypeassert
 }

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -433,7 +433,7 @@ func (p *Polybft) verifyHeaderImpl(parent, header *types.Header, parents []*type
 		return err
 	}
 
-	if err := extra.Validate(header, parentExtra, nil, nil); err != nil {
+	if err := extra.ValidateBasic(parentExtra); err != nil {
 		return err
 	}
 
@@ -446,6 +446,7 @@ func (p *Polybft) verifyHeaderImpl(parent, header *types.Header, parents []*type
 		return fmt.Errorf("failed to calculate sign hash: %w", err)
 	}
 
+	// TODO: Move signature validation logic to Extra
 	if err := extra.Committed.VerifyCommittedFields(validators, checkpointHash, p.logger); err != nil {
 		return fmt.Errorf("failed to verify signatures for block %d. Signed hash %v: %w",
 			blockNumber, checkpointHash, err)

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -428,6 +428,15 @@ func (p *Polybft) verifyHeaderImpl(parent, header *types.Header, parents []*type
 		return fmt.Errorf("failed to verify header for block %d. get extra error = %w", blockNumber, err)
 	}
 
+	parentExtra, err := GetIbftExtra(parent.ExtraData)
+	if err != nil {
+		return err
+	}
+
+	if err := extra.Validate(header, parentExtra, nil, nil); err != nil {
+		return err
+	}
+
 	if extra.Committed == nil {
 		return fmt.Errorf("failed to verify signatures for block %d because signatures are not present", blockNumber)
 	}
@@ -456,11 +465,6 @@ func (p *Polybft) verifyHeaderImpl(parent, header *types.Header, parents []*type
 				blockNumber,
 				err,
 			)
-		}
-
-		parentExtra, err := GetIbftExtra(parent.ExtraData)
-		if err != nil {
-			return err
 		}
 
 		parentCheckpointHash, err := parentExtra.Checkpoint.Hash(p.blockchain.GetChainID(), parent.Number, parent.Hash)

--- a/consensus/polybft/polybft_test.go
+++ b/consensus/polybft/polybft_test.go
@@ -145,18 +145,33 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 		MixHash:    PolyBFTMixDigest,
 		Difficulty: 1,
 	}
-	updateHeaderExtra(currentHeader, currentDelta, nil, &CheckpointData{EpochNumber: 2}, nil)
+	updateHeaderExtra(currentHeader, currentDelta, nil,
+		&CheckpointData{
+			EpochNumber:           2,
+			CurrentValidatorsHash: types.StringToHash("Foo"),
+			NextValidatorsHash:    types.StringToHash("Bar"),
+		}, nil)
 
 	currentHeader.Hash[0] = currentHeader.Hash[0] + 1
 	assert.ErrorContains(t, polybft.VerifyHeader(currentHeader), "invalid header hash")
 
-	// forget Parent field (parent signature) intentionally
-	updateHeaderExtra(currentHeader, currentDelta, nil, nil, accountSetCurrent)
+	// omit Parent field (parent signature) intentionally
+	updateHeaderExtra(currentHeader, currentDelta, nil,
+		&CheckpointData{
+			EpochNumber:           1,
+			CurrentValidatorsHash: types.StringToHash("Foo"),
+			NextValidatorsHash:    types.StringToHash("Bar")},
+		accountSetCurrent)
 
 	// since parent signature is intentionally disregarded the following error is expected
 	assert.ErrorContains(t, polybft.VerifyHeader(currentHeader), "failed to verify signatures for parent of block")
 
-	updateHeaderExtra(currentHeader, currentDelta, parentCommitment, nil, accountSetCurrent)
+	updateHeaderExtra(currentHeader, currentDelta, parentCommitment,
+		&CheckpointData{
+			EpochNumber:           1,
+			CurrentValidatorsHash: types.StringToHash("Foo"),
+			NextValidatorsHash:    types.StringToHash("Bar")},
+		accountSetCurrent)
 
 	assert.NoError(t, polybft.VerifyHeader(currentHeader))
 

--- a/consensus/polybft/validator_metadata.go
+++ b/consensus/polybft/validator_metadata.go
@@ -124,6 +124,21 @@ func (v *ValidatorMetadata) String() string {
 // AccountSet is a type alias for slice of ValidatorMetadata instances
 type AccountSet []*ValidatorMetadata
 
+// Equals compares checks if two AccountSet instances are equal (ordering is important)
+func (as AccountSet) Equals(other AccountSet) bool {
+	if len(as) != len(other) {
+		return false
+	}
+
+	for i := range as {
+		if !as[i].Equals(other[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // fmt.Stringer implementation
 func (as AccountSet) String() string {
 	metadataString := make([]string, len(as))


### PR DESCRIPTION
# Description

This PR implements validations for checkpoint data. Validations are categorized as basic and full validations, depending if it is being validated from consensus or synchronization protocol (note that in synchronization protocol, only headers are available and therefore there are certain limitations about validation scope).

## Epoch Number
- When epoch number changes (epoch-beginning blocks), it must be incremented by one compared to the parent block’s epoch number. This validation is checked for both consensus and synchronization protocol.
- In case the current validators and next validators are not the same, it is required that the epoch number remains the same. This is due to the fact that if the validator set changes, it is happening on the epoch-ending block, which belongs to the current epoch. This is being validated only during consensus protocol.

## Current/Next Validators Hash
- The current and next validators hash must not be empty (checked for both consensus and synchronization protocol)
- Current validators hash is calculated based on the current validators, whereas the next validators hash is calculated based on the next validators. (checked only during consensus protocol, since we are not able to determine actual validator sets when running synchronization protocol. It is due to not being able to execute block, since only headers are verified)

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually