### PR TITLE
EVM-352 Event tracker block finalization

### DIFF
--- a/command/server/config/config.go
+++ b/command/server/config/config.go
@@ -79,7 +79,7 @@ const (
 	// requests with fromBlock/toBlock values (e.g. eth_getLogs)
 	DefaultJSONRPCBlockRangeLimit uint64 = 1000
 
-	// after how many blocks we consider block is finalized, default value
+	// DefaultBlockFinalityDepth minimal number of child blocks required for the parent block to be considered final
 	DefaultBlockFinalityDepth uint64 = 100
 )
 

--- a/command/server/config/config.go
+++ b/command/server/config/config.go
@@ -80,7 +80,8 @@ const (
 	DefaultJSONRPCBlockRangeLimit uint64 = 1000
 
 	// DefaultBlockFinalityDepth minimal number of child blocks required for the parent block to be considered final
-	DefaultBlockFinalityDepth uint64 = 100
+	// on ethereum epoch lasts for 32 blocks. more details: https://www.alchemy.com/overviews/ethereum-commitment-levels
+	DefaultBlockFinalityDepth uint64 = 64
 )
 
 // DefaultConfig returns the default server configuration

--- a/command/server/config/config.go
+++ b/command/server/config/config.go
@@ -31,7 +31,9 @@ type Config struct {
 	JSONRPCBatchRequestLimit uint64     `json:"json_rpc_batch_request_limit" yaml:"json_rpc_batch_request_limit"`
 	JSONRPCBlockRangeLimit   uint64     `json:"json_rpc_block_range_limit" yaml:"json_rpc_block_range_limit"`
 	JSONLogFormat            bool       `json:"json_log_format" yaml:"json_log_format"`
-	Relayer                  bool       `json:"relayer" yaml:"relayer"`
+
+	Relayer                 bool   `json:"relayer" yaml:"relayer"`
+	BlockFinalizedThreshold uint64 `json:"block_finalized_threshold" yaml:"block_finalized_threshold"`
 }
 
 // Telemetry holds the config details for metric services.
@@ -76,6 +78,9 @@ const (
 	// DefaultJSONRPCBlockRangeLimit maximum block range allowed for json_rpc
 	// requests with fromBlock/toBlock values (e.g. eth_getLogs)
 	DefaultJSONRPCBlockRangeLimit uint64 = 1000
+
+	// after how many blocks we consider block is finalized, default value
+	DefaultBlockFinalizedThreshold uint64 = 100
 )
 
 // DefaultConfig returns the default server configuration
@@ -113,6 +118,7 @@ func DefaultConfig() *Config {
 		JSONRPCBatchRequestLimit: DefaultJSONRPCBatchRequestLimit,
 		JSONRPCBlockRangeLimit:   DefaultJSONRPCBlockRangeLimit,
 		Relayer:                  false,
+		BlockFinalizedThreshold:  DefaultBlockFinalizedThreshold,
 	}
 }
 

--- a/command/server/config/config.go
+++ b/command/server/config/config.go
@@ -32,8 +32,8 @@ type Config struct {
 	JSONRPCBlockRangeLimit   uint64     `json:"json_rpc_block_range_limit" yaml:"json_rpc_block_range_limit"`
 	JSONLogFormat            bool       `json:"json_log_format" yaml:"json_log_format"`
 
-	Relayer            bool   `json:"relayer" yaml:"relayer"`
-	BlockFinalityDepth uint64 `json:"block_finality_depth" yaml:"block_finality_depth"`
+	Relayer               bool   `json:"relayer" yaml:"relayer"`
+	NumBlockConfirmations uint64 `json:"num_block_confirmations" yaml:"num_block_confirmations"`
 }
 
 // Telemetry holds the config details for metric services.
@@ -79,9 +79,9 @@ const (
 	// requests with fromBlock/toBlock values (e.g. eth_getLogs)
 	DefaultJSONRPCBlockRangeLimit uint64 = 1000
 
-	// DefaultBlockFinalityDepth minimal number of child blocks required for the parent block to be considered final
+	// DefaultNumBlockConfirmations minimal number of child blocks required for the parent block to be considered final
 	// on ethereum epoch lasts for 32 blocks. more details: https://www.alchemy.com/overviews/ethereum-commitment-levels
-	DefaultBlockFinalityDepth uint64 = 64
+	DefaultNumBlockConfirmations uint64 = 64
 )
 
 // DefaultConfig returns the default server configuration
@@ -119,7 +119,7 @@ func DefaultConfig() *Config {
 		JSONRPCBatchRequestLimit: DefaultJSONRPCBatchRequestLimit,
 		JSONRPCBlockRangeLimit:   DefaultJSONRPCBlockRangeLimit,
 		Relayer:                  false,
-		BlockFinalityDepth:       DefaultBlockFinalityDepth,
+		NumBlockConfirmations:    DefaultNumBlockConfirmations,
 	}
 }
 

--- a/command/server/config/config.go
+++ b/command/server/config/config.go
@@ -32,8 +32,8 @@ type Config struct {
 	JSONRPCBlockRangeLimit   uint64     `json:"json_rpc_block_range_limit" yaml:"json_rpc_block_range_limit"`
 	JSONLogFormat            bool       `json:"json_log_format" yaml:"json_log_format"`
 
-	Relayer                 bool   `json:"relayer" yaml:"relayer"`
-	BlockFinalizedThreshold uint64 `json:"block_finalized_threshold" yaml:"block_finalized_threshold"`
+	Relayer            bool   `json:"relayer" yaml:"relayer"`
+	BlockFinalityDepth uint64 `json:"block_finality_depth" yaml:"block_finality_depth"`
 }
 
 // Telemetry holds the config details for metric services.
@@ -80,7 +80,7 @@ const (
 	DefaultJSONRPCBlockRangeLimit uint64 = 1000
 
 	// after how many blocks we consider block is finalized, default value
-	DefaultBlockFinalizedThreshold uint64 = 100
+	DefaultBlockFinalityDepth uint64 = 100
 )
 
 // DefaultConfig returns the default server configuration
@@ -118,7 +118,7 @@ func DefaultConfig() *Config {
 		JSONRPCBatchRequestLimit: DefaultJSONRPCBatchRequestLimit,
 		JSONRPCBlockRangeLimit:   DefaultJSONRPCBlockRangeLimit,
 		Relayer:                  false,
-		BlockFinalizedThreshold:  DefaultBlockFinalizedThreshold,
+		BlockFinalityDepth:       DefaultBlockFinalityDepth,
 	}
 }
 

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -40,7 +40,7 @@ const (
 	logFileLocationFlag          = "log-to"
 
 	relayerFlag            = "relayer"
-	blockFinalityDepthFlag = "block_finality_depth"
+	blockFinalityDepthFlag = "block-finality-depth"
 )
 
 // Flags that are deprecated, but need to be preserved for

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -39,8 +39,8 @@ const (
 	corsOriginFlag               = "access-control-allow-origins"
 	logFileLocationFlag          = "log-to"
 
-	relayerFlag                 = "relayer"
-	blockFinalizedThresholdFlag = "block-finalized-threshold"
+	relayerFlag            = "relayer"
+	blockFinalityDepthFlag = "block_finality_depth"
 )
 
 // Flags that are deprecated, but need to be preserved for
@@ -184,7 +184,7 @@ func (p *serverParams) generateConfig() *server.Config {
 		JSONLogFormat:      p.rawConfig.JSONLogFormat,
 		LogFilePath:        p.logFileLocation,
 
-		Relayer:                 p.relayer,
-		BlockFinalizedThreshold: p.rawConfig.BlockFinalizedThreshold,
+		Relayer:            p.relayer,
+		BlockFinalityDepth: p.rawConfig.BlockFinalityDepth,
 	}
 }

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -38,7 +38,9 @@ const (
 	devFlag                      = "dev"
 	corsOriginFlag               = "access-control-allow-origins"
 	logFileLocationFlag          = "log-to"
-	relayerFlag                  = "relayer"
+
+	relayerFlag                 = "relayer"
+	blockFinalizedThresholdFlag = "block-finalized-threshold"
 )
 
 // Flags that are deprecated, but need to be preserved for
@@ -181,6 +183,8 @@ func (p *serverParams) generateConfig() *server.Config {
 		LogLevel:           hclog.LevelFromString(p.rawConfig.LogLevel),
 		JSONLogFormat:      p.rawConfig.JSONLogFormat,
 		LogFilePath:        p.logFileLocation,
-		Relayer:            p.relayer,
+
+		Relayer:                 p.relayer,
+		BlockFinalizedThreshold: p.rawConfig.BlockFinalizedThreshold,
 	}
 }

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -39,8 +39,8 @@ const (
 	corsOriginFlag               = "access-control-allow-origins"
 	logFileLocationFlag          = "log-to"
 
-	relayerFlag            = "relayer"
-	blockFinalityDepthFlag = "block-finality-depth"
+	relayerFlag               = "relayer"
+	numBlockConfirmationsFlag = "num-block-confirmations"
 )
 
 // Flags that are deprecated, but need to be preserved for
@@ -184,7 +184,7 @@ func (p *serverParams) generateConfig() *server.Config {
 		JSONLogFormat:      p.rawConfig.JSONLogFormat,
 		LogFilePath:        p.logFileLocation,
 
-		Relayer:            p.relayer,
-		BlockFinalityDepth: p.rawConfig.BlockFinalityDepth,
+		Relayer:               p.relayer,
+		NumBlockConfirmations: p.rawConfig.NumBlockConfirmations,
 	}
 }

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -232,7 +232,7 @@ func setFlags(cmd *cobra.Command) {
 		&params.rawConfig.BlockFinalityDepth,
 		blockFinalityDepthFlag,
 		defaultConfig.BlockFinalityDepth,
-		"after how many blocks we consider block is finalized",
+		"minimal number of child blocks required for the parent block to be considered final",
 	)
 
 	setLegacyFlags(cmd)

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -229,9 +229,9 @@ func setFlags(cmd *cobra.Command) {
 	)
 
 	cmd.Flags().Uint64Var(
-		&params.rawConfig.BlockFinalizedThreshold,
-		blockFinalizedThresholdFlag,
-		defaultConfig.BlockFinalizedThreshold,
+		&params.rawConfig.BlockFinalityDepth,
+		blockFinalityDepthFlag,
+		defaultConfig.BlockFinalityDepth,
 		"after how many blocks we consider block is finalized",
 	)
 

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -229,9 +229,9 @@ func setFlags(cmd *cobra.Command) {
 	)
 
 	cmd.Flags().Uint64Var(
-		&params.rawConfig.BlockFinalityDepth,
-		blockFinalityDepthFlag,
-		defaultConfig.BlockFinalityDepth,
+		&params.rawConfig.NumBlockConfirmations,
+		numBlockConfirmationsFlag,
+		defaultConfig.NumBlockConfirmations,
 		"minimal number of child blocks required for the parent block to be considered final",
 	)
 

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -228,6 +228,13 @@ func setFlags(cmd *cobra.Command) {
 		"start the state sync relayer service (PolyBFT only)",
 	)
 
