### PR TITLE
Introduce signature file in validator secrets to handle validator key signature

### DIFF
--- a/command/e2e/register_validator.go
+++ b/command/e2e/register_validator.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -125,7 +126,12 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	blsSignature, err := bls.UnmarshalSignature(sRaw)
+	sb, err := hex.DecodeString(string(sRaw))
+	if err != nil {
+		return err
+	}
+
+	blsSignature, err := bls.UnmarshalSignature(sb)
 	if err != nil {
 		return err
 	}

--- a/command/e2e/register_validator.go
+++ b/command/e2e/register_validator.go
@@ -10,12 +10,12 @@ import (
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/helper"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/crypto"
+	"github.com/0xPolygon/polygon-edge/secrets"
 	secretsHelper "github.com/0xPolygon/polygon-edge/secrets/helper"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/mitchellh/go-glint"
@@ -120,6 +120,16 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	sRaw, err := secretsManager.GetSecret(secrets.ValidatorBLSSignature)
+	if err != nil {
+		return err
+	}
+
+	blsSignature, err := bls.UnmarshalSignature(sRaw)
+	if err != nil {
+		return err
+	}
+
 	var validator *NewValidator
 
 	steps := []*txnStep{
@@ -138,7 +148,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		{
 			name: "register",
 			action: func() asyncTxn {
-				return registerValidator(newValidatorSender, newValidatorAccount, params.chainID)
+				return registerValidator(newValidatorSender, newValidatorAccount, blsSignature)
 			},
 			postHook: func(receipt *ethgo.Receipt) error {
 				if receipt.Status != uint64(types.ReceiptSuccess) {
@@ -484,15 +494,9 @@ func fund(sender *txnSender, addr types.Address) asyncTxn {
 	return sender.sendTransaction(txn)
 }
 
-func registerValidator(sender *txnSender, account *wallet.Account, chainID int64) asyncTxn {
+func registerValidator(sender *txnSender, account *wallet.Account, signature *bls.Signature) asyncTxn {
 	if registerFn == nil {
 		return &asyncTxnImpl{err: errors.New("failed to create register ABI function")}
-	}
-
-	signature, err := polybft.MakeKOSKSignature(
-		account.Bls, types.Address(sender.account.Ecdsa.Address()), chainID, bls.DomainValidatorSet)
-	if err != nil {
-		return &asyncTxnImpl{err: err}
 	}
 
 	sigMarshal, err := signature.ToBigInt()

--- a/command/genesis/utils.go
+++ b/command/genesis/utils.go
@@ -137,7 +137,7 @@ func ReadValidatorsByPrefix(dir, prefix string) ([]*polybft.Validator, error) {
 	for i, file := range validatorKeyFiles {
 		path := filepath.Join(dir, file)
 
-		account, nodeID, err := getSecrets(path)
+		account, nodeID, blsSignature, err := getSecrets(path)
 		if err != nil {
 			return nil, err
 		}
@@ -146,6 +146,7 @@ func ReadValidatorsByPrefix(dir, prefix string) ([]*polybft.Validator, error) {
 			Address:       types.Address(account.Ecdsa.Address()),
 			BlsPrivateKey: account.Bls,
 			BlsKey:        hex.EncodeToString(account.Bls.PublicKey().Marshal()),
+			BlsSignature:  blsSignature,
 			NodeID:        nodeID,
 		}
 	}
@@ -153,7 +154,7 @@ func ReadValidatorsByPrefix(dir, prefix string) ([]*polybft.Validator, error) {
 	return validators, nil
 }
 
-func getSecrets(directory string) (*wallet.Account, string, error) {
+func getSecrets(directory string) (*wallet.Account, string, string, error) {
 	baseConfig := &secrets.SecretsManagerParams{
 		Logger: hclog.NewNullLogger(),
 		Extra: map[string]interface{}{
@@ -163,18 +164,20 @@ func getSecrets(directory string) (*wallet.Account, string, error) {
 
 	localManager, err := local.SecretsManagerFactory(nil, baseConfig)
 	if err != nil {
-		return nil, "", fmt.Errorf("unable to instantiate local secrets manager, %w", err)
+		return nil, "", "", fmt.Errorf("unable to instantiate local secrets manager, %w", err)
 	}
 
 	nodeID, err := helper.LoadNodeID(localManager)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 
 	account, err := wallet.NewAccountFromSecret(localManager)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 
-	return account, nodeID, nil
+	blsSignature, err := helper.LoadBLSSignature(localManager)
+
+	return account, nodeID, blsSignature, err
 }

--- a/command/polybftmanifest/manifest_init.go
+++ b/command/polybftmanifest/manifest_init.go
@@ -21,6 +21,7 @@ const (
 	validatorsFlag        = "validators"
 	validatorsPathFlag    = "validators-path"
 	validatorsPrefixFlag  = "validators-prefix"
+	chainIDFlag           = "chain-id"
 
 	defaultValidatorPrefixPath = "test-chain-"
 	defaultManifestPath        = "./manifest.json"
@@ -88,6 +89,13 @@ func setFlags(cmd *cobra.Command) {
 		"the amount which will be pre-mined to all the validators",
 	)
 
+	cmd.Flags().Int64Var(
+		&params.chainID,
+		chainIDFlag,
+		command.DefaultChainID,
+		"the ID of the chain",
+	)
+
 	cmd.MarkFlagsMutuallyExclusive(validatorsFlag, validatorsPathFlag)
 	cmd.MarkFlagsMutuallyExclusive(validatorsFlag, validatorsPrefixFlag)
 }
@@ -103,7 +111,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	manifest := &polybft.Manifest{GenesisValidators: validators}
+	manifest := &polybft.Manifest{GenesisValidators: validators, ChainID: params.chainID}
 	if err = manifest.Save(params.manifestPath); err != nil {
 		outputter.SetError(fmt.Errorf("failed to save manifest file '%s': %w", params.manifestPath, err))
 
@@ -119,6 +127,7 @@ type manifestInitParams struct {
 	validatorsPrefixPath string
 	premineValidators    string
 	validators           []string
+	chainID              int64
 }
 
 func (p *manifestInitParams) validateFlags() error {

--- a/command/polybftmanifest/manifest_init.go
+++ b/command/polybftmanifest/manifest_init.go
@@ -86,7 +86,7 @@ func setFlags(cmd *cobra.Command) {
 		&params.validators,
 		validatorsFlag,
 		[]string{},
-		"validators defined by user (format: <node id>:<ECDSA address>:<public BLS key>)",
+		"validators defined by user (format: <node id>:<ECDSA address>:<public BLS key>:<BLS signature>)",
 	)
 
 	cmd.Flags().StringVar(

--- a/command/polybftmanifest/manifest_init.go
+++ b/command/polybftmanifest/manifest_init.go
@@ -21,7 +21,6 @@ const (
 	validatorsFlag        = "validators"
 	validatorsPathFlag    = "validators-path"
 	validatorsPrefixFlag  = "validators-prefix"
-	chainIDFlag           = "chain-id"
 
 	defaultValidatorPrefixPath = "test-chain-"
 	defaultManifestPath        = "./manifest.json"
@@ -75,13 +74,6 @@ func setFlags(cmd *cobra.Command) {
 		"folder prefix names for polybft validator keys",
 	)
 
-	cmd.Flags().Int64Var(
-		&params.chainID,
-		chainIDFlag,
-		command.DefaultChainID,
-		"the ID of the chain",
-	)
-
 	cmd.Flags().StringArrayVar(
 		&params.validators,
 		validatorsFlag,
@@ -111,7 +103,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	manifest := &polybft.Manifest{GenesisValidators: validators, ChainID: params.chainID}
+	manifest := &polybft.Manifest{GenesisValidators: validators}
 	if err = manifest.Save(params.manifestPath); err != nil {
 		outputter.SetError(fmt.Errorf("failed to save manifest file '%s': %w", params.manifestPath, err))
 
@@ -127,7 +119,6 @@ type manifestInitParams struct {
 	validatorsPrefixPath string
 	premineValidators    string
 	validators           []string
-	chainID              int64
 }
 
 func (p *manifestInitParams) validateFlags() error {
@@ -199,10 +190,6 @@ func (p *manifestInitParams) getValidatorAccounts() ([]*polybft.Validator, error
 	}
 
 	for _, v := range validators {
-		if err = v.InitKOSKSignature(p.chainID); err != nil {
-			return nil, err
-		}
-
 		v.Balance = balance
 	}
 

--- a/command/polybftsecrets/params.go
+++ b/command/polybftsecrets/params.go
@@ -198,7 +198,14 @@ func (ip *initParams) initKeys(secretsManager secrets.SecretsManager) error {
 			return fmt.Errorf("secrets '%s' has been already initialized", secrets.ValidatorBLSKey)
 		}
 
-		return wallet.GenerateAccount().Save(secretsManager)
+		a := wallet.GenerateAccount()
+		if err := a.Save(secretsManager); err != nil {
+			return err
+		}
+
+		if _, err := helper.InitValidatorBLSSignature(secretsManager, a, ip.chainID); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/command/polybftsecrets/params.go
+++ b/command/polybftsecrets/params.go
@@ -23,6 +23,7 @@ const (
 	networkFlag    = "network"
 	numFlag        = "num"
 	outputFlag     = "output"
+	chainIDFlag    = "chain-id"
 
 	// maxInitNum is the maximum value for "num" flag
 	maxInitNum = 30
@@ -55,6 +56,8 @@ type initParams struct {
 	insecureLocalStore bool
 
 	output bool
+
+	chainID int64
 }
 
 func (ip *initParams) validateFlags() error {
@@ -133,6 +136,13 @@ func (ip *initParams) setFlags(cmd *cobra.Command) {
 		false,
 		"the flag indicating to output existing secrets",
 	)
+
+	cmd.Flags().Int64Var(
+		&ip.chainID,
+		chainIDFlag,
+		command.DefaultChainID,
+		"the ID of the chain",
+	)
 }
 
 func (ip *initParams) Execute() (Results, error) {
@@ -210,7 +220,12 @@ func (ip *initParams) getResult(secretsManager secrets.SecretsManager) (command.
 		res.Address = types.Address(account.Ecdsa.Address())
 		res.BLSPubkey = hex.EncodeToString(account.Bls.PublicKey().Marshal())
 
-		s, err := polybft.MakeKOSKSignature(account.Bls, types.Address(account.Ecdsa.Address()), 10, bls.DomainValidatorSet)
+		s, err := polybft.MakeKOSKSignature(
+			account.Bls,
+			types.Address(account.Ecdsa.Address()),
+			ip.chainID,
+			bls.DomainValidatorSet,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/command/polybftsecrets/params.go
+++ b/command/polybftsecrets/params.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 
 	"github.com/0xPolygon/polygon-edge/command"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft"
+	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/secrets"
 	"github.com/0xPolygon/polygon-edge/secrets/helper"
@@ -207,6 +209,18 @@ func (ip *initParams) getResult(secretsManager secrets.SecretsManager) (command.
 
 		res.Address = types.Address(account.Ecdsa.Address())
 		res.BLSPubkey = hex.EncodeToString(account.Bls.PublicKey().Marshal())
+
+		s, err := polybft.MakeKOSKSignature(account.Bls, types.Address(account.Ecdsa.Address()), 10, bls.DomainValidatorSet)
+		if err != nil {
+			return nil, err
+		}
+
+		sb, err := s.Marshal()
+		if err != nil {
+			return nil, err
+		}
+
+		res.BLSSignature = types.BytesToHash(sb).String()
 
 		if ip.printPrivateKey {
 			pk, err := account.Ecdsa.MarshallPrivateKey()

--- a/command/polybftsecrets/params.go
+++ b/command/polybftsecrets/params.go
@@ -235,7 +235,7 @@ func (ip *initParams) getResult(secretsManager secrets.SecretsManager) (command.
 			return nil, err
 		}
 
-		res.BLSSignature = types.BytesToHash(sb).String()
+		res.BLSSignature = hex.EncodeToString(sb)
 
 		if ip.printPrivateKey {
 			pk, err := account.Ecdsa.MarshallPrivateKey()

--- a/command/polybftsecrets/params.go
+++ b/command/polybftsecrets/params.go
@@ -194,8 +194,10 @@ func (ip *initParams) initKeys(secretsManager secrets.SecretsManager) ([]string,
 	}
 
 	if ip.generatesAccount {
-		var a *wallet.Account
-		var err error
+		var (
+			a   *wallet.Account
+			err error
+		)
 
 		if !secretsManager.HasSecret(secrets.ValidatorKey) && !secretsManager.HasSecret(secrets.ValidatorBLSKey) {
 			a = wallet.GenerateAccount()

--- a/command/polybftsecrets/params.go
+++ b/command/polybftsecrets/params.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
@@ -162,14 +163,15 @@ func (ip *initParams) Execute() (Results, error) {
 			return results, err
 		}
 
+		var gen []string
 		if !ip.output {
-			_, err = ip.initKeys(secretManager)
+			gen, err = ip.initKeys(secretManager)
 			if err != nil {
 				return results, err
 			}
 		}
 
-		res, err := ip.getResult(secretManager)
+		res, err := ip.getResult(secretManager, gen)
 		if err != nil {
 			return results, err
 		}
@@ -226,7 +228,10 @@ func (ip *initParams) initKeys(secretsManager secrets.SecretsManager) ([]string,
 }
 
 // getResult gets keys from secret manager and return result to display
-func (ip *initParams) getResult(secretsManager secrets.SecretsManager) (command.CommandResult, error) {
+func (ip *initParams) getResult(
+	secretsManager secrets.SecretsManager,
+	generated []string,
+) (command.CommandResult, error) {
 	var (
 		res = &SecretsInitResult{}
 		err error
@@ -247,6 +252,7 @@ func (ip *initParams) getResult(secretsManager secrets.SecretsManager) (command.
 		}
 
 		res.BLSSignature = hex.EncodeToString(s)
+		res.Generated = strings.Join(generated, ", ")
 
 		if ip.printPrivateKey {
 			pk, err := account.Ecdsa.MarshallPrivateKey()

--- a/command/polybftsecrets/params.go
+++ b/command/polybftsecrets/params.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 
 	"github.com/0xPolygon/polygon-edge/command"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft"
-	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/secrets"
 	"github.com/0xPolygon/polygon-edge/secrets/helper"
@@ -227,22 +225,12 @@ func (ip *initParams) getResult(secretsManager secrets.SecretsManager) (command.
 		res.Address = types.Address(account.Ecdsa.Address())
 		res.BLSPubkey = hex.EncodeToString(account.Bls.PublicKey().Marshal())
 
-		s, err := polybft.MakeKOSKSignature(
-			account.Bls,
-			types.Address(account.Ecdsa.Address()),
-			ip.chainID,
-			bls.DomainValidatorSet,
-		)
+		s, err := secretsManager.GetSecret(secrets.ValidatorBLSSignature)
 		if err != nil {
 			return nil, err
 		}
 
-		sb, err := s.Marshal()
-		if err != nil {
-			return nil, err
-		}
-
-		res.BLSSignature = hex.EncodeToString(sb)
+		res.BLSSignature = hex.EncodeToString(s)
 
 		if ip.printPrivateKey {
 			pk, err := account.Ecdsa.MarshallPrivateKey()

--- a/command/polybftsecrets/params_test.go
+++ b/command/polybftsecrets/params_test.go
@@ -56,5 +56,6 @@ func fileExists(filename string) bool {
 	if os.IsNotExist(err) {
 		return false
 	}
+
 	return !info.IsDir()
 }

--- a/command/polybftsecrets/params_test.go
+++ b/command/polybftsecrets/params_test.go
@@ -1,0 +1,60 @@
+package polybftsecrets
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/0xPolygon/polygon-edge/secrets/helper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test initKeys
+func Test_initKeys(t *testing.T) {
+	// Creates test directory
+	dir, err := os.MkdirTemp("", "test")
+	defer os.RemoveAll(dir)
+
+	sm, err := helper.SetupLocalSecretsManager(dir)
+	require.NoError(t, err)
+
+	ip := &initParams{
+		generatesAccount: false,
+		generatesNetwork: false,
+		chainID:          1,
+	}
+
+	_, err = ip.initKeys(sm)
+	require.NoError(t, err)
+
+	assert.False(t, fileExists(path.Join(dir, "consensus/validator.key")))
+	assert.False(t, fileExists(path.Join(dir, "consensus/validator-bls.key")))
+	assert.False(t, fileExists(path.Join(dir, "libp2p/libp2p.key")))
+	assert.False(t, fileExists(path.Join(dir, "consensus/validator.sig")))
+
+	ip.generatesAccount = true
+	res, err := ip.initKeys(sm)
+	require.NoError(t, err)
+	assert.Len(t, res, 3)
+
+	assert.True(t, fileExists(path.Join(dir, "consensus/validator.key")))
+	assert.True(t, fileExists(path.Join(dir, "consensus/validator-bls.key")))
+	assert.True(t, fileExists(path.Join(dir, "consensus/validator.sig")))
+	assert.False(t, fileExists(path.Join(dir, "libp2p/libp2p.key")))
+
+	ip.generatesNetwork = true
+	res, err = ip.initKeys(sm)
+	require.NoError(t, err)
+	assert.Len(t, res, 1)
+
+	assert.True(t, fileExists(path.Join(dir, "libp2p/libp2p.key")))
+}
+
+func fileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}

--- a/command/polybftsecrets/result.go
+++ b/command/polybftsecrets/result.go
@@ -28,6 +28,7 @@ type SecretsInitResult struct {
 	NodeID        string        `json:"node_id"`
 	PrivateKey    string        `json:"private_key"`
 	BLSPrivateKey string        `json:"bls_private_key"`
+	BLSSignature  string        `json:"bls_signature"`
 	Insecure      bool          `json:"insecure"`
 }
 
@@ -59,6 +60,13 @@ func (r *SecretsInitResult) GetOutput() string {
 		vals = append(
 			vals,
 			fmt.Sprintf("BLS Public key|%s", r.BLSPubkey),
+		)
+	}
+
+	if r.BLSSignature != "" {
+		vals = append(
+			vals,
+			fmt.Sprintf("BLS Signature|%s", r.BLSSignature),
 		)
 	}
 

--- a/command/polybftsecrets/result.go
+++ b/command/polybftsecrets/result.go
@@ -30,6 +30,7 @@ type SecretsInitResult struct {
 	BLSPrivateKey string        `json:"bls_private_key"`
 	BLSSignature  string        `json:"bls_signature"`
 	Insecure      bool          `json:"insecure"`
+	Generated     string        `json:"generated"`
 }
 
 func (r *SecretsInitResult) GetOutput() string {
@@ -74,6 +75,12 @@ func (r *SecretsInitResult) GetOutput() string {
 
 	if r.Insecure {
 		buffer.WriteString("\n[WARNING: INSECURE LOCAL SECRETS - SHOULD NOT BE RUN IN PRODUCTION]\n")
+	}
+
+	if r.Generated != "" {
+		buffer.WriteString("\n[SECRETS GENERATED]\n")
+		buffer.WriteString(r.Generated)
+		buffer.WriteString("\n")
 	}
 
 	buffer.WriteString("\n[SECRETS INIT]\n")

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -93,22 +93,6 @@ type validatorRaw struct {
 	NodeID       string        `json:"nodeId"`
 }
 
-func (v *Validator) InitKOSKSignature(chainID int64) error {
-	signature, err := MakeKOSKSignature(v.BlsPrivateKey, v.Address, chainID, bls.DomainValidatorSet)
-	if err != nil {
-		return err
-	}
-
-	signatureBytes, err := signature.Marshal()
-	if err != nil {
-		return err
-	}
-
-	v.BlsSignature = hex.EncodeToString(signatureBytes)
-
-	return nil
-}
-
 func (v *Validator) MarshalJSON() ([]byte, error) {
 	raw := &validatorRaw{Address: v.Address, BlsKey: v.BlsKey, NodeID: v.NodeID, BlsSignature: v.BlsSignature}
 	raw.Balance = types.EncodeBigInt(v.Balance)

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -14,7 +14,6 @@ import (
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/umbracle/ethgo/abi"
 )
 
 // PolyBFTConfig is the configuration file for the Polybft consensus protocol.
@@ -238,18 +237,4 @@ func (m *Manifest) Save(manifestPath string) error {
 	}
 
 	return nil
-}
-
-// MakeKOSKSignature creates KOSK signature which prevents rogue attack
-func MakeKOSKSignature(
-	privateKey *bls.PrivateKey, address types.Address, chainID int64, domain []byte) (*bls.Signature, error) {
-	message, err := abi.Encode(
-		[]interface{}{address, big.NewInt(chainID)},
-		abi.MustNewType("tuple(address, uint256)"))
-	if err != nil {
-		return nil, err
-	}
-
-	// abi.Encode adds 12 zero bytes before actual address bytes
-	return privateKey.Sign(message[12:], domain)
 }

--- a/consensus/polybft/polybft_test.go
+++ b/consensus/polybft/polybft_test.go
@@ -1,14 +1,12 @@
 package polybft
 
 import (
-	"encoding/hex"
 	"errors"
 	"testing"
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/consensus"
 	"github.com/0xPolygon/polygon-edge/consensus/ibft/signer"
-	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/helper/progress"
 	"github.com/0xPolygon/polygon-edge/txpool"
@@ -271,32 +269,4 @@ func Test_Factory(t *testing.T) {
 	assert.Equal(t, txPool, polybft.txPool)
 	assert.Equal(t, epochSize, polybft.consensusConfig.EpochSize)
 	assert.Equal(t, params, polybft.config)
-}
-
-func Test_MakeKOSKSignature(t *testing.T) {
-	t.Parallel()
-
-	expected := "127cfb8e2512b447056f33b91fca6cb2a7039e8b330edc4e5e5287f1c58bba5206373a97c9f09db144c8db5681c39e013ee6039ebbe36e0448e9f704f2d326c0"
-	bytes, _ := hex.DecodeString("3139343634393730313533353434353137333331343333303931343932303731313035313730303336303738373134363131303435323837383335373237343933383834303135343336383231")
-
-	pk, err := bls.UnmarshalPrivateKey(bytes)
-	require.NoError(t, err)
-
-	address := types.BytesToAddress((pk.PublicKey().Marshal())[:types.AddressLength])
-
-	signature, err := MakeKOSKSignature(pk, address, 10, bls.DomainValidatorSet)
-	require.NoError(t, err)
-
-	signatureBytes, err := signature.Marshal()
-	require.NoError(t, err)
-
-	assert.Equal(t, expected, hex.EncodeToString(signatureBytes))
-
-	signature, err = MakeKOSKSignature(pk, address, 100, bls.DomainValidatorSet)
-	require.NoError(t, err)
-
-	signatureBytes, err = signature.Marshal()
-	require.NoError(t, err)
-
-	assert.NotEqual(t, expected, hex.EncodeToString(signatureBytes))
 }

--- a/consensus/polybft/sc_integration_test.go
+++ b/consensus/polybft/sc_integration_test.go
@@ -15,6 +15,7 @@ import (
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	secretsHelper "github.com/0xPolygon/polygon-edge/secrets/helper"
 	"github.com/0xPolygon/polygon-edge/state"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/assert"
@@ -238,7 +239,7 @@ func TestIntegration_CommitEpoch(t *testing.T) {
 				Balance: validator.VotingPower,
 			}
 
-			signature, err := MakeKOSKSignature(accSetPrivateKeys[i].Bls, validator.Address, 0, bls.DomainValidatorSet)
+			signature, err := secretsHelper.MakeKOSKSignature(accSetPrivateKeys[i].Bls, validator.Address, 0, bls.DomainValidatorSet)
 			require.NoError(t, err)
 
 			signatureBytes, err := signature.Marshal()

--- a/network/gossip.go
+++ b/network/gossip.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"sync/atomic"
 
@@ -85,7 +86,7 @@ func (t *Topic) readLoop(sub *pubsub.Subscription, handler func(obj interface{},
 		msg, err := sub.Next(ctx)
 		if err != nil {
 			// Above cancelFn() called.
-			if err == ctx.Err() {
+			if errors.Is(err, ctx.Err()) {
 				break
 			}
 

--- a/secrets/helper/helper.go
+++ b/secrets/helper/helper.go
@@ -166,7 +166,10 @@ func InitValidatorBLSSignature(
 	}
 
 	// Write the signature to the secrets manager storage
-	if err := secretsManager.SetSecret(secrets.ValidatorBLSSignature, sb); err != nil {
+	if err := secretsManager.SetSecret(
+		secrets.ValidatorBLSSignature,
+		[]byte(hex.EncodeToString(sb)),
+	); err != nil {
 		return nil, err
 	}
 

--- a/secrets/helper/helper.go
+++ b/secrets/helper/helper.go
@@ -166,10 +166,7 @@ func InitValidatorBLSSignature(
 	}
 
 	// Write the signature to the secrets manager storage
-	if setErr := secretsManager.SetSecret(
-		secrets.ValidatorBLSSignature,
-		[]byte(hex.EncodeToString(sb)),
-	); setErr != nil {
+	if setErr := secretsManager.SetSecret(secrets.ValidatorBLSSignature, sb); setErr != nil {
 		return nil, setErr
 	}
 

--- a/secrets/helper/helper.go
+++ b/secrets/helper/helper.go
@@ -166,11 +166,11 @@ func InitValidatorBLSSignature(
 	}
 
 	// Write the signature to the secrets manager storage
-	if setErr := secretsManager.SetSecret(secrets.ValidatorBLSSignature, sb); setErr != nil {
-		return nil, setErr
+	if err := secretsManager.SetSecret(secrets.ValidatorBLSSignature, sb); err != nil {
+		return nil, err
 	}
 
-	return sb, err
+	return sb, nil
 }
 
 // LoadValidatorAddress loads ECDSA key by SecretsManager and returns validator address

--- a/secrets/helper/helper_test.go
+++ b/secrets/helper/helper_test.go
@@ -1,0 +1,39 @@
+package helper
+
+import (
+	"testing"
+
+	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
+	"github.com/0xPolygon/polygon-edge/helper/hex"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_MakeKOSKSignature(t *testing.T) {
+	t.Parallel()
+
+	expected := "127cfb8e2512b447056f33b91fca6cb2a7039e8b330edc4e5e5287f1c58bba5206373a97c9f09db144c8db5681c39e013ee6039ebbe36e0448e9f704f2d326c0"
+	bytes, _ := hex.DecodeString("3139343634393730313533353434353137333331343333303931343932303731313035313730303336303738373134363131303435323837383335373237343933383834303135343336383231")
+
+	pk, err := bls.UnmarshalPrivateKey(bytes)
+	require.NoError(t, err)
+
+	address := types.BytesToAddress((pk.PublicKey().Marshal())[:types.AddressLength])
+
+	signature, err := MakeKOSKSignature(pk, address, 10, bls.DomainValidatorSet)
+	require.NoError(t, err)
+
+	signatureBytes, err := signature.Marshal()
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, hex.EncodeToString(signatureBytes))
+
+	signature, err = MakeKOSKSignature(pk, address, 100, bls.DomainValidatorSet)
+	require.NoError(t, err)
+
+	signatureBytes, err = signature.Marshal()
+	require.NoError(t, err)
+
+	assert.NotEqual(t, expected, hex.EncodeToString(signatureBytes))
+}

--- a/secrets/local/local.go
+++ b/secrets/local/local.go
@@ -84,6 +84,13 @@ func (l *LocalSecretsManager) Setup() error {
 		secrets.ValidatorBLSKeyLocal,
 	)
 
+	// baseDir/consensus/validator.sig
+	l.secretPathMap[secrets.ValidatorBLSSignature] = filepath.Join(
+		l.path,
+		secrets.ConsensusFolderLocal,
+		secrets.ValidatorBLSSignatureLocal,
+	)
+
 	// baseDir/libp2p/libp2p.key
 	l.secretPathMap[secrets.NetworkKey] = filepath.Join(
 		l.path,

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -31,13 +31,17 @@ const (
 
 	// NetworkKey is the libp2p private key secret used for networking
 	NetworkKey = "network-key"
+
+	// ValidatorBLSSignature is the BLS signature of the validator node
+	ValidatorBLSSignature = "validator-bls-signature"
 )
 
 // Define constant file names for the local StorageManager
 const (
-	ValidatorKeyLocal    = "validator.key"
-	ValidatorBLSKeyLocal = "validator-bls.key"
-	NetworkKeyLocal      = "libp2p.key"
+	ValidatorKeyLocal          = "validator.key"
+	ValidatorBLSKeyLocal       = "validator-bls.key"
+	NetworkKeyLocal            = "libp2p.key"
+	ValidatorBLSSignatureLocal = "validator.sig"
 )
 
 // Define constant folder names for the local StorageManager

--- a/syncer/client.go
+++ b/syncer/client.go
@@ -212,6 +212,7 @@ func (m *syncPeerClient) handleStatusUpdate(obj interface{}, from peer.ID) {
 
 	if atomic.LoadUint64(m.closed) > 0 {
 		m.logger.Debug("received status from peer after client was closed, ignoring", "id", from)
+
 		return
 	}
 
@@ -258,6 +259,7 @@ func (m *syncPeerClient) startPeerEventProcess() {
 	peerEventCh, err := m.network.SubscribeCh(context.Background())
 	if err != nil {
 		m.logger.Error("failed to subscribe", "err", err)
+
 		return
 	}
 


### PR DESCRIPTION
# Description

This PR introduces a new file in validator secrets to handle validator key signature, this is a necessary change to allow secure deployments.

Also implement generating secrets that weren't previously generated with the init command, and letting the use know:

```
[SECRETS GENERATED]
network-key, validator-key, validator-bls-key, validator-bls-signature
```

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

The secrets init command now accepts the `chain-id` param

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
