### PR TITLE
Remove `GetNonce` function from `TxRelayer`

### DIFF
--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -144,11 +144,6 @@ func (t *TxRelayerImpl) SendTransactionLocal(txn *ethgo.Transaction) (*ethgo.Rec
 	return t.waitForReceipt(txnHash)
 }
 
-// GetNonce queries nonce for the provided account
-func (t *TxRelayerImpl) GetNonce(address ethgo.Address) (uint64, error) {
-	return t.client.Eth().GetNonce(address, ethgo.Pending)
-}
-
 func (t *TxRelayerImpl) waitForReceipt(hash ethgo.Hash) (*ethgo.Receipt, error) {
 	count := uint(0)
 


### PR DESCRIPTION
# Description

Remove leftover `GetNonce` function from `TxRelayer` as it is dead code.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
