### PR TITLE
EVM-369 fix architecture dependent `int` type

### DIFF
--- a/chain/params.go
+++ b/chain/params.go
@@ -9,7 +9,7 @@ import (
 // Params are all the set of params for the chain
 type Params struct {
 	Forks          *Forks                 `json:"forks"`
-	ChainID        int                    `json:"chainID"`
+	ChainID        int64                  `json:"chainID"`
 	Engine         map[string]interface{} `json:"engine"`
 	Whitelists     *Whitelists            `json:"whitelists,omitempty"`
 	BlockGasTarget uint64                 `json:"blockGasTarget"`

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -42,7 +42,7 @@ func setFlags(cmd *cobra.Command) {
 		"the directory for the Polygon Edge genesis data",
 	)
 
-	cmd.Flags().Int64Var(
+	cmd.Flags().Uint64Var(
 		&params.chainID,
 		chainIDFlag,
 		command.DefaultChainID,
@@ -207,7 +207,7 @@ func setFlags(cmd *cobra.Command) {
 // with running partners
 func setLegacyFlags(cmd *cobra.Command) {
 	// Legacy chainid flag
-	cmd.Flags().Int64Var(
+	cmd.Flags().Uint64Var(
 		&params.chainID,
 		chainIDFlagLEGACY,
 		command.DefaultChainID,

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -42,7 +42,7 @@ func setFlags(cmd *cobra.Command) {
 		"the directory for the Polygon Edge genesis data",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().Int64Var(
 		&params.chainID,
 		chainIDFlag,
 		command.DefaultChainID,
@@ -207,7 +207,7 @@ func setFlags(cmd *cobra.Command) {
 // with running partners
 func setLegacyFlags(cmd *cobra.Command) {
 	// Legacy chainid flag
-	cmd.Flags().Uint64Var(
+	cmd.Flags().Int64Var(
 		&params.chainID,
 		chainIDFlagLEGACY,
 		command.DefaultChainID,

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -58,7 +58,7 @@ type genesisParams struct {
 
 	ibftValidatorsRaw []string
 
-	chainID   uint64
+	chainID   int64
 	epochSize uint64
 
 	blockGasLimit uint64
@@ -320,7 +320,7 @@ func (p *genesisParams) initGenesisConfig() error {
 			GasUsed:    command.DefaultGenesisGasUsed,
 		},
 		Params: &chain.Params{
-			ChainID: int(p.chainID),
+			ChainID: p.chainID,
 			Forks:   chain.AllForksEnabled,
 			Engine:  p.consensusEngineConfig,
 		},

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -58,7 +58,7 @@ type genesisParams struct {
 
 	ibftValidatorsRaw []string
 
-	chainID   int64
+	chainID   uint64
 	epochSize uint64
 
 	blockGasLimit uint64
@@ -320,7 +320,7 @@ func (p *genesisParams) initGenesisConfig() error {
 			GasUsed:    command.DefaultGenesisGasUsed,
 		},
 		Params: &chain.Params{
-			ChainID: p.chainID,
+			ChainID: int64(p.chainID),
 			Forks:   chain.AllForksEnabled,
 			Engine:  p.consensusEngineConfig,
 		},

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -80,7 +80,7 @@ func (p *genesisParams) generatePolyBftChainConfig() error {
 	chainConfig := &chain.Chain{
 		Name: p.name,
 		Params: &chain.Params{
-			ChainID: int(p.chainID),
+			ChainID: p.chainID,
 			Forks:   chain.AllForksEnabled,
 			Engine: map[string]interface{}{
 				string(server.PolyBFTConsensus): polyBftConfig,

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -80,7 +80,7 @@ func (p *genesisParams) generatePolyBftChainConfig() error {
 	chainConfig := &chain.Chain{
 		Name: p.name,
 		Params: &chain.Params{
-			ChainID: p.chainID,
+			ChainID: int64(p.chainID),
 			Forks:   chain.AllForksEnabled,
 			Engine: map[string]interface{}{
 				string(server.PolyBFTConsensus): polyBftConfig,

--- a/command/ibft/snapshot/ibft_snapshot.go
+++ b/command/ibft/snapshot/ibft_snapshot.go
@@ -19,7 +19,7 @@ func GetCommand() *cobra.Command {
 }
 
 func setFlags(cmd *cobra.Command) {
-	cmd.Flags().IntVar(
+	cmd.Flags().Int64Var(
 		&params.blockNumber,
 		numberFlag,
 		-1,

--- a/command/ibft/snapshot/ibft_snapshot.go
+++ b/command/ibft/snapshot/ibft_snapshot.go
@@ -1,6 +1,8 @@
 package snapshot
 
 import (
+	"math"
+
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/spf13/cobra"
@@ -19,10 +21,10 @@ func GetCommand() *cobra.Command {
 }
 
 func setFlags(cmd *cobra.Command) {
-	cmd.Flags().Int64Var(
+	cmd.Flags().Uint64Var(
 		&params.blockNumber,
 		numberFlag,
-		-1,
+		math.MaxUint64,
 		"the block height (number) for the snapshot",
 	)
 }

--- a/command/ibft/snapshot/params.go
+++ b/command/ibft/snapshot/params.go
@@ -16,7 +16,7 @@ var (
 )
 
 type snapshotParams struct {
-	blockNumber int
+	blockNumber int64
 
 	snapshot *ibftOp.Snapshot
 }

--- a/command/ibft/snapshot/params.go
+++ b/command/ibft/snapshot/params.go
@@ -2,6 +2,7 @@ package snapshot
 
 import (
 	"context"
+	"math"
 
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	ibftOp "github.com/0xPolygon/polygon-edge/consensus/ibft/proto"
@@ -16,7 +17,7 @@ var (
 )
 
 type snapshotParams struct {
-	blockNumber int64
+	blockNumber uint64
 
 	snapshot *ibftOp.Snapshot
 }
@@ -45,9 +46,9 @@ func (p *snapshotParams) getSnapshotRequest() *ibftOp.SnapshotReq {
 		Latest: true,
 	}
 
-	if p.blockNumber >= 0 {
+	if p.blockNumber != math.MaxUint64 {
 		req.Latest = false
-		req.Number = uint64(p.blockNumber)
+		req.Number = p.blockNumber
 	}
 
 	return req

--- a/command/sidechain/staking/stake.go
+++ b/command/sidechain/staking/stake.go
@@ -108,7 +108,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		From:     validatorAccount.Ecdsa.Address(),
 		Input:    encoded,
 		To:       (*ethgo.Address)(&contracts.ValidatorSetContract),
-		Value:    big.NewInt(int64(params.amount)),
+		Value:    new(big.Int).SetUint64(params.amount),
 		GasPrice: sidechainHelper.DefaultGasPrice,
 	}
 

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer.go
@@ -135,7 +135,7 @@ func (r *StateSyncRelayer) AddLog(log *ethgo.Log) {
 
 		r.logger.Info("Commit", "Block", log.BlockNumber, "StartID", startID, "EndID", endID)
 
-		for i := startID.Int64(); i <= endID.Int64(); i++ {
+		for i := startID.Uint64(); i <= endID.Uint64(); i++ {
 			// query the state sync proof
 			stateSyncProof, err := r.queryStateSyncProof(fmt.Sprintf("0x%x", i))
 			if err != nil {

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer.go
@@ -137,7 +137,7 @@ func (r *StateSyncRelayer) AddLog(log *ethgo.Log) {
 
 		for i := startID.Int64(); i <= endID.Int64(); i++ {
 			// query the state sync proof
-			stateSyncProof, err := r.queryStateSyncProof(fmt.Sprintf("0x%x", int(i)))
+			stateSyncProof, err := r.queryStateSyncProof(fmt.Sprintf("0x%x", i))
 			if err != nil {
 				r.logger.Error("Failed to query state sync proof", "err", err)
 

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -44,17 +44,17 @@ func Max(a, b uint64) uint64 {
 	return b
 }
 
-func ConvertUnmarshalledInt(x interface{}) (int64, error) {
+func ConvertUnmarshalledUint(x interface{}) (uint64, error) {
 	switch tx := x.(type) {
 	case float64:
-		return roundFloat(tx), nil
+		return uint64(roundFloat(tx)), nil
 	case string:
 		v, err := types.ParseUint64orHex(&tx)
 		if err != nil {
 			return 0, err
 		}
 
-		return int64(v), nil
+		return v, nil
 	default:
 		return 0, errors.New("unsupported type for unmarshalled integer")
 	}
@@ -222,7 +222,7 @@ func (d *JSONNumber) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	val, err := ConvertUnmarshalledInt(rawValue)
+	val, err := ConvertUnmarshalledUint(rawValue)
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func (d *JSONNumber) UnmarshalJSON(data []byte) error {
 		return errors.New("must be positive value")
 	}
 
-	d.Value = uint64(val)
+	d.Value = val
 
 	return nil
 }

--- a/jsonrpc/txpool_endpoint.go
+++ b/jsonrpc/txpool_endpoint.go
@@ -156,21 +156,21 @@ func (t *TxPool) Inspect() (interface{}, error) {
 func (t *TxPool) Status() (interface{}, error) {
 	pendingTxs, queuedTxs := t.store.GetTxs(true)
 
-	var pendingCount int
+	var pendingCount uint64
 
 	for _, t := range pendingTxs {
-		pendingCount += len(t)
+		pendingCount += uint64(len(t))
 	}
 
-	var queuedCount int
+	var queuedCount uint64
 
 	for _, t := range queuedTxs {
-		queuedCount += len(t)
+		queuedCount += uint64(len(t))
 	}
 
 	resp := StatusResponse{
-		Pending: uint64(pendingCount),
-		Queued:  uint64(queuedCount),
+		Pending: pendingCount,
+		Queued:  queuedCount,
 	}
 
 	return resp, nil

--- a/network/identity_e2e_test.go
+++ b/network/identity_e2e_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 func TestIdentityHandshake(t *testing.T) {
-	defaultChainID := 100
+	defaultChainID := int64(100)
 
 	testTable := []struct {
 		name    string
-		chainID int
+		chainID int64
 	}{
 		{
 			"Successful handshake (same chain ID)",
@@ -53,7 +53,7 @@ func TestIdentityHandshake(t *testing.T) {
 				closeTestServers(t, servers)
 			})
 
-			chainIDs := []int{
+			chainIDs := []int64{
 				servers[0].config.Chain.Params.ChainID,
 				servers[1].config.Chain.Params.ChainID,
 			}

--- a/network/server_identity.go
+++ b/network/server_identity.go
@@ -112,7 +112,7 @@ func (s *Server) setupIdentity() error {
 	identityService := identity.NewIdentityService(
 		s,
 		s.logger,
-		int64(s.config.Chain.Params.ChainID),
+		s.config.Chain.Params.ChainID,
 		s.host.ID(),
 	)
 

--- a/server/system_service.go
+++ b/server/system_service.go
@@ -31,7 +31,7 @@ func (s *systemService) GetStatus(ctx context.Context, req *empty.Empty) (*proto
 	header := s.server.blockchain.Header()
 
 	status := &proto.ServerStatus{
-		Network: int64(s.server.chain.Params.ChainID),
+		Network: s.server.chain.Params.ChainID,
 		Current: &proto.ServerStatus_Block{
 			Number: int64(header.Number),
 			Hash:   header.Hash.String(),

--- a/state/executor.go
+++ b/state/executor.go
@@ -57,7 +57,7 @@ func (e *Executor) WriteGenesis(alloc map[types.Address]*chain.GenesisAccount) t
 	config := e.config.Forks.At(0)
 
 	env := runtime.TxContext{
-		ChainID: int64(e.config.ChainID),
+		ChainID: e.config.ChainID,
 	}
 
 	transition := &Transition{
@@ -169,7 +169,7 @@ func (e *Executor) BeginTxn(
 		Number:     int64(header.Number),
 		Difficulty: types.BytesToHash(new(big.Int).SetUint64(header.Difficulty).Bytes()),
 		GasLimit:   int64(header.GasLimit),
-		ChainID:    int64(e.config.ChainID),
+		ChainID:    e.config.ChainID,
 	}
 
 	txn := &Transition{

--- a/state/runtime/evm/bitmap.go
+++ b/state/runtime/evm/bitmap.go
@@ -2,7 +2,7 @@ package evm
 
 import "github.com/0xPolygon/polygon-edge/helper/common"
 
-const bitmapSize = uint64(8)
+const bitmapSize = 8
 
 type bitmap struct {
 	buf []byte
@@ -25,19 +25,19 @@ func (b *bitmap) reset() {
 }
 
 func (b *bitmap) setCode(code []byte) {
-	codeSize := uint64(len(code))
-	b.buf = common.ExtendByteSlice(b.buf, int(codeSize/bitmapSize+1))
+	codeSize := len(code)
+	b.buf = common.ExtendByteSlice(b.buf, codeSize/bitmapSize+1)
 
-	for i := uint64(0); i < codeSize; {
+	for i := 0; i < codeSize; {
 		c := code[i]
 
 		if isPushOp(c) {
 			// push op
-			i += uint64(c - 0x60 + 2)
+			i += int(c) - 0x60 + 2
 		} else {
 			if c == 0x5B {
 				// jumpdest
-				b.set(i)
+				b.set(uint64(i))
 			}
 			i++
 		}

--- a/state/runtime/evm/bitmap.go
+++ b/state/runtime/evm/bitmap.go
@@ -2,17 +2,17 @@ package evm
 
 import "github.com/0xPolygon/polygon-edge/helper/common"
 
-const bitmapSize = uint(8)
+const bitmapSize = uint64(8)
 
 type bitmap struct {
 	buf []byte
 }
 
-func (b *bitmap) isSet(i uint) bool {
+func (b *bitmap) isSet(i uint64) bool {
 	return b.buf[i/bitmapSize]&(1<<(i%bitmapSize)) != 0
 }
 
-func (b *bitmap) set(i uint) {
+func (b *bitmap) set(i uint64) {
 	b.buf[i/bitmapSize] |= 1 << (i % bitmapSize)
 }
 
@@ -25,15 +25,15 @@ func (b *bitmap) reset() {
 }
 
 func (b *bitmap) setCode(code []byte) {
-	codeSize := uint(len(code))
+	codeSize := uint64(len(code))
 	b.buf = common.ExtendByteSlice(b.buf, int(codeSize/bitmapSize+1))
 
-	for i := uint(0); i < codeSize; {
+	for i := uint64(0); i < codeSize; {
 		c := code[i]
 
 		if isPushOp(c) {
 			// push op
-			i += uint(c - 0x60 + 2)
+			i += uint64(c - 0x60 + 2)
 		} else {
 			if c == 0x5B {
 				// jumpdest

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -114,7 +114,7 @@ func (c *state) validJumpdest(dest *big.Int) bool {
 		return false
 	}
 
-	return c.bitmap.isSet(uint(udest))
+	return c.bitmap.isSet(udest)
 }
 
 func (c *state) Halt() {

--- a/validators/store/snapshot/snapshot.go
+++ b/validators/store/snapshot/snapshot.go
@@ -520,7 +520,7 @@ func (s *SnapshotValidatorStore) removeLowerSnapshots(
 	currentHeight uint64,
 ) {
 	// remove in-memory snapshots from two epochs before this one
-	lowerEpoch := int(currentHeight/s.epochSize) - 2
+	lowerEpoch := int64(currentHeight/s.epochSize) - 2
 	if lowerEpoch > 0 {
 		purgeBlock := uint64(lowerEpoch) * s.epochSize
 		s.store.deleteLower(purgeBlock)

--- a/validators/store/snapshot/snapshot.go
+++ b/validators/store/snapshot/snapshot.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	loggerName = "snapshot_validator_set"
+	loggerName      = "snapshot_validator_set"
+	preservedEpochs = 2
 )
 
 // SignerInterface is an interface of the Signer SnapshotValidatorStore calls
@@ -519,12 +520,15 @@ func (s *SnapshotValidatorStore) resetSnapshot(
 func (s *SnapshotValidatorStore) removeLowerSnapshots(
 	currentHeight uint64,
 ) {
-	// remove in-memory snapshots from two epochs before this one
-	lowerEpoch := int64(currentHeight/s.epochSize) - 2
-	if lowerEpoch > 0 {
-		purgeBlock := uint64(lowerEpoch) * s.epochSize
-		s.store.deleteLower(purgeBlock)
+	currentEpoch := currentHeight / s.epochSize
+	if currentEpoch < preservedEpochs {
+		return
 	}
+
+	// remove in-memory snapshots from two epochs before this one
+	lowerEpoch := currentEpoch - preservedEpochs
+	purgeBlock := lowerEpoch * s.epochSize
+	s.store.deleteLower(purgeBlock)
 }
 
 // processVote processes vote in the given header and update snapshot


### PR DESCRIPTION
# Description

`int` type in golang is architecture dependent, and usage of it in an application where there is a network of computers which shares information, it could be problematic to have 32-bit architecture send information to a 64-bit computer, and vice-verse, since `int` type won't be interpreted the same.

This fix introduces the replacement of `int` type (as much as possible), especially on the bits of the application where information exchange occurs. It is replaced by `int64`, since 32-bit architectures can also use it, even though it adds some overhead, it is negligible.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
