### PR TITLE
EVM-378 Use contracts api generated stubs in client code

### DIFF
--- a/command/rootchain/initcontracts/init_contracts.go
+++ b/command/rootchain/initcontracts/init_contracts.go
@@ -268,14 +268,14 @@ func initializeCheckpointManager(
 		return fmt.Errorf("failed to convert validators to map: %w", err)
 	}
 
-	initCheckpointInput, err := contractsapi.CheckpointManager.Abi.Methods["initialize"].Encode(
-		[]interface{}{
-			manifest.RootchainConfig.BLSAddress,
-			manifest.RootchainConfig.BN256G2Address,
-			bls.GetDomain(),
-			validatorSet,
-		})
+	initialize := contractsapi.InitializeCheckpointManagerFunction{
+		NewBls:          manifest.RootchainConfig.BLSAddress,
+		NewBn256G2:      manifest.RootchainConfig.BN256G2Address,
+		NewDomain:       types.BytesToHash(bls.GetDomain()),
+		NewValidatorSet: validatorSet,
+	}
 
+	initCheckpointInput, err := initialize.EncodeAbi()
 	if err != nil {
 		return fmt.Errorf("failed to encode parameters for CheckpointManager.initialize. error: %w", err)
 	}

--- a/command/rootchain/initcontracts/init_contracts.go
+++ b/command/rootchain/initcontracts/init_contracts.go
@@ -263,7 +263,7 @@ func initializeCheckpointManager(
 	txRelayer txrelayer.TxRelayer,
 	rootchainAdminKey ethgo.Key,
 	manifest *polybft.Manifest) error {
-	validatorSetMap, err := validatorSetToABISlice(manifest.GenesisValidators)
+	validatorSet, err := validatorSetToABISlice(manifest.GenesisValidators)
 	if err != nil {
 		return fmt.Errorf("failed to convert validators to map: %w", err)
 	}
@@ -273,7 +273,7 @@ func initializeCheckpointManager(
 			manifest.RootchainConfig.BLSAddress,
 			manifest.RootchainConfig.BN256G2Address,
 			bls.GetDomain(),
-			validatorSetMap,
+			validatorSet,
 		})
 
 	if err != nil {
@@ -325,7 +325,7 @@ func initializeExitHelper(txRelayer txrelayer.TxRelayer, rootchainConfig *polybf
 
 // validatorSetToABISlice converts given validators to generic map
 // which is used for ABI encoding validator set being sent to the rootchain contract
-func validatorSetToABISlice(validators []*polybft.Validator) ([]map[string]interface{}, error) {
+func validatorSetToABISlice(validators []*polybft.Validator) ([]*contractsapi.Validator, error) {
 	genesisValidators := make([]*polybft.Validator, len(validators))
 	copy(genesisValidators, validators)
 	sort.Slice(genesisValidators, func(i, j int) bool {
@@ -347,5 +347,5 @@ func validatorSetToABISlice(validators []*polybft.Validator) ([]map[string]inter
 		}
 	}
 
-	return accSet.AsGenericMaps(), nil
+	return accSet.ToAPIBinding(), nil
 }

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/blockchain"
 	"github.com/0xPolygon/polygon-edge/chain"
+	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/helper/progress"
 	"github.com/0xPolygon/polygon-edge/network"
 	"github.com/0xPolygon/polygon-edge/secrets"
@@ -81,8 +82,8 @@ type Factory func(*Params) (Consensus, error)
 // BridgeDataProvider is an interface providing bridge related functions
 type BridgeDataProvider interface {
 	// GenerateExit proof generates proof of exit for given exit event
-	GenerateExitProof(exitID, epoch, checkpointBlock uint64) (types.ExitProof, error)
+	GenerateExitProof(exitID, epoch, checkpointBlock uint64) (contracts.ExitProof, error)
 
 	// GetStateSyncProof retrieves the StateSync proof
-	GetStateSyncProof(stateSyncID uint64) (*types.StateSyncProof, error)
+	GetStateSyncProof(stateSyncID uint64) (*contracts.StateSyncProof, error)
 }

--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -242,7 +242,7 @@ func (c *checkpointManager) abiEncodeCheckpointBlock(blockNumber uint64, blockHa
 		return nil, err
 	}
 
-	submit := &contractsapi.Submit{
+	submit := &contractsapi.SubmitFunction{
 		ChainID: new(big.Int).SetUint64(c.blockchain.GetChainID()),
 		CheckpointMetadata: &contractsapi.CheckpointMetadata{
 			BlockHash:               blockHash,

--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -32,7 +32,7 @@ var (
 type CheckpointManager interface {
 	PostBlock(req *PostBlockRequest) error
 	BuildEventRoot(epoch uint64) (types.Hash, error)
-	GenerateExitProof(exitID, epoch, checkpointBlock uint64) (types.ExitProof, error)
+	GenerateExitProof(exitID, epoch, checkpointBlock uint64) (contracts.ExitProof, error)
 }
 
 var _ CheckpointManager = (*dummyCheckpointManager)(nil)
@@ -43,8 +43,8 @@ func (d *dummyCheckpointManager) PostBlock(req *PostBlockRequest) error { return
 func (d *dummyCheckpointManager) BuildEventRoot(epoch uint64) (types.Hash, error) {
 	return types.ZeroHash, nil
 }
-func (d *dummyCheckpointManager) GenerateExitProof(exitID, epoch, checkpointBlock uint64) (types.ExitProof, error) {
-	return types.ExitProof{}, nil
+func (d *dummyCheckpointManager) GenerateExitProof(exitID, epoch, checkpointBlock uint64) (contracts.ExitProof, error) {
+	return contracts.ExitProof{}, nil
 }
 
 var _ CheckpointManager = (*checkpointManager)(nil)
@@ -330,38 +330,38 @@ func (c *checkpointManager) BuildEventRoot(epoch uint64) (types.Hash, error) {
 }
 
 // GenerateExitProof generates proof of exit
-func (c *checkpointManager) GenerateExitProof(exitID, epoch, checkpointBlock uint64) (types.ExitProof, error) {
+func (c *checkpointManager) GenerateExitProof(exitID, epoch, checkpointBlock uint64) (contracts.ExitProof, error) {
 	exitEvent, err := c.state.getExitEvent(exitID, epoch)
 	if err != nil {
-		return types.ExitProof{}, err
+		return contracts.ExitProof{}, err
 	}
 
 	e, err := ExitEventABIType.Encode(exitEvent)
 	if err != nil {
-		return types.ExitProof{}, err
+		return contracts.ExitProof{}, err
 	}
 
 	exitEvents, err := c.state.getExitEventsForProof(epoch, checkpointBlock)
 	if err != nil {
-		return types.ExitProof{}, err
+		return contracts.ExitProof{}, err
 	}
 
 	tree, err := createExitTree(exitEvents)
 	if err != nil {
-		return types.ExitProof{}, err
+		return contracts.ExitProof{}, err
 	}
 
 	leafIndex, err := tree.LeafIndex(e)
 	if err != nil {
-		return types.ExitProof{}, err
+		return contracts.ExitProof{}, err
 	}
 
 	proof, err := tree.GenerateProofForLeaf(e, 0)
 	if err != nil {
-		return types.ExitProof{}, err
+		return contracts.ExitProof{}, err
 	}
 
-	return types.ExitProof{
+	return contracts.ExitProof{
 		Proof:     proof,
 		LeafIndex: leafIndex,
 	}, nil

--- a/consensus/polybft/checkpoint_manager_test.go
+++ b/consensus/polybft/checkpoint_manager_test.go
@@ -171,7 +171,7 @@ func TestCheckpointManager_abiEncodeCheckpointBlock(t *testing.T) {
 	checkpointDataEncoded, err := c.abiEncodeCheckpointBlock(header.Number, header.Hash, extra, nextValidators.getPublicIdentities())
 	require.NoError(t, err)
 
-	submit := &contractsapi.Submit{}
+	submit := &contractsapi.SubmitFunction{}
 	require.NoError(t, submit.DecodeAbi(checkpointDataEncoded))
 
 	require.Equal(t, new(big.Int).SetUint64(checkpoint.EpochNumber), submit.Checkpoint.Epoch)
@@ -820,7 +820,7 @@ func (d *dummyTxRelayer) SendTransactionLocal(txn *ethgo.Transaction) (*ethgo.Re
 func getBlockNumberCheckpointSubmitInput(t *testing.T, input []byte) uint64 {
 	t.Helper()
 
-	submit := &contractsapi.Submit{}
+	submit := &contractsapi.SubmitFunction{}
 	require.NoError(t, submit.DecodeAbi(input))
 
 	return submit.Checkpoint.BlockNumber.Uint64()

--- a/consensus/polybft/checkpoint_manager_test.go
+++ b/consensus/polybft/checkpoint_manager_test.go
@@ -706,7 +706,7 @@ func TestCommitEpoch(t *testing.T) {
 	}
 }
 
-func createCommitEpoch(t *testing.T, epochID uint64, validatorSet AccountSet, epochSize uint64) *CommitEpoch {
+func createCommitEpoch(t *testing.T, epochID uint64, validatorSet AccountSet, epochSize uint64) *contractsapi.CommitEpochFunction {
 	t.Helper()
 
 	var startBlock uint64 = 0
@@ -714,20 +714,24 @@ func createCommitEpoch(t *testing.T, epochID uint64, validatorSet AccountSet, ep
 		startBlock = (epochID - 1) * epochSize
 	}
 
-	uptime := Uptime{EpochID: epochID}
+	uptime := &contractsapi.Uptime{
+		EpochID:     new(big.Int).SetUint64(epochID),
+		UptimeData:  []*contractsapi.UptimeData{},
+		TotalBlocks: new(big.Int).SetUint64(epochSize),
+	}
 
-	commitEpoch := &CommitEpoch{
-		EpochID: uptime.EpochID,
-		Epoch: Epoch{
-			StartBlock: startBlock + 1,
-			EndBlock:   epochSize * epochID,
+	commitEpoch := &contractsapi.CommitEpochFunction{
+		ID: uptime.EpochID,
+		Epoch: &contractsapi.Epoch{
+			StartBlock: new(big.Int).SetUint64(startBlock + 1),
+			EndBlock:   new(big.Int).SetUint64(epochSize * epochID),
 			EpochRoot:  types.Hash{},
 		},
 		Uptime: uptime,
 	}
 
 	for i := range validatorSet {
-		uptime.addValidatorUptime(validatorSet[i].Address, epochSize)
+		uptime.AddValidatorUptime(validatorSet[i].Address, int64(epochSize))
 	}
 
 	return commitEpoch

--- a/consensus/polybft/checkpoint_manager_test.go
+++ b/consensus/polybft/checkpoint_manager_test.go
@@ -740,11 +740,14 @@ func deployRootchainContract(t *testing.T, transition *state.Transition, rootcha
 	assert.NoError(t, result.Err)
 	rcAddress := result.Address
 
-	init, err := rootchainArtifact.Abi.GetMethod("initialize").Encode([4]interface{}{
-		contracts.BLSContract,
-		bn256Addr,
-		bls.GetDomain(),
-		accSet.ToAPIBinding()})
+	initialize := contractsapi.InitializeCheckpointManagerFunction{
+		NewBls:          contracts.BLSContract,
+		NewBn256G2:      bn256Addr,
+		NewDomain:       types.BytesToHash(bls.GetDomain()),
+		NewValidatorSet: accSet.ToAPIBinding(),
+	}
+
+	init, err := initialize.EncodeAbi()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -447,7 +447,7 @@ func (c *consensusRuntime) restartEpoch(header *types.Header) (*epochMetadata, e
 // calculateUptime calculates uptime for blocks starting from the last built block in current epoch,
 // and ending at the last block of previous epoch
 func (c *consensusRuntime) calculateUptime(currentBlock *types.Header,
-	epoch *epochMetadata) (*contractsapi.CommitEpoch, error) {
+	epoch *epochMetadata) (*contractsapi.CommitEpochFunction, error) {
 	uptimeCounter := map[types.Address]int64{}
 	blockHeader := currentBlock
 	epochID := epoch.Number
@@ -519,7 +519,7 @@ func (c *consensusRuntime) calculateUptime(currentBlock *types.Header,
 		uptime.AddValidatorUptime(addr, uptimeCounter[addr])
 	}
 
-	commitEpoch := &contractsapi.CommitEpoch{
+	commitEpoch := &contractsapi.CommitEpochFunction{
 		ID: big.NewInt(int64(epochID)),
 		Epoch: &contractsapi.Epoch{
 			StartBlock: big.NewInt(int64(epoch.FirstBlockInEpoch)),

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -500,7 +500,7 @@ func (c *consensusRuntime) calculateUptime(currentBlock *types.Header,
 	}
 
 	uptime := &contractsapi.Uptime{
-		EpochID:     big.NewInt(int64(epochID)),
+		EpochID:     new(big.Int).SetUint64(epochID),
 		TotalBlocks: big.NewInt(totalBlocks),
 	}
 
@@ -520,10 +520,10 @@ func (c *consensusRuntime) calculateUptime(currentBlock *types.Header,
 	}
 
 	commitEpoch := &contractsapi.CommitEpochFunction{
-		ID: big.NewInt(int64(epochID)),
+		ID: new(big.Int).SetUint64(epochID),
 		Epoch: &contractsapi.Epoch{
-			StartBlock: big.NewInt(int64(epoch.FirstBlockInEpoch)),
-			EndBlock:   big.NewInt(int64(currentBlock.Number + 1)),
+			StartBlock: new(big.Int).SetUint64(epoch.FirstBlockInEpoch),
+			EndBlock:   new(big.Int).SetUint64(currentBlock.Number + 1),
 			EpochRoot:  types.Hash{},
 		},
 		Uptime: uptime,

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
+	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 
@@ -529,12 +530,12 @@ func (c *consensusRuntime) calculateUptime(currentBlock *types.Header, epoch *ep
 }
 
 // GenerateExitProof generates proof of exit and is a bridge endpoint store function
-func (c *consensusRuntime) GenerateExitProof(exitID, epoch, checkpointBlock uint64) (types.ExitProof, error) {
+func (c *consensusRuntime) GenerateExitProof(exitID, epoch, checkpointBlock uint64) (contracts.ExitProof, error) {
 	return c.checkpointManager.GenerateExitProof(exitID, epoch, checkpointBlock)
 }
 
 // GetStateSyncProof returns the proof for the state sync
-func (c *consensusRuntime) GetStateSyncProof(stateSyncID uint64) (*types.StateSyncProof, error) {
+func (c *consensusRuntime) GetStateSyncProof(stateSyncID uint64) (*contracts.StateSyncProof, error) {
 	return c.stateSyncManager.GetStateSyncProof(stateSyncID)
 }
 

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -583,9 +583,9 @@ func TestConsensusRuntime_calculateUptime_SecondEpoch(t *testing.T) {
 	uptime, err := consensusRuntime.calculateUptime(lastBuiltBlock, consensusRuntime.epoch)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, uptime)
-	assert.Equal(t, uint64(epoch), uptime.EpochID)
-	assert.Equal(t, uint64(epochStartBlock), uptime.Epoch.StartBlock)
-	assert.Equal(t, uint64(epochEndBlock), uptime.Epoch.EndBlock)
+	assert.Equal(t, uint64(epoch), uptime.ID.Uint64())
+	assert.Equal(t, uint64(epochStartBlock), uptime.Epoch.StartBlock.Uint64())
+	assert.Equal(t, uint64(epochEndBlock), uptime.Epoch.EndBlock.Uint64())
 
 	blockchainMock.AssertExpectations(t)
 	polybftBackendMock.AssertExpectations(t)

--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -294,7 +294,7 @@ func ({{.Sig}} *{{.TName}}) DecodeAbi(buf []byte) error {
 	inputs := map[string]interface{}{
 		"Structs":      res,
 		"Type":         methodType,
-		"Sig":          string(methodName[0]),
+		"Sig":          strings.ToLower(string(methodName[0])),
 		"Name":         method.Name,
 		"ContractName": contractName,
 		"TName":        strings.Title(methodName),

--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -15,12 +15,9 @@ import (
 )
 
 const (
-	contractVariableName   = "%sContract"
-	contractStructName     = "%sContractImpl"
-	contractVariableFormat = "%s = &%s{Artifact: %s}"
-	abiTypeNameFormat      = "var %sABIType = abi.MustNewType(\"%s\")"
-	eventNameFormat        = "%sEvent"
-	functionNameFormat     = "%sFunction"
+	abiTypeNameFormat  = "var %sABIType = abi.MustNewType(\"%s\")"
+	eventNameFormat    = "%sEvent"
+	functionNameFormat = "%sFunction"
 )
 
 type generatedData struct {

--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -215,7 +215,7 @@ func genAbiFuncsForNestedType(name string) string {
 	title := strings.Title(name)
 
 	inputs := map[string]interface{}{
-		"Sig":   string(name[0]),
+		"Sig":   strings.ToLower(string(name[0])),
 		"Name":  title,
 		"TName": title,
 	}

--- a/consensus/polybft/contractsapi/contractsapi.go
+++ b/consensus/polybft/contractsapi/contractsapi.go
@@ -246,10 +246,10 @@ type InitializeCheckpointManagerFunction struct {
 	NewValidatorSet []*Validator  `abi:"newValidatorSet"`
 }
 
-func (I *InitializeCheckpointManagerFunction) EncodeAbi() ([]byte, error) {
-	return CheckpointManager.Abi.Methods["initialize"].Encode(I)
+func (i *InitializeCheckpointManagerFunction) EncodeAbi() ([]byte, error) {
+	return CheckpointManager.Abi.Methods["initialize"].Encode(i)
 }
 
-func (I *InitializeCheckpointManagerFunction) DecodeAbi(buf []byte) error {
-	return decodeMethod(CheckpointManager.Abi.Methods["initialize"], buf, I)
+func (i *InitializeCheckpointManagerFunction) DecodeAbi(buf []byte) error {
+	return decodeMethod(CheckpointManager.Abi.Methods["initialize"], buf, i)
 }

--- a/consensus/polybft/contractsapi/contractsapi.go
+++ b/consensus/polybft/contractsapi/contractsapi.go
@@ -238,3 +238,18 @@ func (s *SubmitFunction) EncodeAbi() ([]byte, error) {
 func (s *SubmitFunction) DecodeAbi(buf []byte) error {
 	return decodeMethod(CheckpointManager.Abi.Methods["submit"], buf, s)
 }
+
+type InitializeCheckpointManagerFunction struct {
+	NewBls          types.Address `abi:"newBls"`
+	NewBn256G2      types.Address `abi:"newBn256G2"`
+	NewDomain       types.Hash    `abi:"newDomain"`
+	NewValidatorSet []*Validator  `abi:"newValidatorSet"`
+}
+
+func (I *InitializeCheckpointManagerFunction) EncodeAbi() ([]byte, error) {
+	return CheckpointManager.Abi.Methods["initialize"].Encode(I)
+}
+
+func (I *InitializeCheckpointManagerFunction) DecodeAbi(buf []byte) error {
+	return decodeMethod(CheckpointManager.Abi.Methods["initialize"], buf, I)
+}

--- a/consensus/polybft/contractsapi/contractsapi.go
+++ b/consensus/polybft/contractsapi/contractsapi.go
@@ -17,12 +17,12 @@ type StateSyncCommitment struct {
 
 var StateSyncCommitmentABIType = abi.MustNewType("tuple(uint256 startId,uint256 endId,bytes32 root)")
 
-func (S *StateSyncCommitment) EncodeAbi() ([]byte, error) {
-	return StateSyncCommitmentABIType.Encode(S)
+func (s *StateSyncCommitment) EncodeAbi() ([]byte, error) {
+	return StateSyncCommitmentABIType.Encode(s)
 }
 
-func (S *StateSyncCommitment) DecodeAbi(buf []byte) error {
-	return decodeStruct(StateSyncCommitmentABIType, buf, &S)
+func (s *StateSyncCommitment) DecodeAbi(buf []byte) error {
+	return decodeStruct(StateSyncCommitmentABIType, buf, &s)
 }
 
 type CommitFunction struct {
@@ -48,12 +48,12 @@ type StateSync struct {
 
 var StateSyncABIType = abi.MustNewType("tuple(uint256 id,address sender,address receiver,bytes data)")
 
-func (S *StateSync) EncodeAbi() ([]byte, error) {
-	return StateSyncABIType.Encode(S)
+func (s *StateSync) EncodeAbi() ([]byte, error) {
+	return StateSyncABIType.Encode(s)
 }
 
-func (S *StateSync) DecodeAbi(buf []byte) error {
-	return decodeStruct(StateSyncABIType, buf, &S)
+func (s *StateSync) DecodeAbi(buf []byte) error {
+	return decodeStruct(StateSyncABIType, buf, &s)
 }
 
 type ExecuteFunction struct {
@@ -97,12 +97,12 @@ type Epoch struct {
 
 var EpochABIType = abi.MustNewType("tuple(uint256 startBlock,uint256 endBlock,bytes32 epochRoot)")
 
-func (E *Epoch) EncodeAbi() ([]byte, error) {
-	return EpochABIType.Encode(E)
+func (e *Epoch) EncodeAbi() ([]byte, error) {
+	return EpochABIType.Encode(e)
 }
 
-func (E *Epoch) DecodeAbi(buf []byte) error {
-	return decodeStruct(EpochABIType, buf, &E)
+func (e *Epoch) DecodeAbi(buf []byte) error {
+	return decodeStruct(EpochABIType, buf, &e)
 }
 
 type UptimeData struct {
@@ -112,12 +112,12 @@ type UptimeData struct {
 
 var UptimeDataABIType = abi.MustNewType("tuple(address validator,uint256 signedBlocks)")
 
-func (U *UptimeData) EncodeAbi() ([]byte, error) {
-	return UptimeDataABIType.Encode(U)
+func (u *UptimeData) EncodeAbi() ([]byte, error) {
+	return UptimeDataABIType.Encode(u)
 }
 
-func (U *UptimeData) DecodeAbi(buf []byte) error {
-	return decodeStruct(UptimeDataABIType, buf, &U)
+func (u *UptimeData) DecodeAbi(buf []byte) error {
+	return decodeStruct(UptimeDataABIType, buf, &u)
 }
 
 type Uptime struct {
@@ -128,12 +128,12 @@ type Uptime struct {
 
 var UptimeABIType = abi.MustNewType("tuple(uint256 epochId,tuple(address validator,uint256 signedBlocks)[] uptimeData,uint256 totalBlocks)")
 
-func (U *Uptime) EncodeAbi() ([]byte, error) {
-	return UptimeABIType.Encode(U)
+func (u *Uptime) EncodeAbi() ([]byte, error) {
+	return UptimeABIType.Encode(u)
 }
 
-func (U *Uptime) DecodeAbi(buf []byte) error {
-	return decodeStruct(UptimeABIType, buf, &U)
+func (u *Uptime) DecodeAbi(buf []byte) error {
+	return decodeStruct(UptimeABIType, buf, &u)
 }
 
 type CommitEpochFunction struct {
@@ -182,12 +182,12 @@ type CheckpointMetadata struct {
 
 var CheckpointMetadataABIType = abi.MustNewType("tuple(bytes32 blockHash,uint256 blockRound,bytes32 currentValidatorSetHash)")
 
-func (C *CheckpointMetadata) EncodeAbi() ([]byte, error) {
-	return CheckpointMetadataABIType.Encode(C)
+func (c *CheckpointMetadata) EncodeAbi() ([]byte, error) {
+	return CheckpointMetadataABIType.Encode(c)
 }
 
-func (C *CheckpointMetadata) DecodeAbi(buf []byte) error {
-	return decodeStruct(CheckpointMetadataABIType, buf, &C)
+func (c *CheckpointMetadata) DecodeAbi(buf []byte) error {
+	return decodeStruct(CheckpointMetadataABIType, buf, &c)
 }
 
 type Checkpoint struct {
@@ -198,12 +198,12 @@ type Checkpoint struct {
 
 var CheckpointABIType = abi.MustNewType("tuple(uint256 epoch,uint256 blockNumber,bytes32 eventRoot)")
 
-func (C *Checkpoint) EncodeAbi() ([]byte, error) {
-	return CheckpointABIType.Encode(C)
+func (c *Checkpoint) EncodeAbi() ([]byte, error) {
+	return CheckpointABIType.Encode(c)
 }
 
-func (C *Checkpoint) DecodeAbi(buf []byte) error {
-	return decodeStruct(CheckpointABIType, buf, &C)
+func (c *Checkpoint) DecodeAbi(buf []byte) error {
+	return decodeStruct(CheckpointABIType, buf, &c)
 }
 
 type Validator struct {
@@ -214,12 +214,12 @@ type Validator struct {
 
 var ValidatorABIType = abi.MustNewType("tuple(address _address,uint256[4] blsKey,uint256 votingPower)")
 
-func (V *Validator) EncodeAbi() ([]byte, error) {
-	return ValidatorABIType.Encode(V)
+func (v *Validator) EncodeAbi() ([]byte, error) {
+	return ValidatorABIType.Encode(v)
 }
 
-func (V *Validator) DecodeAbi(buf []byte) error {
-	return decodeStruct(ValidatorABIType, buf, &V)
+func (v *Validator) DecodeAbi(buf []byte) error {
+	return decodeStruct(ValidatorABIType, buf, &v)
 }
 
 type SubmitFunction struct {

--- a/consensus/polybft/contractsapi/decoder.go
+++ b/consensus/polybft/contractsapi/decoder.go
@@ -24,7 +24,7 @@ func decodeEvent(event *abi.Event, log *ethgo.Log, out interface{}) error {
 
 func decodeMethod(method *abi.Method, input []byte, out interface{}) error {
 	if len(input) < abiMethodIDLength {
-		return fmt.Errorf("invalid bundle data, len = %d", len(input))
+		return fmt.Errorf("invalid method data, len = %d", len(input))
 	}
 
 	sig := method.ID()
@@ -42,7 +42,7 @@ func decodeMethod(method *abi.Method, input []byte, out interface{}) error {
 
 func decodeStruct(t *abi.Type, input []byte, out interface{}) error {
 	if len(input) < abiMethodIDLength {
-		return fmt.Errorf("invalid commitment data, len = %d", len(input))
+		return fmt.Errorf("invalid struct data, len = %d", len(input))
 	}
 
 	val, err := abi.Decode(t, input)

--- a/consensus/polybft/contractsapi/helper.go
+++ b/consensus/polybft/contractsapi/helper.go
@@ -13,11 +13,7 @@ type StateTransactionInput interface {
 	EncodeAbi() ([]byte, error)
 	// DecodeAbi contains logic for decoding given ABI data
 	DecodeAbi(b []byte) error
-	// Type returns type of state transaction input
-	Type() StateTransactionType
 }
-
-type StateTransactionType string
 
 // specific case where we need to encode state sync event as a tuple of tuple
 var stateSyncABIType = abi.MustNewType(
@@ -28,7 +24,7 @@ func (sse *StateSyncedEvent) EncodeAbi() ([]byte, error) {
 	return stateSyncABIType.Encode([]interface{}{sse})
 }
 
-// addValidatorUptime is an extension (helper) function on a generated Uptime type
+// AddValidatorUptime is an extension (helper) function on a generated Uptime type
 // that adds uptime data for given validator to Uptime struct
 func (u *Uptime) AddValidatorUptime(address types.Address, count int64) {
 	u.UptimeData = append(u.UptimeData, &UptimeData{
@@ -38,7 +34,3 @@ func (u *Uptime) AddValidatorUptime(address types.Address, count int64) {
 }
 
 var _ StateTransactionInput = &CommitEpochFunction{}
-
-func (c *CommitEpochFunction) Type() StateTransactionType {
-	return "end-epoch"
-}

--- a/consensus/polybft/contractsapi/helper.go
+++ b/consensus/polybft/contractsapi/helper.go
@@ -1,0 +1,12 @@
+package contractsapi
+
+import "github.com/umbracle/ethgo/abi"
+
+// specific case where we need to encode state sync event as a tuple of tuple
+var stateSyncABIType = abi.MustNewType(
+	"tuple(tuple(uint256 id, address sender, address receiver, bytes data))")
+
+// ToABI converts StateSyncEvent to ABI
+func (sse *StateSyncedEvent) EncodeAbi() ([]byte, error) {
+	return stateSyncABIType.Encode([]interface{}{sse})
+}

--- a/consensus/polybft/contractsapi/helper.go
+++ b/consensus/polybft/contractsapi/helper.go
@@ -41,8 +41,8 @@ func (u *Uptime) AddValidatorUptime(address types.Address, count int64) {
 	})
 }
 
-var _ StateTransactionInput = &CommitEpoch{}
+var _ StateTransactionInput = &CommitEpochFunction{}
 
-func (c *CommitEpoch) Type() StateTransactionType {
+func (c *CommitEpochFunction) Type() StateTransactionType {
 	return "end-epoch"
 }

--- a/consensus/polybft/contractsapi/helper.go
+++ b/consensus/polybft/contractsapi/helper.go
@@ -1,6 +1,23 @@
 package contractsapi
 
-import "github.com/umbracle/ethgo/abi"
+import (
+	"math/big"
+
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/umbracle/ethgo/abi"
+)
+
+// StateTransactionInput is an abstraction for different state transaction inputs
+type StateTransactionInput interface {
+	// EncodeAbi contains logic for encoding arbitrary data into ABI format
+	EncodeAbi() ([]byte, error)
+	// DecodeAbi contains logic for decoding given ABI data
+	DecodeAbi(b []byte) error
+	// Type returns type of state transaction input
+	Type() StateTransactionType
+}
+
+type StateTransactionType string
 
 // specific case where we need to encode state sync event as a tuple of tuple
 var stateSyncABIType = abi.MustNewType(
@@ -9,4 +26,23 @@ var stateSyncABIType = abi.MustNewType(
 // ToABI converts StateSyncEvent to ABI
 func (sse *StateSyncedEvent) EncodeAbi() ([]byte, error) {
 	return stateSyncABIType.Encode([]interface{}{sse})
+}
+
+// addValidatorUptime is an extension (helper) function on a generated Uptime type
+// that adds uptime data for given validator to Uptime struct
+func (u *Uptime) AddValidatorUptime(address types.Address, count int64) {
+	if u.UptimeData == nil {
+		u.UptimeData = []*UptimeData{}
+	}
+
+	u.UptimeData = append(u.UptimeData, &UptimeData{
+		Validator:    address,
+		SignedBlocks: big.NewInt(count),
+	})
+}
+
+var _ StateTransactionInput = &CommitEpoch{}
+
+func (c *CommitEpoch) Type() StateTransactionType {
+	return "end-epoch"
 }

--- a/consensus/polybft/contractsapi/helper.go
+++ b/consensus/polybft/contractsapi/helper.go
@@ -31,10 +31,6 @@ func (sse *StateSyncedEvent) EncodeAbi() ([]byte, error) {
 // addValidatorUptime is an extension (helper) function on a generated Uptime type
 // that adds uptime data for given validator to Uptime struct
 func (u *Uptime) AddValidatorUptime(address types.Address, count int64) {
-	if u.UptimeData == nil {
-		u.UptimeData = []*UptimeData{}
-	}
-
 	u.UptimeData = append(u.UptimeData, &UptimeData{
 		Validator:    address,
 		SignedBlocks: big.NewInt(count),

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -53,7 +53,7 @@ type fsm struct {
 	epochNumber uint64
 
 	// uptimeCounter holds info about number of times validators sealed a block (only present if isEndOfEpoch is true)
-	uptimeCounter *contractsapi.CommitEpoch
+	uptimeCounter *contractsapi.CommitEpochFunction
 
 	// isEndOfEpoch indicates if epoch reached its end
 	isEndOfEpoch bool

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -378,7 +378,7 @@ func (f *fsm) VerifyStateTransactions(transactions []*types.Transaction) error {
 				return fmt.Errorf("error for state transaction while unmarshaling signature: tx = %v, error = %w", tx.Hash, err)
 			}
 
-			hash, err := stateTxData.Message.Hash()
+			hash, err := stateTxData.Hash()
 			if err != nil {
 				return err
 			}

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -9,6 +9,7 @@ import (
 	"github.com/0xPolygon/go-ibft/messages"
 	"github.com/0xPolygon/go-ibft/messages/proto"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
@@ -52,7 +53,7 @@ type fsm struct {
 	epochNumber uint64
 
 	// uptimeCounter holds info about number of times validators sealed a block (only present if isEndOfEpoch is true)
-	uptimeCounter *CommitEpoch
+	uptimeCounter *contractsapi.CommitEpoch
 
 	// isEndOfEpoch indicates if epoch reached its end
 	isEndOfEpoch bool

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -1333,19 +1333,19 @@ func newBlockBuilderMock(stateBlock *types.FullBlock) *blockBuilderMock {
 	return mBlockBuilder
 }
 
-func createTestUptimeCounter(t *testing.T, validatorSet AccountSet, epochSize uint64) *CommitEpoch {
+func createTestUptimeCounter(t *testing.T, validatorSet AccountSet, epochSize uint64) *contractsapi.CommitEpoch {
 	t.Helper()
 
 	if validatorSet == nil {
 		validatorSet = newTestValidators(5).getPublicIdentities()
 	}
 
-	uptime := Uptime{EpochID: 0}
-	commitEpoch := &CommitEpoch{
-		EpochID: 0,
-		Epoch: Epoch{
-			StartBlock: 1,
-			EndBlock:   1 + epochSize,
+	uptime := &contractsapi.Uptime{EpochID: big.NewInt(0), TotalBlocks: big.NewInt(int64(epochSize))}
+	commitEpoch := &contractsapi.CommitEpoch{
+		ID: big.NewInt(0),
+		Epoch: &contractsapi.Epoch{
+			StartBlock: big.NewInt(1),
+			EndBlock:   big.NewInt(int64(epochSize + 1)),
 			EpochRoot:  types.Hash{},
 		},
 		Uptime: uptime,
@@ -1356,7 +1356,7 @@ func createTestUptimeCounter(t *testing.T, validatorSet AccountSet, epochSize ui
 		validatorIndex := indexToStart
 		for j := 0; j < validatorSet.Len()-1; j++ {
 			validatorIndex = validatorIndex % validatorSet.Len()
-			uptime.addValidatorUptime(validatorSet[validatorIndex].Address, 1)
+			uptime.AddValidatorUptime(validatorSet[validatorIndex].Address, 1)
 			validatorIndex++
 		}
 

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -1293,7 +1293,7 @@ func createTestCommitment(t *testing.T, accounts []*wallet.Account) *CommitmentM
 		bitmap.Set(uint64(i))
 	}
 
-	commitment, err := NewCommitment(1, stateSyncEvents)
+	commitment, err := NewPendingCommitment(1, stateSyncEvents)
 	require.NoError(t, err)
 
 	hash, err := commitment.Hash()

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -1333,7 +1333,7 @@ func newBlockBuilderMock(stateBlock *types.FullBlock) *blockBuilderMock {
 	return mBlockBuilder
 }
 
-func createTestUptimeCounter(t *testing.T, validatorSet AccountSet, epochSize uint64) *contractsapi.CommitEpoch {
+func createTestUptimeCounter(t *testing.T, validatorSet AccountSet, epochSize uint64) *contractsapi.CommitEpochFunction {
 	t.Helper()
 
 	if validatorSet == nil {
@@ -1341,7 +1341,7 @@ func createTestUptimeCounter(t *testing.T, validatorSet AccountSet, epochSize ui
 	}
 
 	uptime := &contractsapi.Uptime{EpochID: big.NewInt(0), TotalBlocks: big.NewInt(int64(epochSize))}
-	commitEpoch := &contractsapi.CommitEpoch{
+	commitEpoch := &contractsapi.CommitEpochFunction{
 		ID: big.NewInt(0),
 		Epoch: &contractsapi.Epoch{
 			StartBlock: big.NewInt(1),

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/0xPolygon/go-ibft/messages"
 	"github.com/0xPolygon/polygon-edge/consensus"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
@@ -1031,7 +1032,7 @@ func TestFSM_VerifyStateTransaction_ValidBothTypesOfStateTransactions(t *testing
 
 	var (
 		commitments       [2]*PendingCommitment
-		stateSyncs        [2][]*contracts.StateSyncEvent
+		stateSyncs        [2][]*contractsapi.StateSyncedEvent
 		signedCommitments [2]*CommitmentMessageSigned
 	)
 
@@ -1279,15 +1280,15 @@ func createTestCommitment(t *testing.T, accounts []*wallet.Account) *CommitmentM
 	t.Helper()
 
 	bitmap := bitmap.Bitmap{}
-	stateSyncEvents := make([]*contracts.StateSyncEvent, len(accounts))
+	stateSyncEvents := make([]*contractsapi.StateSyncedEvent, len(accounts))
 
 	for i := 0; i < len(accounts); i++ {
-		stateSyncEvents[i] = newStateSyncEvent(
-			uint64(i),
-			accounts[i].Ecdsa.Address(),
-			accounts[0].Ecdsa.Address(),
-			[]byte{},
-		)
+		stateSyncEvents[i] = &contractsapi.StateSyncedEvent{
+			ID:       big.NewInt(int64(i)),
+			Sender:   types.Address(accounts[i].Ecdsa.Address()),
+			Receiver: types.Address(accounts[0].Ecdsa.Address()),
+			Data:     []byte{},
+		}
 
 		bitmap.Set(uint64(i))
 	}

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -1031,7 +1031,7 @@ func TestFSM_VerifyStateTransaction_ValidBothTypesOfStateTransactions(t *testing
 
 	var (
 		commitments       [2]*PendingCommitment
-		stateSyncs        [2][]*types.StateSyncEvent
+		stateSyncs        [2][]*contracts.StateSyncEvent
 		signedCommitments [2]*CommitmentMessageSigned
 	)
 
@@ -1279,7 +1279,7 @@ func createTestCommitment(t *testing.T, accounts []*wallet.Account) *CommitmentM
 	t.Helper()
 
 	bitmap := bitmap.Bitmap{}
-	stateSyncEvents := make([]*types.StateSyncEvent, len(accounts))
+	stateSyncEvents := make([]*contracts.StateSyncEvent, len(accounts))
 
 	for i := 0; i < len(accounts); i++ {
 		stateSyncEvents[i] = newStateSyncEvent(

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -1319,7 +1319,7 @@ func createTestCommitment(t *testing.T, accounts []*wallet.Account) *CommitmentM
 	assert.NoError(t, err)
 
 	return &CommitmentMessageSigned{
-		Message:      commitment.Commitment,
+		Message:      commitment.StateSyncCommitment,
 		AggSignature: signature,
 	}
 }

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -988,21 +988,8 @@ func TestFSM_StateTransactionsEndOfSprint(t *testing.T) {
 		eventsSize       = 40
 	)
 
-	var commitments [commitmentsCount]*CommitmentMessage
+	_, signedCommitment, _ := buildCommitmentAndStateSyncs(t, eventsSize, uint64(3), from)
 
-	for i := 0; i < commitmentsCount; i++ {
-		_, commitmentMessage, _ := buildCommitmentAndStateSyncs(t, eventsSize, uint64(3), eventsSize*uint64(i))
-		commitments[i] = commitmentMessage
-	}
-
-	signedCommitment := &CommitmentMessageSigned{
-		Message: commitments[0],
-		AggSignature: Signature{
-			AggregatedSignature: []byte{1, 2},
-			Bitmap:              []byte{1},
-		},
-		PublicKeys: [][]byte{},
-	}
 	f := &fsm{
 		config:                       &PolyBFTConfig{},
 		isEndOfEpoch:                 true,
@@ -1011,6 +998,7 @@ func TestFSM_StateTransactionsEndOfSprint(t *testing.T) {
 		uptimeCounter:                createTestUptimeCounter(t, nil, 10),
 		logger:                       hclog.NewNullLogger(),
 	}
+
 	txs := f.stateTransactions()
 
 	for i, tx := range txs {
@@ -1042,26 +1030,22 @@ func TestFSM_VerifyStateTransaction_ValidBothTypesOfStateTransactions(t *testing
 	t.Parallel()
 
 	var (
-		commitmentMessages [2]*CommitmentMessage
-		commitments        [2]*Commitment
-		stateSyncs         [2][]*types.StateSyncEvent
-		signedCommitments  [2]*CommitmentMessageSigned
+		commitments       [2]*PendingCommitment
+		stateSyncs        [2][]*types.StateSyncEvent
+		signedCommitments [2]*CommitmentMessageSigned
 	)
 
 	validators := newTestValidatorsWithAliases([]string{"A", "B", "C", "D", "E"})
-	commitments[0], commitmentMessages[0], stateSyncs[0] = buildCommitmentAndStateSyncs(t, 10, uint64(3), 2)
-	commitments[1], commitmentMessages[1], stateSyncs[1] = buildCommitmentAndStateSyncs(t, 10, uint64(3), 12)
+	commitments[0], signedCommitments[0], stateSyncs[0] = buildCommitmentAndStateSyncs(t, 10, uint64(3), 2)
+	commitments[1], signedCommitments[1], stateSyncs[1] = buildCommitmentAndStateSyncs(t, 10, uint64(3), 12)
 
 	executeForValidators := func(aliases ...string) error {
-		for i, x := range commitmentMessages {
+		for _, sc := range signedCommitments {
 			// add register commitment state transaction
-			hash, err := x.Hash()
+			hash, err := sc.Hash()
 			require.NoError(t, err)
 			signature := createSignature(t, validators.getPrivateIdentities(aliases...), hash)
-			signedCommitments[i] = &CommitmentMessageSigned{
-				Message:      x,
-				AggSignature: *signature,
-			}
+			sc.AggSignature = *signature
 		}
 
 		f := &fsm{
@@ -1072,8 +1056,8 @@ func TestFSM_VerifyStateTransaction_ValidBothTypesOfStateTransactions(t *testing
 
 		var txns []*types.Transaction
 
-		for i := range commitmentMessages {
-			inputData, err := signedCommitments[i].EncodeAbi()
+		for i, sc := range signedCommitments {
+			inputData, err := sc.EncodeAbi()
 			require.NoError(t, err)
 
 			if i == 0 {
@@ -1109,24 +1093,22 @@ func TestFSM_VerifyStateTransaction_QuorumNotReached(t *testing.T) {
 	t.Parallel()
 
 	validators := newTestValidatorsWithAliases([]string{"A", "B", "C", "D", "E", "F"})
-	_, commitmentMessage, _ := buildCommitmentAndStateSyncs(t, 10, uint64(3), 2)
+	_, commitmentMessageSigned, _ := buildCommitmentAndStateSyncs(t, 10, uint64(3), 2)
 	f := &fsm{
 		isEndOfSprint: true,
 		config:        &PolyBFTConfig{},
 		validators:    validators.toValidatorSet(),
 	}
 
-	hash, err := commitmentMessage.Hash()
+	hash, err := commitmentMessageSigned.Hash()
 	require.NoError(t, err)
 
 	var txns []*types.Transaction
 
 	signature := createSignature(t, validators.getPrivateIdentities("A", "B"), hash)
-	cmSigned := &CommitmentMessageSigned{
-		Message:      commitmentMessage,
-		AggSignature: *signature,
-	}
-	inputData, err := cmSigned.EncodeAbi()
+	commitmentMessageSigned.AggSignature = *signature
+
+	inputData, err := commitmentMessageSigned.EncodeAbi()
 	require.NoError(t, err)
 
 	txns = append(txns,
@@ -1140,14 +1122,14 @@ func TestFSM_VerifyStateTransaction_InvalidSignature(t *testing.T) {
 	t.Parallel()
 
 	validators := newTestValidatorsWithAliases([]string{"A", "B", "C", "D", "E", "F"})
-	_, commitmentMessage, _ := buildCommitmentAndStateSyncs(t, 10, uint64(3), 2)
+	_, commitmentMessageSigned, _ := buildCommitmentAndStateSyncs(t, 10, uint64(3), 2)
 	f := &fsm{
 		isEndOfSprint: true,
 		config:        &PolyBFTConfig{},
 		validators:    validators.toValidatorSet(),
 	}
 
-	hash, err := commitmentMessage.Hash()
+	hash, err := commitmentMessageSigned.Hash()
 	require.NoError(t, err)
 
 	var txns []*types.Transaction
@@ -1157,15 +1139,12 @@ func TestFSM_VerifyStateTransaction_InvalidSignature(t *testing.T) {
 	invalidSignature, err := invalidValidator.mustSign([]byte("malicious message")).Marshal()
 	require.NoError(t, err)
 
-	cmSigned := &CommitmentMessageSigned{
-		Message: commitmentMessage,
-		AggSignature: Signature{
-			Bitmap:              signature.Bitmap,
-			AggregatedSignature: invalidSignature,
-		},
+	commitmentMessageSigned.AggSignature = Signature{
+		Bitmap:              signature.Bitmap,
+		AggregatedSignature: invalidSignature,
 	}
 
-	inputData, err := cmSigned.EncodeAbi()
+	inputData, err := commitmentMessageSigned.EncodeAbi()
 	require.NoError(t, err)
 
 	txns = append(txns,
@@ -1179,7 +1158,7 @@ func TestFSM_VerifyStateTransaction_TwoCommitmentMessages(t *testing.T) {
 	t.Parallel()
 
 	validators := newTestValidatorsWithAliases([]string{"A", "B", "C", "D", "E", "F"})
-	_, commitmentMessage, _ := buildCommitmentAndStateSyncs(t, 10, uint64(3), 2)
+	_, commitmentMessageSigned, _ := buildCommitmentAndStateSyncs(t, 10, uint64(3), 2)
 
 	validatorSet := NewValidatorSet(validators.getPublicIdentities(), hclog.NewNullLogger())
 
@@ -1189,22 +1168,20 @@ func TestFSM_VerifyStateTransaction_TwoCommitmentMessages(t *testing.T) {
 		validators:    validatorSet,
 	}
 
-	hash, err := commitmentMessage.Hash()
+	hash, err := commitmentMessageSigned.Hash()
 	require.NoError(t, err)
 
 	var txns []*types.Transaction
 
 	signature := createSignature(t, validators.getPrivateIdentities("A", "B", "C", "D"), hash)
-	cmSigned := &CommitmentMessageSigned{
-		Message:      commitmentMessage,
-		AggSignature: *signature,
-	}
-	inputData, err := cmSigned.EncodeAbi()
+	commitmentMessageSigned.AggSignature = *signature
+
+	inputData, err := commitmentMessageSigned.EncodeAbi()
 	require.NoError(t, err)
 
 	txns = append(txns,
 		createStateTransactionWithData(f.config.StateReceiverAddr, inputData))
-	inputData, err = cmSigned.EncodeAbi()
+	inputData, err = commitmentMessageSigned.EncodeAbi()
 	require.NoError(t, err)
 
 	txns = append(txns,
@@ -1315,10 +1292,9 @@ func createTestCommitment(t *testing.T, accounts []*wallet.Account) *CommitmentM
 		bitmap.Set(uint64(i))
 	}
 
-	stateSyncsTrie, err := createMerkleTree(stateSyncEvents)
+	commitment, err := NewCommitment(1, stateSyncEvents)
 	require.NoError(t, err)
 
-	commitment := NewCommitmentMessage(stateSyncsTrie.Hash(), 0, uint64(len(stateSyncEvents)))
 	hash, err := commitment.Hash()
 	require.NoError(t, err)
 
@@ -1342,7 +1318,7 @@ func createTestCommitment(t *testing.T, accounts []*wallet.Account) *CommitmentM
 	assert.NoError(t, err)
 
 	return &CommitmentMessageSigned{
-		Message:      commitment,
+		Message:      commitment.Commitment,
 		AggSignature: signature,
 	}
 }

--- a/consensus/polybft/helpers_test.go
+++ b/consensus/polybft/helpers_test.go
@@ -3,15 +3,15 @@ package polybft
 import (
 	"crypto/rand"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
-	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/require"
-	"github.com/umbracle/ethgo"
 )
 
 func createTestKey(t *testing.T) *wallet.Key {
@@ -53,14 +53,14 @@ func createSignature(t *testing.T, accounts []*wallet.Account, hash types.Hash) 
 	return &Signature{AggregatedSignature: aggs, Bitmap: bmp}
 }
 
-func generateStateSyncEvents(t *testing.T, eventsCount int, startIdx uint64) []*contracts.StateSyncEvent {
+func generateStateSyncEvents(t *testing.T, eventsCount int, startIdx uint64) []*contractsapi.StateSyncedEvent {
 	t.Helper()
 
-	stateSyncEvents := make([]*contracts.StateSyncEvent, eventsCount)
+	stateSyncEvents := make([]*contractsapi.StateSyncedEvent, eventsCount)
 	for i := 0; i < eventsCount; i++ {
-		stateSyncEvents[i] = &contracts.StateSyncEvent{
-			ID:     startIdx + uint64(i),
-			Sender: ethgo.Address(types.StringToAddress(fmt.Sprintf("0x5%d", i))),
+		stateSyncEvents[i] = &contractsapi.StateSyncedEvent{
+			ID:     big.NewInt(int64(startIdx + uint64(i))),
+			Sender: types.StringToAddress(fmt.Sprintf("0x5%d", i)),
 			Data:   generateRandomBytes(t),
 		}
 	}

--- a/consensus/polybft/helpers_test.go
+++ b/consensus/polybft/helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
+	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/require"
 	"github.com/umbracle/ethgo"
@@ -52,12 +53,12 @@ func createSignature(t *testing.T, accounts []*wallet.Account, hash types.Hash) 
 	return &Signature{AggregatedSignature: aggs, Bitmap: bmp}
 }
 
-func generateStateSyncEvents(t *testing.T, eventsCount int, startIdx uint64) []*types.StateSyncEvent {
+func generateStateSyncEvents(t *testing.T, eventsCount int, startIdx uint64) []*contracts.StateSyncEvent {
 	t.Helper()
 
-	stateSyncEvents := make([]*types.StateSyncEvent, eventsCount)
+	stateSyncEvents := make([]*contracts.StateSyncEvent, eventsCount)
 	for i := 0; i < eventsCount; i++ {
-		stateSyncEvents[i] = &types.StateSyncEvent{
+		stateSyncEvents[i] = &contracts.StateSyncEvent{
 			ID:     startIdx + uint64(i),
 			Sender: ethgo.Address(types.StringToAddress(fmt.Sprintf("0x5%d", i))),
 			Data:   generateRandomBytes(t),

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -505,7 +505,7 @@ func (s *State) insertCommitmentMessage(commitment *CommitmentMessageSigned) err
 			return err
 		}
 
-		if err := tx.Bucket(commitmentsBucket).Put(itob(commitment.Message.ToIndex), raw); err != nil {
+		if err := tx.Bucket(commitmentsBucket).Put(itob(commitment.Message.EndID.Uint64()), raw); err != nil {
 			return err
 		}
 

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -310,12 +310,12 @@ func (s *State) getLastSnapshot() (*validatorSnapshot, error) {
 }
 
 // list iterates through all events in events bucket in db, un-marshals them, and returns as array
-func (s *State) list() ([]*contracts.StateSyncEvent, error) {
-	events := []*contracts.StateSyncEvent{}
+func (s *State) list() ([]*contractsapi.StateSyncedEvent, error) {
+	events := []*contractsapi.StateSyncedEvent{}
 
 	err := s.db.View(func(tx *bolt.Tx) error {
 		return tx.Bucket(syncStateEventsBucket).ForEach(func(k, v []byte) error {
-			var event *contracts.StateSyncEvent
+			var event *contractsapi.StateSyncedEvent
 			if err := json.Unmarshal(v, &event); err != nil {
 				return err
 			}
@@ -437,7 +437,7 @@ func (s *State) getExitEvents(epoch uint64, filter func(exitEvent *ExitEvent) bo
 }
 
 // insertStateSyncEvent inserts a new state sync event to state event bucket in db
-func (s *State) insertStateSyncEvent(event *contracts.StateSyncEvent) error {
+func (s *State) insertStateSyncEvent(event *contractsapi.StateSyncedEvent) error {
 	return s.db.Update(func(tx *bolt.Tx) error {
 		raw, err := json.Marshal(event)
 		if err != nil {
@@ -446,13 +446,13 @@ func (s *State) insertStateSyncEvent(event *contracts.StateSyncEvent) error {
 
 		bucket := tx.Bucket(syncStateEventsBucket)
 
-		return bucket.Put(itob(event.ID), raw)
+		return bucket.Put(itob(event.ID.Uint64()), raw)
 	})
 }
 
 // getStateSyncEventsForCommitment returns state sync events for commitment
-func (s *State) getStateSyncEventsForCommitment(fromIndex, toIndex uint64) ([]*contracts.StateSyncEvent, error) {
-	var events []*contracts.StateSyncEvent
+func (s *State) getStateSyncEventsForCommitment(fromIndex, toIndex uint64) ([]*contractsapi.StateSyncedEvent, error) {
+	var events []*contractsapi.StateSyncedEvent
 
 	err := s.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(syncStateEventsBucket)
@@ -462,7 +462,7 @@ func (s *State) getStateSyncEventsForCommitment(fromIndex, toIndex uint64) ([]*c
 				return errNotEnoughStateSyncs
 			}
 
-			var event *contracts.StateSyncEvent
+			var event *contractsapi.StateSyncedEvent
 			if err := json.Unmarshal(v, &event); err != nil {
 				return err
 			}
@@ -540,7 +540,7 @@ func (s *State) insertStateSyncProofs(stateSyncProof []*contracts.StateSyncProof
 				return err
 			}
 
-			if err := bucket.Put(itob(ssp.StateSync.ID), raw); err != nil {
+			if err := bucket.Put(itob(ssp.StateSync.ID.Uint64()), raw); err != nil {
 				return err
 			}
 		}

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
 	bolt "go.etcd.io/bbolt"
@@ -309,12 +310,12 @@ func (s *State) getLastSnapshot() (*validatorSnapshot, error) {
 }
 
 // list iterates through all events in events bucket in db, un-marshals them, and returns as array
-func (s *State) list() ([]*types.StateSyncEvent, error) {
-	events := []*types.StateSyncEvent{}
+func (s *State) list() ([]*contracts.StateSyncEvent, error) {
+	events := []*contracts.StateSyncEvent{}
 
 	err := s.db.View(func(tx *bolt.Tx) error {
 		return tx.Bucket(syncStateEventsBucket).ForEach(func(k, v []byte) error {
-			var event *types.StateSyncEvent
+			var event *contracts.StateSyncEvent
 			if err := json.Unmarshal(v, &event); err != nil {
 				return err
 			}
@@ -436,7 +437,7 @@ func (s *State) getExitEvents(epoch uint64, filter func(exitEvent *ExitEvent) bo
 }
 
 // insertStateSyncEvent inserts a new state sync event to state event bucket in db
-func (s *State) insertStateSyncEvent(event *types.StateSyncEvent) error {
+func (s *State) insertStateSyncEvent(event *contracts.StateSyncEvent) error {
 	return s.db.Update(func(tx *bolt.Tx) error {
 		raw, err := json.Marshal(event)
 		if err != nil {
@@ -450,8 +451,8 @@ func (s *State) insertStateSyncEvent(event *types.StateSyncEvent) error {
 }
 
 // getStateSyncEventsForCommitment returns state sync events for commitment
-func (s *State) getStateSyncEventsForCommitment(fromIndex, toIndex uint64) ([]*types.StateSyncEvent, error) {
-	var events []*types.StateSyncEvent
+func (s *State) getStateSyncEventsForCommitment(fromIndex, toIndex uint64) ([]*contracts.StateSyncEvent, error) {
+	var events []*contracts.StateSyncEvent
 
 	err := s.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(syncStateEventsBucket)
@@ -461,7 +462,7 @@ func (s *State) getStateSyncEventsForCommitment(fromIndex, toIndex uint64) ([]*t
 				return errNotEnoughStateSyncs
 			}
 
-			var event *types.StateSyncEvent
+			var event *contracts.StateSyncEvent
 			if err := json.Unmarshal(v, &event); err != nil {
 				return err
 			}
@@ -530,7 +531,7 @@ func (s *State) getCommitmentMessage(toIndex uint64) (*CommitmentMessageSigned, 
 }
 
 // insertStateSyncProofs inserts the provided state sync proofs to db
-func (s *State) insertStateSyncProofs(stateSyncProof []*types.StateSyncProof) error {
+func (s *State) insertStateSyncProofs(stateSyncProof []*contracts.StateSyncProof) error {
 	return s.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(stateSyncProofsBucket)
 		for _, ssp := range stateSyncProof {
@@ -549,8 +550,8 @@ func (s *State) insertStateSyncProofs(stateSyncProof []*types.StateSyncProof) er
 }
 
 // getStateSyncProof gets state sync proof that are not executed
-func (s *State) getStateSyncProof(stateSyncID uint64) (*types.StateSyncProof, error) {
-	var ssp *types.StateSyncProof
+func (s *State) getStateSyncProof(stateSyncID uint64) (*contracts.StateSyncProof, error) {
+	var ssp *contracts.StateSyncProof
 
 	err := s.db.View(func(tx *bolt.Tx) error {
 		if v := tx.Bucket(stateSyncProofsBucket).Get(itob(stateSyncID)); v != nil {

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -480,7 +480,7 @@ func (s *stateSyncManager) buildCommitment() error {
 		return nil
 	}
 
-	commitment, err := NewCommitment(epoch, stateSyncEvents)
+	commitment, err := NewPendingCommitment(epoch, stateSyncEvents)
 	if err != nil {
 		return err
 	}

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -347,7 +347,6 @@ func (s *stateSyncManager) PostEpoch(req *PostEpochRequest) error {
 		return err
 	}
 
-	s.logger.Info("Post epoch received", "NextCommittedIndex", nextCommittedIndex)
 	s.nextCommittedIndex = nextCommittedIndex
 
 	s.lock.Unlock()
@@ -367,10 +366,6 @@ func (s *stateSyncManager) PostBlock(req *PostBlockRequest) error {
 	if commitment == nil {
 		return nil
 	}
-
-	s.logger.Info("PostBlock received",
-		"From", commitment.Message.StartID.Uint64(),
-		"To", commitment.Message.EndID.Uint64())
 
 	if err := s.state.insertCommitmentMessage(commitment); err != nil {
 		return fmt.Errorf("insert commitment message error: %w", err)

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -254,7 +254,7 @@ func (s *stateSyncManager) Commitment() (*CommitmentMessageSigned, error) {
 		}
 
 		largestCommitment = &CommitmentMessageSigned{
-			Message:      commitment.Commitment,
+			Message:      commitment.StateSyncCommitment,
 			AggSignature: aggregatedSignature,
 			PublicKeys:   publicKeys,
 		}
@@ -420,7 +420,7 @@ func (s *stateSyncManager) GetStateSyncProof(stateSyncID uint64) (*contracts.Sta
 }
 
 // buildProofs builds state sync proofs for the submitted commitment and saves them in boltDb for later execution
-func (s *stateSyncManager) buildProofs(commitmentMsg *contractsapi.Commitment) error {
+func (s *stateSyncManager) buildProofs(commitmentMsg *contractsapi.StateSyncCommitment) error {
 	from := commitmentMsg.StartID.Uint64()
 	to := commitmentMsg.EndID.Uint64()
 

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -185,7 +185,14 @@ func TestStateSyncManager_BuildCommitment(t *testing.T) {
 	require.NoError(t, err)
 
 	s.pendingCommitments = []*PendingCommitment{
-		{MerkleTree: tree, Commitment: &contractsapi.Commitment{Root: tree.Hash(), StartID: big.NewInt(0), EndID: big.NewInt(1)}},
+		{
+			MerkleTree: tree,
+			StateSyncCommitment: &contractsapi.StateSyncCommitment{
+				Root:    tree.Hash(),
+				StartID: big.NewInt(0),
+				EndID:   big.NewInt(1),
+			},
+		},
 	}
 
 	hash, err := s.pendingCommitments[0].Hash()
@@ -224,7 +231,7 @@ func TestStateSyncerManager_BuildProofs(t *testing.T) {
 	require.Len(t, s.pendingCommitments, 1)
 
 	mockMsg := &CommitmentMessageSigned{
-		Message: &contractsapi.Commitment{
+		Message: &contractsapi.StateSyncCommitment{
 			StartID: s.pendingCommitments[0].StartID,
 			EndID:   s.pendingCommitments[0].EndID,
 		},
@@ -429,7 +436,7 @@ func TestStateSyncManager_GetProofs_NoProof_BuildProofs(t *testing.T) {
 	require.NoError(t, err)
 
 	commitment := &CommitmentMessageSigned{
-		Message: &contractsapi.Commitment{
+		Message: &contractsapi.StateSyncCommitment{
 			StartID: big.NewInt(fromIndex),
 			EndID:   big.NewInt(maxCommitmentSize),
 			Root:    tree.Hash(),

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -2,11 +2,13 @@ package polybft
 
 import (
 	"fmt"
+	"math/big"
 	"math/rand"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -63,8 +65,8 @@ func TestStateSyncManager_PostEpoch_BuildCommitment(t *testing.T) {
 
 	require.NoError(t, s.buildCommitment())
 	require.Len(t, s.pendingCommitments, 1)
-	require.Equal(t, uint64(0), s.pendingCommitments[0].FromIndex)
-	require.Equal(t, uint64(4), s.pendingCommitments[0].ToIndex)
+	require.Equal(t, uint64(0), s.pendingCommitments[0].StartID.Uint64())
+	require.Equal(t, uint64(4), s.pendingCommitments[0].EndID.Uint64())
 	require.Equal(t, uint64(0), s.pendingCommitments[0].Epoch)
 
 	// add the next 5 state syncs, at that point, so that it generates a larger commitment
@@ -74,8 +76,8 @@ func TestStateSyncManager_PostEpoch_BuildCommitment(t *testing.T) {
 
 	require.NoError(t, s.buildCommitment())
 	require.Len(t, s.pendingCommitments, 2)
-	require.Equal(t, uint64(0), s.pendingCommitments[1].FromIndex)
-	require.Equal(t, uint64(9), s.pendingCommitments[1].ToIndex)
+	require.Equal(t, uint64(0), s.pendingCommitments[1].StartID.Uint64())
+	require.Equal(t, uint64(9), s.pendingCommitments[1].EndID.Uint64())
 	require.Equal(t, uint64(0), s.pendingCommitments[1].Epoch)
 
 	// the message was sent
@@ -182,8 +184,8 @@ func TestStateSyncManager_BuildCommitment(t *testing.T) {
 	tree, err := NewMerkleTree([][]byte{{0x1}})
 	require.NoError(t, err)
 
-	s.pendingCommitments = []*Commitment{
-		{MerkleTree: tree},
+	s.pendingCommitments = []*PendingCommitment{
+		{MerkleTree: tree, Commitment: &contractsapi.Commitment{Root: tree.Hash(), StartID: big.NewInt(0), EndID: big.NewInt(1)}},
 	}
 
 	hash, err := s.pendingCommitments[0].Hash()
@@ -222,9 +224,9 @@ func TestStateSyncerManager_BuildProofs(t *testing.T) {
 	require.Len(t, s.pendingCommitments, 1)
 
 	mockMsg := &CommitmentMessageSigned{
-		Message: &CommitmentMessage{
-			FromIndex: s.pendingCommitments[0].FromIndex,
-			ToIndex:   s.pendingCommitments[0].ToIndex,
+		Message: &contractsapi.Commitment{
+			StartID: s.pendingCommitments[0].StartID,
+			EndID:   s.pendingCommitments[0].EndID,
 		},
 	}
 
@@ -296,8 +298,8 @@ func TestStateSyncerManager_AddLog_BuildCommitments(t *testing.T) {
 	s.AddLog(goodLog2)
 
 	require.Len(t, s.pendingCommitments, 1)
-	require.Equal(t, uint64(0), s.pendingCommitments[0].FromIndex)
-	require.Equal(t, uint64(1), s.pendingCommitments[0].ToIndex)
+	require.Equal(t, uint64(0), s.pendingCommitments[0].StartID.Uint64())
+	require.Equal(t, uint64(1), s.pendingCommitments[0].EndID.Uint64())
 
 	// add two more logs to have larger commitments
 	goodLog3 := goodLog.Copy()
@@ -309,8 +311,8 @@ func TestStateSyncerManager_AddLog_BuildCommitments(t *testing.T) {
 	s.AddLog(goodLog4)
 
 	require.Len(t, s.pendingCommitments, 3)
-	require.Equal(t, uint64(0), s.pendingCommitments[2].FromIndex)
-	require.Equal(t, uint64(3), s.pendingCommitments[2].ToIndex)
+	require.Equal(t, uint64(0), s.pendingCommitments[2].StartID.Uint64())
+	require.Equal(t, uint64(3), s.pendingCommitments[2].EndID.Uint64())
 }
 
 func TestStateSyncerManager_EventTracker_Sync(t *testing.T) {
@@ -416,8 +418,7 @@ func TestStateSyncManager_GetProofs_NoProof_BuildProofs(t *testing.T) {
 
 	const (
 		stateSyncID = uint64(5)
-		fromIndex   = uint64(1)
-		epoch       = uint64(1)
+		fromIndex   = 1
 	)
 
 	state := newTestState(t)
@@ -426,13 +427,19 @@ func TestStateSyncManager_GetProofs_NoProof_BuildProofs(t *testing.T) {
 	tree, err := createMerkleTree(stateSyncs)
 	require.NoError(t, err)
 
-	commitment := &CommitmentMessage{FromIndex: fromIndex, ToIndex: maxCommitmentSize, Epoch: epoch, MerkleRootHash: tree.Hash()}
+	commitment := &CommitmentMessageSigned{
+		Message: &contractsapi.Commitment{
+			StartID: big.NewInt(fromIndex),
+			EndID:   big.NewInt(maxCommitmentSize),
+			Root:    tree.Hash(),
+		},
+	}
 
 	for _, sse := range stateSyncs {
 		require.NoError(t, state.insertStateSyncEvent(sse))
 	}
 
-	require.NoError(t, state.insertCommitmentMessage(&CommitmentMessageSigned{Message: commitment}))
+	require.NoError(t, state.insertCommitmentMessage(commitment))
 
 	stateSyncManager := &stateSyncManager{state: state, logger: hclog.NewNullLogger()}
 

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -244,6 +244,7 @@ func TestStateSyncerManager_BuildProofs(t *testing.T) {
 	}
 
 	require.NoError(t, s.PostBlock(req))
+	require.Equal(t, mockMsg.Message.EndID.Uint64()+1, s.nextCommittedIndex)
 
 	for i := uint64(0); i < 10; i++ {
 		proof, err := s.state.getStateSyncProof(i)
@@ -380,7 +381,7 @@ func TestStateSyncManager_GetProofs(t *testing.T) {
 
 	proof, err := stateSyncManager.GetStateSyncProof(stateSyncID)
 	require.NoError(t, err)
-	require.Equal(t, stateSyncID, proof.StateSync.ID)
+	require.Equal(t, stateSyncID, proof.StateSync.ID.Uint64())
 	require.NotEmpty(t, proof.Proof)
 }
 
@@ -445,7 +446,7 @@ func TestStateSyncManager_GetProofs_NoProof_BuildProofs(t *testing.T) {
 
 	proof, err := stateSyncManager.GetStateSyncProof(stateSyncID)
 	require.NoError(t, err)
-	require.Equal(t, stateSyncID, proof.StateSync.ID)
+	require.Equal(t, stateSyncID, proof.StateSync.ID.Uint64())
 	require.NotEmpty(t, proof.Proof)
 
 	require.NoError(t, commitment.VerifyStateSyncProof(proof))

--- a/consensus/polybft/state_test.go
+++ b/consensus/polybft/state_test.go
@@ -620,7 +620,7 @@ func createTestCommitmentMessage(t *testing.T, fromIndex uint64) *CommitmentMess
 
 	require.NoError(t, err)
 
-	msg := &contractsapi.Commitment{
+	msg := &contractsapi.StateSyncCommitment{
 		Root:    tree.Hash(),
 		StartID: big.NewInt(int64(fromIndex)),
 		EndID:   big.NewInt(int64(fromIndex + maxCommitmentSize - 1)),

--- a/consensus/polybft/state_test.go
+++ b/consensus/polybft/state_test.go
@@ -12,6 +12,7 @@ import (
 
 	gensc "github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
+	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
@@ -279,7 +280,7 @@ func TestState_getStateSyncEventsForCommitment_NotEnoughEvents(t *testing.T) {
 	state := newTestState(t)
 
 	for i := 0; i < maxCommitmentSize-2; i++ {
-		assert.NoError(t, state.insertStateSyncEvent(&types.StateSyncEvent{
+		assert.NoError(t, state.insertStateSyncEvent(&contracts.StateSyncEvent{
 			ID:   uint64(i),
 			Data: []byte{1, 2},
 		}))
@@ -295,7 +296,7 @@ func TestState_getStateSyncEventsForCommitment(t *testing.T) {
 	state := newTestState(t)
 
 	for i := 0; i < maxCommitmentSize; i++ {
-		assert.NoError(t, state.insertStateSyncEvent(&types.StateSyncEvent{
+		assert.NoError(t, state.insertStateSyncEvent(&contracts.StateSyncEvent{
 			ID:   uint64(i),
 			Data: []byte{1, 2},
 		}))
@@ -580,10 +581,10 @@ func insertTestCommitments(t *testing.T, state *State, numberOfCommitments uint6
 func insertTestStateSyncProofs(t *testing.T, state *State, numberOfProofs uint64) {
 	t.Helper()
 
-	ssProofs := make([]*types.StateSyncProof, numberOfProofs)
+	ssProofs := make([]*contracts.StateSyncProof, numberOfProofs)
 
 	for i := uint64(0); i < numberOfProofs; i++ {
-		proofs := &types.StateSyncProof{
+		proofs := &contracts.StateSyncProof{
 			Proof:     []types.Hash{types.BytesToHash(generateRandomBytes(t))},
 			StateSync: createTestStateSync(i),
 		}
@@ -593,8 +594,8 @@ func insertTestStateSyncProofs(t *testing.T, state *State, numberOfProofs uint64
 	require.NoError(t, state.insertStateSyncProofs(ssProofs))
 }
 
-func createTestStateSync(index uint64) *types.StateSyncEvent {
-	return &types.StateSyncEvent{
+func createTestStateSync(index uint64) *contracts.StateSyncEvent {
+	return &contracts.StateSyncEvent{
 		ID:       index,
 		Sender:   ethgo.ZeroAddress,
 		Receiver: ethgo.ZeroAddress,

--- a/consensus/polybft/state_transaction.go
+++ b/consensus/polybft/state_transaction.go
@@ -101,7 +101,7 @@ func (cm *CommitmentMessageSigned) EncodeAbi() ([]byte, error) {
 		return nil, err
 	}
 
-	commit := &contractsapi.Commit{
+	commit := &contractsapi.CommitFunction{
 		Commitment: cm.Message,
 		Signature:  cm.AggSignature.AggregatedSignature,
 		Bitmap:     blsVerificationPart,
@@ -116,7 +116,7 @@ func (cm *CommitmentMessageSigned) DecodeAbi(txData []byte) error {
 		return fmt.Errorf("invalid commitment data, len = %d", len(txData))
 	}
 
-	commit := contractsapi.Commit{}
+	commit := contractsapi.CommitFunction{}
 
 	err := commit.DecodeAbi(txData)
 	if err != nil {

--- a/consensus/polybft/state_transaction.go
+++ b/consensus/polybft/state_transaction.go
@@ -25,8 +25,8 @@ type PendingCommitment struct {
 	Epoch      uint64
 }
 
-// NewCommitment creates a new commitment object
-func NewCommitment(epoch uint64, stateSyncEvents []*contractsapi.StateSyncedEvent) (*PendingCommitment, error) {
+// NewPendingCommitment creates a new commitment object
+func NewPendingCommitment(epoch uint64, stateSyncEvents []*contractsapi.StateSyncedEvent) (*PendingCommitment, error) {
 	tree, err := createMerkleTree(stateSyncEvents)
 	if err != nil {
 		return nil, err
@@ -153,11 +153,6 @@ func (cm *CommitmentMessageSigned) DecodeAbi(txData []byte) error {
 	}
 
 	return nil
-}
-
-// Type returns type of state transaction input
-func (cm *CommitmentMessageSigned) Type() contractsapi.StateTransactionType {
-	return stTypeBridgeCommitment
 }
 
 func decodeStateTransaction(txData []byte) (contractsapi.StateTransactionInput, error) {

--- a/consensus/polybft/state_transaction.go
+++ b/consensus/polybft/state_transaction.go
@@ -20,7 +20,7 @@ const (
 
 // PendingCommitment holds merkle trie of bridge transactions accompanied by epoch number
 type PendingCommitment struct {
-	*contractsapi.Commitment
+	*contractsapi.StateSyncCommitment
 	MerkleTree *MerkleTree
 	Epoch      uint64
 }
@@ -35,7 +35,7 @@ func NewCommitment(epoch uint64, stateSyncEvents []*contractsapi.StateSyncedEven
 	return &PendingCommitment{
 		MerkleTree: tree,
 		Epoch:      epoch,
-		Commitment: &contractsapi.Commitment{
+		StateSyncCommitment: &contractsapi.StateSyncCommitment{
 			StartID: stateSyncEvents[0].ID,
 			EndID:   stateSyncEvents[len(stateSyncEvents)-1].ID,
 			Root:    tree.Hash(),
@@ -45,7 +45,7 @@ func NewCommitment(epoch uint64, stateSyncEvents []*contractsapi.StateSyncedEven
 
 // Hash calculates hash value for commitment object.
 func (cm *PendingCommitment) Hash() (types.Hash, error) {
-	data, err := cm.Commitment.EncodeAbi()
+	data, err := cm.StateSyncCommitment.EncodeAbi()
 	if err != nil {
 		return types.Hash{}, err
 	}
@@ -57,7 +57,7 @@ var _ contractsapi.StateTransactionInput = &CommitmentMessageSigned{}
 
 // CommitmentMessageSigned encapsulates commitment message with aggregated signatures
 type CommitmentMessageSigned struct {
-	Message      *contractsapi.Commitment
+	Message      *contractsapi.StateSyncCommitment
 	AggSignature Signature
 	PublicKeys   [][]byte
 }

--- a/consensus/polybft/state_transaction_test.go
+++ b/consensus/polybft/state_transaction_test.go
@@ -182,7 +182,7 @@ func TestStateTransaction_Signature(t *testing.T) {
 		sig string
 	}{
 		{
-			commitEpochMethod,
+			contractsapi.ChildValidatorSet.Abi.GetMethod("commitEpoch"),
 			"410899c9",
 		},
 	}
@@ -195,11 +195,18 @@ func TestStateTransaction_Signature(t *testing.T) {
 func TestStateTransaction_Encoding(t *testing.T) {
 	t.Parallel()
 
-	cases := []StateTransactionInput{
-		// empty commit epoch
-		&CommitEpoch{
-			Uptime: Uptime{
-				UptimeData: []ValidatorUptime{},
+	cases := []contractsapi.StateTransactionInput{
+		&contractsapi.CommitEpoch{
+			ID: big.NewInt(1),
+			Epoch: &contractsapi.Epoch{
+				StartBlock: big.NewInt(1),
+				EndBlock:   big.NewInt(10),
+				EpochRoot:  types.Hash{},
+			},
+			Uptime: &contractsapi.Uptime{
+				EpochID:     big.NewInt(1),
+				TotalBlocks: big.NewInt(10),
+				UptimeData:  []*contractsapi.UptimeData{},
 			},
 		},
 	}
@@ -211,7 +218,7 @@ func TestStateTransaction_Encoding(t *testing.T) {
 
 		// use reflection to create another type and decode
 		val := reflect.New(reflect.TypeOf(c).Elem()).Interface()
-		obj, ok := val.(StateTransactionInput)
+		obj, ok := val.(contractsapi.StateTransactionInput)
 		assert.True(t, ok)
 
 		err = obj.DecodeAbi(res)

--- a/consensus/polybft/state_transaction_test.go
+++ b/consensus/polybft/state_transaction_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -94,7 +95,7 @@ func TestCommitmentMessage_VerifyProof(t *testing.T) {
 
 	for i, stateSync := range stateSyncs {
 		proof := commitment.MerkleTree.GenerateProof(uint64(i), 0)
-		stateSyncsProof := &types.StateSyncProof{
+		stateSyncsProof := &contracts.StateSyncProof{
 			Proof:     proof,
 			StateSync: stateSync,
 		}
@@ -102,7 +103,7 @@ func TestCommitmentMessage_VerifyProof(t *testing.T) {
 		inputData, err := stateSyncsProof.EncodeAbi()
 		require.NoError(t, err)
 
-		executionStateSync := &types.StateSyncProof{}
+		executionStateSync := &contracts.StateSyncProof{}
 		require.NoError(t, executionStateSync.DecodeAbi(inputData))
 		require.Equal(t, stateSyncsProof.StateSync, executionStateSync.StateSync)
 
@@ -115,7 +116,7 @@ func TestCommitmentMessage_VerifyProof_NoStateSyncsInCommitment(t *testing.T) {
 	t.Parallel()
 
 	commitment := &CommitmentMessageSigned{Message: &contractsapi.Commitment{StartID: big.NewInt(1), EndID: big.NewInt(10)}}
-	err := commitment.VerifyStateSyncProof(&types.StateSyncProof{})
+	err := commitment.VerifyStateSyncProof(&contracts.StateSyncProof{})
 	assert.ErrorContains(t, err, "no state sync event")
 }
 
@@ -133,7 +134,7 @@ func TestCommitmentMessage_VerifyProof_StateSyncHashNotEqualToProof(t *testing.T
 
 	proof := trie.GenerateProof(0, 0)
 
-	stateSyncProof := &types.StateSyncProof{
+	stateSyncProof := &contracts.StateSyncProof{
 		StateSync: stateSyncs[4],
 		Proof:     proof,
 	}
@@ -150,7 +151,7 @@ func TestCommitmentMessage_VerifyProof_StateSyncHashNotEqualToProof(t *testing.T
 }
 
 func buildCommitmentAndStateSyncs(t *testing.T, stateSyncsCount int,
-	epoch, startIdx uint64) (*PendingCommitment, *CommitmentMessageSigned, []*types.StateSyncEvent) {
+	epoch, startIdx uint64) (*PendingCommitment, *CommitmentMessageSigned, []*contracts.StateSyncEvent) {
 	t.Helper()
 
 	stateSyncEvents := generateStateSyncEvents(t, stateSyncsCount, startIdx)

--- a/consensus/polybft/state_transaction_test.go
+++ b/consensus/polybft/state_transaction_test.go
@@ -105,7 +105,11 @@ func TestCommitmentMessage_VerifyProof(t *testing.T) {
 
 		executionStateSync := &contracts.StateSyncProof{}
 		require.NoError(t, executionStateSync.DecodeAbi(inputData))
-		require.Equal(t, stateSyncsProof.StateSync, executionStateSync.StateSync)
+		require.Equal(t, stateSyncsProof.StateSync.ID.Uint64(), executionStateSync.StateSync.ID.Uint64())
+		require.Equal(t, stateSyncsProof.StateSync.Sender, executionStateSync.StateSync.Sender)
+		require.Equal(t, stateSyncsProof.StateSync.Receiver, executionStateSync.StateSync.Receiver)
+		require.Equal(t, stateSyncsProof.StateSync.Data, executionStateSync.StateSync.Data)
+		require.Equal(t, stateSyncsProof.Proof, executionStateSync.Proof)
 
 		err = commitmentSigned.VerifyStateSyncProof(executionStateSync)
 		require.NoError(t, err)
@@ -151,7 +155,7 @@ func TestCommitmentMessage_VerifyProof_StateSyncHashNotEqualToProof(t *testing.T
 }
 
 func buildCommitmentAndStateSyncs(t *testing.T, stateSyncsCount int,
-	epoch, startIdx uint64) (*PendingCommitment, *CommitmentMessageSigned, []*contracts.StateSyncEvent) {
+	epoch, startIdx uint64) (*PendingCommitment, *CommitmentMessageSigned, []*contractsapi.StateSyncedEvent) {
 	t.Helper()
 
 	stateSyncEvents := generateStateSyncEvents(t, stateSyncsCount, startIdx)

--- a/consensus/polybft/state_transaction_test.go
+++ b/consensus/polybft/state_transaction_test.go
@@ -16,7 +16,7 @@ import (
 
 func newTestCommitmentSigned(root types.Hash, startID, endID int64) *CommitmentMessageSigned {
 	return &CommitmentMessageSigned{
-		Message: &contractsapi.Commitment{
+		Message: &contractsapi.StateSyncCommitment{
 			StartID: big.NewInt(startID),
 			EndID:   big.NewInt(endID),
 			Root:    root,
@@ -67,7 +67,7 @@ func TestCommitmentMessage_ToRegisterCommitmentInputData(t *testing.T) {
 	const epoch, eventsCount = uint64(100), 11
 	pendingCommitment, _, _ := buildCommitmentAndStateSyncs(t, eventsCount, epoch, uint64(2))
 	expectedSignedCommitmentMsg := &CommitmentMessageSigned{
-		Message: pendingCommitment.Commitment,
+		Message: pendingCommitment.StateSyncCommitment,
 		AggSignature: Signature{
 			Bitmap:              []byte{5, 1},
 			AggregatedSignature: []byte{1, 1},
@@ -119,7 +119,7 @@ func TestCommitmentMessage_VerifyProof(t *testing.T) {
 func TestCommitmentMessage_VerifyProof_NoStateSyncsInCommitment(t *testing.T) {
 	t.Parallel()
 
-	commitment := &CommitmentMessageSigned{Message: &contractsapi.Commitment{StartID: big.NewInt(1), EndID: big.NewInt(10)}}
+	commitment := &CommitmentMessageSigned{Message: &contractsapi.StateSyncCommitment{StartID: big.NewInt(1), EndID: big.NewInt(10)}}
 	err := commitment.VerifyStateSyncProof(&contracts.StateSyncProof{})
 	assert.ErrorContains(t, err, "no state sync event")
 }
@@ -144,7 +144,7 @@ func TestCommitmentMessage_VerifyProof_StateSyncHashNotEqualToProof(t *testing.T
 	}
 
 	commitment := &CommitmentMessageSigned{
-		Message: &contractsapi.Commitment{
+		Message: &contractsapi.StateSyncCommitment{
 			StartID: big.NewInt(fromIndex),
 			EndID:   big.NewInt(toIndex),
 			Root:    trie.Hash(),
@@ -163,7 +163,7 @@ func buildCommitmentAndStateSyncs(t *testing.T, stateSyncsCount int,
 	require.NoError(t, err)
 
 	commitmentSigned := &CommitmentMessageSigned{
-		Message: commitment.Commitment,
+		Message: commitment.StateSyncCommitment,
 		AggSignature: Signature{
 			AggregatedSignature: []byte{},
 			Bitmap:              []byte{},

--- a/consensus/polybft/state_transaction_test.go
+++ b/consensus/polybft/state_transaction_test.go
@@ -196,7 +196,7 @@ func TestStateTransaction_Encoding(t *testing.T) {
 	t.Parallel()
 
 	cases := []contractsapi.StateTransactionInput{
-		&contractsapi.CommitEpoch{
+		&contractsapi.CommitEpochFunction{
 			ID: big.NewInt(1),
 			Epoch: &contractsapi.Epoch{
 				StartBlock: big.NewInt(1),

--- a/consensus/polybft/state_transaction_test.go
+++ b/consensus/polybft/state_transaction_test.go
@@ -159,7 +159,7 @@ func buildCommitmentAndStateSyncs(t *testing.T, stateSyncsCount int,
 	t.Helper()
 
 	stateSyncEvents := generateStateSyncEvents(t, stateSyncsCount, startIdx)
-	commitment, err := NewCommitment(epoch, stateSyncEvents)
+	commitment, err := NewPendingCommitment(epoch, stateSyncEvents)
 	require.NoError(t, err)
 
 	commitmentSigned := &CommitmentMessageSigned{

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer.go
@@ -154,9 +154,9 @@ func (r *StateSyncRelayer) AddLog(log *ethgo.Log) {
 }
 
 // queryStateSyncProof queries the state sync proof
-func (r *StateSyncRelayer) queryStateSyncProof(stateSyncID string) (*types.StateSyncProof, error) {
+func (r *StateSyncRelayer) queryStateSyncProof(stateSyncID string) (*contracts.StateSyncProof, error) {
 	// retrieve state sync proof
-	var stateSyncProof types.StateSyncProof
+	var stateSyncProof contracts.StateSyncProof
 
 	err := r.client.Call("bridge_getStateSyncProof", &stateSyncProof, stateSyncID)
 	if err != nil {
@@ -169,7 +169,7 @@ func (r *StateSyncRelayer) queryStateSyncProof(stateSyncID string) (*types.State
 }
 
 // executeStateSync executes the state sync
-func (r *StateSyncRelayer) executeStateSync(stateSyncProof *types.StateSyncProof) error {
+func (r *StateSyncRelayer) executeStateSync(stateSyncProof *contracts.StateSyncProof) error {
 	input, err := stateSyncProof.EncodeAbi()
 	if err != nil {
 		return err

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer_test.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer_test.go
@@ -45,12 +45,12 @@ func Test_executeStateSync(t *testing.T) {
 		key:       key,
 	}
 
-	sp := &types.StateSyncProof{
+	sp := &contracts.StateSyncProof{
 		Proof:     []types.Hash{},
-		StateSync: &types.StateSyncEvent{},
+		StateSync: &contracts.StateSyncEvent{},
 	}
 
-	input, _ := types.ExecuteStateSyncABIMethod.Encode(
+	input, _ := contracts.ExecuteStateSyncABIMethod.Encode(
 		[2]interface{}{sp.Proof, sp.StateSync.ToMap()},
 	)
 

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer_test.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer_test.go
@@ -1,8 +1,10 @@
 package statesyncrelayer
 
 import (
+	"math/big"
 	"testing"
 
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
@@ -46,13 +48,17 @@ func Test_executeStateSync(t *testing.T) {
 	}
 
 	sp := &contracts.StateSyncProof{
-		Proof:     []types.Hash{},
-		StateSync: &contracts.StateSyncEvent{},
+		Proof: []types.Hash{},
+		StateSync: &contractsapi.StateSyncedEvent{
+			ID:       big.NewInt(1),
+			Sender:   types.ZeroAddress,
+			Receiver: types.ZeroAddress,
+			Data:     []byte{},
+		},
 	}
 
-	input, _ := contracts.ExecuteStateSyncABIMethod.Encode(
-		[2]interface{}{sp.Proof, sp.StateSync.ToMap()},
-	)
+	input, err := sp.EncodeAbi()
+	require.NoError(t, err)
 
 	txn := &ethgo.Transaction{
 		From:  key.Address(),

--- a/consensus/polybft/validator_metadata.go
+++ b/consensus/polybft/validator_metadata.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/crypto"
 
@@ -209,7 +210,7 @@ func (as AccountSet) Copy() AccountSet {
 
 // Hash returns hash value of the AccountSet
 func (as AccountSet) Hash() (types.Hash, error) {
-	abiEncoded, err := accountSetABIType.Encode([]interface{}{as.AsGenericMaps()})
+	abiEncoded, err := accountSetABIType.Encode([]interface{}{as.ToAPIBinding()})
 	if err != nil {
 		return types.ZeroHash, err
 	}
@@ -217,18 +218,18 @@ func (as AccountSet) Hash() (types.Hash, error) {
 	return types.BytesToHash(crypto.Keccak256(abiEncoded)), nil
 }
 
-// AsGenericMaps convert AccountSet object to slice of maps, where each key denotes field name mapped to a value
-func (as AccountSet) AsGenericMaps() []map[string]interface{} {
-	accountSetMaps := make([]map[string]interface{}, len(as))
+// ToAPIBinding converts AccountSet to slice of contract api stubs to be encoded
+func (as AccountSet) ToAPIBinding() []*contractsapi.Validator {
+	apiBinding := make([]*contractsapi.Validator, len(as))
 	for i, v := range as {
-		accountSetMaps[i] = map[string]interface{}{
-			"_address":    v.Address,
-			"blsKey":      v.BlsKey.ToBigInt(),
-			"votingPower": new(big.Int).Set(v.VotingPower),
+		apiBinding[i] = &contractsapi.Validator{
+			Address:     v.Address,
+			BlsKey:      v.BlsKey.ToBigInt(),
+			VotingPower: new(big.Int).Set(v.VotingPower),
 		}
 	}
 
-	return accountSetMaps
+	return apiBinding
 }
 
 // GetValidatorMetadata tries to retrieve validator account metadata by given address from the account set.

--- a/contracts/state_transaction.go
+++ b/contracts/state_transaction.go
@@ -28,10 +28,8 @@ func (ssp *StateSyncProof) DecodeAbi(txData []byte) error {
 		return err
 	}
 
-	*ssp = StateSyncProof{
-		Proof:     execute.Proof,
-		StateSync: (*contractsapi.StateSyncedEvent)(execute.Obj),
-	}
+	ssp.Proof = execute.Proof
+	ssp.StateSync = (*contractsapi.StateSyncedEvent)(execute.Obj)
 
 	return nil
 }

--- a/contracts/state_transaction.go
+++ b/contracts/state_transaction.go
@@ -12,7 +12,7 @@ type StateSyncProof struct {
 
 // EncodeAbi contains logic for encoding given ABI data
 func (ssp *StateSyncProof) EncodeAbi() ([]byte, error) {
-	execute := contractsapi.Execute{
+	execute := contractsapi.ExecuteFunction{
 		Proof: ssp.Proof,
 		Obj:   (*contractsapi.StateSync)(ssp.StateSync),
 	}
@@ -22,7 +22,7 @@ func (ssp *StateSyncProof) EncodeAbi() ([]byte, error) {
 
 // DecodeAbi contains logic for decoding given ABI data
 func (ssp *StateSyncProof) DecodeAbi(txData []byte) error {
-	execute := &contractsapi.Execute{}
+	execute := &contractsapi.ExecuteFunction{}
 
 	if err := execute.DecodeAbi(txData); err != nil {
 		return err

--- a/contracts/state_transaction.go
+++ b/contracts/state_transaction.go
@@ -1,9 +1,10 @@
-package types
+package contracts
 
 import (
 	"fmt"
 	"math/big"
 
+	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/umbracle/ethgo"
 	"github.com/umbracle/ethgo/abi"
 )
@@ -54,7 +55,7 @@ func (sse *StateSyncEvent) String() string {
 }
 
 type StateSyncProof struct {
-	Proof     []Hash
+	Proof     []types.Hash
 	StateSync *StateSyncEvent
 }
 
@@ -79,7 +80,7 @@ func (ssp *StateSyncProof) DecodeAbi(txData []byte) error {
 		return fmt.Errorf("invalid proof data")
 	}
 
-	stateSyncEventEncoded, isOk := result["stateSync"].(map[string]interface{})
+	stateSyncEventEncoded, isOk := result["obj"].(map[string]interface{})
 	if !isOk {
 		return fmt.Errorf("invalid state sync data")
 	}
@@ -116,9 +117,9 @@ func (ssp *StateSyncProof) DecodeAbi(txData []byte) error {
 		Data:     data,
 	}
 
-	proof := make([]Hash, len(proofEncoded))
+	proof := make([]types.Hash, len(proofEncoded))
 	for i := 0; i < len(proofEncoded); i++ {
-		proof[i] = Hash(proofEncoded[i])
+		proof[i] = types.Hash(proofEncoded[i])
 	}
 
 	*ssp = StateSyncProof{
@@ -130,6 +131,6 @@ func (ssp *StateSyncProof) DecodeAbi(txData []byte) error {
 }
 
 type ExitProof struct {
-	Proof     []Hash
+	Proof     []types.Hash
 	LeafIndex uint64
 }

--- a/contracts/state_transaction.go
+++ b/contracts/state_transaction.go
@@ -14,7 +14,7 @@ type StateSyncProof struct {
 func (ssp *StateSyncProof) EncodeAbi() ([]byte, error) {
 	execute := contractsapi.Execute{
 		Proof: ssp.Proof,
-		Obj:   (*contractsapi.Obj)(ssp.StateSync),
+		Obj:   (*contractsapi.StateSync)(ssp.StateSync),
 	}
 
 	return execute.EncodeAbi()

--- a/contracts/state_transaction.go
+++ b/contracts/state_transaction.go
@@ -1,130 +1,36 @@
 package contracts
 
 import (
-	"fmt"
-	"math/big"
-
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/umbracle/ethgo"
-	"github.com/umbracle/ethgo/abi"
 )
-
-var (
-	stateSyncABIType = abi.MustNewType(
-		"tuple(tuple(uint256 id, address sender, address receiver, bytes data))")
-
-	// this will change to use the generated code, but for now, we leave it as is, because of the circular import
-	ExecuteStateSyncABIMethod, _ = abi.NewMethod("function execute(" +
-		"bytes32[] proof, " +
-		"tuple(uint256 id, address sender, address receiver, bytes data) obj)")
-)
-
-const (
-	abiMethodIDLength = 4
-)
-
-// StateSyncEvent is a bridge event from the rootchain
-type StateSyncEvent struct {
-	// ID is the decoded 'index' field from the event
-	ID uint64
-	// Sender is the decoded 'sender' field from the event
-	Sender ethgo.Address
-	// Receiver is the decoded 'receiver' field from the event
-	Receiver ethgo.Address
-	// Data is the decoded 'data' field from the event
-	Data []byte
-}
-
-// ToMap converts StateSyncEvent to map
-func (sse *StateSyncEvent) ToMap() map[string]interface{} {
-	return map[string]interface{}{
-		"id":       sse.ID,
-		"sender":   sse.Sender,
-		"receiver": sse.Receiver,
-		"data":     sse.Data,
-	}
-}
-
-// ToABI converts StateSyncEvent to ABI
-func (sse *StateSyncEvent) EncodeAbi() ([]byte, error) {
-	return stateSyncABIType.Encode([]interface{}{sse.ToMap()})
-}
-
-func (sse *StateSyncEvent) String() string {
-	return fmt.Sprintf("Id=%d, Sender=%v, Target=%v", sse.ID, sse.Sender, sse.Receiver)
-}
 
 type StateSyncProof struct {
 	Proof     []types.Hash
-	StateSync *StateSyncEvent
+	StateSync *contractsapi.StateSyncedEvent
 }
 
 // EncodeAbi contains logic for encoding given ABI data
 func (ssp *StateSyncProof) EncodeAbi() ([]byte, error) {
-	return ExecuteStateSyncABIMethod.Encode([2]interface{}{ssp.Proof, ssp.StateSync.ToMap()})
+	execute := contractsapi.Execute{
+		Proof: ssp.Proof,
+		Obj:   (*contractsapi.Obj)(ssp.StateSync),
+	}
+
+	return execute.EncodeAbi()
 }
 
 // DecodeAbi contains logic for decoding given ABI data
 func (ssp *StateSyncProof) DecodeAbi(txData []byte) error {
-	if len(txData) < abiMethodIDLength {
-		return fmt.Errorf("invalid proof data, len = %d", len(txData))
-	}
+	execute := &contractsapi.Execute{}
 
-	rawResult, err := ExecuteStateSyncABIMethod.Inputs.Decode(txData[abiMethodIDLength:])
-	if err != nil {
+	if err := execute.DecodeAbi(txData); err != nil {
 		return err
 	}
 
-	result, isOk := rawResult.(map[string]interface{})
-	if !isOk {
-		return fmt.Errorf("invalid proof data")
-	}
-
-	stateSyncEventEncoded, isOk := result["obj"].(map[string]interface{})
-	if !isOk {
-		return fmt.Errorf("invalid state sync data")
-	}
-
-	proofEncoded, isOk := result["proof"].([][32]byte)
-	if !isOk {
-		return fmt.Errorf("invalid proof data")
-	}
-
-	id, isOk := stateSyncEventEncoded["id"].(*big.Int)
-	if !isOk {
-		return fmt.Errorf("invalid state sync event id")
-	}
-
-	senderEthgo, isOk := stateSyncEventEncoded["sender"].(ethgo.Address)
-	if !isOk {
-		return fmt.Errorf("invalid state sync sender field")
-	}
-
-	receiverEthgo, isOk := stateSyncEventEncoded["receiver"].(ethgo.Address)
-	if !isOk {
-		return fmt.Errorf("invalid state sync receiver field")
-	}
-
-	data, isOk := stateSyncEventEncoded["data"].([]byte)
-	if !isOk {
-		return fmt.Errorf("invalid state sync data field")
-	}
-
-	stateSync := &StateSyncEvent{
-		ID:       id.Uint64(),
-		Sender:   senderEthgo,
-		Receiver: receiverEthgo,
-		Data:     data,
-	}
-
-	proof := make([]types.Hash, len(proofEncoded))
-	for i := 0; i < len(proofEncoded); i++ {
-		proof[i] = types.Hash(proofEncoded[i])
-	}
-
 	*ssp = StateSyncProof{
-		Proof:     proof,
-		StateSync: stateSync,
+		Proof:     execute.Proof,
+		StateSync: (*contractsapi.StateSyncedEvent)(execute.Obj),
 	}
 
 	return nil

--- a/e2e-polybft/bridge_test.go
+++ b/e2e-polybft/bridge_test.go
@@ -359,7 +359,7 @@ func TestE2E_Bridge_L2toL1Exit(t *testing.T) {
 		fail++
 	}
 
-	var proof types.ExitProof
+	var proof contracts.ExitProof
 
 	for i := 0; i < userNumber; i++ {
 		exitID := uint64(i + 1) // because exit events start from ID = 1
@@ -470,7 +470,7 @@ func TestE2E_Bridge_L2toL1ExitMultiple(t *testing.T) {
 		}
 	}
 
-	var proof types.ExitProof
+	var proof contracts.ExitProof
 
 	for i := 0; i < roundNumber; i++ {
 		for j := 0; j < userNumber; j++ {
@@ -483,7 +483,7 @@ func TestE2E_Bridge_L2toL1ExitMultiple(t *testing.T) {
 	}
 }
 
-func isExitEventProcessed(sidechainKey *ethgow.Key, proof types.ExitProof, checkpointBlock uint64, stateSenderData []byte, l1ExitTestAddr, exitHelperAddr, adminAddr ethgo.Address, l1TxRelayer txrelayer.TxRelayer, exitEventID uint64) (bool, error) {
+func isExitEventProcessed(sidechainKey *ethgow.Key, proof contracts.ExitProof, checkpointBlock uint64, stateSenderData []byte, l1ExitTestAddr, exitHelperAddr, adminAddr ethgo.Address, l1TxRelayer txrelayer.TxRelayer, exitEventID uint64) (bool, error) {
 	proofExitEventEncoded, err := polybft.ExitEventABIType.Encode(&polybft.ExitEvent{
 		ID:       exitEventID,
 		Sender:   sidechainKey.Address(),
@@ -523,7 +523,7 @@ func isExitEventProcessed(sidechainKey *ethgow.Key, proof types.ExitProof, check
 	return parserRes == uint64(1), nil
 }
 
-func getExitProof(rpcAddress string, exitID, epoch, checkpointBlock uint64) (types.ExitProof, error) {
+func getExitProof(rpcAddress string, exitID, epoch, checkpointBlock uint64) (contracts.ExitProof, error) {
 	query := struct {
 		Jsonrpc string   `json:"jsonrpc"`
 		Method  string   `json:"method"`
@@ -538,26 +538,26 @@ func getExitProof(rpcAddress string, exitID, epoch, checkpointBlock uint64) (typ
 
 	d, err := json.Marshal(query)
 	if err != nil {
-		return types.ExitProof{}, err
+		return contracts.ExitProof{}, err
 	}
 
 	resp, err := http.Post(rpcAddress, "application/json", bytes.NewReader(d))
 	if err != nil {
-		return types.ExitProof{}, err
+		return contracts.ExitProof{}, err
 	}
 
 	s, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return types.ExitProof{}, err
+		return contracts.ExitProof{}, err
 	}
 
 	rspProof := struct {
-		Result types.ExitProof `json:"result"`
+		Result contracts.ExitProof `json:"result"`
 	}{}
 
 	err = json.Unmarshal(s, &rspProof)
 	if err != nil {
-		return types.ExitProof{}, err
+		return contracts.ExitProof{}, err
 	}
 
 	return rspProof.Result, nil

--- a/jsonrpc/bridge_endpoint.go
+++ b/jsonrpc/bridge_endpoint.go
@@ -1,13 +1,13 @@
 package jsonrpc
 
 import (
-	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/0xPolygon/polygon-edge/contracts"
 )
 
 // bridgeStore interface provides access to the methods needed by bridge endpoint
 type bridgeStore interface {
-	GenerateExitProof(exitID, epoch, checkpointBlock uint64) (types.ExitProof, error)
-	GetStateSyncProof(stateSyncID uint64) (*types.StateSyncProof, error)
+	GenerateExitProof(exitID, epoch, checkpointBlock uint64) (contracts.ExitProof, error)
+	GetStateSyncProof(stateSyncID uint64) (*contracts.StateSyncProof, error)
 }
 
 // Bridge is the bridge jsonrpc endpoint

--- a/jsonrpc/mocks_test.go
+++ b/jsonrpc/mocks_test.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 
 	"github.com/0xPolygon/polygon-edge/blockchain"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
@@ -172,21 +174,24 @@ func (m *mockStore) GetCapacity() (uint64, uint64) {
 	return 0, 0
 }
 
-func (m *mockStore) GenerateExitProof(exitID, epoch, checkpointNumber uint64) (types.ExitProof, error) {
+func (m *mockStore) GenerateExitProof(exitID, epoch, checkpointNumber uint64) (contracts.ExitProof, error) {
 	hash := types.BytesToHash([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
 
-	return types.ExitProof{[]types.Hash{hash}, 1}, nil
+	return contracts.ExitProof{
+		Proof:     []types.Hash{hash},
+		LeafIndex: 1,
+	}, nil
 }
 
 func (m *mockStore) GetPeers() int {
 	return 20
 }
 
-func (m *mockStore) GetStateSyncProof(stateSyncID uint64) (*types.StateSyncProof, error) {
+func (m *mockStore) GetStateSyncProof(stateSyncID uint64) (*contracts.StateSyncProof, error) {
 	hash := types.BytesToHash([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
-	ssp := &types.StateSyncProof{
+	ssp := &contracts.StateSyncProof{
 		Proof:     []types.Hash{hash},
-		StateSync: &types.StateSyncEvent{},
+		StateSync: &contractsapi.StateSyncedEvent{},
 	}
 
 	return ssp, nil

--- a/types/state_transaction.go
+++ b/types/state_transaction.go
@@ -79,7 +79,7 @@ func (ssp *StateSyncProof) DecodeAbi(txData []byte) error {
 		return fmt.Errorf("invalid proof data")
 	}
 
-	stateSyncEventEncoded, isOk := result["obj"].(map[string]interface{})
+	stateSyncEventEncoded, isOk := result["stateSync"].(map[string]interface{})
 	if !isOk {
 		return fmt.Errorf("invalid state sync data")
 	}


### PR DESCRIPTION
# Description

This PR uses the generated contracts api stubs from https://github.com/0xPolygon/polygon-edge/pull/1062 in the client code.

It moves the `state_transaction.go` from `types` package (this file contains the `StateSyncProof` and `ExitEventProof` structs), to another package, because of the circular import (it uses the stubs from `contractsapi`, but `contractsapi` uses the `types` package).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually
