### PR TITLE
Fix EVM-372 & EVM-373 already existing directories and files are not checked for ownership and permissions

### DIFF
--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -238,7 +238,7 @@ func WriteGenesisConfigToDisk(genesisConfig *chain.Chain, genesisPath string) er
 		return fmt.Errorf("failed to generate genesis: %w", err)
 	}
 
-	if err := common.CreateOrOverwriteFileSafe(genesisPath, data, 0660, false); err != nil {
+	if err := common.CreateOrOverwriteFileSafe(genesisPath, data, 0660); err != nil {
 		return fmt.Errorf("failed to write genesis: %w", err)
 	}
 

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -238,7 +238,7 @@ func WriteGenesisConfigToDisk(genesisConfig *chain.Chain, genesisPath string) er
 		return fmt.Errorf("failed to generate genesis: %w", err)
 	}
 
-	if err := common.CreateFileSafe(genesisPath, data, 0660, false); err != nil {
+	if err := common.CreateOrOverwriteFileSafe(genesisPath, data, 0660, false); err != nil {
 		return fmt.Errorf("failed to write genesis: %w", err)
 	}
 

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -238,7 +238,7 @@ func WriteGenesisConfigToDisk(genesisConfig *chain.Chain, genesisPath string) er
 		return fmt.Errorf("failed to generate genesis: %w", err)
 	}
 
-	if err := common.CreateOrOverwriteFileSafe(genesisPath, data, 0660); err != nil {
+	if err := common.SaveFileSafe(genesisPath, data, 0660); err != nil {
 		return fmt.Errorf("failed to write genesis: %w", err)
 	}
 

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"os"
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/chain"
@@ -239,7 +238,7 @@ func WriteGenesisConfigToDisk(genesisConfig *chain.Chain, genesisPath string) er
 		return fmt.Errorf("failed to generate genesis: %w", err)
 	}
 
