### PR TITLE
EVM-453 Build proposal header's extra validators bug

### DIFF
--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -114,7 +114,7 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 	if f.config.IsBridgeEnabled() {
 		for _, tx := range f.stateTransactions() {
 			if err := f.blockBuilder.WriteTx(tx); err != nil {
-				return nil, fmt.Errorf("failed to commit state transaction. Error: %w", err)
+				return nil, fmt.Errorf("failed to apply state transaction. Error: %w", err)
 			}
 		}
 	}
@@ -138,17 +138,6 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 		extra.Validators = validatorsDelta
 		f.logger.Trace("[FSM Build Proposal]", "Validators Delta", validatorsDelta)
 	}
-
-	if f.config.IsBridgeEnabled() {
-		for _, tx := range f.stateTransactions() {
-			if err := f.blockBuilder.WriteTx(tx); err != nil {
-				return nil, fmt.Errorf("failed to apply state transaction. Error: %w", err)
-			}
-		}
-	}
-
-	// fill the block with transactions
-	f.blockBuilder.Fill()
 
 	currentValidatorsHash, err := f.validators.Accounts().Hash()
 	if err != nil {

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -109,7 +109,22 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 		if err := f.blockBuilder.WriteTx(tx); err != nil {
 			return nil, fmt.Errorf("failed to apply commit epoch transaction: %w", err)
 		}
+	}
 
+	if f.config.IsBridgeEnabled() {
+		for _, tx := range f.stateTransactions() {
+			if err := f.blockBuilder.WriteTx(tx); err != nil {
+				return nil, fmt.Errorf("failed to commit state transaction. Error: %w", err)
+			}
+		}
+	}
+
+	// fill the block with transactions
+	f.blockBuilder.Fill()
+
+	// update extra validators if needed, but only after all transactions has been written
+	// each transaction can update state and therefore change validators stake for example
+	if f.isEndOfEpoch {
 		nextValidators, err = f.getCurrentValidators(f.blockBuilder.GetState())
 		if err != nil {
 			return nil, err

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -406,6 +406,7 @@ func TestFSM_BuildProposal_EpochEndingBlock_FailToCreateValidatorsDelta(t *testi
 	blockBuilderMock.On("WriteTx", mock.Anything).Return(error(nil)).Once()
 	blockBuilderMock.On("GetState").Return(transition).Once()
 	blockBuilderMock.On("Reset").Return(error(nil)).Once()
+	blockBuilderMock.On("Fill").Once()
 
 	systemStateMock := new(systemStateMock)
 	systemStateMock.On("GetValidatorSet").Return(nil, errors.New("failed to get validators set")).Once()
@@ -430,7 +431,6 @@ func TestFSM_BuildProposal_EpochEndingBlock_FailToCreateValidatorsDelta(t *testi
 	assert.Nil(t, proposal)
 
 	blockBuilderMock.AssertNotCalled(t, "Build")
-	blockBuilderMock.AssertNotCalled(t, "Fill")
 	blockBuilderMock.AssertExpectations(t)
 	systemStateMock.AssertExpectations(t)
 	blockChainMock.AssertExpectations(t)


### PR DESCRIPTION
# Description

Build proposal should calculate next validators hash and populate it to header's extra data, only after all other transactions have been applied to the block.

There is a problem if block contains stake transaction (which changes stake of some of existing validators and essentially change validator set).
In that case, validator stake change will not take effect on proposer node itself, but it is going to take effect on validators (since they would calculate state differently, by taking into account stake transaction as well)

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually

