### PR TITLE
GetDelegatorReward fix

### DIFF
--- a/command/sidechain/helper.go
+++ b/command/sidechain/helper.go
@@ -90,7 +90,7 @@ func GetValidatorInfo(validatorAddr ethgo.Address, txRelayer txrelayer.TxRelayer
 // GetDelegatorReward queries delegator reward for given validator and delegator addresses
 func GetDelegatorReward(validatorAddr ethgo.Address, delegatorAddr ethgo.Address,
 	txRelayer txrelayer.TxRelayer) (*big.Int, error) {
-	input, err := contractsapi.ChildValidatorSet.Abi.Methods["getValidatorReward"].Encode(
+	input, err := contractsapi.ChildValidatorSet.Abi.Methods["getDelegatorReward"].Encode(
 		[]interface{}{validatorAddr, delegatorAddr})
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode input parameters for getDelegatorReward fn: %w", err)

--- a/e2e-polybft/consensus_test.go
+++ b/e2e-polybft/consensus_test.go
@@ -226,12 +226,14 @@ func TestE2E_Consensus_Delegation_Undelegation(t *testing.T) {
 	// wait for consensus to start
 	cluster.WaitForBlock(1, 10*time.Second)
 
+	// extract delegator's secrets
 	delegatorSecretsPath := path.Join(cluster.Config.TmpDir, delegatorSecrets)
 	delegatorAcc, err := sidechain.GetAccountFromDir(delegatorSecretsPath)
 	require.NoError(t, err)
 
 	delegatorAddr := delegatorAcc.Ecdsa.Address()
 
+	// extract validator's secrets
 	validatorSecretsPath := path.Join(cluster.Config.TmpDir, validatorSecrets)
 
 	validatorAcc, err := sidechain.GetAccountFromDir(validatorSecretsPath)
@@ -248,6 +250,7 @@ func TestE2E_Consensus_Delegation_Undelegation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(types.ReceiptSuccess), receipt.Status)
 
+	// getDelegatorInfo queries delegator's balance and its rewards
 	getDelegatorInfo := func() (balance *big.Int, reward *big.Int) {
 		currentBlockNum, err := srv.JSONRPC().Eth().BlockNumber()
 		require.NoError(t, err)
@@ -263,6 +266,7 @@ func TestE2E_Consensus_Delegation_Undelegation(t *testing.T) {
 		return
 	}
 
+	// assert that delegator received fund amount from validator
 	delegatorBalance, _ := getDelegatorInfo()
 	require.Equal(t, fundAmount, delegatorBalance)
 


### PR DESCRIPTION
# Description

This fix includes changes in `GetDelegatorReward` fn where `getValidatorReward` was wrongly called on `ChildValidatorSet` contract instead of `getDelegatorReward`. Also, it includes modifications in `TestE2E_Consensus_Delegation_Undelegation` where proper key (delegator's) is now used for sending delegate, undelegate and withdraw requests and some minor test improvements. 

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
