### PR TITLE
Commitment vote signature verification

### DIFF
--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -39,8 +39,8 @@ type TransportMessage struct {
 	Hash []byte
 	// Message signature
 	Signature []byte
-	// Node identifier
-	NodeID string
+	// Address of the message signer
+	From string
 	// Number of epoch
 	EpochNumber uint64
 }

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -39,7 +39,7 @@ type TransportMessage struct {
 	Hash []byte
 	// Message signature
 	Signature []byte
-	// Address of the message signer
+	// From is the address of the message signer
 	From string
 	// Number of epoch
 	EpochNumber uint64

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -210,7 +210,7 @@ func (s *stateSyncManager) verifyVoteSignature(valSet ValidatorSet, signer types
 
 	unmarshaledSignature, err := bls.UnmarshalSignature(signature)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal signature: %w", err)
+		return fmt.Errorf("failed to unmarshal signature from signer %s, %w", signer.String(), err)
 	}
 
 	if !unmarshaledSignature.Verify(validator.BlsKey, hash, bls.DomainCheckpointManager) {

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -172,7 +172,7 @@ func (s *stateSyncManager) saveVote(msg *TransportMessage) error {
 	s.lock.RUnlock()
 
 	if valSet == nil || msg.EpochNumber != epoch {
-		// Epoch metadata is undefined or received message for the unrelvant epoch
+		// Epoch metadata is undefined or received a message for the irrelevant epoch
 		return nil
 	}
 

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -176,8 +176,7 @@ func (s *stateSyncManager) saveVote(msg *TransportMessage) error {
 		return nil
 	}
 
-	err := s.verifyVoteSignature(valSet, types.StringToAddress(msg.From), msg.Signature, msg.Hash)
-	if err != nil {
+	if err := s.verifyVoteSignature(valSet, types.StringToAddress(msg.From), msg.Signature, msg.Hash); err != nil {
 		return fmt.Errorf("error verifying vote signature: %w", err)
 	}
 
@@ -201,6 +200,7 @@ func (s *stateSyncManager) saveVote(msg *TransportMessage) error {
 	return nil
 }
 
+// Verifies signature of the message against the public key of the signer and checks if the signer is a validator
 func (s *stateSyncManager) verifyVoteSignature(valSet ValidatorSet, signer types.Address, signature []byte,
 	hash []byte) error {
 	validator := valSet.Accounts().GetValidatorMetadata(signer)
@@ -210,7 +210,7 @@ func (s *stateSyncManager) verifyVoteSignature(valSet ValidatorSet, signer types
 
 	unmarshaledSignature, err := bls.UnmarshalSignature(signature)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshall signature: %w", err)
+		return fmt.Errorf("failed to unmarshal signature: %w", err)
 	}
 
 	if !unmarshaledSignature.Verify(validator.BlsKey, hash, bls.DomainCheckpointManager) {

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -143,6 +143,8 @@ func TestStateSyncManager_MessagePool_SenderIsNoValidator(t *testing.T) {
 }
 
 func TestStateSyncManager_MessagePool_InvalidEpoch(t *testing.T) {
+	t.Parallel()
+
 	vals := newTestValidators(5)
 
 	s := newTestStateSyncManager(t, vals.getValidator("0"))
@@ -166,6 +168,8 @@ func TestStateSyncManager_MessagePool_InvalidEpoch(t *testing.T) {
 }
 
 func TestStateSyncManager_MessagePool_SenderAndSignatureMissmatch(t *testing.T) {
+	t.Parallel()
+
 	vals := newTestValidators(5)
 
 	s := newTestStateSyncManager(t, vals.getValidator("0"))


### PR DESCRIPTION
# Description

The signature of the vote for a commitment was not verified against the sender address, this PR includes this fix.

In the audit report, where this issue is originally reported, there is a concern if EpochNumber (included in a TransportMessage and used in a key when saving votes) can be used for replay attack. This is not possible because:
- if the malicious user replays the signed message with the same EpochNumber, the existing vote will be overwritten with the same data
- if the malicious user replays the signed message setting different EpochNumber, the vote would not be taken into consideration. Before this fix, votes with equal or greater EpochNumber than the current epoch are taken into consideration, but irrelevant votes with the higher epoch number would not be saved anyway since the bucket for that epoch is not yet created. The fix now allows only votes for the current epoch, since there is no point of processing votes for higher epoch
- even without EpochNumber check mentioned above, if the replayed vote is saved for the higher epoch it would never participate in a tally since the commitment with the hash from the vote is deleted from the pending commitments upon is submitted for the current epoch or the epoch change happens

This PR also includes a minor change of renaming 'NodeID' of TransportMessage to 'From', since it represents the address of the message signer and it's not the node identifier. 

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