-	if err := os.WriteFile(genesisPath, data, os.ModePerm); err != nil {
+	if err := common.CreateFileSafe(genesisPath, data, 0660, false); err != nil {
 		return fmt.Errorf("failed to write genesis: %w", err)
 	}
 

--- a/command/rootchain/server/server.go
+++ b/command/rootchain/server/server.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 )
 
 const (
@@ -133,7 +134,7 @@ func runRootchain(ctx context.Context, outputter command.OutputFormatter, closeC
 	}
 
 	// target directory for the chain
-	if err = os.MkdirAll(params.dataDir, 0700); err != nil {
+	if err = common.CreateDirSafe(params.dataDir, 0700); err != nil {
 		return err
 	}
 

--- a/command/server/export/export.go
+++ b/command/server/export/export.go
@@ -74,8 +74,7 @@ func generateConfig(config config.Config) error {
 	if err := common.CreateOrOverwriteFileSafe(
 		fmt.Sprintf("default-config.%s", paramFlagValues.FileType),
 		data,
-		0660,
-		false); err != nil {
+		0660); err != nil {
 		return fmt.Errorf("failed to create config file %w", err)
 	}
 

--- a/command/server/export/export.go
+++ b/command/server/export/export.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/server/config"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -71,10 +71,11 @@ func generateConfig(config config.Config) error {
 		return fmt.Errorf("could not marshal config struct, %w", err)
 	}
 
-	if err := os.WriteFile(
+	if err := common.CreateFileSafe(
 		fmt.Sprintf("default-config.%s", paramFlagValues.FileType),
 		data,
-		os.ModePerm); err != nil {
+		0660,
+		false); err != nil {
 		return errors.New("could not create and write config file")
 	}
 

--- a/command/server/export/export.go
+++ b/command/server/export/export.go
@@ -76,7 +76,7 @@ func generateConfig(config config.Config) error {
 		data,
 		0660,
 		false); err != nil {
-		return errors.New("could not create and write config file")
+		return fmt.Errorf("failed to create config file %w", err)
 	}
 
 	return nil

--- a/command/server/export/export.go
+++ b/command/server/export/export.go
@@ -71,7 +71,7 @@ func generateConfig(config config.Config) error {
 		return fmt.Errorf("could not marshal config struct, %w", err)
 	}
 
-	if err := common.CreateOrOverwriteFileSafe(
+	if err := common.SaveFileSafe(
 		fmt.Sprintf("default-config.%s", paramFlagValues.FileType),
 		data,
 		0660); err != nil {

--- a/command/server/export/export.go
+++ b/command/server/export/export.go
@@ -71,7 +71,7 @@ func generateConfig(config config.Config) error {
 		return fmt.Errorf("could not marshal config struct, %w", err)
 	}
 
-	if err := common.CreateFileSafe(
+	if err := common.CreateOrOverwriteFileSafe(
 		fmt.Sprintf("default-config.%s", paramFlagValues.FileType),
 		data,
 		0660,

--- a/consensus/ibft/fork/helper.go
+++ b/consensus/ibft/fork/helper.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/validators/store/snapshot"
 )
 
@@ -53,7 +54,7 @@ func writeDataStore(path string, obj interface{}) error {
 		return err
 	}
 
-	if err := os.WriteFile(path, data, os.ModePerm); err != nil {
+	if err := common.CreateFileSafe(path, data, 0660, false); err != nil {
 		return err
 	}
 

--- a/consensus/ibft/fork/helper.go
+++ b/consensus/ibft/fork/helper.go
@@ -54,7 +54,7 @@ func writeDataStore(path string, obj interface{}) error {
 		return err
 	}
 
-	if err := common.CreateOrOverwriteFileSafe(path, data, 0660); err != nil {
+	if err := common.SaveFileSafe(path, data, 0660); err != nil {
 		return err
 	}
 

--- a/consensus/ibft/fork/helper.go
+++ b/consensus/ibft/fork/helper.go
@@ -54,7 +54,7 @@ func writeDataStore(path string, obj interface{}) error {
 		return err
 	}
 
-	if err := common.CreateOrOverwriteFileSafe(path, data, 0660, false); err != nil {
+	if err := common.CreateOrOverwriteFileSafe(path, data, 0660); err != nil {
 		return err
 	}
 

--- a/consensus/ibft/fork/helper.go
+++ b/consensus/ibft/fork/helper.go
@@ -54,7 +54,7 @@ func writeDataStore(path string, obj interface{}) error {
 		return err
 	}
 
-	if err := common.CreateFileSafe(path, data, 0660, false); err != nil {
+	if err := common.CreateOrOverwriteFileSafe(path, data, 0660, false); err != nil {
 		return err
 	}
 

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -4,7 +4,6 @@ package polybft
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/helper/progress"
 	"github.com/0xPolygon/polygon-edge/network"
 	"github.com/0xPolygon/polygon-edge/state"
@@ -186,7 +186,7 @@ func (p *Polybft) Initialize() error {
 	// initialize polybft consensus data directory
 	p.dataDir = filepath.Join(p.config.Config.Path, "polybft")
 	// create the data dir if not exists
-	if err = os.MkdirAll(p.dataDir, 0750); err != nil {
+	if err = common.CreateDirSafe(p.dataDir, 0750); err != nil {
 		return fmt.Errorf("failed to create data directory. Error: %w", err)
 	}
 

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -191,7 +191,7 @@ func (m *Manifest) Save(manifestPath string) error {
 		return fmt.Errorf("failed to marshal rootchain manifest to JSON: %w", err)
 	}
 
-	if err := common.CreateOrOverwriteFileSafe(filepath.Clean(manifestPath), data, 0660); err != nil {
+	if err := common.SaveFileSafe(filepath.Clean(manifestPath), data, 0660); err != nil {
 		return fmt.Errorf("failed to save rootchain manifest file: %w", err)
 	}
 

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -191,7 +191,7 @@ func (m *Manifest) Save(manifestPath string) error {
 		return fmt.Errorf("failed to marshal rootchain manifest to JSON: %w", err)
 	}
 
-	if err := common.CreateFileSafe(filepath.Clean(manifestPath), data, 0660, false); err != nil {
+	if err := common.CreateOrOverwriteFileSafe(filepath.Clean(manifestPath), data, 0660, false); err != nil {
 		return fmt.Errorf("failed to save rootchain manifest file: %w", err)
 	}
 

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
@@ -190,7 +191,7 @@ func (m *Manifest) Save(manifestPath string) error {
 		return fmt.Errorf("failed to marshal rootchain manifest to JSON: %w", err)
 	}
 
-	if err := os.WriteFile(filepath.Clean(manifestPath), data, os.ModePerm); err != nil {
+	if err := common.CreateFileSafe(filepath.Clean(manifestPath), data, 0660, false); err != nil {
 		return fmt.Errorf("failed to save rootchain manifest file: %w", err)
 	}
 

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -191,7 +191,7 @@ func (m *Manifest) Save(manifestPath string) error {
 		return fmt.Errorf("failed to marshal rootchain manifest to JSON: %w", err)
 	}
 
-	if err := common.CreateOrOverwriteFileSafe(filepath.Clean(manifestPath), data, 0660, false); err != nil {
+	if err := common.CreateOrOverwriteFileSafe(filepath.Clean(manifestPath), data, 0660); err != nil {
 		return fmt.Errorf("failed to save rootchain manifest file: %w", err)
 	}
 

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -19,6 +19,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/genesis"
 	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/require"
 )
@@ -134,7 +135,7 @@ func (c *TestClusterConfig) GetStdout(name string, custom ...io.Writer) io.Write
 func (c *TestClusterConfig) initLogsDir() {
 	logsDir := path.Join("..", fmt.Sprintf("e2e-logs-%d", startTime), c.t.Name())
 
-	if err := os.MkdirAll(logsDir, 0750); err != nil {
+	if err := common.CreateDirSafe(logsDir, 0750); err != nil {
 		c.t.Fatal(err)
 	}
 

--- a/e2e/framework/ibft.go
+++ b/e2e/framework/ibft.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
@@ -136,7 +137,7 @@ func initLogsDir(t *testing.T) (string, error) {
 	t.Helper()
 	logsDir := path.Join("..", fmt.Sprintf("e2e-logs-%d", startTime), t.Name())
 
-	if err := os.MkdirAll(logsDir, 0755); err != nil {
+	if err := common.CreateDirSafe(logsDir, 0755); err != nil {
 		return "", err
 	}
 

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -155,9 +155,9 @@ func CreateDirSafe(path string, perms fs.FileMode) error {
 	return nil
 }
 
-// Creates a file at path and with perms level permissions or updates the file.
-// If file already exists, owner and permissions are verified.
-// If shouldNotExist is true, an error is returned if file exists
+// Creates a file at path and with perms level permissions.
+// If file already exists, owner and permissions are
+// verified, and the file is overwritten.
 func SaveFileSafe(path string, data []byte, perms fs.FileMode) error {
 	info, err := os.Stat(path)
 	// check if an error occurred other than path not exists

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -201,7 +201,7 @@ func verifyFileOwnerAndPermissions(path string, info fs.FileInfo, expectedPerms 
 
 	// check if permissions are set correctly by the owner
 	if info.Mode() != expectedPerms {
-		return fmt.Errorf("permissions of the file/directory is set incorrectly by another user: %s", path)
+		return fmt.Errorf("permissions of the file/directory '%s' are set incorrectly by another user", path)
 	}
 
 	return nil

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -181,9 +181,9 @@ func SaveFileSafe(path string, data []byte, perms fs.FileMode) error {
 	return nil
 }
 
-// Verifies that the file owner is the current user, or the file owner is in
-// the same group as current user and permissions are set correctly by the owner.
-// Returns an error if occurred, and a bool indicating whether the current user is the owner.
+// Verifies that the file owner is the current user,
+// or the file owner is in the same group as current user
+// and permissions are set correctly by the owner.
 func verifyFileOwnerAndPermissions(path string, info fs.FileInfo, expectedPerms fs.FileMode) error {
 	// get stats
 	stat, ok := info.Sys().(*syscall.Stat_t)

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -147,12 +147,7 @@ func CreateDirSafe(path string, perms fs.FileMode) error {
 	}
 
 	// verify that existing directory's owner and permissions are safe
-	err = verifyFileOwnerAndPermissions(path, info, perms)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return verifyFileOwnerAndPermissions(path, info, perms)
 }
 
 // Creates a file at path and with perms level permissions.
@@ -167,18 +162,13 @@ func SaveFileSafe(path string, data []byte, perms fs.FileMode) error {
 
 	if FileExists(path) {
 		// verify that existing file's owner and permissions are safe
-		err := verifyFileOwnerAndPermissions(path, info, perms)
-		if err != nil {
+		if err := verifyFileOwnerAndPermissions(path, info, perms); err != nil {
 			return err
 		}
 	}
 
 	// create or overwrite the file
-	if err := os.WriteFile(path, data, perms); err != nil {
-		return err
-	}
-
-	return nil
+	return os.WriteFile(path, data, perms)
 }
 
 // Verifies that the file owner is the current user,

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -158,19 +158,14 @@ func CreateDirSafe(path string, perms fs.FileMode) error {
 // Creates a file at path and with perms level permissions.
 // If file already exists, owner and permissions are verified.
 // If shouldNotExist is true, an error is returned if file exists
-func CreateOrOverwriteFileSafe(path string, data []byte, perms fs.FileMode, shouldNotExist bool) error {
+func CreateOrOverwriteFileSafe(path string, data []byte, perms fs.FileMode) error {
 	info, err := os.Stat(path)
 	// check if an error occurred other than path not exists
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 
-	fileExists := FileExists(path)
-	if fileExists && shouldNotExist {
-		return fmt.Errorf("%s already initialized", path)
-	}
-
-	if fileExists {
+	if FileExists(path) {
 		// verify that existing file's owner and permissions are safe
 		err = verifyFileAndTryUpdatePermissions(path, info, perms)
 		if err != nil {

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -155,10 +155,10 @@ func CreateDirSafe(path string, perms fs.FileMode) error {
 	return nil
 }
 
-// Creates a file at path and with perms level permissions.
+// Creates a file at path and with perms level permissions or updates the file.
 // If file already exists, owner and permissions are verified.
 // If shouldNotExist is true, an error is returned if file exists
-func CreateOrOverwriteFileSafe(path string, data []byte, perms fs.FileMode) error {
+func SaveFileSafe(path string, data []byte, perms fs.FileMode) error {
 	info, err := os.Stat(path)
 	// check if an error occurred other than path not exists
 	if err != nil && !os.IsNotExist(err) {

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -88,6 +88,11 @@ func SetupDataDir(dataDir string, paths []string, perms fs.FileMode) error {
 
 // DirectoryExists checks if the directory at the specified path exists
 func DirectoryExists(directoryPath string) bool {
+	// Check if path is empty
+	if directoryPath == "" {
+		return false
+	}
+
 	// Grab the absolute filepath
 	pathAbs, err := filepath.Abs(directoryPath)
 	if err != nil {
@@ -104,6 +109,11 @@ func DirectoryExists(directoryPath string) bool {
 
 // Checks if the file at the specified path exists
 func FileExists(filePath string) bool {
+	// Check if path is empty
+	if filePath == "" {
+		return false
+	}
+
 	// Grab the absolute filepath
 	pathAbs, err := filepath.Abs(filePath)
 	if err != nil {

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -126,6 +126,7 @@ func CreateDirSafe(path string, perms fs.FileMode) error {
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
+
 	// create directory if it does not exist
 	if !DirectoryExists(path) {
 		if err := os.MkdirAll(path, perms); err != nil {

--- a/helper/ipc/ipc_unix.go
+++ b/helper/ipc/ipc_unix.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/0xPolygon/polygon-edge/helper/common"
 )
 
 // Dial dials an IPC path
@@ -22,7 +24,7 @@ func DialTimeout(path string, timeout time.Duration) (net.Conn, error) {
 
 // Listen listens an IPC path
 func Listen(path string) (net.Listener, error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0751); err != nil {
+	if err := common.CreateDirSafe(filepath.Dir(path), 0751); err != nil {
 		return nil, err
 	}
 

--- a/helper/keystore/keystore.go
+++ b/helper/keystore/keystore.go
@@ -4,6 +4,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+
+	"github.com/0xPolygon/polygon-edge/helper/common"
 )
 
 type createFn func() ([]byte, error)
@@ -35,7 +37,7 @@ func CreateIfNotExists(path string, create createFn) ([]byte, error) {
 
 	// Encode it to a readable format (Base64) and write to disk
 	keyBuff = []byte(hex.EncodeToString(keyBuff))
-	if err = os.WriteFile(path, keyBuff, os.ModePerm); err != nil {
+	if err = common.CreateFileSafe(path, keyBuff, 0440, true); err != nil {
 		return nil, fmt.Errorf("unable to write private key to disk (%s), %w", path, err)
 	}
 

--- a/helper/keystore/keystore.go
+++ b/helper/keystore/keystore.go
@@ -37,7 +37,7 @@ func CreateIfNotExists(path string, create createFn) ([]byte, error) {
 
 	// Encode it to a readable format (Base64) and write to disk
 	keyBuff = []byte(hex.EncodeToString(keyBuff))
-	if err = common.CreateFileSafe(path, keyBuff, 0440, true); err != nil {
+	if err = common.CreateOrOverwriteFileSafe(path, keyBuff, 0440, true); err != nil {
 		return nil, fmt.Errorf("unable to write private key to disk (%s), %w", path, err)
 	}
 

--- a/helper/keystore/keystore.go
+++ b/helper/keystore/keystore.go
@@ -37,7 +37,7 @@ func CreateIfNotExists(path string, create createFn) ([]byte, error) {
 
 	// Encode it to a readable format (Base64) and write to disk
 	keyBuff = []byte(hex.EncodeToString(keyBuff))
-	if err = common.CreateOrOverwriteFileSafe(path, keyBuff, 0440); err != nil {
+	if err = common.SaveFileSafe(path, keyBuff, 0440); err != nil {
 		return nil, fmt.Errorf("unable to write private key to disk (%s), %w", path, err)
 	}
 

--- a/helper/keystore/keystore.go
+++ b/helper/keystore/keystore.go
@@ -37,7 +37,7 @@ func CreateIfNotExists(path string, create createFn) ([]byte, error) {
 
 	// Encode it to a readable format (Base64) and write to disk
 	keyBuff = []byte(hex.EncodeToString(keyBuff))
-	if err = common.CreateOrOverwriteFileSafe(path, keyBuff, 0440, true); err != nil {
+	if err = common.CreateOrOverwriteFileSafe(path, keyBuff, 0440); err != nil {
 		return nil, fmt.Errorf("unable to write private key to disk (%s), %w", path, err)
 	}
 

--- a/network/e2e_testing.go
+++ b/network/e2e_testing.go
@@ -373,7 +373,7 @@ func GenerateTestLibp2pKey(t *testing.T) (crypto.PrivKey, string) {
 	assert.NoError(t, err)
 
 	// Instantiate the correct folder structure
-	setupErr := common.SetupDataDir(dir, []string{"libp2p"})
+	setupErr := common.SetupDataDir(dir, []string{"libp2p"}, 0770)
 	if setupErr != nil {
 		t.Fatalf("unable to generate libp2p folder structure, %v", setupErr)
 	}

--- a/secrets/config.go
+++ b/secrets/config.go
@@ -22,7 +22,7 @@ type SecretsManagerConfig struct {
 func (c *SecretsManagerConfig) WriteConfig(path string) error {
 	jsonBytes, _ := json.MarshalIndent(c, "", " ")
 
-	return common.CreateFileSafe(path, jsonBytes, 0660, false)
+	return common.CreateOrOverwriteFileSafe(path, jsonBytes, 0660, false)
 }
 
 // ReadConfig reads the SecretsManagerConfig from the specified path

--- a/secrets/config.go
+++ b/secrets/config.go
@@ -22,7 +22,7 @@ type SecretsManagerConfig struct {
 func (c *SecretsManagerConfig) WriteConfig(path string) error {
 	jsonBytes, _ := json.MarshalIndent(c, "", " ")
 
-	return common.CreateOrOverwriteFileSafe(path, jsonBytes, 0660)
+	return common.SaveFileSafe(path, jsonBytes, 0660)
 }
 
 // ReadConfig reads the SecretsManagerConfig from the specified path

--- a/secrets/config.go
+++ b/secrets/config.go
@@ -3,6 +3,8 @@ package secrets
 import (
 	"encoding/json"
 	"os"
+
+	"github.com/0xPolygon/polygon-edge/helper/common"
 )
 
 // SecretsManagerConfig is the configuration that gets
@@ -20,7 +22,7 @@ type SecretsManagerConfig struct {
 func (c *SecretsManagerConfig) WriteConfig(path string) error {
 	jsonBytes, _ := json.MarshalIndent(c, "", " ")
 
-	return os.WriteFile(path, jsonBytes, os.ModePerm)
+	return common.CreateFileSafe(path, jsonBytes, 0660, false)
 }
 
 // ReadConfig reads the SecretsManagerConfig from the specified path

--- a/secrets/config.go
+++ b/secrets/config.go
@@ -22,7 +22,7 @@ type SecretsManagerConfig struct {
 func (c *SecretsManagerConfig) WriteConfig(path string) error {
 	jsonBytes, _ := json.MarshalIndent(c, "", " ")
 
-	return common.CreateOrOverwriteFileSafe(path, jsonBytes, 0660, false)
+	return common.CreateOrOverwriteFileSafe(path, jsonBytes, 0660)
 }
 
 // ReadConfig reads the SecretsManagerConfig from the specified path

--- a/secrets/local/local.go
+++ b/secrets/local/local.go
@@ -133,7 +133,7 @@ func (l *LocalSecretsManager) SetSecret(name string, value []byte) error {
 	}
 
 	// Write the secret to disk
-	if err := common.CreateFileSafe(secretPath, value, 0440, true); err != nil {
+	if err := common.CreateOrOverwriteFileSafe(secretPath, value, 0440, true); err != nil {
 		return fmt.Errorf(
 			"unable to write secret to disk (%s), %w",
 			secretPath,

--- a/secrets/local/local.go
+++ b/secrets/local/local.go
@@ -132,15 +132,8 @@ func (l *LocalSecretsManager) SetSecret(name string, value []byte) error {
 		return secrets.ErrSecretNotFound
 	}
 
-	// Checks for existing secret
-	if _, err := os.Stat(secretPath); err == nil {
-		return fmt.Errorf(
-			"%s already initialized",
-			secretPath,
-		)
-	}
 	// Write the secret to disk
-	if err := os.WriteFile(secretPath, value, os.ModePerm); err != nil {
+	if err := common.CreateFileSafe(secretPath, value, 0440, true); err != nil {
 		return fmt.Errorf(
 			"unable to write secret to disk (%s), %w",
 			secretPath,

--- a/secrets/local/local.go
+++ b/secrets/local/local.go
@@ -140,7 +140,7 @@ func (l *LocalSecretsManager) SetSecret(name string, value []byte) error {
 		)
 	}
 	// Write the secret to disk
-	if err := common.CreateOrOverwriteFileSafe(secretPath, value, 0440); err != nil {
+	if err := common.SaveFileSafe(secretPath, value, 0440); err != nil {
 		return fmt.Errorf(
 			"unable to write secret to disk (%s), %w",
 			secretPath,

--- a/secrets/local/local.go
+++ b/secrets/local/local.go
@@ -131,7 +131,7 @@ func (l *LocalSecretsManager) SetSecret(name string, value []byte) error {
 	if !ok {
 		return secrets.ErrSecretNotFound
 	}
-	
+
 	// Checks for existing secret
 	if _, err := os.Stat(secretPath); err == nil {
 		return fmt.Errorf(

--- a/secrets/local/local.go
+++ b/secrets/local/local.go
@@ -66,7 +66,7 @@ func (l *LocalSecretsManager) Setup() error {
 	subDirectories := []string{secrets.ConsensusFolderLocal, secrets.NetworkFolderLocal}
 
 	// Set up the local directories
-	if err := common.SetupDataDir(l.path, subDirectories); err != nil {
+	if err := common.SetupDataDir(l.path, subDirectories, 0770); err != nil {
 		return err
 	}
 

--- a/secrets/local/local.go
+++ b/secrets/local/local.go
@@ -131,9 +131,16 @@ func (l *LocalSecretsManager) SetSecret(name string, value []byte) error {
 	if !ok {
 		return secrets.ErrSecretNotFound
 	}
-
+	
+	// Checks for existing secret
+	if _, err := os.Stat(secretPath); err == nil {
+		return fmt.Errorf(
+			"%s already initialized",
+			secretPath,
+		)
+	}
 	// Write the secret to disk
-	if err := common.CreateOrOverwriteFileSafe(secretPath, value, 0440, true); err != nil {
+	if err := common.CreateOrOverwriteFileSafe(secretPath, value, 0440); err != nil {
 		return fmt.Errorf(
 			"unable to write secret to disk (%s), %w",
 			secretPath,

--- a/secrets/local/local_test.go
+++ b/secrets/local/local_test.go
@@ -77,7 +77,7 @@ func getLocalSecretsManager(t *testing.T) secrets.SecretsManager {
 		t.Fatalf("Unable to instantiate local secrets manager directories, %v", tempErr)
 	}
 
-	setupErr := common.SetupDataDir(workingDirectory, []string{secrets.ConsensusFolderLocal, secrets.NetworkFolderLocal})
+	setupErr := common.SetupDataDir(workingDirectory, []string{secrets.ConsensusFolderLocal, secrets.NetworkFolderLocal}, 0770)
 	if setupErr != nil {
 		t.Fatalf("Unable to instantiate local secrets manager directories, %v", setupErr)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -143,7 +143,7 @@ func NewServer(config *Config) (*Server, error) {
 	m.logger.Info("Data dir", "path", config.DataDir)
 
 	// Generate all the paths in the dataDir
-	if err := common.SetupDataDir(config.DataDir, dirPaths); err != nil {
+	if err := common.SetupDataDir(config.DataDir, dirPaths, 0770); err != nil {
 		return nil, fmt.Errorf("failed to create data directories: %w", err)
 	}
 


### PR DESCRIPTION
# Description

This fix addresses the EVM-372 ticket, which states the:

*While creating new file or folder, already existing files and directories are not checked for permissions and ownership. A malicious user might create the file/folder beforehand with high permissions which could cause a security issue.*

This PR brings 2 functions called `SaveFileSafe` and `CreateDirSafe`.

- They check whether the file or directory exists at the given path,
  - if it doesn't, they simply create it with the given permissions (and data in case of file).
  - If it exists, they check whether the owner is current user,
    - if so, just return
    - if not, check whether the owner is in the same group as current user (check this PR for the reason of this decision #1143)
      - if not in the same group, then return error
      - if in the same group, then check whether the permissions are set correctly
        - if permissions are set correctly, continue with creation
        - if not set correctly, return error (since permissions can only be changed by owner, and we are not sure whether it is safe)

**NOTE:** This fix inherently contains EVM-373 as well, since 373 contains only file permissions change.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
