### PR TITLE
Execute block in `fsm.Insert` if cached block is undefined or mismatch detected

### DIFF
--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -435,14 +435,9 @@ func (f *fsm) Insert(proposal []byte, committedSeals []*messages.CommittedSeal) 
 	}
 
 	if newBlock == nil || newBlock.Block.Hash() != proposedBlock.Hash() {
-		f.logger.Warn("insert block: cached block is either undefined or hashes don't match. Executing retrieved proposal...")
-		// execute block
-		finalBlock, err := f.backend.ProcessBlock(f.parent, &proposedBlock, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to execute block %d: %w", proposedBlock.Number(), err)
-		}
-
-		newBlock = finalBlock
+		// if this is the case, we will let syncer insert the block
+		return nil, errors.New(`failed to insert proposal, because the validated proposal is either nil 
+		or it does not match the received one`)
 	}
 
 	// In this function we should try to return little to no errors since

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -436,8 +436,8 @@ func (f *fsm) Insert(proposal []byte, committedSeals []*messages.CommittedSeal) 
 
 	if newBlock == nil || newBlock.Block.Hash() != proposedBlock.Hash() {
 		// if this is the case, we will let syncer insert the block
-		return nil, errors.New(`failed to insert proposal, because the validated proposal is either nil 
-		or it does not match the received one`)
+		return nil, errors.New("failed to insert proposal, because the validated proposal is either nil 
+		or it does not match the received one")
 	}
 
 	// In this function we should try to return little to no errors since

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -31,6 +31,8 @@ var (
 	errCommitEpochTxDoesNotExist   = errors.New("commit epoch transaction is not found in the epoch ending block")
 	errCommitEpochTxNotExpected    = errors.New("didn't expect commit epoch transaction in a non epoch ending block")
 	errCommitEpochTxSingleExpected = errors.New("only one commit epoch transaction is allowed in an epoch ending block")
+	errProposalDontMatch           = errors.New("failed to insert proposal, because the validated proposal " +
+		"is either nil or it does not match the received one")
 )
 
 type fsm struct {
@@ -436,8 +438,7 @@ func (f *fsm) Insert(proposal []byte, committedSeals []*messages.CommittedSeal) 
 
 	if newBlock == nil || newBlock.Block.Hash() != proposedBlock.Hash() {
 		// if this is the case, we will let syncer insert the block
-		return nil, errors.New("failed to insert proposal, because the validated proposal is either nil 
-		or it does not match the received one")
+		return nil, errProposalDontMatch
 	}
 
 	// In this function we should try to return little to no errors since

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -849,59 +849,79 @@ func TestFSM_Insert_Good(t *testing.T) {
 		signaturesCount   = 3
 	)
 
-	validators := newTestValidators(accountCount)
-	allAccounts := validators.getPrivateIdentities()
-	validatorsMetadata := validators.getPublicIdentities()
+	setupFn := func() (*fsm, []*messages.CommittedSeal, *types.FullBlock, *blockchainMock) {
+		validators := newTestValidators(accountCount)
+		allAccounts := validators.getPrivateIdentities()
+		validatorsMetadata := validators.getPublicIdentities()
 
-	extraParent := createTestExtra(validatorsMetadata, AccountSet{}, len(allAccounts)-1, signaturesCount, signaturesCount)
-	parent := &types.Header{Number: parentBlockNumber, ExtraData: extraParent}
-	extraBlock := createTestExtra(validatorsMetadata, AccountSet{}, len(allAccounts)-1, signaturesCount, signaturesCount)
-	finalBlock := consensus.BuildBlock(consensus.BuildBlockParams{
-		Header: &types.Header{Number: parentBlockNumber + 1, ParentHash: parent.Hash, ExtraData: extraBlock},
+		extraParent := createTestExtra(validatorsMetadata, AccountSet{}, len(allAccounts)-1, signaturesCount, signaturesCount)
+		parent := &types.Header{Number: parentBlockNumber, ExtraData: extraParent}
+		extraBlock := createTestExtra(validatorsMetadata, AccountSet{}, len(allAccounts)-1, signaturesCount, signaturesCount)
+		block := consensus.BuildBlock(
+			consensus.BuildBlockParams{
+				Header: &types.Header{Number: parentBlockNumber + 1, ParentHash: parent.Hash, ExtraData: extraBlock},
+			})
+
+		builtBlock := &types.FullBlock{Block: block}
+
+		builderMock := newBlockBuilderMock(builtBlock)
+		chainMock := &blockchainMock{}
+		chainMock.On("CommitBlock", mock.Anything).Return(error(nil)).Once()
+		chainMock.On("ProcessBlock", mock.Anything, mock.Anything, mock.Anything).
+			Return(builtBlock, error(nil)).
+			Maybe()
+
+		f := &fsm{
+			parent:       parent,
+			blockBuilder: builderMock,
+			config:       &PolyBFTConfig{},
+			target:       builtBlock,
+			backend:      chainMock,
+			validators:   NewValidatorSet(validatorsMetadata[0:len(validatorsMetadata)-1], hclog.NewNullLogger()),
+			logger:       hclog.NewNullLogger(),
+		}
+
+		seals := make([]*messages.CommittedSeal, signaturesCount)
+
+		for i := 0; i < signaturesCount; i++ {
+			sign, err := allAccounts[i].Bls.Sign(builtBlock.Block.Hash().Bytes(), bls.DomainValidatorSet)
+			require.NoError(t, err)
+			sigRaw, err := sign.Marshal()
+			require.NoError(t, err)
+
+			seals[i] = &messages.CommittedSeal{
+				Signer:    validatorsMetadata[i].Address.Bytes(),
+				Signature: sigRaw,
+			}
+		}
+
+		return f, seals, builtBlock, chainMock
+	}
+
+	t.Run("Insert with target block defined", func(t *testing.T) {
+		t.Parallel()
+
+		fsm, seals, builtBlock, chainMock := setupFn()
+		proposal := builtBlock.Block.MarshalRLP()
+		fullBlock, err := fsm.Insert(proposal, seals)
+
+		require.NoError(t, err)
+		require.Equal(t, parentBlockNumber+1, fullBlock.Block.Number())
+		chainMock.AssertExpectations(t)
 	})
 
-	buildBlock := &types.FullBlock{Block: finalBlock}
-	mBlockBuilder := newBlockBuilderMock(buildBlock)
-	mBackendMock := &blockchainMock{}
-	mBackendMock.On("CommitBlock", mock.MatchedBy(func(i interface{}) bool {
-		stateBlock, ok := i.(*types.FullBlock)
-		require.True(t, ok)
+	t.Run("Insert with target block undefined", func(t *testing.T) {
+		t.Parallel()
 
-		return stateBlock.Block.Number() == buildBlock.Block.Number() && stateBlock.Block.Hash() == buildBlock.Block.Hash()
-	})).Return(error(nil)).Once()
+		fsm, seals, builtBlock, chainMock := setupFn()
+		fsm.target = nil
+		proposal := builtBlock.Block.MarshalRLP()
+		fullBlock, err := fsm.Insert(proposal, seals)
 
-	validatorSet := NewValidatorSet(validatorsMetadata[0:len(validatorsMetadata)-1], hclog.NewNullLogger())
-
-	fsm := &fsm{parent: parent,
-		blockBuilder: mBlockBuilder,
-		config:       &PolyBFTConfig{},
-		backend:      mBackendMock,
-		validators:   validatorSet,
-	}
-
-	var commitedSeals []*messages.CommittedSeal
-
-	for i := 0; i < signaturesCount; i++ {
-		sign, err := allAccounts[i].Bls.Sign(buildBlock.Block.Hash().Bytes(), bls.DomainValidatorSet)
-		assert.NoError(t, err)
-		sigRaw, err := sign.Marshal()
-		assert.NoError(t, err)
-
-		commitedSeals = append(commitedSeals, &messages.CommittedSeal{
-			Signer:    validatorsMetadata[i].Address.Bytes(),
-			Signature: sigRaw,
-		})
-	}
-
-	proposal := buildBlock.Block.MarshalRLP()
-
-	fsm.target = buildBlock
-
-	fullBlock, err := fsm.Insert(proposal, commitedSeals)
-
-	require.NoError(t, err)
-	mBackendMock.AssertExpectations(t)
-	assert.Equal(t, parentBlockNumber+1, fullBlock.Block.Number())
+		require.NoError(t, err)
+		require.Equal(t, parentBlockNumber+1, fullBlock.Block.Number())
+		chainMock.AssertExpectations(t)
+	})
 }
 
 func TestFSM_Insert_InvalidNode(t *testing.T) {

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -918,7 +918,7 @@ func TestFSM_Insert_Good(t *testing.T) {
 		proposal := builtBlock.Block.MarshalRLP()
 		_, err := fsm.Insert(proposal, seals)
 
-		require.ErrorContains(t, err, "validated proposal is either nil")
+		require.ErrorIs(t, err, errProposalDontMatch)
 	})
 
 	t.Run("Insert with target block hash not match", func(t *testing.T) {
@@ -930,7 +930,7 @@ func TestFSM_Insert_Good(t *testing.T) {
 		fsm.target.Block.Header.Hash = types.BytesToHash(generateRandomBytes(t))
 		_, err := fsm.Insert(proposal, seals)
 
-		require.ErrorContains(t, err, "does not match the received one")
+		require.ErrorIs(t, err, errProposalDontMatch)
 	})
 }
 


### PR DESCRIPTION
# Description

This PR fixes a situation when a `FullBlock` cached in the fsm, during `Validate` function execution remains undefined. It can happen in case any of the validations fail and `Validate` function doesn't get fully executed, due to some data invalidity.

The solution proposal consists of detecting two scenarios:
1. a cached proposal that we verified is undefined
2. a hash of the cached proposal that was verified doesn't match the hash of the received proposal via `Insert` function invocation.
In any of these two scenarios, an error is returned, and we let the syncer insert the block, just to make sure we don't have any unwanted errors and inconsistencies in our data. 

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
