### PR TITLE
Expose `ValidatorInfo` struct

### DIFF
--- a/command/sidechain/validators/validator_info.go
+++ b/command/sidechain/validators/validator_info.go
@@ -2,7 +2,6 @@ package validators
 
 import (
 	"fmt"
-	"math/big"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/helper"
@@ -60,18 +59,18 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 
 	validatorAddr := validatorAccount.Ecdsa.Address()
 
-	responseMap, err := sidechainHelper.GetValidatorInfo(validatorAddr, txRelayer)
+	validatorInfo, err := sidechainHelper.GetValidatorInfo(validatorAddr, txRelayer)
 	if err != nil {
 		return fmt.Errorf("failed to get validator info for %s: %w", validatorAddr, err)
 	}
 
 	outputter.WriteCommandResult(&validatorsInfoResult{
-		address:             validatorAccount.Ecdsa.Address().String(),
-		stake:               responseMap["stake"].(*big.Int).Uint64(),               //nolint:forcetypeassert
-		totalStake:          responseMap["totalStake"].(*big.Int).Uint64(),          //nolint:forcetypeassert
-		commission:          responseMap["commission"].(*big.Int).Uint64(),          //nolint:forcetypeassert
-		withdrawableRewards: responseMap["withdrawableRewards"].(*big.Int).Uint64(), //nolint:forcetypeassert
-		active:              responseMap["active"].(bool),                           //nolint:forcetypeassert
+		address:             validatorInfo.Address.String(),
+		stake:               validatorInfo.Stake.Uint64(),
+		totalStake:          validatorInfo.TotalStake.Uint64(),
+		commission:          validatorInfo.Commission.Uint64(),
+		withdrawableRewards: validatorInfo.WithdrawableRewards.Uint64(),
+		active:              validatorInfo.Active,
 	})
 
 	return nil

--- a/consensus/polybft/system_state.go
+++ b/consensus/polybft/system_state.go
@@ -14,6 +14,17 @@ import (
 	"github.com/umbracle/ethgo/contract"
 )
 
+// ValidatorInfo is data transfer object which holds validator information,
+// provided by smart contract
+type ValidatorInfo struct {
+	Address             ethgo.Address
+	Stake               *big.Int
+	TotalStake          *big.Int
+	Commission          *big.Int
+	WithdrawableRewards *big.Int
+	Active              bool
+}
+
 // SystemState is an interface to interact with the consensus system contracts in the chain
 type SystemState interface {
 	// GetValidatorSet retrieves current validator set from the smart contract

--- a/e2e-polybft/consensus_test.go
+++ b/e2e-polybft/consensus_test.go
@@ -181,9 +181,8 @@ func TestE2E_Consensus_RegisterValidator(t *testing.T) {
 	require.NoError(t, err)
 
 	// assert registered validator's stake
-	stake := newValidatorInfo["totalStake"].(*big.Int) //nolint:forcetypeassert
-	t.Logf("New validator stake=%s\n", stake.String())
-	require.Equal(t, newValidatorStake, stake)
+	t.Logf("New validator stake=%d\n", newValidatorInfo.TotalStake)
+	require.Equal(t, newValidatorStake, newValidatorInfo.TotalStake)
 
 	// wait 3 more epochs, so that rewards get accumulated to the registered validator account
 	cluster.WaitForBlock(20, 2*time.Minute)
@@ -193,9 +192,8 @@ func TestE2E_Consensus_RegisterValidator(t *testing.T) {
 	require.NoError(t, err)
 
 	// assert registered validator's rewards
-	rewards := newValidatorInfo["withdrawableRewards"].(*big.Int) //nolint:forcetypeassert
-	t.Logf("New validator rewards=%s\n", rewards)
-	require.True(t, rewards.Cmp(big.NewInt(0)) > 0)
+	t.Logf("New validator rewards=%d\n", newValidatorInfo.WithdrawableRewards)
+	require.True(t, newValidatorInfo.WithdrawableRewards.Cmp(big.NewInt(0)) > 0)
 }
 
 func TestE2E_Consensus_Delegation_Undelegation(t *testing.T) {
@@ -336,11 +334,11 @@ func TestE2E_Consensus_Validator_Unstake(t *testing.T) {
 	// wait for one epoch to accumulate validator rewards
 	require.NoError(t, cluster.WaitForBlock(5, 20*time.Second))
 
-	validatorInfoRaw, err := sidechain.GetValidatorInfo(validatorAddr, txRelayer)
+	validatorInfo, err := sidechain.GetValidatorInfo(validatorAddr, txRelayer)
 	require.NoError(t, err)
 
-	initialStake := validatorInfoRaw["totalStake"].(*big.Int) //nolint:forcetypeassert
-	t.Logf("Stake (before unstake)=%s\n", initialStake.String())
+	initialStake := validatorInfo.TotalStake
+	t.Logf("Stake (before unstake)=%d\n", initialStake)
 
 	// unstake entire balance (which should remove validator from the validator set in next epoch)
 	require.NoError(t, srv.Unstake(initialStake.Uint64()))
@@ -354,12 +352,12 @@ func TestE2E_Consensus_Validator_Unstake(t *testing.T) {
 	// assert that validator isn't present in new validator set
 	require.Equal(t, 4, validatorSet.Len())
 
-	validatorInfoRaw, err = sidechain.GetValidatorInfo(validatorAddr, txRelayer)
+	validatorInfo, err = sidechain.GetValidatorInfo(validatorAddr, txRelayer)
 	require.NoError(t, err)
 
-	reward := validatorInfoRaw["withdrawableRewards"].(*big.Int) //nolint:forcetypeassert
+	reward := validatorInfo.WithdrawableRewards
 	t.Logf("Rewards=%d\n", reward)
-	t.Logf("Stake (after unstake)=%d\n", validatorInfoRaw["totalStake"].(*big.Int)) //nolint:forcetypeassert
+	t.Logf("Stake (after unstake)=%d\n", validatorInfo.TotalStake)
 	require.Greater(t, reward.Uint64(), uint64(0))
 
 	oldValidatorBalance, err := srv.JSONRPC().Eth().GetBalance(validatorAcc.Ecdsa.Address(), ethgo.Latest)
@@ -385,7 +383,7 @@ func TestE2E_Consensus_Validator_Unstake(t *testing.T) {
 
 	// query rootchain validator set and make sure that validator which unstaked all the funds isn't present in validator set anymore
 	// (execute it multiple times if needed, because it is unknown in advance how much time it is going to take until checkpoint is submitted)
-	rootchainValidators := []*validatorInfo{}
+	rootchainValidators := []*polybft.ValidatorInfo{}
 	err = cluster.Bridge.WaitUntil(time.Second, 10*time.Second, func() (bool, error) {
 		rootchainValidators, err = getRootchainValidators(l1Relayer, checkpointManagerAddr, rootchainSender)
 		if err != nil {
@@ -398,8 +396,8 @@ func TestE2E_Consensus_Validator_Unstake(t *testing.T) {
 	require.Equal(t, 4, len(rootchainValidators))
 
 	for _, validator := range rootchainValidators {
-		if validator.address == validatorAddr {
-			t.Fatalf("not expected to find validator %v in the current validator set", validator.address)
+		if validator.Address == validatorAddr {
+			t.Fatalf("not expected to find validator %v in the current validator set", validator.Address)
 		}
 	}
 }


### PR DESCRIPTION
# Description

This PR exposes and utilizes the `ValidatorInfo` struct. It represents a data transfer object, which is used to hold all validator data retrieved from the smart contract.
Note: It is worth to consider merging it with the `ValidatorMetadata` object at some point.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backward-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in the code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