+	cmd.Flags().Uint64Var(
+		&params.rawConfig.BlockFinalizedThreshold,
+		blockFinalizedThresholdFlag,
+		defaultConfig.BlockFinalizedThreshold,
+		"after how many blocks we consider block is finalized",
+	)
+
 	setLegacyFlags(cmd)
 
 	setDevFlags(cmd)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -73,6 +73,8 @@ type Params struct {
 	Logger         hclog.Logger
 	SecretsManager secrets.SecretsManager
 	BlockTime      uint64
+
+	BlockFinalizedThreshold uint64
 }
 
 // Factory is the factory function to create a discovery consensus

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -74,7 +74,7 @@ type Params struct {
 	SecretsManager secrets.SecretsManager
 	BlockTime      uint64
 
-	BlockFinalizedThreshold uint64
+	BlockFinalityDepth uint64
 }
 
 // Factory is the factory function to create a discovery consensus

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -74,7 +74,7 @@ type Params struct {
 	SecretsManager secrets.SecretsManager
 	BlockTime      uint64
 
-	BlockFinalityDepth uint64
+	NumBlockConfirmations uint64
 }
 
 // Factory is the factory function to create a discovery consensus

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -68,15 +68,15 @@ type guardedDataDTO struct {
 
 // runtimeConfig is a struct that holds configuration data for given consensus runtime
 type runtimeConfig struct {
-	PolyBFTConfig           *PolyBFTConfig
-	DataDir                 string
-	Key                     *wallet.Key
-	State                   *State
-	blockchain              blockchainBackend
-	polybftBackend          polybftBackend
-	txPool                  txPoolInterface
-	bridgeTopic             topic
-	blockFinalizedThreshold uint64
+	PolyBFTConfig      *PolyBFTConfig
+	DataDir            string
+	Key                *wallet.Key
+	State              *State
+	blockchain         blockchainBackend
+	polybftBackend     polybftBackend
+	txPool             txPoolInterface
+	bridgeTopic        topic
+	blockFinalityDepth uint64
 }
 
 // consensusRuntime is a struct that provides consensus runtime features like epoch, state and event management
@@ -160,13 +160,13 @@ func (c *consensusRuntime) initStateSyncManager(logger hcf.Logger) error {
 			logger,
 			c.config.State,
 			&stateSyncConfig{
-				key:                     c.config.Key,
-				stateSenderAddr:         c.config.PolyBFTConfig.Bridge.BridgeAddr,
-				jsonrpcAddr:             c.config.PolyBFTConfig.Bridge.JSONRPCEndpoint,
-				dataDir:                 c.config.DataDir,
-				topic:                   c.config.bridgeTopic,
-				maxCommitmentSize:       maxCommitmentSize,
-				blockFinalizedThreshold: c.config.blockFinalizedThreshold,
+				key:                c.config.Key,
+				stateSenderAddr:    c.config.PolyBFTConfig.Bridge.BridgeAddr,
+				jsonrpcAddr:        c.config.PolyBFTConfig.Bridge.JSONRPCEndpoint,
+				dataDir:            c.config.DataDir,
+				topic:              c.config.bridgeTopic,
+				maxCommitmentSize:  maxCommitmentSize,
+				blockFinalityDepth: c.config.blockFinalityDepth,
 			},
 		)
 

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -68,14 +68,15 @@ type guardedDataDTO struct {
 
 // runtimeConfig is a struct that holds configuration data for given consensus runtime
 type runtimeConfig struct {
-	PolyBFTConfig  *PolyBFTConfig
-	DataDir        string
-	Key            *wallet.Key
-	State          *State
-	blockchain     blockchainBackend
-	polybftBackend polybftBackend
-	txPool         txPoolInterface
-	bridgeTopic    topic
+	PolyBFTConfig           *PolyBFTConfig
+	DataDir                 string
+	Key                     *wallet.Key
+	State                   *State
+	blockchain              blockchainBackend
+	polybftBackend          polybftBackend
+	txPool                  txPoolInterface
+	bridgeTopic             topic
+	blockFinalizedThreshold uint64
 }
 
 // consensusRuntime is a struct that provides consensus runtime features like epoch, state and event management
@@ -159,12 +160,13 @@ func (c *consensusRuntime) initStateSyncManager(logger hcf.Logger) error {
 			logger,
 			c.config.State,
 			&stateSyncConfig{
-				key:               c.config.Key,
-				stateSenderAddr:   c.config.PolyBFTConfig.Bridge.BridgeAddr,
-				jsonrpcAddr:       c.config.PolyBFTConfig.Bridge.JSONRPCEndpoint,
-				dataDir:           c.config.DataDir,
-				topic:             c.config.bridgeTopic,
-				maxCommitmentSize: maxCommitmentSize,
+				key:                     c.config.Key,
+				stateSenderAddr:         c.config.PolyBFTConfig.Bridge.BridgeAddr,
+				jsonrpcAddr:             c.config.PolyBFTConfig.Bridge.JSONRPCEndpoint,
+				dataDir:                 c.config.DataDir,
+				topic:                   c.config.bridgeTopic,
+				maxCommitmentSize:       maxCommitmentSize,
+				blockFinalizedThreshold: c.config.blockFinalizedThreshold,
 			},
 		)
 

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -68,15 +68,15 @@ type guardedDataDTO struct {
 
 // runtimeConfig is a struct that holds configuration data for given consensus runtime
 type runtimeConfig struct {
-	PolyBFTConfig      *PolyBFTConfig
-	DataDir            string
-	Key                *wallet.Key
-	State              *State
-	blockchain         blockchainBackend
-	polybftBackend     polybftBackend
-	txPool             txPoolInterface
-	bridgeTopic        topic
-	blockFinalityDepth uint64
+	PolyBFTConfig         *PolyBFTConfig
+	DataDir               string
+	Key                   *wallet.Key
+	State                 *State
+	blockchain            blockchainBackend
+	polybftBackend        polybftBackend
+	txPool                txPoolInterface
+	bridgeTopic           topic
+	numBlockConfirmations uint64
 }
 
 // consensusRuntime is a struct that provides consensus runtime features like epoch, state and event management
@@ -160,13 +160,13 @@ func (c *consensusRuntime) initStateSyncManager(logger hcf.Logger) error {
 			logger,
 			c.config.State,
 			&stateSyncConfig{
-				key:                c.config.Key,
-				stateSenderAddr:    c.config.PolyBFTConfig.Bridge.BridgeAddr,
-				jsonrpcAddr:        c.config.PolyBFTConfig.Bridge.JSONRPCEndpoint,
-				dataDir:            c.config.DataDir,
-				topic:              c.config.bridgeTopic,
-				maxCommitmentSize:  maxCommitmentSize,
-				blockFinalityDepth: c.config.blockFinalityDepth,
+				key:                   c.config.Key,
+				stateSenderAddr:       c.config.PolyBFTConfig.Bridge.BridgeAddr,
+				jsonrpcAddr:           c.config.PolyBFTConfig.Bridge.JSONRPCEndpoint,
+				dataDir:               c.config.DataDir,
+				topic:                 c.config.bridgeTopic,
+				maxCommitmentSize:     maxCommitmentSize,
+				numBlockConfirmations: c.config.numBlockConfirmations,
 			},
 		)
 

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -250,14 +250,15 @@ func (p *Polybft) Start() error {
 // initRuntime creates consensus runtime
 func (p *Polybft) initRuntime() error {
 	runtimeConfig := &runtimeConfig{
-		PolyBFTConfig:  p.consensusConfig,
-		Key:            p.key,
-		DataDir:        p.dataDir,
-		State:          p.state,
-		blockchain:     p.blockchain,
-		polybftBackend: p,
-		txPool:         p.txPool,
-		bridgeTopic:    p.bridgeTopic,
+		PolyBFTConfig:           p.consensusConfig,
+		Key:                     p.key,
+		DataDir:                 p.dataDir,
+		State:                   p.state,
+		blockchain:              p.blockchain,
+		polybftBackend:          p,
+		txPool:                  p.txPool,
+		bridgeTopic:             p.bridgeTopic,
+		blockFinalizedThreshold: p.config.BlockFinalizedThreshold,
 	}
 
 	runtime, err := newConsensusRuntime(p.logger, runtimeConfig)

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -250,15 +250,15 @@ func (p *Polybft) Start() error {
 // initRuntime creates consensus runtime
 func (p *Polybft) initRuntime() error {
 	runtimeConfig := &runtimeConfig{
-		PolyBFTConfig:           p.consensusConfig,
-		Key:                     p.key,
-		DataDir:                 p.dataDir,
-		State:                   p.state,
-		blockchain:              p.blockchain,
-		polybftBackend:          p,
-		txPool:                  p.txPool,
-		bridgeTopic:             p.bridgeTopic,
-		blockFinalizedThreshold: p.config.BlockFinalizedThreshold,
+		PolyBFTConfig:      p.consensusConfig,
+		Key:                p.key,
+		DataDir:            p.dataDir,
+		State:              p.state,
+		blockchain:         p.blockchain,
+		polybftBackend:     p,
+		txPool:             p.txPool,
+		bridgeTopic:        p.bridgeTopic,
+		blockFinalityDepth: p.config.BlockFinalityDepth,
 	}
 
 	runtime, err := newConsensusRuntime(p.logger, runtimeConfig)

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -250,15 +250,15 @@ func (p *Polybft) Start() error {
 // initRuntime creates consensus runtime
 func (p *Polybft) initRuntime() error {
 	runtimeConfig := &runtimeConfig{
-		PolyBFTConfig:      p.consensusConfig,
-		Key:                p.key,
-		DataDir:            p.dataDir,
-		State:              p.state,
-		blockchain:         p.blockchain,
-		polybftBackend:     p,
-		txPool:             p.txPool,
-		bridgeTopic:        p.bridgeTopic,
-		blockFinalityDepth: p.config.BlockFinalityDepth,
+		PolyBFTConfig:         p.consensusConfig,
+		Key:                   p.key,
+		DataDir:               p.dataDir,
+		State:                 p.state,
+		blockchain:            p.blockchain,
+		polybftBackend:        p,
+		txPool:                p.txPool,
+		bridgeTopic:           p.bridgeTopic,
+		numBlockConfirmations: p.config.NumBlockConfirmations,
 	}
 
 	runtime, err := newConsensusRuntime(p.logger, runtimeConfig)

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -59,13 +59,13 @@ func (n *dummyStateSyncManager) GetStateSyncProof(stateSyncID uint64) (types.Pro
 
 // stateSyncConfig holds the configuration data of state sync manager
 type stateSyncConfig struct {
-	stateSenderAddr    types.Address
-	jsonrpcAddr        string
-	dataDir            string
-	topic              topic
-	key                *wallet.Key
-	maxCommitmentSize  uint64
-	blockFinalityDepth uint64
+	stateSenderAddr       types.Address
+	jsonrpcAddr           string
+	dataDir               string
+	topic                 topic
+	key                   *wallet.Key
+	maxCommitmentSize     uint64
+	numBlockConfirmations uint64
 }
 
 var _ StateSyncManager = (*stateSyncManager)(nil)
@@ -131,7 +131,7 @@ func (s *stateSyncManager) initTracker() error {
 		s.config.jsonrpcAddr,
 		ethgo.Address(s.config.stateSenderAddr),
 		s,
-		s.config.blockFinalityDepth,
+		s.config.numBlockConfirmations,
 		s.logger)
 
 	go func() {

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -59,14 +59,12 @@ func (n *dummyStateSyncManager) GetStateSyncProof(stateSyncID uint64) (types.Pro
 
 // stateSyncConfig holds the configuration data of state sync manager
 type stateSyncConfig struct {
-	stateSenderAddr   types.Address
-	jsonrpcAddr       string
-	dataDir           string
-	topic             topic
-	key               *wallet.Key
-	maxCommitmentSize uint64
-
-	// after how many blocks we consider block is finalized
+	stateSenderAddr    types.Address
+	jsonrpcAddr        string
+	dataDir            string
+	topic              topic
+	key                *wallet.Key
+	maxCommitmentSize  uint64
 	blockFinalityDepth uint64
 }
 

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -67,7 +67,7 @@ type stateSyncConfig struct {
 	maxCommitmentSize uint64
 
 	// after how many blocks we consider block is finalized
-	blockFinalizedThreshold uint64
+	blockFinalityDepth uint64
 }
 
 var _ StateSyncManager = (*stateSyncManager)(nil)
@@ -133,7 +133,7 @@ func (s *stateSyncManager) initTracker() error {
 		s.config.jsonrpcAddr,
 		ethgo.Address(s.config.stateSenderAddr),
 		s,
-		s.config.blockFinalizedThreshold,
+		s.config.blockFinalityDepth,
 		s.logger)
 
 	go func() {

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -130,6 +130,7 @@ func (s *stateSyncManager) initTracker() error {
 		s.config.jsonrpcAddr,
 		ethgo.Address(s.config.stateSenderAddr),
 		s,
+		tracker.DefaultFinalizedThreshold,
 		s.logger)
 
 	go func() {

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -65,6 +65,9 @@ type stateSyncConfig struct {
 	topic             topic
 	key               *wallet.Key
 	maxCommitmentSize uint64
+
+	// after how many blocks we consider block is finalized
+	blockFinalizedThreshold uint64
 }
 
 var _ StateSyncManager = (*stateSyncManager)(nil)
@@ -130,7 +133,7 @@ func (s *stateSyncManager) initTracker() error {
 		s.config.jsonrpcAddr,
 		ethgo.Address(s.config.stateSenderAddr),
 		s,
-		tracker.DefaultFinalizedThreshold,
+		s.config.blockFinalizedThreshold,
 		s.logger)
 
 	go func() {

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer.go
@@ -87,6 +87,7 @@ func (r *StateSyncRelayer) Start() error {
 		r.rpcEndpoint,
 		r.stateReceiverAddr,
 		r,
+		tracker.DefaultFinalizedThreshold,
 		r.logger,
 	)
 

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer.go
@@ -24,15 +24,14 @@ import (
 var commitEvent = contractsapi.StateReceiver.Abi.Events["NewCommitment"]
 
 type StateSyncRelayer struct {
-	dataDir                 string
-	rpcEndpoint             string
-	stateReceiverAddr       ethgo.Address
-	logger                  hcf.Logger
-	client                  *jsonrpc.Client
-	txRelayer               txrelayer.TxRelayer
-	key                     ethgo.Key
-	closeCh                 chan struct{}
-	blockFinalizedThreshold uint64
+	dataDir           string
+	rpcEndpoint       string
+	stateReceiverAddr ethgo.Address
+	logger            hcf.Logger
+	client            *jsonrpc.Client
+	txRelayer         txrelayer.TxRelayer
+	key               ethgo.Key
+	closeCh           chan struct{}
 }
 
 func sanitizeRPCEndpoint(rpcEndpoint string) string {
@@ -52,7 +51,6 @@ func NewRelayer(
 	dataDir string,
 	rpcEndpoint string,
 	stateReceiverAddr ethgo.Address,
-	blockFinalizedThreshold uint64,
 	logger hcf.Logger,
 	key ethgo.Key,
 ) *StateSyncRelayer {
@@ -72,15 +70,14 @@ func NewRelayer(
 	}
 
 	return &StateSyncRelayer{
-		dataDir:                 dataDir,
-		rpcEndpoint:             endpoint,
-		stateReceiverAddr:       stateReceiverAddr,
-		logger:                  logger,
-		client:                  client,
-		txRelayer:               txRelayer,
-		blockFinalizedThreshold: blockFinalizedThreshold,
-		key:                     key,
-		closeCh:                 make(chan struct{}),
+		dataDir:           dataDir,
+		rpcEndpoint:       endpoint,
+		stateReceiverAddr: stateReceiverAddr,
+		logger:            logger,
+		client:            client,
+		txRelayer:         txRelayer,
+		key:               key,
+		closeCh:           make(chan struct{}),
 	}
 }
 
@@ -90,7 +87,7 @@ func (r *StateSyncRelayer) Start() error {
 		r.rpcEndpoint,
 		r.stateReceiverAddr,
 		r,
-		r.blockFinalizedThreshold,
+		0, // our (side-chain) is instant finality POS, so no need to wait
 		r.logger,
 	)
 

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer.go
@@ -87,7 +87,7 @@ func (r *StateSyncRelayer) Start() error {
 		r.rpcEndpoint,
 		r.stateReceiverAddr,
 		r,
-		0, // our (side-chain) is instant finality POS, so no need to wait
+		0, // sidechain (Polygon POS) is instant finality, so no need to wait
 		r.logger,
 	)
 

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer.go
@@ -24,14 +24,15 @@ import (
 var commitEvent = contractsapi.StateReceiver.Abi.Events["NewCommitment"]
 
 type StateSyncRelayer struct {
-	dataDir           string
-	rpcEndpoint       string
-	stateReceiverAddr ethgo.Address
-	logger            hcf.Logger
-	client            *jsonrpc.Client
-	txRelayer         txrelayer.TxRelayer
-	key               ethgo.Key
-	closeCh           chan struct{}
+	dataDir                 string
+	rpcEndpoint             string
+	stateReceiverAddr       ethgo.Address
+	logger                  hcf.Logger
+	client                  *jsonrpc.Client
+	txRelayer               txrelayer.TxRelayer
+	key                     ethgo.Key
+	closeCh                 chan struct{}
+	blockFinalizedThreshold uint64
 }
 
 func sanitizeRPCEndpoint(rpcEndpoint string) string {
@@ -51,6 +52,7 @@ func NewRelayer(
 	dataDir string,
 	rpcEndpoint string,
 	stateReceiverAddr ethgo.Address,
+	blockFinalizedThreshold uint64,
 	logger hcf.Logger,
 	key ethgo.Key,
 ) *StateSyncRelayer {
@@ -70,14 +72,15 @@ func NewRelayer(
 	}
 
 	return &StateSyncRelayer{
-		dataDir:           dataDir,
-		rpcEndpoint:       endpoint,
-		stateReceiverAddr: stateReceiverAddr,
-		logger:            logger,
-		client:            client,
-		txRelayer:         txRelayer,
-		key:               key,
-		closeCh:           make(chan struct{}),
+		dataDir:                 dataDir,
+		rpcEndpoint:             endpoint,
+		stateReceiverAddr:       stateReceiverAddr,
+		logger:                  logger,
+		client:                  client,
+		txRelayer:               txRelayer,
+		blockFinalizedThreshold: blockFinalizedThreshold,
+		key:                     key,
+		closeCh:                 make(chan struct{}),
 	}
 }
 
@@ -87,7 +90,7 @@ func (r *StateSyncRelayer) Start() error {
 		r.rpcEndpoint,
 		r.stateReceiverAddr,
 		r,
-		tracker.DefaultFinalizedThreshold,
+		r.blockFinalizedThreshold,
 		r.logger,
 	)
 

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer_test.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer_test.go
@@ -115,7 +115,7 @@ func TestStateSyncRelayer_Stop(t *testing.T) {
 	key, err := wallet.GenerateKey()
 	require.NoError(t, err)
 
-	r := NewRelayer("test-chain-1", "http://127.0.0.1:8545", ethgo.Address(contracts.StateReceiverContract), hclog.NewNullLogger(), key)
+	r := NewRelayer("test-chain-1", "http://127.0.0.1:8545", ethgo.Address(contracts.StateReceiverContract), 0, hclog.NewNullLogger(), key)
 
 	require.NotPanics(t, func() { r.Stop() })
 }

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer_test.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer_test.go
@@ -115,7 +115,7 @@ func TestStateSyncRelayer_Stop(t *testing.T) {
 	key, err := wallet.GenerateKey()
 	require.NoError(t, err)
 
-	r := NewRelayer("test-chain-1", "http://127.0.0.1:8545", ethgo.Address(contracts.StateReceiverContract), 0, hclog.NewNullLogger(), key)
+	r := NewRelayer("test-chain-1", "http://127.0.0.1:8545", ethgo.Address(contracts.StateReceiverContract), hclog.NewNullLogger(), key)
 
 	require.NotPanics(t, func() { r.Stop() })
 }

--- a/e2e-polybft/bridge_test.go
+++ b/e2e-polybft/bridge_test.go
@@ -57,8 +57,8 @@ func checkLogs(
 
 func TestE2E_Bridge_MainWorkflow(t *testing.T) {
 	const (
-		num                     = 10
-		blockFinalizedThreshold = 4
+		num                = 10
+		blockFinalityDepth = 4
 	)
 
 	var (
@@ -75,7 +75,7 @@ func TestE2E_Bridge_MainWorkflow(t *testing.T) {
 	}
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithBridge(), framework.WithPremine(premine[:]...), framework.WithBlockFinalizedThreshold(blockFinalizedThreshold))
+		framework.WithBridge(), framework.WithPremine(premine[:]...), framework.WithBlockFinalityDepth(blockFinalityDepth))
 	defer cluster.Stop()
 
 	// wait for a couple of blocks
@@ -91,7 +91,7 @@ func TestE2E_Bridge_MainWorkflow(t *testing.T) {
 		),
 	)
 
-	require.NoError(t, cluster.WaitForBlock(2+blockFinalizedThreshold*2, 2*time.Minute))
+	require.NoError(t, cluster.WaitForBlock(2+blockFinalityDepth*2, 2*time.Minute))
 
 	// send again to trigger previous transactions
 	require.NoError(

--- a/e2e-polybft/bridge_test.go
+++ b/e2e-polybft/bridge_test.go
@@ -57,8 +57,8 @@ func checkLogs(
 
 func TestE2E_Bridge_MainWorkflow(t *testing.T) {
 	const (
-		num                = 10
-		blockFinalityDepth = 4
+		num                   = 10
+		numBlockConfirmations = 4
 	)
 
 	var (
@@ -75,7 +75,8 @@ func TestE2E_Bridge_MainWorkflow(t *testing.T) {
 	}
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithBridge(), framework.WithPremine(premine[:]...), framework.WithBlockFinalityDepth(blockFinalityDepth))
+		framework.WithBridge(), framework.WithPremine(premine[:]...),
+		framework.WithNumBlockConfirmations(numBlockConfirmations))
 	defer cluster.Stop()
 
 	// wait for a couple of blocks
@@ -91,7 +92,7 @@ func TestE2E_Bridge_MainWorkflow(t *testing.T) {
 		),
 	)
 
-	require.NoError(t, cluster.WaitForBlock(2+blockFinalityDepth*2, 2*time.Minute))
+	require.NoError(t, cluster.WaitForBlock(2+numBlockConfirmations*2, 2*time.Minute))
 
 	// send again to trigger previous transactions
 	require.NoError(

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -47,9 +47,6 @@ const (
 
 	// prefix for validator directory
 	defaultValidatorPrefix = "test-chain-"
-
-	// after how many blocks we consider block is finalized
-	defaultBlockFinalityDepth = 0
 )
 
 var startTime int64

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -49,7 +49,7 @@ const (
 	defaultValidatorPrefix = "test-chain-"
 
 	// after how many blocks we consider block is finalized
-	defaultBlockFinalizedThreshold = 0
+	defaultBlockFinalityDepth = 0
 )
 
 var startTime int64
@@ -90,7 +90,7 @@ type TestClusterConfig struct {
 	PropertyBaseTests bool
 	SecretsCallback   func([]types.Address, *TestClusterConfig)
 
-	BlockFinalizedThreshold uint64
+	BlockFinalityDepth uint64
 
 	logsDirOnce sync.Once
 }
@@ -229,9 +229,9 @@ func WithPropertyBaseTests(propertyBaseTests bool) ClusterOption {
 	}
 }
 
-func WithBlockFinalizedThreshold(blockFinalizedThreshold uint64) ClusterOption {
+func WithBlockFinalityDepth(blockFinalityDepth uint64) ClusterOption {
 	return func(h *TestClusterConfig) {
-		h.BlockFinalizedThreshold = blockFinalizedThreshold
+		h.BlockFinalityDepth = blockFinalityDepth
 	}
 }
 
@@ -400,7 +400,7 @@ func (c *TestCluster) InitTestServer(t *testing.T, i int, isValidator bool, rela
 		config.P2PPort = c.getOpenPort()
 		config.LogLevel = logLevel
 		config.Relayer = relayer
-		config.BlockFinalizedThreshold = c.Config.BlockFinalizedThreshold // 0 by default
+		config.BlockFinalityDepth = c.Config.BlockFinalityDepth
 	})
 
 	// watch the server for stop signals. It is important to fix the specific

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -87,7 +87,7 @@ type TestClusterConfig struct {
 	PropertyBaseTests bool
 	SecretsCallback   func([]types.Address, *TestClusterConfig)
 
-	BlockFinalityDepth uint64
+	NumBlockConfirmations uint64
 
 	logsDirOnce sync.Once
 }
@@ -226,9 +226,9 @@ func WithPropertyBaseTests(propertyBaseTests bool) ClusterOption {
 	}
 }
 
-func WithBlockFinalityDepth(blockFinalityDepth uint64) ClusterOption {
+func WithNumBlockConfirmations(numBlockConfirmations uint64) ClusterOption {
 	return func(h *TestClusterConfig) {
-		h.BlockFinalityDepth = blockFinalityDepth
+		h.NumBlockConfirmations = numBlockConfirmations
 	}
 }
 
@@ -397,7 +397,7 @@ func (c *TestCluster) InitTestServer(t *testing.T, i int, isValidator bool, rela
 		config.P2PPort = c.getOpenPort()
 		config.LogLevel = logLevel
 		config.Relayer = relayer
-		config.BlockFinalityDepth = c.Config.BlockFinalityDepth
+		config.NumBlockConfirmations = c.Config.NumBlockConfirmations
 	})
 
 	// watch the server for stop signals. It is important to fix the specific

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -47,6 +47,9 @@ const (
 
 	// prefix for validator directory
 	defaultValidatorPrefix = "test-chain-"
+
+	// after how many blocks we consider block is finalized
+	defaultBlockFinalizedThreshold = 0
 )
 
 var startTime int64
@@ -86,6 +89,8 @@ type TestClusterConfig struct {
 	EpochReward       int
 	PropertyBaseTests bool
 	SecretsCallback   func([]types.Address, *TestClusterConfig)
+
+	BlockFinalizedThreshold uint64
 
 	logsDirOnce sync.Once
 }
@@ -221,6 +226,12 @@ func WithBlockGasLimit(blockGasLimit uint64) ClusterOption {
 func WithPropertyBaseTests(propertyBaseTests bool) ClusterOption {
 	return func(h *TestClusterConfig) {
 		h.PropertyBaseTests = propertyBaseTests
+	}
+}
+
+func WithBlockFinalizedThreshold(blockFinalizedThreshold uint64) ClusterOption {
+	return func(h *TestClusterConfig) {
+		h.BlockFinalizedThreshold = blockFinalizedThreshold
 	}
 }
 
@@ -389,6 +400,7 @@ func (c *TestCluster) InitTestServer(t *testing.T, i int, isValidator bool, rela
 		config.P2PPort = c.getOpenPort()
 		config.LogLevel = logLevel
 		config.Relayer = relayer
+		config.BlockFinalizedThreshold = c.Config.BlockFinalizedThreshold // 0 by default
 	})
 
 	// watch the server for stop signals. It is important to fix the specific

--- a/e2e-polybft/framework/test-server.go
+++ b/e2e-polybft/framework/test-server.go
@@ -124,7 +124,7 @@ func (t *TestServer) Start() {
 		"--grpc-address", fmt.Sprintf("localhost:%d", config.GRPCPort),
 		// enable jsonrpc
 		"--jsonrpc", fmt.Sprintf(":%d", config.JSONRPCPort),
-		// after how many blocks we consider block is finalized
+		// minimal number of child blocks required for the parent block to be considered final
 		"--block_finality_depth", strconv.FormatUint(config.BlockFinalityDepth, 10),
 	}
 

--- a/e2e-polybft/framework/test-server.go
+++ b/e2e-polybft/framework/test-server.go
@@ -125,7 +125,7 @@ func (t *TestServer) Start() {
 		// enable jsonrpc
 		"--jsonrpc", fmt.Sprintf(":%d", config.JSONRPCPort),
 		// minimal number of child blocks required for the parent block to be considered final
-		"--block_finality_depth", strconv.FormatUint(config.BlockFinalityDepth, 10),
+		"--block-finality-depth", strconv.FormatUint(config.BlockFinalityDepth, 10),
 	}
 
 	if len(config.LogLevel) > 0 {

--- a/e2e-polybft/framework/test-server.go
+++ b/e2e-polybft/framework/test-server.go
@@ -17,16 +17,16 @@ import (
 )
 
 type TestServerConfig struct {
-	Name               string
-	JSONRPCPort        int64
-	GRPCPort           int64
-	P2PPort            int64
-	Seal               bool
-	DataDir            string
-	Chain              string
-	LogLevel           string
-	Relayer            bool
-	BlockFinalityDepth uint64
+	Name                  string
+	JSONRPCPort           int64
+	GRPCPort              int64
+	P2PPort               int64
+	Seal                  bool
+	DataDir               string
+	Chain                 string
+	LogLevel              string
+	Relayer               bool
+	NumBlockConfirmations uint64
 }
 
 type TestServerConfigCallback func(*TestServerConfig)
@@ -125,7 +125,7 @@ func (t *TestServer) Start() {
 		// enable jsonrpc
 		"--jsonrpc", fmt.Sprintf(":%d", config.JSONRPCPort),
 		// minimal number of child blocks required for the parent block to be considered final
-		"--block-finality-depth", strconv.FormatUint(config.BlockFinalityDepth, 10),
+		"--num-block-confirmations", strconv.FormatUint(config.NumBlockConfirmations, 10),
 	}
 
 	if len(config.LogLevel) > 0 {

--- a/e2e-polybft/framework/test-server.go
+++ b/e2e-polybft/framework/test-server.go
@@ -17,15 +17,16 @@ import (
 )
 
 type TestServerConfig struct {
-	Name        string
-	JSONRPCPort int64
-	GRPCPort    int64
-	P2PPort     int64
-	Seal        bool
-	DataDir     string
-	Chain       string
-	LogLevel    string
-	Relayer     bool
+	Name                    string
+	JSONRPCPort             int64
+	GRPCPort                int64
+	P2PPort                 int64
+	Seal                    bool
+	DataDir                 string
+	Chain                   string
+	LogLevel                string
+	Relayer                 bool
+	BlockFinalizedThreshold uint64
 }
 
 type TestServerConfigCallback func(*TestServerConfig)
@@ -123,6 +124,8 @@ func (t *TestServer) Start() {
 		"--grpc-address", fmt.Sprintf("localhost:%d", config.GRPCPort),
 		// enable jsonrpc
 		"--jsonrpc", fmt.Sprintf(":%d", config.JSONRPCPort),
+		// after how many blocks we consider block is finalized
+		"--block-finalized-threshold", strconv.FormatUint(config.BlockFinalizedThreshold, 10),
 	}
 
 	if len(config.LogLevel) > 0 {

--- a/e2e-polybft/framework/test-server.go
+++ b/e2e-polybft/framework/test-server.go
@@ -17,16 +17,16 @@ import (
 )
 
 type TestServerConfig struct {
-	Name                    string
-	JSONRPCPort             int64
-	GRPCPort                int64
-	P2PPort                 int64
-	Seal                    bool
-	DataDir                 string
-	Chain                   string
-	LogLevel                string
-	Relayer                 bool
-	BlockFinalizedThreshold uint64
+	Name               string
+	JSONRPCPort        int64
+	GRPCPort           int64
+	P2PPort            int64
+	Seal               bool
+	DataDir            string
+	Chain              string
+	LogLevel           string
+	Relayer            bool
+	BlockFinalityDepth uint64
 }
 
 type TestServerConfigCallback func(*TestServerConfig)
@@ -125,7 +125,7 @@ func (t *TestServer) Start() {
 		// enable jsonrpc
 		"--jsonrpc", fmt.Sprintf(":%d", config.JSONRPCPort),
 		// after how many blocks we consider block is finalized
-		"--block-finalized-threshold", strconv.FormatUint(config.BlockFinalizedThreshold, 10),
+		"--block_finality_depth", strconv.FormatUint(config.BlockFinalityDepth, 10),
 	}
 
 	if len(config.LogLevel) > 0 {

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -297,3 +297,8 @@ func EncodeUint64ToBytes(value uint64) []byte {
 
 	return result
 }
+
+// EncodeBytesToUint64 big endian byte slice to uint64
+func EncodeBytesToUint64(b []byte) uint64 {
+	return binary.BigEndian.Uint64(b)
+}

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -27,10 +27,10 @@ function createGenesis() {
 }
 
 function startServerFromBinary() {
-  ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 --block-finality-depth 2 --seal --log-level DEBUG &
-  ./polygon-edge server --data-dir ./test-chain-2 --chain genesis.json --grpc-address :20000 --libp2p :30302 --jsonrpc :20002 --block-finality-depth 2 --seal --log-level DEBUG &
-  ./polygon-edge server --data-dir ./test-chain-3 --chain genesis.json --grpc-address :30000 --libp2p :30303 --jsonrpc :30002 --block-finality-depth 2 --seal --log-level DEBUG &
-  ./polygon-edge server --data-dir ./test-chain-4 --chain genesis.json --grpc-address :40000 --libp2p :30304 --jsonrpc :40002 --block-finality-depth 2 --seal --log-level DEBUG &
+  ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 --num-block-confirmations 2 --seal --log-level DEBUG &
+  ./polygon-edge server --data-dir ./test-chain-2 --chain genesis.json --grpc-address :20000 --libp2p :30302 --jsonrpc :20002 --num-block-confirmations 2 --seal --log-level DEBUG &
+  ./polygon-edge server --data-dir ./test-chain-3 --chain genesis.json --grpc-address :30000 --libp2p :30303 --jsonrpc :30002 --num-block-confirmations 2 --seal --log-level DEBUG &
+  ./polygon-edge server --data-dir ./test-chain-4 --chain genesis.json --grpc-address :40000 --libp2p :30304 --jsonrpc :40002 --num-block-confirmations 2 --seal --log-level DEBUG &
   wait
 }
 

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -27,10 +27,10 @@ function createGenesis() {
 }
 
 function startServerFromBinary() {
-  ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 --seal --log-level DEBUG &
-  ./polygon-edge server --data-dir ./test-chain-2 --chain genesis.json --grpc-address :20000 --libp2p :30302 --jsonrpc :20002 --seal --log-level DEBUG &
-  ./polygon-edge server --data-dir ./test-chain-3 --chain genesis.json --grpc-address :30000 --libp2p :30303 --jsonrpc :30002 --seal --log-level DEBUG &
-  ./polygon-edge server --data-dir ./test-chain-4 --chain genesis.json --grpc-address :40000 --libp2p :30304 --jsonrpc :40002 --seal --log-level DEBUG &
+  ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 --block-finality-depth 2 --seal --log-level DEBUG &
+  ./polygon-edge server --data-dir ./test-chain-2 --chain genesis.json --grpc-address :20000 --libp2p :30302 --jsonrpc :20002 --block-finality-depth 2 --seal --log-level DEBUG &
+  ./polygon-edge server --data-dir ./test-chain-3 --chain genesis.json --grpc-address :30000 --libp2p :30303 --jsonrpc :30002 --block-finality-depth 2 --seal --log-level DEBUG &
+  ./polygon-edge server --data-dir ./test-chain-4 --chain genesis.json --grpc-address :40000 --libp2p :30304 --jsonrpc :40002 --block-finality-depth 2 --seal --log-level DEBUG &
   wait
 }
 

--- a/server/config.go
+++ b/server/config.go
@@ -43,6 +43,9 @@ type Config struct {
 	LogFilePath string
 
 	Relayer bool
+
+	// after how many blocks we consider block is finalized
+	BlockFinalizedThreshold uint64
 }
 
 // Telemetry holds the config details for metric services

--- a/server/config.go
+++ b/server/config.go
@@ -44,7 +44,6 @@ type Config struct {
 
 	Relayer bool
 
-	// after how many blocks we consider block is finalized
 	BlockFinalityDepth uint64
 }
 

--- a/server/config.go
+++ b/server/config.go
@@ -44,7 +44,7 @@ type Config struct {
 
 	Relayer bool
 
-	BlockFinalityDepth uint64
+	NumBlockConfirmations uint64
 }
 
 // Telemetry holds the config details for metric services

--- a/server/config.go
+++ b/server/config.go
@@ -45,7 +45,7 @@ type Config struct {
 	Relayer bool
 
 	// after how many blocks we consider block is finalized
-	BlockFinalizedThreshold uint64
+	BlockFinalityDepth uint64
 }
 
 // Telemetry holds the config details for metric services

--- a/server/server.go
+++ b/server/server.go
@@ -429,17 +429,17 @@ func (s *Server) setupConsensus() error {
 
 	consensus, err := engine(
 		&consensus.Params{
-			Context:                 context.Background(),
-			Config:                  config,
-			TxPool:                  s.txpool,
-			Network:                 s.network,
-			Blockchain:              s.blockchain,
-			Executor:                s.executor,
-			Grpc:                    s.grpcServer,
-			Logger:                  s.logger,
-			SecretsManager:          s.secretsManager,
-			BlockTime:               s.config.BlockTime,
-			BlockFinalizedThreshold: s.config.BlockFinalizedThreshold,
+			Context:            context.Background(),
+			Config:             config,
+			TxPool:             s.txpool,
+			Network:            s.network,
+			Blockchain:         s.blockchain,
+			Executor:           s.executor,
+			Grpc:               s.grpcServer,
+			Logger:             s.logger,
+			SecretsManager:     s.secretsManager,
+			BlockTime:          s.config.BlockTime,
+			BlockFinalityDepth: s.config.BlockFinalityDepth,
 		},
 	)
 

--- a/server/server.go
+++ b/server/server.go
@@ -429,17 +429,17 @@ func (s *Server) setupConsensus() error {
 
 	consensus, err := engine(
 		&consensus.Params{
-			Context:            context.Background(),
-			Config:             config,
-			TxPool:             s.txpool,
-			Network:            s.network,
-			Blockchain:         s.blockchain,
-			Executor:           s.executor,
-			Grpc:               s.grpcServer,
-			Logger:             s.logger,
-			SecretsManager:     s.secretsManager,
-			BlockTime:          s.config.BlockTime,
-			BlockFinalityDepth: s.config.BlockFinalityDepth,
+			Context:               context.Background(),
+			Config:                config,
+			TxPool:                s.txpool,
+			Network:               s.network,
+			Blockchain:            s.blockchain,
+			Executor:              s.executor,
+			Grpc:                  s.grpcServer,
+			Logger:                s.logger,
+			SecretsManager:        s.secretsManager,
+			BlockTime:             s.config.BlockTime,
+			NumBlockConfirmations: s.config.NumBlockConfirmations,
 		},
 	)
 

--- a/server/server.go
+++ b/server/server.go
@@ -463,7 +463,6 @@ func (s *Server) setupRelayer() error {
 		s.config.DataDir,
 		s.config.JSONRPC.JSONRPCAddr.String(),
 		ethgo.Address(contracts.StateReceiverContract),
-		s.config.BlockFinalizedThreshold,
 		s.logger.Named("relayer"),
 		wallet.NewEcdsaSigner(wallet.NewKey(account, bls.DomainCheckpointManager)),
 	)

--- a/server/server.go
+++ b/server/server.go
@@ -429,16 +429,17 @@ func (s *Server) setupConsensus() error {
 
 	consensus, err := engine(
 		&consensus.Params{
-			Context:        context.Background(),
-			Config:         config,
-			TxPool:         s.txpool,
-			Network:        s.network,
-			Blockchain:     s.blockchain,
-			Executor:       s.executor,
-			Grpc:           s.grpcServer,
-			Logger:         s.logger,
-			SecretsManager: s.secretsManager,
-			BlockTime:      s.config.BlockTime,
+			Context:                 context.Background(),
+			Config:                  config,
+			TxPool:                  s.txpool,
+			Network:                 s.network,
+			Blockchain:              s.blockchain,
+			Executor:                s.executor,
+			Grpc:                    s.grpcServer,
+			Logger:                  s.logger,
+			SecretsManager:          s.secretsManager,
+			BlockTime:               s.config.BlockTime,
+			BlockFinalizedThreshold: s.config.BlockFinalizedThreshold,
 		},
 	)
 
@@ -462,6 +463,7 @@ func (s *Server) setupRelayer() error {
 		s.config.DataDir,
 		s.config.JSONRPC.JSONRPCAddr.String(),
 		ethgo.Address(contracts.StateReceiverContract),
+		s.config.BlockFinalizedThreshold,
 		s.logger.Named("relayer"),
 		wallet.NewEcdsaSigner(wallet.NewKey(account, bls.DomainCheckpointManager)),
 	)

--- a/tracker/event_tracker.go
+++ b/tracker/event_tracker.go
@@ -14,12 +14,12 @@ type eventSubscription interface {
 }
 
 type EventTracker struct {
-	dbPath             string
-	rpcEndpoint        string
-	contractAddr       ethgo.Address
-	subscriber         eventSubscription
-	logger             hcf.Logger
-	finalizedThreshold uint64 // after how many blocks we consider block is finalized
+	dbPath        string
+	rpcEndpoint   string
+	contractAddr  ethgo.Address
+	subscriber    eventSubscription
+	logger        hcf.Logger
+	finalityDepth uint64 // after how many blocks we consider block is finalized
 }
 
 func NewEventTracker(
@@ -27,16 +27,16 @@ func NewEventTracker(
 	rpcEndpoint string,
 	contractAddr ethgo.Address,
 	subscriber eventSubscription,
-	finalizedThreshold uint64,
+	finalityDepth uint64,
 	logger hcf.Logger,
 ) *EventTracker {
 	return &EventTracker{
-		dbPath:             dbPath,
-		rpcEndpoint:        rpcEndpoint,
-		contractAddr:       contractAddr,
-		subscriber:         subscriber,
-		finalizedThreshold: finalizedThreshold,
-		logger:             logger.Named("event_tracker"),
+		dbPath:        dbPath,
+		rpcEndpoint:   rpcEndpoint,
+		contractAddr:  contractAddr,
+		subscriber:    subscriber,
+		finalityDepth: finalityDepth,
+		logger:        logger.Named("event_tracker"),
 	}
 }
 
@@ -48,12 +48,12 @@ func (e *EventTracker) Start(ctx context.Context) error {
 
 	notifierCh := make(chan []*ethgo.Log)
 
-	store, err := NewEventTrackerStore(e.dbPath, e.finalizedThreshold, notifierCh, e.logger)
+	store, err := NewEventTrackerStore(e.dbPath, e.finalityDepth, notifierCh, e.logger)
 	if err != nil {
 		return err
 	}
 
-	e.logger.Info("Start tracking events", "threshold", e.finalizedThreshold, "contract address", e.contractAddr)
+	e.logger.Info("Start tracking events", "block finality depth", e.finalityDepth, "contract address", e.contractAddr)
 
 	tt, err := tracker.NewTracker(provider.Eth(),
 		tracker.WithBatchSize(10),

--- a/tracker/event_tracker.go
+++ b/tracker/event_tracker.go
@@ -19,7 +19,7 @@ type EventTracker struct {
 	contractAddr  ethgo.Address
 	subscriber    eventSubscription
 	logger        hcf.Logger
-	finalityDepth uint64 // after how many blocks we consider block is finalized
+	finalityDepth uint64 // minimal number of child blocks required for the parent block to be considered final
 }
 
 func NewEventTracker(

--- a/tracker/event_tracker.go
+++ b/tracker/event_tracker.go
@@ -79,6 +79,10 @@ func (e *EventTracker) Start(ctx context.Context) error {
 		for {
 			select {
 			case <-ctx.Done():
+				if err := store.Close(); err != nil {
+					e.logger.Info("error while closing store", "err", err)
+				}
+
 				close(notifierCh) // close notifier channel after everything is finished
 
 				return

--- a/tracker/event_tracker.go
+++ b/tracker/event_tracker.go
@@ -9,8 +9,6 @@ import (
 	"github.com/umbracle/ethgo/tracker"
 )
 
-const DefaultFinalizedThreshold = uint64(0)
-
 type eventSubscription interface {
 	AddLog(log *ethgo.Log)
 }
@@ -55,7 +53,7 @@ func (e *EventTracker) Start(ctx context.Context) error {
 		return err
 	}
 
-	e.logger.Info("Start tracking events", "contract address", e.contractAddr)
+	e.logger.Info("Start tracking events", "threshold", e.finalizedThreshold, "contract address", e.contractAddr)
 
 	tt, err := tracker.NewTracker(provider.Eth(),
 		tracker.WithBatchSize(10),

--- a/tracker/event_tracker_store.go
+++ b/tracker/event_tracker_store.go
@@ -201,8 +201,6 @@ func (e *Entry) StoreLogs(logs []*ethgo.Log) error {
 			if err := bucketLogs.Put(itob(logIdx), val); err != nil {
 				return err
 			}
-
-			lastBlockNumber = log.BlockNumber
 		}
 
 		e.logger.Info("write event logs",
@@ -212,6 +210,8 @@ func (e *Entry) StoreLogs(logs []*ethgo.Log) error {
 	}); err != nil {
 		return err
 	}
+
+	lastBlockNumber = logs[len(logs)-1].BlockNumber
 
 	notifyLogs, lastProcessedIdx, err := e.getFinalizedLogs(lastBlockNumber - e.finalizedThreshold)
 	if err != nil {

--- a/tracker/event_tracker_store.go
+++ b/tracker/event_tracker_store.go
@@ -1,0 +1,331 @@
+package tracker
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+
+	hcf "github.com/hashicorp/go-hclog"
+	"github.com/umbracle/ethgo"
+	"github.com/umbracle/ethgo/tracker/store"
+	bolt "go.etcd.io/bbolt"
+)
+
+var _ store.Store = (*EventTrackerStore)(nil)
+
+var (
+	dbLogs          = []byte("logs")
+	dbConf          = []byte("conf")
+	dbNextToProcess = []byte("nextToProcess")
+)
+
+// EventTrackerStore is a tracker store implementation.
+type EventTrackerStore struct {
+	conn               *bolt.DB
+	finalizedThreshold uint64 // after how many blocks we consider block is finalized
+	notifierCh         chan<- []*ethgo.Log
+	logger             hcf.Logger
+}
+
+// NewEventTrackerStore creates a new EventTrackerStore
+func NewEventTrackerStore(
+	path string,
+	finalizedTrashhold uint64,
+	notifierCh chan<- []*ethgo.Log,
+	logger hcf.Logger) (*EventTrackerStore, error) {
+	db, err := bolt.Open(path, 0600, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	store := &EventTrackerStore{
+		conn:               db,
+		finalizedThreshold: finalizedTrashhold,
+		notifierCh:         notifierCh,
+		logger:             logger,
+	}
+
+	if err := store.setupDB(); err != nil {
+		store.Close()
+
+		return nil, err
+	}
+
+	return store, nil
+}
+
+func (b *EventTrackerStore) setupDB() error {
+	return b.conn.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucketIfNotExists(dbConf); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+// Close implements the store interface
+func (b *EventTrackerStore) Close() error {
+	return b.conn.Close()
+}
+
+// Get implements the store interface
+func (b *EventTrackerStore) Get(k string) (string, error) {
+	var result []byte
+
+	if err := b.conn.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(dbConf)
+		result = bucket.Get([]byte(k))
+
+		return nil
+	}); err != nil {
+		return "", err
+	}
+
+	return string(result), nil
+}
+
+// ListPrefix implements the store interface
+func (b *EventTrackerStore) ListPrefix(prefix string) ([]string, error) {
+	var result []string
+
+	if err := b.conn.View(func(tx *bolt.Tx) error {
+		pfx := []byte(prefix)
+		c := tx.Bucket(dbConf).Cursor()
+
+		for k, v := c.Seek(pfx); k != nil && bytes.HasPrefix(k, pfx); k, v = c.Next() {
+			result = append(result, string(v))
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// Set implements the store interface
+func (b *EventTrackerStore) Set(k, v string) error {
+	return b.conn.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(dbConf)
+
+		return bucket.Put([]byte(k), []byte(v))
+	})
+}
+
+// GetEntry implements the store interface
+func (b *EventTrackerStore) GetEntry(hash string) (store.Entry, error) {
+	var result store.Entry
+
+	if err := b.conn.Update(func(tx *bolt.Tx) error {
+		logsBucketName := append(dbLogs, []byte(hash)...)
+		if _, err := tx.CreateBucketIfNotExists(logsBucketName); err != nil {
+			return err
+		}
+
+		nextToProcessBucketName := append(dbNextToProcess, []byte(hash)...)
+		if _, err := tx.CreateBucketIfNotExists(nextToProcessBucketName); err != nil {
+			return err
+		}
+
+		result = &Entry{
+			conn:                b.conn,
+			bucketLogs:          logsBucketName,
+			bucketNextToProcess: nextToProcessBucketName,
+			finalizedThreshold:  b.finalizedThreshold,
+			notifierCh:          b.notifierCh,
+			logger:              b.logger,
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// Entry is an store.Entry implementation
+type Entry struct {
+	conn                *bolt.DB
+	bucketLogs          []byte
+	bucketNextToProcess []byte
+	finalizedThreshold  uint64 // after how many blocks we consider block is finalized
+	notifierCh          chan<- []*ethgo.Log
+	logger              hcf.Logger
+}
+
+// LastIndex implements the store interface
+func (e *Entry) LastIndex() (uint64, error) {
+	var result uint64
+
+	if err := e.conn.View(func(tx *bolt.Tx) error {
+		result = getLastIndex(tx.Bucket(e.bucketLogs))
+
+		return nil
+	}); err != nil {
+		return 0, err
+	}
+
+	return result, nil
+}
+
+// StoreLog implements the store interface
+func (e *Entry) StoreLog(log *ethgo.Log) error {
+	return e.StoreLogs([]*ethgo.Log{log})
+}
+
+// StoreLogs implements the store interface
+// logs are added in sequentional order
+func (e *Entry) StoreLogs(logs []*ethgo.Log) error {
+	if len(logs) == 0 {
+		return nil
+	}
+
+	var lastBlockNumber uint64
+
+	if err := e.conn.Update(func(tx *bolt.Tx) error {
+		bucketLogs := tx.Bucket(e.bucketLogs)
+		lastLogIndx := getLastIndex(bucketLogs)
+
+		for idx, log := range logs {
+			logIdx := lastLogIndx + uint64(idx)
+
+			val, err := log.MarshalJSON()
+			if err != nil {
+				return err
+			}
+
+			if err := bucketLogs.Put(itob(logIdx), val); err != nil {
+				return err
+			}
+
+			lastBlockNumber = log.BlockNumber
+		}
+
+		e.logger.Info("write event logs",
+			"from", lastLogIndx, "to", lastLogIndx+uint64(len(logs))-1, "block", lastBlockNumber)
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	notifyLogs, lastProcessedIdx, err := e.getFinalizedLogs(lastBlockNumber - e.finalizedThreshold)
+	if err != nil {
+		return err
+	}
+
+	return e.notifyFinalizedLogs(notifyLogs, lastProcessedIdx)
+}
+
+// RemoveLogs implements the store interface
+func (e *Entry) RemoveLogs(indx uint64) error {
+	return e.conn.Update(func(tx *bolt.Tx) error {
+		cursorLogs := tx.Bucket(e.bucketLogs).Cursor()
+
+		// remove logs
+		for k, _ := cursorLogs.Seek(itob(indx)); k != nil; k, _ = cursorLogs.Next() {
+			if err := cursorLogs.Delete(); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+// GetLog implements the store interface
+func (e *Entry) GetLog(idx uint64, log *ethgo.Log) error {
+	return e.conn.View(func(tx *bolt.Tx) error {
+		val := tx.Bucket(e.bucketLogs).Get(itob(idx))
+		if val == nil {
+			return fmt.Errorf("log not found: %d", idx)
+		}
+
+		return log.UnmarshalJSON(val)
+	})
+}
+
+func (e *Entry) getFinalizedLogs(untilBlockNumber uint64) ([]*ethgo.Log, uint64, error) {
+	var (
+		logs             []*ethgo.Log
+		lastProcessedIdx uint64 = 0
+	)
+
+	if err := e.conn.View(func(tx *bolt.Tx) error {
+		bucketLastProcessedBlock := tx.Bucket(e.bucketNextToProcess)
+		cursorLogs := tx.Bucket(e.bucketLogs).Cursor()
+
+		var key, value []byte
+
+		// pick first unprocessed block
+		if _, val := bucketLastProcessedBlock.Cursor().First(); val != nil {
+			key, value = cursorLogs.Seek(val)
+		} else {
+			key, value = cursorLogs.First()
+		}
+
+		for ; key != nil; key, value = cursorLogs.Next() {
+			log := &ethgo.Log{}
+			if err := json.Unmarshal(value, log); err != nil {
+				return err
+			}
+
+			if log.BlockNumber > untilBlockNumber {
+				break
+			}
+
+			logs = append(logs, log)
+			lastProcessedIdx = btoi(key)
+		}
+
+		return nil
+	}); err != nil {
+		return nil, 0, err
+	}
+
+	return logs, lastProcessedIdx, nil
+}
+
+func (e *Entry) notifyFinalizedLogs(logs []*ethgo.Log, lastProcessedIdx uint64) error {
+	if len(logs) == 0 {
+		return nil
+	}
+
+	e.logger.Info("notify event logs", "len", len(logs), "last processed", lastProcessedIdx)
+
+	if err := e.conn.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(e.bucketNextToProcess).Put([]byte("0"), itob(lastProcessedIdx+1))
+	}); err != nil {
+		return err
+	}
+
+	// notify logs - for testing purpose chan can be nil
+	if e.notifierCh != nil {
+		e.notifierCh <- logs
+	}
+
+	return nil
+}
+
+func getLastIndex(bucket *bolt.Bucket) uint64 {
+	if last, _ := bucket.Cursor().Last(); last != nil {
+		return btoi(last) + 1
+	}
+
+	return 0
+}
+
+func btoi(b []byte) uint64 {
+	return binary.BigEndian.Uint64(b)
+}
+
+func itob(u uint64) []byte {
+	buf := [8]byte{}
+	binary.BigEndian.PutUint64(buf[:], u)
+
+	return buf[:]
+}

--- a/tracker/event_tracker_store.go
+++ b/tracker/event_tracker_store.go
@@ -23,7 +23,7 @@ var (
 // EventTrackerStore is a tracker store implementation.
 type EventTrackerStore struct {
 	conn          *bolt.DB
-	finalityDepth uint64 // after how many blocks we consider block is finalized
+	finalityDepth uint64
 	notifierCh    chan<- []*ethgo.Log
 	logger        hcf.Logger
 }
@@ -152,7 +152,7 @@ type Entry struct {
 	conn                *bolt.DB
 	bucketLogs          []byte
 	bucketNextToProcess []byte
-	finalityDepth       uint64 // after how many blocks we consider block is finalized
+	finalityDepth       uint64
 	notifierCh          chan<- []*ethgo.Log
 	logger              hcf.Logger
 }

--- a/tracker/event_tracker_store_test.go
+++ b/tracker/event_tracker_store_test.go
@@ -126,7 +126,7 @@ func TestEventTrackerStore_OnNewBlockNothingToProcess(t *testing.T) {
 
 	value := hex.EncodeToString(bytes)
 
-	// block less than finality depth
+	// block less than numBlockConfirmations
 	assert.NoError(t, tstore.(*EventTrackerStore).onNewBlock("dummy", value)) //nolint
 	assert.Len(t, subs.logs, 0)
 

--- a/tracker/event_tracker_store_test.go
+++ b/tracker/event_tracker_store_test.go
@@ -1,0 +1,33 @@
+package tracker
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+	"github.com/umbracle/ethgo/tracker/store"
+)
+
+func setupDB(t *testing.T) (store.Store, func()) {
+	t.Helper()
+
+	dir, err := ioutil.TempDir("/tmp", "boltdb-test")
+	require.NoError(t, err)
+
+	path := filepath.Join(dir, "test.db")
+	store, err := NewEventTrackerStore(path, 2, nil, hclog.Default())
+	require.NoError(t, err)
+
+	closeFn := func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}
+
+	return store, closeFn
+}
+
+func TestBoltDBStore(t *testing.T) {
+	store.TestStore(t, setupDB)
+}

--- a/tracker/event_tracker_store_test.go
+++ b/tracker/event_tracker_store_test.go
@@ -1,35 +1,177 @@
 package tracker
 
 import (
+	"encoding/hex"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/umbracle/ethgo"
 	"github.com/umbracle/ethgo/tracker/store"
 )
 
-func setupDB(t *testing.T) (store.Store, func()) {
-	t.Helper()
+func createSetupDB(subscriber eventSubscription, finalityDepth uint64) store.SetupDB {
+	return func(t *testing.T) (store.Store, func()) {
+		t.Helper()
 
-	dir, err := ioutil.TempDir("/tmp", "boltdb-test")
-	require.NoError(t, err)
+		dir, err := ioutil.TempDir("/tmp", "boltdb-test")
+		require.NoError(t, err)
 
-	path := filepath.Join(dir, "test.db")
-	store, err := NewEventTrackerStore(path, 2, nil, hclog.Default())
-	require.NoError(t, err)
+		path := filepath.Join(dir, "test.db")
+		store, err := NewEventTrackerStore(path, finalityDepth, subscriber, hclog.Default())
+		require.NoError(t, err)
 
-	closeFn := func() {
-		require.NoError(t, os.RemoveAll(dir))
+		closeFn := func() {
+			require.NoError(t, os.RemoveAll(dir))
+		}
+
+		return store, closeFn
 	}
-
-	return store, closeFn
 }
 
 func TestBoltDBStore(t *testing.T) {
 	t.Parallel()
 
-	store.TestStore(t, setupDB)
+	store.TestStore(t, createSetupDB(nil, 2))
+}
+
+func Test_Entry_getFinalizedLogs(t *testing.T) {
+	t.Parallel()
+
+	const someFilterHash = "test"
+
+	tstore, fn := createSetupDB(nil, 3)(t)
+	defer fn()
+
+	entry, err := tstore.(*EventTrackerStore).getImplEntry(someFilterHash)
+	require.NoError(t, err)
+
+	entry.StoreLogs([]*ethgo.Log{
+		{BlockNumber: 1}, {BlockNumber: 5}, {BlockNumber: 8}, {BlockNumber: 11}, {BlockNumber: 12}, {BlockNumber: 15},
+	})
+
+	logs, key, err := entry.getFinalizedLogs(10)
+
+	assert.NoError(t, err)
+	assert.Len(t, logs, 3)
+	assert.Equal(t, common.EncodeUint64ToBytes(2), key)
+
+	err = entry.saveNextToProcessIndx(1) // next time should start from the second one
+	require.NoError(t, err)
+
+	logs, key, err = entry.getFinalizedLogs(14)
+
+	assert.NoError(t, err)
+	assert.Len(t, logs, 4)
+	assert.Equal(t, common.EncodeUint64ToBytes(4), key)
+}
+
+func Test_Entry_saveNextToProcessIndx(t *testing.T) {
+	const someFilterHash = "test"
+
+	tstore, fn := createSetupDB(nil, 2)(t)
+	defer fn()
+
+	entry, err := tstore.(*EventTrackerStore).getImplEntry(someFilterHash)
+	require.NoError(t, err)
+
+	entry.StoreLogs([]*ethgo.Log{
+		{BlockNumber: 1}, {BlockNumber: 5}, {BlockNumber: 8}, {BlockNumber: 11}, {BlockNumber: 12}, {BlockNumber: 15},
+	})
+
+	for i := 0; i < 10; i++ {
+		require.NoError(t, entry.saveNextToProcessIndx(uint64(i)))
+	}
+}
+
+func Test_EventTrackerStore_SetNotLastBlock(t *testing.T) {
+	t.Parallel()
+
+	subs := &mockEventSubscriber{}
+
+	tstore, fn := createSetupDB(subs, 2)(t)
+	defer fn()
+
+	assert.NoError(t, tstore.(*EventTrackerStore).Set("dummy", "dummy")) //nolint
+	assert.Len(t, subs.logs, 0)
+}
+
+func Test_EventTrackerStore_onNewBlockBad(t *testing.T) {
+	t.Parallel()
+
+	tstore, fn := createSetupDB(nil, 0)(t)
+	defer fn()
+
+	assert.Error(t, tstore.(*EventTrackerStore).onNewBlock("dummy", "dummy"))                          //nolint
+	assert.Error(t, tstore.(*EventTrackerStore).onNewBlock("dummy", hex.EncodeToString([]byte{0, 1}))) //nolint
+}
+
+func Test_EventTrackerStore_OnNewBlockNothingToProcess(t *testing.T) {
+	t.Parallel()
+
+	subs := &mockEventSubscriber{}
+
+	tstore, fn := createSetupDB(subs, 10)(t)
+	defer fn()
+
+	block := ethgo.Block{Number: 8}
+
+	bytes, err := block.MarshalJSON()
+	require.NoError(t, err)
+
+	value := hex.EncodeToString(bytes)
+
+	// block less than finality depth
+	assert.NoError(t, tstore.(*EventTrackerStore).onNewBlock("dummy", value)) //nolint
+	assert.Len(t, subs.logs, 0)
+
+	block = ethgo.Block{Number: 12}
+
+	bytes, err = block.MarshalJSON()
+	require.NoError(t, err)
+
+	value = hex.EncodeToString(bytes)
+
+	// no logs
+	assert.NoError(t, tstore.(*EventTrackerStore).onNewBlock("dummy", value)) //nolint
+	assert.Len(t, subs.logs, 0)
+}
+
+func Test_EventTrackerStore_SetLastBlockSubscriberNotified(t *testing.T) {
+	t.Parallel()
+
+	const hash = "dummy_hash"
+
+	subs := &mockEventSubscriber{}
+
+	tstore, fn := createSetupDB(subs, 2)(t)
+	defer fn()
+
+	entry, err := tstore.GetEntry(hash)
+	require.NoError(t, err)
+
+	require.NoError(t, entry.StoreLogs([]*ethgo.Log{
+		{BlockNumber: 1}, {BlockNumber: 2}, {BlockNumber: 3},
+	}))
+
+	for i := 0; i < 3; i++ {
+		block := ethgo.Block{Number: uint64(i + 2)}
+
+		bytes, err := block.MarshalJSON()
+		require.NoError(t, err)
+
+		value := hex.EncodeToString(bytes)
+
+		assert.NoError(t, tstore.Set(dbLastBlockPrefix+hash, value))
+		assert.Len(t, subs.logs, i)
+
+		subs.logs = nil
+
+		require.NoError(t, entry.(*Entry).saveNextToProcessIndx(0)) //nolint
+	}
 }

--- a/tracker/event_tracker_store_test.go
+++ b/tracker/event_tracker_store_test.go
@@ -29,5 +29,7 @@ func setupDB(t *testing.T) (store.Store, func()) {
 }
 
 func TestBoltDBStore(t *testing.T) {
+	t.Parallel()
+
 	store.TestStore(t, setupDB)
 }

--- a/tracker/event_tracker_test.go
+++ b/tracker/event_tracker_test.go
@@ -89,7 +89,7 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 	require.Equal(t, eventsPerStep, sub.len())
-	// send 10 more events
+	// send eventsPerStep more events
 	for i := 0; i < eventsPerStep; i++ {
 		receipt, err := server.TxnTo(addr, "emitEvent")
 		require.NoError(t, err)

--- a/tracker/event_tracker_test.go
+++ b/tracker/event_tracker_test.go
@@ -42,7 +42,7 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 	t.Parallel()
 
 	const (
-		finalizedThreshold = 2
+		blockFinalityDepth = 2
 		eventsPerStep      = 8
 	)
 
@@ -67,7 +67,7 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 	require.NoError(t, err)
 
 	// prefill with eventsPerStep + finalizedTrashhold events
-	for i := 0; i < eventsPerStep+finalizedThreshold; i++ {
+	for i := 0; i < eventsPerStep+blockFinalityDepth; i++ {
 		receipt, err := server.TxnTo(addr, "emitEvent")
 		require.NoError(t, err)
 		require.Equal(t, uint64(types.ReceiptSuccess), receipt.Status)
@@ -76,12 +76,12 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 	sub := &mockEventSubscriber{}
 
 	tracker := &EventTracker{
-		logger:             hclog.NewNullLogger(),
-		subscriber:         sub,
-		dbPath:             path.Join(tmpDir, "test.db"),
-		rpcEndpoint:        server.HTTPAddr(),
-		contractAddr:       addr,
-		finalizedThreshold: finalizedThreshold,
+		logger:        hclog.NewNullLogger(),
+		subscriber:    sub,
+		dbPath:        path.Join(tmpDir, "test.db"),
+		rpcEndpoint:   server.HTTPAddr(),
+		contractAddr:  addr,
+		finalityDepth: blockFinalityDepth,
 	}
 
 	err = tracker.Start(context.Background())

--- a/tracker/event_tracker_test.go
+++ b/tracker/event_tracker_test.go
@@ -42,8 +42,8 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 	t.Parallel()
 
 	const (
-		blockFinalityDepth = 6
-		eventsPerStep      = 8
+		numBlockConfirmations = 6
+		eventsPerStep         = 8
 	)
 
 	server := testutil.DeployTestServer(t, nil)
@@ -67,7 +67,7 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 	require.NoError(t, err)
 
 	// prefill with eventsPerStep + blockFinalityDepth events
-	for i := 0; i < eventsPerStep+blockFinalityDepth; i++ {
+	for i := 0; i < eventsPerStep+numBlockConfirmations; i++ {
 		receipt, err := server.TxnTo(addr, "emitEvent")
 		require.NoError(t, err)
 		require.Equal(t, uint64(types.ReceiptSuccess), receipt.Status)
@@ -76,12 +76,12 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 	sub := &mockEventSubscriber{}
 
 	tracker := &EventTracker{
-		logger:        hclog.NewNullLogger(),
-		subscriber:    sub,
-		dbPath:        path.Join(tmpDir, "test.db"),
-		rpcEndpoint:   server.HTTPAddr(),
-		contractAddr:  addr,
-		finalityDepth: blockFinalityDepth,
+		logger:                hclog.NewNullLogger(),
+		subscriber:            sub,
+		dbPath:                path.Join(tmpDir, "test.db"),
+		rpcEndpoint:           server.HTTPAddr(),
+		contractAddr:          addr,
+		numBlockConfirmations: numBlockConfirmations,
 	}
 
 	err = tracker.Start(context.Background())

--- a/tracker/event_tracker_test.go
+++ b/tracker/event_tracker_test.go
@@ -42,7 +42,7 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 	t.Parallel()
 
 	const (
-		blockFinalityDepth = 2
+		blockFinalityDepth = 6
 		eventsPerStep      = 8
 	)
 
@@ -66,7 +66,7 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 	_, addr, err := server.DeployContract(cc)
 	require.NoError(t, err)
 
-	// prefill with eventsPerStep + finalizedTrashhold events
+	// prefill with eventsPerStep + blockFinalityDepth events
 	for i := 0; i < eventsPerStep+blockFinalityDepth; i++ {
 		receipt, err := server.TxnTo(addr, "emitEvent")
 		require.NoError(t, err)

--- a/tracker/event_tracker_test.go
+++ b/tracker/event_tracker_test.go
@@ -41,6 +41,11 @@ func (m *mockEventSubscriber) len() int {
 func TestEventTracker_TrackSyncEvents(t *testing.T) {
 	t.Parallel()
 
+	const (
+		finalizedThreshold = 2
+		eventsPerStep      = 8
+	)
+
 	server := testutil.DeployTestServer(t, nil)
 
 	tmpDir, err := os.MkdirTemp("/tmp", "test-event-tracker")
@@ -61,8 +66,8 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 	_, addr, err := server.DeployContract(cc)
 	require.NoError(t, err)
 
-	// prefill with 10 events
-	for i := 0; i < 10; i++ {
+	// prefill with eventsPerStep + finalizedTrashhold events
+	for i := 0; i < eventsPerStep+finalizedThreshold; i++ {
 		receipt, err := server.TxnTo(addr, "emitEvent")
 		require.NoError(t, err)
 		require.Equal(t, uint64(types.ReceiptSuccess), receipt.Status)
@@ -71,25 +76,26 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 	sub := &mockEventSubscriber{}
 
 	tracker := &EventTracker{
-		logger:       hclog.NewNullLogger(),
-		subscriber:   sub,
-		dbPath:       path.Join(tmpDir, "test.db"),
-		rpcEndpoint:  server.HTTPAddr(),
-		contractAddr: addr,
+		logger:             hclog.NewNullLogger(),
+		subscriber:         sub,
+		dbPath:             path.Join(tmpDir, "test.db"),
+		rpcEndpoint:        server.HTTPAddr(),
+		contractAddr:       addr,
+		finalizedThreshold: finalizedThreshold,
 	}
 
 	err = tracker.Start(context.Background())
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)
-	require.Equal(t, sub.len(), 10)
+	require.Equal(t, eventsPerStep, sub.len())
 	// send 10 more events
-	for i := 0; i < 10; i++ {
+	for i := 0; i < eventsPerStep; i++ {
 		receipt, err := server.TxnTo(addr, "emitEvent")
 		require.NoError(t, err)
 		require.Equal(t, uint64(types.ReceiptSuccess), receipt.Status)
 	}
 
 	time.Sleep(2 * time.Second)
-	require.Equal(t, sub.len(), 20)
+	require.Equal(t, eventsPerStep*2, sub.len())
 }

--- a/tracker/event_tracker_test.go
+++ b/tracker/event_tracker_test.go
@@ -66,7 +66,7 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 	_, addr, err := server.DeployContract(cc)
 	require.NoError(t, err)
 
-	// prefill with eventsPerStep + blockFinalityDepth events
+	// prefill with eventsPerStep + numBlockConfirmations events
 	for i := 0; i < eventsPerStep+numBlockConfirmations; i++ {
 		receipt, err := server.TxnTo(addr, "emitEvent")
 		require.NoError(t, err)


### PR DESCRIPTION
# Description

Block should not be considered final until at least `NumBlockConfirmations` number of children blocks appear.
Only logs of finalized blocks should be delegated to the subscriber.

The changes should only affect `stateSyncManager`, as it relies on the event tracker to retrieve logs from the `eth` node.
`BlockFinalityDepth` will be `0` for the `StateSyncRelayer` because we have instant finality on our chain.

Server command has been updated to include an optional `--num-block-confirmations` flag, which controls the minimum number of child blocks that must appear after a block before we consider that block finalized. By default, this value is set to 64.
That parameter can be set from configuration also with `num_block_confirmations`. 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
