### PR TITLE
opReturnCopyData panic fix

### DIFF
--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -101,22 +101,22 @@ func TestMStore(t *testing.T) {
 	assert.Len(t, s.memory, 1024+32)
 }
 
-type mockHostForInstrustions struct {
+type mockHostForInstructions struct {
 	mockHost
 	nonce       uint64
 	code        []byte
 	callxResult *runtime.ExecutionResult
 }
 
-func (m *mockHostForInstrustions) GetNonce(types.Address) uint64 {
+func (m *mockHostForInstructions) GetNonce(types.Address) uint64 {
 	return m.nonce
 }
 
-func (m *mockHostForInstrustions) Callx(*runtime.Contract, runtime.Host) *runtime.ExecutionResult {
+func (m *mockHostForInstructions) Callx(*runtime.Contract, runtime.Host) *runtime.ExecutionResult {
 	return m.callxResult
 }
 
-func (m *mockHostForInstrustions) GetCode(addr types.Address) []byte {
+func (m *mockHostForInstructions) GetCode(addr types.Address) []byte {
 	return m.code
 }
 
@@ -145,7 +145,7 @@ func TestCreate(t *testing.T) {
 		config      *chain.ForksInTime
 		initState   *state
 		resultState *state
-		mockHost    *mockHostForInstrustions
+		mockHost    *mockHostForInstructions
 	}{
 		{
 			name: "should succeed in case of CREATE",
@@ -179,7 +179,7 @@ func TestCreate(t *testing.T) {
 					byte(REVERT),
 				},
 			},
-			mockHost: &mockHostForInstrustions{
+			mockHost: &mockHostForInstructions{
 				nonce: 0,
 				callxResult: &runtime.ExecutionResult{
 					GasLeft: 500,
@@ -223,7 +223,7 @@ func TestCreate(t *testing.T) {
 				stop: true,
 				err:  errWriteProtection,
 			},
-			mockHost: &mockHostForInstrustions{},
+			mockHost: &mockHostForInstructions{},
 		},
 		{
 			name:     "should throw errOpCodeNotFound when op is CREATE2 and config.Constantinople is disabled",
@@ -261,7 +261,7 @@ func TestCreate(t *testing.T) {
 				stop: true,
 				err:  errOpCodeNotFound,
 			},
-			mockHost: &mockHostForInstrustions{},
+			mockHost: &mockHostForInstructions{},
 		},
 		{
 			name: "should set zero address if op is CREATE and contract call throws ErrCodeStoreOutOfGas",
@@ -303,7 +303,7 @@ func TestCreate(t *testing.T) {
 				stop: false,
 				err:  nil,
 			},
-			mockHost: &mockHostForInstrustions{
+			mockHost: &mockHostForInstructions{
 				nonce: 0,
 				callxResult: &runtime.ExecutionResult{
 					GasLeft: 1000,
@@ -351,7 +351,7 @@ func TestCreate(t *testing.T) {
 				stop: false,
 				err:  nil,
 			},
-			mockHost: &mockHostForInstrustions{
+			mockHost: &mockHostForInstructions{
 				nonce: 0,
 				callxResult: &runtime.ExecutionResult{
 					GasLeft: 1000,
@@ -429,7 +429,7 @@ func Test_opReturnDataCopy(t *testing.T) {
 				},
 				sp:   0,
 				stop: true,
-				err:  errGasUintOverflow,
+				err:  errReturnDataOutOfBounds,
 			},
 		},
 		{
@@ -454,7 +454,7 @@ func Test_opReturnDataCopy(t *testing.T) {
 				sp:     0,
 				memory: make([]byte, 1),
 				stop:   true,
-				err:    errGasUintOverflow,
+				err:    errReturnDataOutOfBounds,
 			},
 		},
 		{
@@ -477,7 +477,7 @@ func Test_opReturnDataCopy(t *testing.T) {
 				},
 				sp:   0,
 				stop: true,
-				err:  errGasUintOverflow,
+				err:  errReturnDataOutOfBounds,
 			},
 		},
 		{
@@ -618,7 +618,7 @@ func Test_opCall(t *testing.T) {
 		config      *chain.ForksInTime
 		initState   *state
 		resultState *state
-		mockHost    *mockHostForInstrustions
+		mockHost    *mockHostForInstructions
 	}{
 		{
 			// this test case also verifies that code does not panic when the outSize is 0 and outOffset > len(memory)
@@ -646,7 +646,7 @@ func Test_opCall(t *testing.T) {
 				stop:   false,
 				err:    nil,
 			},
-			mockHost: &mockHostForInstrustions{
+			mockHost: &mockHostForInstructions{
 				callxResult: &runtime.ExecutionResult{
 					ReturnValue: []byte{0x03},
 				},

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -101,18 +101,23 @@ func TestMStore(t *testing.T) {
 	assert.Len(t, s.memory, 1024+32)
 }
 
-type mockHostForCreate struct {
+type mockHostForInstrustions struct {
 	mockHost
 	nonce       uint64
+	code        []byte
 	callxResult *runtime.ExecutionResult
 }
 
-func (m *mockHostForCreate) GetNonce(types.Address) uint64 {
+func (m *mockHostForInstrustions) GetNonce(types.Address) uint64 {
 	return m.nonce
 }
 
-func (m *mockHostForCreate) Callx(*runtime.Contract, runtime.Host) *runtime.ExecutionResult {
+func (m *mockHostForInstrustions) Callx(*runtime.Contract, runtime.Host) *runtime.ExecutionResult {
 	return m.callxResult
+}
+
+func (m *mockHostForInstrustions) GetCode(addr types.Address) []byte {
+	return m.code
 }
 
 var (
@@ -140,7 +145,7 @@ func TestCreate(t *testing.T) {
 		config      *chain.ForksInTime
 		initState   *state
 		resultState *state
-		mockHost    *mockHostForCreate
+		mockHost    *mockHostForInstrustions
 	}{
 		{
 			name: "should succeed in case of CREATE",
@@ -174,7 +179,7 @@ func TestCreate(t *testing.T) {
 					byte(REVERT),
 				},
 			},
-			mockHost: &mockHostForCreate{
+			mockHost: &mockHostForInstrustions{
 				nonce: 0,
 				callxResult: &runtime.ExecutionResult{
 					GasLeft: 500,
@@ -218,7 +223,7 @@ func TestCreate(t *testing.T) {
 				stop: true,
 				err:  errWriteProtection,
 			},
-			mockHost: &mockHostForCreate{},
+			mockHost: &mockHostForInstrustions{},
 		},
 		{
 			name:     "should throw errOpCodeNotFound when op is CREATE2 and config.Constantinople is disabled",
@@ -256,7 +261,7 @@ func TestCreate(t *testing.T) {
 				stop: true,
 				err:  errOpCodeNotFound,
 			},
-			mockHost: &mockHostForCreate{},
+			mockHost: &mockHostForInstrustions{},
 		},
 		{
 			name: "should set zero address if op is CREATE and contract call throws ErrCodeStoreOutOfGas",
@@ -298,7 +303,7 @@ func TestCreate(t *testing.T) {
 				stop: false,
 				err:  nil,
 			},
-			mockHost: &mockHostForCreate{
+			mockHost: &mockHostForInstrustions{
 				nonce: 0,
 				callxResult: &runtime.ExecutionResult{
 					GasLeft: 1000,
@@ -346,7 +351,7 @@ func TestCreate(t *testing.T) {
 				stop: false,
 				err:  nil,
 			},
-			mockHost: &mockHostForCreate{
+			mockHost: &mockHostForInstrustions{
 				nonce: 0,
 				callxResult: &runtime.ExecutionResult{
 					GasLeft: 1000,
@@ -409,7 +414,7 @@ func Test_opReturnDataCopy(t *testing.T) {
 			config: &allEnabledForks,
 			initState: &state{
 				stack: []*big.Int{
-					big.NewInt(0),  // length
+					big.NewInt(1),  // length
 					big.NewInt(0),  // dataOffset
 					big.NewInt(-1), // memOffset
 				},
@@ -418,7 +423,7 @@ func Test_opReturnDataCopy(t *testing.T) {
 			resultState: &state{
 				config: &allEnabledForks,
 				stack: []*big.Int{
-					big.NewInt(0),
+					big.NewInt(1),
 					big.NewInt(0),
 					big.NewInt(-1),
 				},
@@ -541,6 +546,34 @@ func Test_opReturnDataCopy(t *testing.T) {
 				err:                nil,
 			},
 		},
+		{
+			// this test case also verifies that code does not panic when the length is 0 and memOffset > len(memory)
+			name:   "should not copy data if length is zero",
+			config: &allEnabledForks,
+			initState: &state{
+				stack: []*big.Int{
+					big.NewInt(0), // length
+					big.NewInt(0), // dataOffset
+					big.NewInt(4), // memOffset
+				},
+				sp:         3,
+				returnData: []byte{0x01},
+				memory:     []byte{0x02},
+			},
+			resultState: &state{
+				config: &allEnabledForks,
+				stack: []*big.Int{
+					big.NewInt(0),
+					big.NewInt(0),
+					big.NewInt(4),
+				},
+				sp:         0,
+				returnData: []byte{0x01},
+				memory:     []byte{0x02},
+				stop:       false,
+				err:        nil,
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -571,6 +604,76 @@ func Test_opReturnDataCopy(t *testing.T) {
 			opReturnDataCopy(state)
 
 			assert.Equal(t, test.resultState, state)
+		})
+	}
+}
+
+func Test_opCall(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		op          OpCode
+		contract    *runtime.Contract
+		config      *chain.ForksInTime
+		initState   *state
+		resultState *state
+		mockHost    *mockHostForInstrustions
+	}{
+		{
+			// this test case also verifies that code does not panic when the outSize is 0 and outOffset > len(memory)
+			name: "should not copy result into memory if outSize is 0",
+			op:   STATICCALL,
+			contract: &runtime.Contract{
+				Static: true,
+			},
+			config: &allEnabledForks,
+			initState: &state{
+				gas: 1000,
+				sp:  6,
+				stack: []*big.Int{
+					big.NewInt(0x00), // outSize
+					big.NewInt(0x02), // outOffset
+					big.NewInt(0x00), // inSize
+					big.NewInt(0x00), // inOffset
+					big.NewInt(0x00), // address
+					big.NewInt(0x00), // initialGas
+				},
+				memory: []byte{0x01},
+			},
+			resultState: &state{
+				memory: []byte{0x01},
+				stop:   false,
+				err:    nil,
+			},
+			mockHost: &mockHostForInstrustions{
+				callxResult: &runtime.ExecutionResult{
+					ReturnValue: []byte{0x03},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			state, closeFn := getState()
+			defer closeFn()
+
+			state.gas = test.initState.gas
+			state.msg = test.contract
+			state.sp = test.initState.sp
+			state.stack = test.initState.stack
+			state.memory = test.initState.memory
+			state.config = test.config
+			state.host = test.mockHost
+
+			opCall(test.op)(state)
+
+			assert.Equal(t, test.resultState.memory, state.memory, "memory in state after execution is not correct")
+			assert.Equal(t, test.resultState.stop, state.stop, "stop in state after execution is not correct")
+			assert.Equal(t, test.resultState.err, state.err, "err in state after execution is not correct")
 		})
 	}
 }

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -298,7 +298,7 @@ func (c *state) Len() int {
 // consumes gas if memory needs to be expanded
 func (c *state) allocateMemory(offset, size *big.Int) bool {
 	if !offset.IsUint64() || !size.IsUint64() {
-		c.exit(errGasUintOverflow)
+		c.exit(errReturnDataOutOfBounds)
 
 		return false
 	}
@@ -311,7 +311,7 @@ func (c *state) allocateMemory(offset, size *big.Int) bool {
 	s := size.Uint64()
 
 	if o > 0xffffffffe0 || s > 0xffffffffe0 {
-		c.exit(errGasUintOverflow)
+		c.exit(errReturnDataOutOfBounds)
 
 		return false
 	}


### PR DESCRIPTION
# Description

The problem with the opReturnDataCopy, as stated in the audit, was when length was set to 0 and memoryOffset was greater than memory length. Length being 0 caused no data allocation. In normal scenario when length (data size) is greater than 0, allocateMemory fn would allocate enough space so that data can be copied to memory starting from the memoryOffset. In the case of 0 length, where no memory was allocated, panic occurred while trying to copy data accessing the memory out of its bounds.
The fix includes:
 - checking memory length against sum of the length and memOffset (as suggested in the audit report) 
 - also, before even allocating the memory there is a check if length equals 0, because it that case there is no need for memory allocation nor for data copying and the fn returns. This excludes further unnecessary calculations, which will result in no data copying anyway. This means that the added check for valid memory length should never return an error because in the case of either unsuccessful memory allocation or length size 0 the fn returned before reaching this point. Putting length check before allocating memory will give precedence to the length in the case when 	length is 0 and memoryOffset is invalid (negative), because in that case we won't have error return (which is expected for negative memOffset) instead the fn will just return without error (which 	should be the case for the 0 length as stated in the audit that is behavior of go-ethereum). If we want to give precedence to the invalid memOffset the check for the length can be put after allocation.
 	
All other places in the code which writes data to the memory after calling allocate(opExtCodeCopy, opCallDataCopy, opCodeCopy, get2), have a check if size is greater than 0 except opCall (allocate is called from buildCallContract). The fix for opCall is included in this PR as well, and tests for this specific scenario are added for both opReturnDataCopy and opCall.

An alternative fix could be removing check for size==0 in allocateMemory fn, which will allocated additional space if memory offset is greater than memory length, but that would be unnecessary allocation since the data length is 0 and no data would be copied.


# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
- [x] I have tested this code with the unit test
