### PR TITLE
EVM-375 Reject contract creation transactions with large init data

### DIFF
--- a/state/executor.go
+++ b/state/executor.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	spuriousDragonMaxCodeSize = 24576
+	SpuriousDragonMaxCodeSize = 24576
 
 	TxGas                 uint64 = 21000 // Per transaction not creating a contract
 	TxGasContractCreation uint64 = 53000 // Per transaction that creates a contract
@@ -673,7 +673,7 @@ func (t *Transition) applyCreate(c *runtime.Contract, host runtime.Host) *runtim
 		return result
 	}
 
-	if t.config.EIP158 && len(result.ReturnValue) > spuriousDragonMaxCodeSize {
+	if t.config.EIP158 && len(result.ReturnValue) > SpuriousDragonMaxCodeSize {
 		// Contract size exceeds 'SpuriousDragon' size limit
 		t.state.RevertToSnapshot(snapshot)
 


### PR DESCRIPTION
# Description

This PR fixes the issue when we send a bunch of handcrafted transactions to node, that create some large smart contracts, which are too large and can cause a decrease in network performance, making the nodes stuck from time to time. Before, these transactions got rejected by the nodes, but only after they were executed.

A check is introduced in transaction pool as well, where if a transaction is a contract creation transaction, we will check the size of its input, and if it is larger than the `MaxCodeInitSize` we will not add the given transaction to the pool. 

_Additional info_: _`MaxInitCodeSize` is a limit in the `Ethereum` blockchain that sets a maximum size for the initial code that is executed when a smart contract is created. This is done to prevent the deployment of smart contracts that are too large, as this could lead to increased costs and decreased network performance. The current value of `MaxInitCodeSize` in `Ethereum` is 24576 bytes._

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually