### PR TITLE
Add unhappy path tests for verify signature

### DIFF
--- a/consensus/polybft/signer/signature_test.go
+++ b/consensus/polybft/signer/signature_test.go
@@ -2,6 +2,7 @@ package bls
 
 import (
 	"crypto/rand"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -65,10 +66,12 @@ func Test_VerifySignature_NegativeCases(t *testing.T) {
 		t.Parallel()
 
 		sigCopy := signature
-		for i := 0; i < len(validTestMsg); i++ {
-			sigCopy.g1.Add(sigCopy.g1, sigCopy.g1) // change signature
-			require.False(t, sigCopy.Verify(blsKey.PublicKey(), validTestMsg))
-		}
+		sigCopy.g1.Add(sigCopy.g1, sigCopy.g1) // change signature
+		require.False(t, sigCopy.Verify(blsKey.PublicKey(), validTestMsg))
+
+		sigCopy = signature
+		sigCopy.g1.ScalarMult(sigCopy.g1, big.NewInt(2)) // change signature
+		require.False(t, sigCopy.Verify(blsKey.PublicKey(), validTestMsg))
 	})
 }
 

--- a/consensus/polybft/signer/signature_test.go
+++ b/consensus/polybft/signer/signature_test.go
@@ -85,11 +85,18 @@ func Test_VerifySignature_NegativeCases(t *testing.T) {
 			x, randomG1, err := bn256.RandomG1(rand.Reader)
 			require.NoError(t, err)
 
-			sigCopy := signature
+			raw, err := signature.Marshal()
+			require.NoError(t, err)
+
+			sigCopy, err := UnmarshalSignature(raw)
+			require.NoError(t, err)
+
 			sigCopy.g1.Add(sigCopy.g1, randomG1) // change signature
 			require.False(t, sigCopy.Verify(blsKey.PublicKey(), validTestMsg))
 
-			sigCopy = signature
+			sigCopy, err = UnmarshalSignature(raw)
+			require.NoError(t, err)
+
 			sigCopy.g1.ScalarMult(sigCopy.g1, x) // change signature
 			require.False(t, sigCopy.Verify(blsKey.PublicKey(), validTestMsg))
 		}

--- a/consensus/polybft/signer/signature_test.go
+++ b/consensus/polybft/signer/signature_test.go
@@ -26,6 +26,42 @@ func Test_VerifySignature(t *testing.T) {
 	assert.False(t, signature.Verify(blsKey.PublicKey(), invalidTestMsg))
 }
 
+func Test_VerifySignature_InvalidMessage(t *testing.T) {
+	t.Parallel()
+
+	validTestMsg := testGenRandomBytes(t, 32)
+
+	blsKey, _ := GenerateBlsKey()
+	signature, err := blsKey.Sign(validTestMsg)
+	require.NoError(t, err)
+
+	assert.True(t, signature.Verify(blsKey.PublicKey(), validTestMsg))
+
+	for i := 0; i < len(validTestMsg); i++ {
+		b := validTestMsg[i]
+		validTestMsg[i] = b + 1
+
+		assert.False(t, signature.Verify(blsKey.PublicKey(), validTestMsg))
+		validTestMsg[i] = b
+	}
+}
+
+func Test_VerifySignature_InvalidSignature(t *testing.T) {
+	t.Parallel()
+
+	validTestMsg := testGenRandomBytes(t, 32)
+
+	blsKey, _ := GenerateBlsKey()
+	signature, err := blsKey.Sign(validTestMsg)
+	require.NoError(t, err)
+
+	assert.True(t, signature.Verify(blsKey.PublicKey(), validTestMsg))
+
+	signature.g1.Add(signature.g1, signature.g1) // change signature
+
+	assert.False(t, signature.Verify(blsKey.PublicKey(), validTestMsg))
+}
+
 func Test_AggregatedSignatureSimple(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# Description

Added negative test cases for verifying `bls` signatures:
- change signed message and see that verify fails
- change signature and see that verify fails
- change public key and see that verify fails

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually