### PR TITLE
Fix  validation of state transactions

### DIFF
--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -27,6 +27,10 @@ type blockBuilder interface {
 	Receipts() []*types.Receipt
 }
 
+var (
+	errUptimeTxDoesNotExist = errors.New("uptime transaction is not found in the epoch ending block")
+)
+
 type fsm struct {
 	// PolyBFT consensus protocol configuration
 	config *PolyBFTConfig
@@ -342,35 +346,27 @@ func (f *fsm) ValidateSender(msg *proto.Message) error {
 }
 
 func (f *fsm) VerifyStateTransactions(transactions []*types.Transaction) error {
-	if f.isEndOfEpoch {
-		err := f.verifyValidatorsUptimeTx(transactions)
-		if err != nil {
-			return err
-		}
-
-		if len(transactions) > 0 {
-			transactions = transactions[1:]
-		}
-	}
-
-	commitmentMessageSignedExists := false
+	var (
+		commitmentMessageSignedExists bool
+		uptimeTransactionExists       bool
+	)
 
 	for _, tx := range transactions {
 		if tx.Type != types.StateTx {
 			continue
 		}
 
-		if !f.isEndOfSprint {
-			return fmt.Errorf("state transaction in block which should not contain it: tx = %v", tx.Hash)
-		}
-
 		decodedStateTx, err := decodeStateTransaction(tx.Input) // used to be Data
 		if err != nil {
-			return fmt.Errorf("state transaction error while decoding: tx = %v, err = %w", tx.Hash, err)
+			return fmt.Errorf("unknown state transaction: tx = %v, err = %w", tx.Hash, err)
 		}
 
 		switch stateTxData := decodedStateTx.(type) {
 		case *CommitmentMessageSigned:
+			if !f.isEndOfSprint {
+				return fmt.Errorf("found commitment in block which should not contain it: tx = %v", tx.Hash)
+			}
+
 			if commitmentMessageSignedExists {
 				return fmt.Errorf("only one commitment is allowed per block: %v", tx.Hash)
 			}
@@ -400,7 +396,17 @@ func (f *fsm) VerifyStateTransactions(transactions []*types.Transaction) error {
 			if !verified {
 				return fmt.Errorf("invalid signature for tx = %v", tx.Hash)
 			}
+		case *contractsapi.CommitEpochFunction:
+			uptimeTransactionExists = true
+
+			if err := f.verifyValidatorsUptimeTx(tx); err != nil {
+				return fmt.Errorf("error while verifying uptime transaction. error: %w", err)
+			}
 		}
+	}
+
+	if f.isEndOfEpoch && !uptimeTransactionExists {
+		return errUptimeTxDoesNotExist
 	}
 
 	return nil
@@ -456,7 +462,7 @@ func (f *fsm) Insert(proposal []byte, committedSeals []*messages.CommittedSeal) 
 		Bitmap:              bitmap,
 	}
 
-	// Write extar data to header
+	// Write extra data to header
 	newBlock.Block.Header.ExtraData = append(make([]byte, ExtraVanity), extra.MarshalRLPTo(nil)...)
 
 	if err := f.backend.CommitBlock(newBlock); err != nil {
@@ -494,20 +500,11 @@ func (f *fsm) getCurrentValidators(pendingBlockState *state.Transition) (Account
 }
 
 // verifyValidatorsUptimeTx creates uptime transaction and compares its hash with the one extracted from the block.
-func (f *fsm) verifyValidatorsUptimeTx(transactions []*types.Transaction) error {
-	var blockUptimeTx *types.Transaction
-	if len(transactions) > 0 {
-		blockUptimeTx = transactions[0]
-	}
-
-	createdUptimeTx, err := f.createValidatorsUptimeTx()
-	if err != nil {
-		return err
-	}
-
+func (f *fsm) verifyValidatorsUptimeTx(blockUptimeTx *types.Transaction) error {
 	if f.isEndOfEpoch {
-		if blockUptimeTx == nil {
-			return errors.New("uptime transaction is not found in the epoch ending block")
+		createdUptimeTx, err := f.createValidatorsUptimeTx()
+		if err != nil {
+			return err
 		}
 
 		if blockUptimeTx.Hash != createdUptimeTx.Hash {
@@ -517,13 +514,11 @@ func (f *fsm) verifyValidatorsUptimeTx(transactions []*types.Transaction) error 
 				createdUptimeTx.Hash,
 			)
 		}
-	} else {
-		if blockUptimeTx != nil && blockUptimeTx.Hash == createdUptimeTx.Hash {
-			return errors.New("didn't expect uptime transaction in the middle of an epoch")
-		}
+
+		return nil
 	}
 
-	return nil
+	return errors.New("didn't expect uptime transaction in a non ending epoch block")
 }
 
 func validateHeaderFields(parent *types.Header, header *types.Header) error {

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -29,6 +29,7 @@ type blockBuilder interface {
 
 var (
 	errUptimeTxDoesNotExist = errors.New("uptime transaction is not found in the epoch ending block")
+	errUptimeTxNotExpected  = errors.New("didn't expect uptime transaction in a non ending epoch block")
 )
 
 type fsm struct {
@@ -520,7 +521,7 @@ func (f *fsm) verifyValidatorsUptimeTx(blockUptimeTx *types.Transaction) error {
 		return nil
 	}
 
-	return errors.New("didn't expect uptime transaction in a non ending epoch block")
+	return errUptimeTxNotExpected
 }
 
 func validateHeaderFields(parent *types.Header, header *types.Header) error {

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -406,6 +406,8 @@ func (f *fsm) VerifyStateTransactions(transactions []*types.Transaction) error {
 	}
 
 	if f.isEndOfEpoch && !uptimeTransactionExists {
+		// this is a check if uptime transaction is not in the list of transactions at all
+		// but it should be
 		return errUptimeTxDoesNotExist
 	}
 

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -82,13 +82,12 @@ func TestFSM_verifyValidatorsUptimeTx(t *testing.T) {
 	}
 	assert.ErrorContains(t, fsm.verifyValidatorsUptimeTx(alteredUptimeTx), "invalid uptime transaction")
 
-	fsm.isEndOfEpoch = false
 	// submit validators uptime transaction to the non-epoch ending block
+	fsm.isEndOfEpoch = false
 	uptimeTx, err = fsm.createValidatorsUptimeTx()
 	assert.NoError(t, err)
 	assert.NotNil(t, uptimeTx)
-	assert.ErrorContains(t, fsm.verifyValidatorsUptimeTx(uptimeTx),
-		"didn't expect uptime transaction in a non ending epoch block")
+	assert.ErrorContains(t, fsm.verifyValidatorsUptimeTx(uptimeTx), errUptimeTxNotExpected.Error())
 }
 
 func TestFSM_BuildProposal_WithoutUptimeTxGood(t *testing.T) {
@@ -443,7 +442,7 @@ func TestFSM_VerifyStateTransactions_MiddleOfEpochWithTransaction(t *testing.T) 
 	tx, err := fsm.createValidatorsUptimeTx()
 	assert.NoError(t, err)
 	err = fsm.VerifyStateTransactions([]*types.Transaction{tx})
-	assert.ErrorContains(t, err, "didn't expect uptime transaction in a non ending epoch block")
+	assert.ErrorContains(t, err, err.Error())
 }
 
 func TestFSM_VerifyStateTransactions_MiddleOfEpochWithoutTransaction(t *testing.T) {

--- a/consensus/polybft/state_transaction.go
+++ b/consensus/polybft/state_transaction.go
@@ -167,6 +167,9 @@ func decodeStateTransaction(txData []byte) (contractsapi.StateTransactionInput, 
 	if bytes.Equal(sig, contractsapi.StateReceiver.Abi.Methods["commit"].ID()) {
 		// bridge commitment
 		obj = &CommitmentMessageSigned{}
+	} else if bytes.Equal(sig, contractsapi.ChildValidatorSet.Abi.Methods["commitEpoch"].ID()) {
+		// uptime
+		obj = &contractsapi.CommitEpochFunction{}
 	} else {
 		return nil, fmt.Errorf("unknown state transaction")
 	}


### PR DESCRIPTION
# Description

This PR fixes the issue where a malicious node can include an `uptime` (`commitEpoch`) transaction in the middle of the epoch, causing the epoch to end abruptly.

Fix includes the check for `uptime` transaction no matter if it is not an epoch ending block.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually