### PR TITLE
Add output flag to polybft-secrets

### DIFF
--- a/command/polybftsecrets/params.go
+++ b/command/polybftsecrets/params.go
@@ -215,6 +215,13 @@ func (ip *initParams) getResult(secretsManager secrets.SecretsManager) (command.
 			}
 
 			res.PrivateKey = hex.EncodeToString(pk)
+
+			blspk, err := account.Bls.Marshal()
+			if err != nil {
+				return nil, err
+			}
+
+			res.BLSPrivateKey = hex.EncodeToString(blspk)
 		}
 	}
 

--- a/command/polybftsecrets/params.go
+++ b/command/polybftsecrets/params.go
@@ -20,6 +20,7 @@ const (
 	privateKeyFlag = "private"
 	networkFlag    = "network"
 	numFlag        = "num"
+	outputFlag     = "output"
 
 	// maxInitNum is the maximum value for "num" flag
 	maxInitNum = 30
@@ -50,6 +51,8 @@ type initParams struct {
 	numberOfSecrets int
 
 	insecureLocalStore bool
+
+	output bool
 }
 
 func (ip *initParams) validateFlags() error {
@@ -121,6 +124,13 @@ func (ip *initParams) setFlags(cmd *cobra.Command) {
 		false,
 		"the flag indicating should the secrets stored on the local storage be encrypted",
 	)
+
+	cmd.Flags().BoolVar(
+		&ip.output,
+		outputFlag,
+		false,
+		"the flag indicating to output existing secrets",
+	)
 }
 
 func (ip *initParams) Execute() (Results, error) {
@@ -142,9 +152,11 @@ func (ip *initParams) Execute() (Results, error) {
 			return results, err
 		}
 
-		err = ip.initKeys(secretManager)
-		if err != nil {
-			return results, err
+		if !ip.output {
+			err = ip.initKeys(secretManager)
+			if err != nil {
+				return results, err
+			}
 		}
 
 		res, err := ip.getResult(secretManager)

--- a/command/polybftsecrets/result.go
+++ b/command/polybftsecrets/result.go
@@ -23,11 +23,12 @@ func (r Results) GetOutput() string {
 }
 
 type SecretsInitResult struct {
-	Address    types.Address `json:"address"`
-	BLSPubkey  string        `json:"bls_pubkey"`
-	NodeID     string        `json:"node_id"`
-	PrivateKey string        `json:"private_key"`
-	Insecure   bool          `json:"insecure"`
+	Address       types.Address `json:"address"`
+	BLSPubkey     string        `json:"bls_pubkey"`
+	NodeID        string        `json:"node_id"`
+	PrivateKey    string        `json:"private_key"`
+	BLSPrivateKey string        `json:"bls_private_key"`
+	Insecure      bool          `json:"insecure"`
 }
 
 func (r *SecretsInitResult) GetOutput() string {
@@ -44,6 +45,13 @@ func (r *SecretsInitResult) GetOutput() string {
 		vals = append(
 			vals,
 			fmt.Sprintf("Private key|%s", r.PrivateKey),
+		)
+	}
+
+	if r.BLSPrivateKey != "" {
+		vals = append(
+			vals,
+			fmt.Sprintf("BLS Private key|%s", r.BLSPrivateKey),
 		)
 	}
 


### PR DESCRIPTION
# Description

The output flag indicates the secrets command that it should output the existing secrets in case they are found in local disk or in the vault configured in the secrets manager conf.

Example usages:

`$ polygon-edge polybft-secrets --data-dir test-chain- --insecure --output --num 4`
`$ polygon-edge polybft-secrets --data-dir test-chain-1 --insecure --output `

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

CLI

# Documentation update

