### PR TITLE
Encapsulate signatures validation logic in `Extra`

### DIFF
--- a/consensus/polybft/extra.go
+++ b/consensus/polybft/extra.go
@@ -148,7 +148,7 @@ func (i *Extra) ValidateFinalizedHeader(header *types.Header, parent *types.Head
 	// validate committed signatures
 	blockNumber := header.Number
 	if i.Committed == nil {
-		return fmt.Errorf("failed to verify signatures for block %d because signatures are not present", blockNumber)
+		return fmt.Errorf("failed to verify signatures for block %d, because signatures are not present", blockNumber)
 	}
 
 	if i.Checkpoint == nil {
@@ -172,7 +172,7 @@ func (i *Extra) ValidateFinalizedHeader(header *types.Header, parent *types.Head
 
 	parentExtra, err := GetIbftExtra(parent.ExtraData)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to verify signatures for block %d: %w", blockNumber, err)
 	}
 
 	// validate parent signatures

--- a/consensus/polybft/extra.go
+++ b/consensus/polybft/extra.go
@@ -166,7 +166,7 @@ func (i *Extra) ValidateFinalizedHeader(header *types.Header, parent *types.Head
 	}
 
 	if err := i.Committed.Verify(validators, checkpointHash, logger); err != nil {
-		return fmt.Errorf("failed to verify signatures for block %d. Signed hash %v: %w",
+		return fmt.Errorf("failed to verify signatures for block %d (proposal hash %s): %w",
 			blockNumber, checkpointHash, err)
 	}
 
@@ -212,7 +212,7 @@ func (i *Extra) ValidateParentSignatures(blockNumber uint64, consensusBackend po
 	}
 
 	if err := i.Parent.Verify(parentValidators, parentCheckpointHash, logger); err != nil {
-		return fmt.Errorf("failed to verify signatures for parent of block %d. Signed hash: %s: %w",
+		return fmt.Errorf("failed to verify signatures for parent of block %d (proposal hash: %s): %w",
 			blockNumber, parentCheckpointHash, err)
 	}
 

--- a/consensus/polybft/extra.go
+++ b/consensus/polybft/extra.go
@@ -151,6 +151,10 @@ func (i *Extra) ValidateFinalizedHeader(header *types.Header, parent *types.Head
 		return fmt.Errorf("failed to verify signatures for block %d because signatures are not present", blockNumber)
 	}
 
+	if i.Checkpoint == nil {
+		return fmt.Errorf("failed to verify signatures for block %d, because checkpoint data are not present", blockNumber)
+	}
+
 	checkpointHash, err := i.Checkpoint.Hash(chainID, header.Number, header.Hash)
 	if err != nil {
 		return fmt.Errorf("failed to calculate proposal hash: %w", err)

--- a/consensus/polybft/extra.go
+++ b/consensus/polybft/extra.go
@@ -161,7 +161,7 @@ func (i *Extra) ValidateFinalizedHeader(header *types.Header, parent *types.Head
 		return fmt.Errorf("failed to validate header for block %d. could not retrieve block validators:%w", blockNumber, err)
 	}
 
-	if err := i.Committed.VerifyCommittedFields(validators, checkpointHash, logger); err != nil {
+	if err := i.Committed.Verify(validators, checkpointHash, logger); err != nil {
 		return fmt.Errorf("failed to verify signatures for block %d. Signed hash %v: %w",
 			blockNumber, checkpointHash, err)
 	}
@@ -207,7 +207,7 @@ func (i *Extra) ValidateParentSignatures(blockNumber uint64, consensusBackend po
 		return fmt.Errorf("failed to calculate parent proposal hash: %w", err)
 	}
 
-	if err := i.Parent.VerifyCommittedFields(parentValidators, parentCheckpointHash, logger); err != nil {
+	if err := i.Parent.Verify(parentValidators, parentCheckpointHash, logger); err != nil {
 		return fmt.Errorf("failed to verify signatures for parent of block %d. Signed hash: %s: %w",
 			blockNumber, parentCheckpointHash, err)
 	}
@@ -438,8 +438,8 @@ func (s *Signature) UnmarshalRLPWith(v *fastrlp.Value) error {
 	return nil
 }
 
-// VerifyCommittedFields is checking for consensus proof in the header
-func (s *Signature) VerifyCommittedFields(validators AccountSet, hash types.Hash, logger hclog.Logger) error {
+// Verify is checking for consensus proof in the header
+func (s *Signature) Verify(validators AccountSet, hash types.Hash, logger hclog.Logger) error {
 	signers, err := validators.GetFilteredValidators(s.Bitmap)
 	if err != nil {
 		return err

--- a/consensus/polybft/extra.go
+++ b/consensus/polybft/extra.go
@@ -142,8 +142,8 @@ func (i *Extra) UnmarshalRLPWith(v *fastrlp.Value) error {
 	return nil
 }
 
-// ValidateFinalizedHeader contains extra data validations for finalized headers
-func (i *Extra) ValidateFinalizedHeader(header *types.Header, parent *types.Header, parents []*types.Header,
+// ValidateFinalizedData contains extra data validations for finalized headers
+func (i *Extra) ValidateFinalizedData(header *types.Header, parent *types.Header, parents []*types.Header,
 	chainID uint64, consensusBackend polybftBackend, logger hclog.Logger) error {
 	// validate committed signatures
 	blockNumber := header.Number
@@ -155,6 +155,7 @@ func (i *Extra) ValidateFinalizedHeader(header *types.Header, parent *types.Head
 		return fmt.Errorf("failed to verify signatures for block %d, because checkpoint data are not present", blockNumber)
 	}
 
+	// validate current block signatures
 	checkpointHash, err := i.Checkpoint.Hash(chainID, header.Number, header.Hash)
 	if err != nil {
 		return fmt.Errorf("failed to calculate proposal hash: %w", err)
@@ -612,6 +613,7 @@ func (c *CheckpointData) ValidateBasic(parentCheckpoint *CheckpointData) error {
 }
 
 // Validate encapsulates validation logic for checkpoint data
+// (with regards to current and next epoch validators)
 func (c *CheckpointData) Validate(parentCheckpoint *CheckpointData,
 	currentValidators AccountSet, nextValidators AccountSet) error {
 	if err := c.ValidateBasic(parentCheckpoint); err != nil {

--- a/consensus/polybft/extra_test.go
+++ b/consensus/polybft/extra_test.go
@@ -222,7 +222,7 @@ func TestExtra_UnmarshalRLPWith_NegativeCases(t *testing.T) {
 	})
 }
 
-func TestSignature_VerifyCommittedFields(t *testing.T) {
+func TestSignature_Verify(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Valid signatures", func(t *testing.T) {
@@ -254,7 +254,7 @@ func TestSignature_VerifyCommittedFields(t *testing.T) {
 				Bitmap:              bitmap,
 			}
 
-			err = s.VerifyCommittedFields(validatorsMetadata, msgHash, hclog.NewNullLogger())
+			err = s.Verify(validatorsMetadata, msgHash, hclog.NewNullLogger())
 			signers[val.Address()] = struct{}{}
 
 			if !validatorSet.HasQuorum(signers) {
@@ -275,7 +275,7 @@ func TestSignature_VerifyCommittedFields(t *testing.T) {
 		bmp.Set(uint64(validatorSet.Len() + 1))
 		s := &Signature{Bitmap: bmp}
 
-		err := s.VerifyCommittedFields(validatorSet, types.Hash{0x1}, hclog.NewNullLogger())
+		err := s.Verify(validatorSet, types.Hash{0x1}, hclog.NewNullLogger())
 		require.Error(t, err)
 	})
 }
@@ -312,7 +312,7 @@ func TestSignature_UnmarshalRLPWith_NegativeCases(t *testing.T) {
 	})
 }
 
-func TestExtra_VerifyCommittedFieldsRandom(t *testing.T) {
+func TestSignature_VerifyRandom(t *testing.T) {
 	t.Parallel()
 
 	numValidators := 100
@@ -343,7 +343,7 @@ func TestExtra_VerifyCommittedFieldsRandom(t *testing.T) {
 		Bitmap:              bitmap,
 	}
 
-	err = s.VerifyCommittedFields(vals.getPublicIdentities(), msgHash, hclog.NewNullLogger())
+	err = s.Verify(vals.getPublicIdentities(), msgHash, hclog.NewNullLogger())
 	assert.NoError(t, err)
 }
 

--- a/consensus/polybft/extra_test.go
+++ b/consensus/polybft/extra_test.go
@@ -2,6 +2,8 @@ package polybft
 
 import (
 	"crypto/rand"
+	"errors"
+	"fmt"
 	"math/big"
 	mrand "math/rand"
 	"testing"
@@ -13,6 +15,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/umbracle/fastrlp"
 )
@@ -220,6 +223,70 @@ func TestExtra_UnmarshalRLPWith_NegativeCases(t *testing.T) {
 		extra := &Extra{}
 		require.Error(t, extra.UnmarshalRLPWith(extraMarshalled))
 	})
+}
+
+func TestExtra_ValidateFinalizedHeader_UnhappyPath(t *testing.T) {
+	t.Parallel()
+
+	const (
+		headerNum = 10
+		chainID   = uint64(20)
+	)
+
+	header := &types.Header{
+		Number: headerNum,
+		Hash:   types.BytesToHash(generateRandomBytes(t)),
+	}
+	parent := &types.Header{
+		Number: headerNum - 1,
+		Hash:   types.BytesToHash(generateRandomBytes(t)),
+	}
+
+	validators := newTestValidators(6)
+
+	polyBackendMock := new(polybftBackendMock)
+	polyBackendMock.On("GetValidators", mock.Anything, mock.Anything).Return(nil, errors.New("validators not found"))
+
+	// missing Committed field
+	extra := &Extra{}
+	err := extra.ValidateFinalizedHeader(header, parent, nil, chainID, nil, hclog.NewNullLogger())
+	require.ErrorContains(t, err, fmt.Sprintf("failed to verify signatures for block %d, because signatures are not present", headerNum))
+
+	// missing Checkpoint field
+	noQuorumSignature := createSignature(t, validators.getPrivateIdentities("0", "1"), types.BytesToHash([]byte("FooBar")))
+	extra = &Extra{Committed: noQuorumSignature}
+	err = extra.ValidateFinalizedHeader(header, parent, nil, chainID, polyBackendMock, hclog.NewNullLogger())
+	require.ErrorContains(t, err, fmt.Sprintf("failed to verify signatures for block %d, because checkpoint data are not present", headerNum))
+
+	// failed to retrieve validators from snapshot
+	checkpoint := &CheckpointData{
+		EpochNumber: 10,
+		BlockRound:  2,
+		EventRoot:   types.BytesToHash(generateRandomBytes(t)),
+	}
+	extra = &Extra{Committed: noQuorumSignature, Checkpoint: checkpoint}
+	err = extra.ValidateFinalizedHeader(header, parent, nil, chainID, polyBackendMock, hclog.NewNullLogger())
+	require.ErrorContains(t, err,
+		fmt.Sprintf("failed to validate header for block %d. could not retrieve block validators:validators not found", headerNum))
+
+	// failed to verify signatures (quorum not reached)
+	polyBackendMock = new(polybftBackendMock)
+	polyBackendMock.On("GetValidators", mock.Anything, mock.Anything).Return(validators.getPublicIdentities())
+
+	checkpointHash, err := checkpoint.Hash(chainID, headerNum, header.Hash)
+	require.NoError(t, err)
+
+	err = extra.ValidateFinalizedHeader(header, parent, nil, chainID, polyBackendMock, hclog.NewNullLogger())
+	require.ErrorContains(t, err,
+		fmt.Sprintf("failed to verify signatures for block %d (proposal hash %s): quorum not reached", headerNum, checkpointHash))
+
+	// incorrect parent extra size
+	validSignature := createSignature(t, validators.getPrivateIdentities(), checkpointHash)
+	extra = &Extra{Committed: validSignature, Checkpoint: checkpoint}
+	err = extra.ValidateFinalizedHeader(header, parent, nil, chainID, polyBackendMock, hclog.NewNullLogger())
+	t.Logf(err.Error())
+	require.ErrorContains(t, err,
+		fmt.Sprintf("failed to verify signatures for block %d: wrong extra size: 0", headerNum))
 }
 
 func TestSignature_Verify(t *testing.T) {
@@ -779,4 +846,32 @@ func TestCheckpointData_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCheckpointData_Copy(t *testing.T) {
+	t.Parallel()
+
+	validatorAccs := newTestValidators(5)
+	currentValidatorsHash, err := validatorAccs.getPublicIdentities("0", "1", "2").Hash()
+	require.NoError(t, err)
+
+	nextValidatorsHash, err := validatorAccs.getPublicIdentities("1", "3", "4").Hash()
+	require.NoError(t, err)
+
+	eventRoot := generateRandomBytes(t)
+	original := &CheckpointData{
+		BlockRound:            1,
+		EpochNumber:           5,
+		CurrentValidatorsHash: currentValidatorsHash,
+		NextValidatorsHash:    nextValidatorsHash,
+		EventRoot:             types.BytesToHash(eventRoot),
+	}
+
+	copied := original.Copy()
+	require.Equal(t, original, copied)
+	require.NotSame(t, original, copied)
+
+	// alter arbitrary field on copied instance
+	copied.BlockRound = 10
+	require.NotEqual(t, original.BlockRound, copied.BlockRound)
 }

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -262,6 +262,14 @@ func (f *fsm) Validate(proposal []byte) error {
 		return err
 	}
 
+	if extra.Checkpoint == nil {
+		return fmt.Errorf("checkpoint data for block %d is missing", block.Number())
+	}
+
+	if parentExtra.Checkpoint == nil {
+		return fmt.Errorf("checkpoint data for parent block %d is missing", f.parent.Number)
+	}
+
 	if err := extra.ValidateParentSignatures(block.Number(), f.polybftBackend, nil, f.parent, parentExtra,
 		f.backend.GetChainID(), f.logger); err != nil {
 		return err
@@ -279,14 +287,6 @@ func (f *fsm) Validate(proposal []byte) error {
 			if nextValidators, err = f.getCurrentValidators(transition); err != nil {
 				return err
 			}
-		}
-
-		if extra.Checkpoint == nil {
-			return fmt.Errorf("checkpoint data for block %d is missing", block.Number())
-		}
-
-		if parentExtra.Checkpoint == nil {
-			return fmt.Errorf("checkpoint data for parent block %d is missing", f.parent.Number)
 		}
 
 		return extra.Checkpoint.Validate(parentExtra.Checkpoint, currentValidators, nextValidators)

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -252,13 +252,18 @@ func (f *fsm) Validate(proposal []byte) error {
 		)
 	}
 
-	currentExtra, err := GetIbftExtra(block.Header.ExtraData)
+	extra, err := GetIbftExtra(block.Header.ExtraData)
 	if err != nil {
 		return fmt.Errorf("cannot get extra data:%w", err)
 	}
 
 	parentExtra, err := GetIbftExtra(f.parent.ExtraData)
 	if err != nil {
+		return err
+	}
+
+	if err := extra.ValidateParentSignatures(block.Number(), f.polybftBackend, nil, f.parent, parentExtra,
+		f.backend.GetChainID(), f.logger); err != nil {
 		return err
 	}
 
@@ -276,39 +281,27 @@ func (f *fsm) Validate(proposal []byte) error {
 			}
 		}
 
-		return currentExtra.Validate(parentExtra, currentValidators, nextValidators)
+		if extra.Checkpoint == nil {
+			return fmt.Errorf("checkpoint data for block %d is missing", block.Number())
+		}
+
+		if parentExtra.Checkpoint == nil {
+			return fmt.Errorf("checkpoint data for parent block %d is missing", f.parent.Number)
+		}
+
+		return extra.Checkpoint.Validate(parentExtra.Checkpoint, currentValidators, nextValidators)
+	}
+
+	if f.logger.IsTrace() && block.Number() > 1 {
+		validators, err := f.polybftBackend.GetValidators(block.Number()-2, nil)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve validators:%w", err)
+		}
+
+		f.logger.Trace("[FSM Validate]", "Block", block.Number(), "parent validators", validators)
 	}
 
 	// TODO: Validate validator set delta?
-
-	// TODO: Move signature validation logic to Extra
-	blockNumber := block.Number()
-	if blockNumber > 1 {
-		// verify parent signature
-		// We skip block 0 (genesis) and block 1 (parent is genesis)
-		// since those blocks do not include any parent information with signatures
-		validators, err := f.polybftBackend.GetValidators(blockNumber-2, nil)
-		if err != nil {
-			return fmt.Errorf("cannot get validators:%w", err)
-		}
-
-		f.logger.Trace("[FSM Validate]", "Block", blockNumber, "parent validators", validators)
-
-		parentCheckpointHash, err := parentExtra.Checkpoint.Hash(f.backend.GetChainID(), f.parent.Number, f.parent.Hash)
-		if err != nil {
-			return fmt.Errorf("failed to calculate parent proposal hash: %w", err)
-		}
-
-		if err := currentExtra.Parent.VerifyCommittedFields(validators, parentCheckpointHash, f.logger); err != nil {
-			return fmt.Errorf(
-				"failed to verify signatures for (parent) block#%d, parent signed hash: %v, current block#%d: %w",
-				f.parent.Number,
-				parentCheckpointHash,
-				blockNumber,
-				err,
-			)
-		}
-	}
 
 	stateBlock, err := f.backend.ProcessBlock(f.parent, &block, validateExtraData)
 	if err != nil {
@@ -316,7 +309,7 @@ func (f *fsm) Validate(proposal []byte) error {
 	}
 
 	if f.logger.IsDebug() {
-		checkpointHash, err := currentExtra.Checkpoint.Hash(f.backend.GetChainID(), block.Number(), block.Hash())
+		checkpointHash, err := extra.Checkpoint.Hash(f.backend.GetChainID(), block.Number(), block.Hash())
 		if err != nil {
 			return fmt.Errorf("failed to calculate proposal hash: %w", err)
 		}

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -1208,6 +1208,9 @@ func TestFSM_Validate_FailToVerifySignatures(t *testing.T) {
 	polybftBackendMock := new(polybftBackendMock)
 	polybftBackendMock.On("GetValidators", mock.Anything, mock.Anything).Return(validatorsMetadata, nil).Once()
 
+	blockchain := new(blockchainMock)
+	blockchain.On("ProcessBlock")
+
 	validatorSet := NewValidatorSet(validatorsMetadata, hclog.NewNullLogger())
 
 	fsm := &fsm{

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -1208,9 +1208,6 @@ func TestFSM_Validate_FailToVerifySignatures(t *testing.T) {
 	polybftBackendMock := new(polybftBackendMock)
 	polybftBackendMock.On("GetValidators", mock.Anything, mock.Anything).Return(validatorsMetadata, nil).Once()
 
-	blockchain := new(blockchainMock)
-	blockchain.On("ProcessBlock")
-
 	validatorSet := NewValidatorSet(validatorsMetadata, hclog.NewNullLogger())
 
 	fsm := &fsm{

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -422,7 +422,7 @@ func (p *Polybft) verifyHeaderImpl(parent, header *types.Header, parents []*type
 	}
 
 	// validate extra data
-	return extra.ValidateBasic(header, parent, parents, p.blockchain.GetChainID(), p, p.logger)
+	return extra.ValidateFinalizedHeader(header, parent, parents, p.blockchain.GetChainID(), p, p.logger)
 }
 
 func (p *Polybft) GetValidators(blockNumber uint64, parents []*types.Header) (AccountSet, error) {

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -422,7 +422,7 @@ func (p *Polybft) verifyHeaderImpl(parent, header *types.Header, parents []*type
 	}
 
 	// validate extra data
-	return extra.ValidateFinalizedHeader(header, parent, parents, p.blockchain.GetChainID(), p, p.logger)
+	return extra.ValidateFinalizedData(header, parent, parents, p.blockchain.GetChainID(), p, p.logger)
 }
 
 func (p *Polybft) GetValidators(blockNumber uint64, parents []*types.Header) (AccountSet, error) {


### PR DESCRIPTION
# Description

This PR encapsulates signatures validation logic in a single place. Prior to this, we were having almost the same logic for `ParentSignature` validation spread to `fsm` and `polybft`. This way `Extra` is more encapsulated and it contains validation logic of its own state.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually