### PR TITLE
Message is not hashed before signature verification

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -814,7 +814,7 @@ func (c *consensusRuntime) BuildPrePrepareMessage(
 		},
 	}
 
-	message, err := c.config.Key.SignEcdsaMessage(&msg)
+	message, err := c.config.Key.SignIBFTMessage(&msg)
 	if err != nil {
 		c.logger.Error("Cannot sign message", "error", err)
 
@@ -837,7 +837,7 @@ func (c *consensusRuntime) BuildPrepareMessage(proposalHash []byte, view *proto.
 		},
 	}
 
-	message, err := c.config.Key.SignEcdsaMessage(&msg)
+	message, err := c.config.Key.SignIBFTMessage(&msg)
 	if err != nil {
 		c.logger.Error("Cannot sign message.", "error", err)
 
@@ -868,7 +868,7 @@ func (c *consensusRuntime) BuildCommitMessage(proposalHash []byte, view *proto.V
 		},
 	}
 
-	message, err := c.config.Key.SignEcdsaMessage(&msg)
+	message, err := c.config.Key.SignIBFTMessage(&msg)
 	if err != nil {
 		c.logger.Error("Cannot sign message", "Error", err)
 
@@ -895,7 +895,7 @@ func (c *consensusRuntime) BuildRoundChangeMessage(
 			}},
 	}
 
-	signedMsg, err := c.config.Key.SignEcdsaMessage(&msg)
+	signedMsg, err := c.config.Key.SignIBFTMessage(&msg)
 	if err != nil {
 		c.logger.Error("Cannot sign message", "Error", err)
 

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -608,112 +608,131 @@ func TestConsensusRuntime_validateVote_VoteSentFromUnknownValidator(t *testing.T
 		fmt.Sprintf("message is received from sender %s, which is not in current validator set", vote.From))
 }
 
-func TestConsensusRuntime_IsValidValidator(t *testing.T) {
+func TestConsensusRuntime_IsValidValidator_BasicCases(t *testing.T) {
+	t.Parallel()
+
+	setupFn := func(t *testing.T) (*consensusRuntime, *testValidators) {
+		t.Helper()
+
+		validatorAccounts := newTestValidatorsWithAliases([]string{"A", "B", "C", "D", "E", "F"})
+		epoch := &epochMetadata{
+			Validators: validatorAccounts.getPublicIdentities("A", "B", "C", "D"),
+		}
+		runtime := &consensusRuntime{
+			epoch:  epoch,
+			logger: hclog.NewNullLogger(),
+			fsm:    &fsm{validators: NewValidatorSet(epoch.Validators, hclog.NewNullLogger())},
+		}
+
+		return runtime, validatorAccounts
+	}
+
+	cases := []struct {
+		name          string
+		signerAlias   string
+		senderAlias   string
+		isValidSender bool
+	}{
+		{
+			name:          "Valid sender",
+			signerAlias:   "A",
+			senderAlias:   "A",
+			isValidSender: true,
+		},
+		{
+			name:          "Sender not amongst current validators",
+			signerAlias:   "F",
+			senderAlias:   "F",
+			isValidSender: false,
+		},
+		{
+			name:          "Sender and signer accounts mismatch",
+			signerAlias:   "A",
+			senderAlias:   "B",
+			isValidSender: false,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			runtime, validatorAccounts := setupFn(t)
+			signer := validatorAccounts.getValidator(c.signerAlias)
+			sender := validatorAccounts.getValidator(c.senderAlias)
+			msg, err := signer.Key().SignEcdsaMessage(&proto.Message{From: sender.Address().Bytes()})
+
+			require.NoError(t, err)
+			require.Equal(t, c.isValidSender, runtime.IsValidValidator(msg))
+		})
+	}
+}
+
+func TestConsensusRuntime_IsValidValidator_TamperSignature(t *testing.T) {
 	t.Parallel()
 
 	validatorAccounts := newTestValidatorsWithAliases([]string{"A", "B", "C", "D", "E", "F"})
-
-	extra := &Extra{}
-	block := &types.Header{
-		Number:    0,
-		ExtraData: append(make([]byte, ExtraVanity), extra.MarshalRLPTo(nil)...),
-	}
-
-	blockchainMock := new(blockchainMock)
-	blockchainMock.On("NewBlockBuilder", mock.Anything).Return(&BlockBuilder{}, nil).Once()
-
-	state := newTestState(t)
-	snapshot := NewProposerSnapshot(0, nil)
-	config := &runtimeConfig{
-		Key:           validatorAccounts.getValidator("B").Key(),
-		blockchain:    blockchainMock,
-		PolyBFTConfig: &PolyBFTConfig{SprintSize: 5},
+	epoch := &epochMetadata{
+		Validators: validatorAccounts.getPublicIdentities("A", "B", "C", "D"),
 	}
 	runtime := &consensusRuntime{
-		state:          state,
-		config:         config,
-		lastBuiltBlock: block,
-		epoch: &epochMetadata{
-			Number:     1,
-			Validators: validatorAccounts.getPublicIdentities()[:len(validatorAccounts.validators)-1],
-		},
-		logger:             hclog.NewNullLogger(),
-		proposerCalculator: NewProposerCalculatorFromSnapshot(snapshot, config, hclog.NewNullLogger()),
-		checkpointManager:  &dummyCheckpointManager{},
+		epoch:  epoch,
+		logger: hclog.NewNullLogger(),
+		fsm:    &fsm{validators: NewValidatorSet(epoch.Validators, hclog.NewNullLogger())},
 	}
 
-	require.NoError(t, runtime.FSM())
-
+	// provide invalid signature
 	sender := validatorAccounts.getValidator("A")
-	msg, err := sender.Key().SignEcdsaMessage(&proto.Message{
-		From: sender.Address().Bytes(),
-	})
-
-	require.NoError(t, err)
-
-	assert.True(t, runtime.IsValidValidator(msg))
-	blockchainMock.AssertExpectations(t)
-
-	// sender not in current epoch validators
-	sender = validatorAccounts.getValidator("F")
-	msg, err = sender.Key().SignEcdsaMessage(&proto.Message{
-		From: sender.Address().Bytes(),
-	})
-	require.NoError(t, err)
-
-	assert.False(t, runtime.IsValidValidator(msg))
-	blockchainMock.AssertExpectations(t)
-
-	// signature does not come from sender
-	sender = validatorAccounts.getValidator("A")
-	msg, err = sender.Key().SignEcdsaMessage(&proto.Message{
-		From: validatorAccounts.getValidator("B").Address().Bytes(),
-	})
-
-	require.NoError(t, err)
-
-	assert.False(t, runtime.IsValidValidator(msg))
-	blockchainMock.AssertExpectations(t)
-
-	// invalid signature
-	sender = validatorAccounts.getValidator("A")
-	msg = &proto.Message{
+	msg := &proto.Message{
 		From:      sender.Address().Bytes(),
-		Signature: []byte{1, 2},
+		Signature: []byte{1, 2, 3, 4, 5},
 	}
+	require.False(t, runtime.IsValidValidator(msg))
+}
 
-	assert.False(t, runtime.IsValidValidator(msg))
-	blockchainMock.AssertExpectations(t)
+func TestConsensusRuntime_TamperMessageContent(t *testing.T) {
+	t.Parallel()
 
-	// modified message after signing
+	validatorAccounts := newTestValidatorsWithAliases([]string{"A", "B", "C", "D", "E", "F"})
+	epoch := &epochMetadata{
+		Validators: validatorAccounts.getPublicIdentities("A", "B", "C", "D"),
+	}
+	runtime := &consensusRuntime{
+		epoch:  epoch,
+		logger: hclog.NewNullLogger(),
+		fsm:    &fsm{validators: NewValidatorSet(epoch.Validators, hclog.NewNullLogger())},
+	}
+	sender := validatorAccounts.getValidator("A")
 	proposalHash := []byte{2, 4, 6, 8, 10}
-	signature, err := sender.Key().Sign(proposalHash)
-	assert.NoError(t, err)
+	proposalSignature, err := sender.Key().Sign(proposalHash)
+	require.NoError(t, err)
 
-	msg = &proto.Message{
+	msg := &proto.Message{
 		View: &proto.View{},
 		From: sender.Address().Bytes(),
 		Type: proto.MessageType_COMMIT,
 		Payload: &proto.Message_CommitData{
 			CommitData: &proto.CommitMessage{
 				ProposalHash:  proposalHash,
-				CommittedSeal: signature,
+				CommittedSeal: proposalSignature,
 			},
 		},
 	}
-	// sign the message
+	// sign the message itself
 	msg, err = sender.Key().SignEcdsaMessage(msg)
 	assert.NoError(t, err)
 	// signature verification works
 	assert.True(t, runtime.IsValidValidator(msg))
 
-	// modified message
+	// modify message without signing it again
 	msg.Payload = &proto.Message_CommitData{
 		CommitData: &proto.CommitMessage{
 			ProposalHash:  []byte{1, 3, 5, 7, 9}, // modification
-			CommittedSeal: signature,
+			CommittedSeal: proposalSignature,
 		},
 	}
+	// signature isn't valid, because message was tampered
 	assert.False(t, runtime.IsValidValidator(msg))
 }
 

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -661,7 +661,7 @@ func TestConsensusRuntime_IsValidValidator_BasicCases(t *testing.T) {
 			runtime, validatorAccounts := setupFn(t)
 			signer := validatorAccounts.getValidator(c.signerAlias)
 			sender := validatorAccounts.getValidator(c.senderAlias)
-			msg, err := signer.Key().SignEcdsaMessage(&proto.Message{From: sender.Address().Bytes()})
+			msg, err := signer.Key().SignIBFTMessage(&proto.Message{From: sender.Address().Bytes()})
 
 			require.NoError(t, err)
 			require.Equal(t, c.isValidSender, runtime.IsValidValidator(msg))
@@ -720,7 +720,7 @@ func TestConsensusRuntime_TamperMessageContent(t *testing.T) {
 		},
 	}
 	// sign the message itself
-	msg, err = sender.Key().SignEcdsaMessage(msg)
+	msg, err = sender.Key().SignIBFTMessage(msg)
 	assert.NoError(t, err)
 	// signature verification works
 	assert.True(t, runtime.IsValidValidator(msg))
@@ -1000,7 +1000,7 @@ func TestConsensusRuntime_BuildRoundChangeMessage(t *testing.T) {
 		}},
 	}
 
-	signedMsg, err := key.SignEcdsaMessage(&expected)
+	signedMsg, err := key.SignIBFTMessage(&expected)
 	require.NoError(t, err)
 
 	assert.Equal(t, signedMsg, runtime.BuildRoundChangeMessage(proposal, certificate, view))
@@ -1033,7 +1033,7 @@ func TestConsensusRuntime_BuildCommitMessage(t *testing.T) {
 		},
 	}
 
