### PR TITLE
Next validator hashes don't match in register validator e2e test

### DIFF
--- a/e2e-polybft/consensus_test.go
+++ b/e2e-polybft/consensus_test.go
@@ -144,8 +144,10 @@ func TestE2E_Consensus_RegisterValidator(t *testing.T) {
 	// register new validator
 	require.NoError(t, srv.RegisterValidator(newValidatorSecrets, newValidatorBalanceRaw, newValidatorStakeRaw))
 
-	// start new validator
-	cluster.InitTestServer(t, 6, true, false)
+	go func() {
+		// start new validator
+		cluster.InitTestServer(t, 6, true, false)
+	}()
 
 	validators := polybft.AccountSet{}
 	// assert that new validator is among validator set


### PR DESCRIPTION
# Description

This PR simplifies register validator e2e test and makes sure we query for the `NextValidatorsHash` on epoch ending block by removing unnecessary waiting for blocks and just relying check whether new validator is part of validator set.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