-	signedMsg, err := key.SignEcdsaMessage(&expected)
+	signedMsg, err := key.SignIBFTMessage(&expected)
 	require.NoError(t, err)
 
 	assert.Equal(t, signedMsg, runtime.BuildCommitMessage(proposalHash, view))
@@ -1078,7 +1078,7 @@ func TestConsensusRuntime_BuildPrepareMessage(t *testing.T) {
 		},
 	}
 
-	signedMsg, err := key.SignEcdsaMessage(&expected)
+	signedMsg, err := key.SignIBFTMessage(&expected)
 	require.NoError(t, err)
 
 	assert.Equal(t, signedMsg, runtime.BuildPrepareMessage(proposalHash, view))

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -13,7 +13,6 @@ import (
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
-	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/state"
 	"github.com/0xPolygon/polygon-edge/types"
 	hcf "github.com/hashicorp/go-hclog"
@@ -337,7 +336,7 @@ func (f *fsm) ValidateSender(msg *proto.Message) error {
 		return err
 	}
 
-	signerAddress, err := wallet.RecoverAddressFromSignature(msg.Signature, crypto.Keccak256(msgNoSig))
+	signerAddress, err := wallet.RecoverAddressFromSignature(msg.Signature, msgNoSig)
 	if err != nil {
 		return fmt.Errorf("failed to recover address from signature: %w", err)
 	}

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -13,6 +13,7 @@ import (
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/state"
 	"github.com/0xPolygon/polygon-edge/types"
 	hcf "github.com/hashicorp/go-hclog"
@@ -336,7 +337,7 @@ func (f *fsm) ValidateSender(msg *proto.Message) error {
 		return err
 	}
 
-	signerAddress, err := wallet.RecoverAddressFromSignature(msg.Signature, msgNoSig)
+	signerAddress, err := wallet.RecoverAddressFromSignature(msg.Signature, crypto.Keccak256(msgNoSig))
 	if err != nil {
 		return fmt.Errorf("failed to recover address from signature: %w", err)
 	}

--- a/consensus/polybft/wallet/key.go
+++ b/consensus/polybft/wallet/key.go
@@ -44,7 +44,7 @@ func (k *Key) SignEcdsaMessage(msg *proto.Message) (*proto.Message, error) {
 		return nil, fmt.Errorf("cannot marshal message: %w", err)
 	}
 
-	if msg.Signature, err = k.raw.Ecdsa.Sign(raw); err != nil {
+	if msg.Signature, err = k.raw.Ecdsa.Sign(crypto.Keccak256(raw)); err != nil {
 		return nil, fmt.Errorf("cannot create message signature: %w", err)
 	}
 
@@ -52,8 +52,8 @@ func (k *Key) SignEcdsaMessage(msg *proto.Message) (*proto.Message, error) {
 }
 
 // RecoverAddressFromSignature recovers signer address from the given digest and signature
-func RecoverAddressFromSignature(sig, msg []byte) (types.Address, error) {
-	pub, err := crypto.RecoverPubkey(sig, msg)
+func RecoverAddressFromSignature(sig, digest []byte) (types.Address, error) {
+	pub, err := crypto.RecoverPubkey(sig, digest)
 	if err != nil {
 		return types.Address{}, fmt.Errorf("cannot recover address from signature: %w", err)
 	}

--- a/consensus/polybft/wallet/key.go
+++ b/consensus/polybft/wallet/key.go
@@ -54,9 +54,10 @@ func (k *Key) SignIBFTMessage(msg *proto.Message) (*proto.Message, error) {
 	return msg, nil
 }
 
-// RecoverAddressFromSignature recovers signer address from the given digest and signature
-func RecoverAddressFromSignature(sig, digest []byte) (types.Address, error) {
-	pub, err := crypto.RecoverPubkey(sig, digest)
+// RecoverAddressFromSignature calculates keccak256 hash of provided rawContent
+// and recovers signer address from given signature and hash
+func RecoverAddressFromSignature(sig, rawContent []byte) (types.Address, error) {
+	pub, err := crypto.RecoverPubkey(sig, crypto.Keccak256(rawContent))
 	if err != nil {
 		return types.Address{}, fmt.Errorf("cannot recover address from signature: %w", err)
 	}

--- a/consensus/polybft/wallet/key.go
+++ b/consensus/polybft/wallet/key.go
@@ -20,31 +20,34 @@ func NewKey(raw *Account) *Key {
 	}
 }
 
+// String returns hex encoded ECDSA address
 func (k *Key) String() string {
 	return k.raw.Ecdsa.Address().String()
 }
 
+// Address returns ECDSA address
 func (k *Key) Address() ethgo.Address {
 	return k.raw.Ecdsa.Address()
 }
 
-func (k *Key) Sign(b []byte) ([]byte, error) {
-	s, err := k.raw.Bls.Sign(b)
+// Sign signs the provided digest with BLS key
+func (k *Key) Sign(digest []byte) ([]byte, error) {
+	signature, err := k.raw.Bls.Sign(digest)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.Marshal()
+	return signature.Marshal()
 }
 
-// SignEcdsaMessage signs the proto message with ecdsa
-func (k *Key) SignEcdsaMessage(msg *proto.Message) (*proto.Message, error) {
-	raw, err := protobuf.Marshal(msg)
+// SignIBFTMessage signs the IBFT consensus message with ECDSA key
+func (k *Key) SignIBFTMessage(msg *proto.Message) (*proto.Message, error) {
+	msgRaw, err := protobuf.Marshal(msg)
 	if err != nil {
 		return nil, fmt.Errorf("cannot marshal message: %w", err)
 	}
 
-	if msg.Signature, err = k.raw.Ecdsa.Sign(crypto.Keccak256(raw)); err != nil {
+	if msg.Signature, err = k.raw.Ecdsa.Sign(crypto.Keccak256(msgRaw)); err != nil {
 		return nil, fmt.Errorf("cannot create message signature: %w", err)
 	}
 

--- a/consensus/polybft/wallet/key_test.go
+++ b/consensus/polybft/wallet/key_test.go
@@ -21,7 +21,7 @@ func Test_RecoverAddressFromSignature(t *testing.T) {
 			Payload: &proto.Message_CommitData{},
 		}
 
-		msg, err := key.SignEcdsaMessage(msgNoSig)
+		msg, err := key.SignIBFTMessage(msgNoSig)
 		require.NoError(t, err)
 
 		payload, err := msgNoSig.PayloadNoSig()

--- a/consensus/polybft/wallet/key_test.go
+++ b/consensus/polybft/wallet/key_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/0xPolygon/go-ibft/messages/proto"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
-	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,7 +26,7 @@ func Test_RecoverAddressFromSignature(t *testing.T) {
 		payload, err := msgNoSig.PayloadNoSig()
 		require.NoError(t, err)
 
-		address, err := RecoverAddressFromSignature(msg.Signature, crypto.Keccak256(payload))
+		address, err := RecoverAddressFromSignature(msg.Signature, payload)
 		require.NoError(t, err)
 		assert.Equal(t, key.Address().Bytes(), address.Bytes())
 	}

--- a/consensus/polybft/wallet/key_test.go
+++ b/consensus/polybft/wallet/key_test.go
@@ -5,11 +5,14 @@ import (
 
 	"github.com/0xPolygon/go-ibft/messages/proto"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
+	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_RecoverAddressFromSignature(t *testing.T) {
+	t.Parallel()
+
 	for _, account := range []*Account{GenerateAccount(), GenerateAccount(), GenerateAccount()} {
 		key := NewKey(account)
 		msgNoSig := &proto.Message{
@@ -24,13 +27,15 @@ func Test_RecoverAddressFromSignature(t *testing.T) {
 		payload, err := msgNoSig.PayloadNoSig()
 		require.NoError(t, err)
 
-		address, err := RecoverAddressFromSignature(msg.Signature, payload)
+		address, err := RecoverAddressFromSignature(msg.Signature, crypto.Keccak256(payload))
 		require.NoError(t, err)
 		assert.Equal(t, key.Address().Bytes(), address.Bytes())
 	}
 }
 
 func Test_Sign(t *testing.T) {
+	t.Parallel()
+
 	msg := []byte("some message")
 
 	for _, account := range []*Account{GenerateAccount(), GenerateAccount()} {
@@ -47,6 +52,8 @@ func Test_Sign(t *testing.T) {
 }
 
 func Test_String(t *testing.T) {
+	t.Parallel()
+
 	for _, account := range []*Account{GenerateAccount(), GenerateAccount(), GenerateAccount()} {
 		key := NewKey(account)
 		assert.Equal(t, key.Address().String(), key.String())


### PR DESCRIPTION
# Description

IBFT messages were not hashed prior to signing it and we were lacking hashing in opposite direction as well (namely when recovering public key from the signature and checking the message sender identity).
Before signing a message it is important to hash it because only the first 32 bytes are being verified and some tampered messages, larger than 32 bytes, could be recognized as valid.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually