### PR TITLE
Secrets manager introduced to commands

### DIFF
--- a/command/polybftsecrets/utils.go
+++ b/command/polybftsecrets/utils.go
@@ -35,7 +35,7 @@ func GetSecretsManager(dataPath, configPath string, insecureLocalStore bool) (se
 	if configPath != "" {
 		secretsConfig, readErr := secrets.ReadConfig(configPath)
 		if readErr != nil {
-			return nil, fmt.Errorf("%w; : %w", ErrInvalidConfig, readErr)
+			return nil, errors.New(ErrInvalidConfig.Error() + ": " + readErr.Error())
 		}
 
 		if !secrets.SupportedServiceManager(secretsConfig.Type) {

--- a/command/polybftsecrets/utils.go
+++ b/command/polybftsecrets/utils.go
@@ -29,8 +29,8 @@ var (
 			"avoid doing so in production")
 )
 
-// function resolve secrets manager instance
-// insecureLocalStore defines if utilization of local secrets manager is allowed
+// GetSecretsManager function resolves secrets manager instance based on provided data or config paths.
+// insecureLocalStore defines if utilization of local secrets manager is allowed.
 func GetSecretsManager(dataPath, configPath string, insecureLocalStore bool) (secrets.SecretsManager, error) {
 	if configPath != "" {
 		secretsConfig, readErr := secrets.ReadConfig(configPath)
@@ -45,9 +45,9 @@ func GetSecretsManager(dataPath, configPath string, insecureLocalStore bool) (se
 		return helper.InitCloudSecretsManager(secretsConfig)
 	}
 
-	//Storing secrets on a local file system should only be allowed with --insecure flag,
-	//to raise awareness that it should be only used in development/testing environments.
-	//Production setups should use one of the supported secrets managers
+	// Storing secrets on a local file system should only be allowed with --insecure flag,
+	// to raise awareness that it should be only used in development/testing environments.
+	// Production setups should use one of the supported secrets managers
 	if !insecureLocalStore {
 		return nil, ErrSecureLocalStoreNotImplemented
 	}

--- a/command/polybftsecrets/utils.go
+++ b/command/polybftsecrets/utils.go
@@ -29,11 +29,13 @@ var (
 			"avoid doing so in production")
 )
 
+// function resolve secrets manager instance
+// insecureLocalStore defines if utilization of local secrets manager is allowed
 func GetSecretsManager(dataPath, configPath string, insecureLocalStore bool) (secrets.SecretsManager, error) {
 	if configPath != "" {
 		secretsConfig, readErr := secrets.ReadConfig(configPath)
 		if readErr != nil {
-			return nil, ErrInvalidConfig
+			return nil, fmt.Errorf("%w; : %w", ErrInvalidConfig, readErr)
 		}
 
 		if !secrets.SupportedServiceManager(secretsConfig.Type) {

--- a/command/polybftsecrets/utils.go
+++ b/command/polybftsecrets/utils.go
@@ -1,0 +1,54 @@
+package polybftsecrets
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/0xPolygon/polygon-edge/secrets"
+	"github.com/0xPolygon/polygon-edge/secrets/helper"
+)
+
+// common flags for all polybft commands
+const (
+	DataPathFlag = "data-dir"
+	ConfigFlag   = "config"
+
+	DataPathFlagDesc = "the directory for the Polygon Edge data if the local FS is used"
+	ConfigFlagDesc   = "the path to the SecretsManager config file, if omitted, the local FS secrets manager is used"
+)
+
+// common errors for all polybft commands
+var (
+	ErrInvalidNum                     = fmt.Errorf("num flag value should be between 1 and %d", maxInitNum)
+	ErrInvalidConfig                  = errors.New("invalid secrets configuration")
+	ErrInvalidParams                  = errors.New("no config file or data directory passed in")
+	ErrUnsupportedType                = errors.New("unsupported secrets manager")
+	ErrSecureLocalStoreNotImplemented = errors.New(
+		"use a secrets backend, or supply an --insecure flag " +
+			"to store the private keys locally on the filesystem, " +
+			"avoid doing so in production")
+)
+
+func GetSecretsManager(dataPath, configPath string, insecureLocalStore bool) (secrets.SecretsManager, error) {
+	if configPath != "" {
+		secretsConfig, readErr := secrets.ReadConfig(configPath)
+		if readErr != nil {
+			return nil, ErrInvalidConfig
+		}
+
+		if !secrets.SupportedServiceManager(secretsConfig.Type) {
+			return nil, ErrUnsupportedType
+		}
+
+		return helper.InitCloudSecretsManager(secretsConfig)
+	}
+
+	//Storing secrets on a local file system should only be allowed with --insecure flag,
+	//to raise awareness that it should be only used in development/testing environments.
+	//Production setups should use one of the supported secrets managers
+	if !insecureLocalStore {
+		return nil, ErrSecureLocalStoreNotImplemented
+	}
+
+	return helper.SetupLocalSecretsManager(dataPath)
+}

--- a/command/sidechain/helper.go
+++ b/command/sidechain/helper.go
@@ -18,9 +18,8 @@ import (
 )
 
 const (
-	AccountDirFlag = "account"
-	SelfFlag       = "self"
-	AmountFlag     = "amount"
+	SelfFlag   = "self"
+	AmountFlag = "amount"
 
 	DefaultGasPrice = 1879048192 // 0x70000000
 )

--- a/command/sidechain/helper.go
+++ b/command/sidechain/helper.go
@@ -45,7 +45,7 @@ func ValidateSecretFlags(dataDir, config string) error {
 }
 
 func GetAccount(dataDir, config string) (*wallet.Account, error) {
-	// get secret manager and allow reading from local directory (true at the end)
+	// resolve secrets manager instance and allow usage of insecure local secrets manager
 	secretsManager, err := polybftsecrets.GetSecretsManager(dataDir, config, true)
 	if err != nil {
 		return nil, err

--- a/command/sidechain/helper.go
+++ b/command/sidechain/helper.go
@@ -12,7 +12,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
-	secretsHelper "github.com/0xPolygon/polygon-edge/secrets/helper"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/umbracle/ethgo"
@@ -45,13 +44,18 @@ func ValidateSecretFlags(dataDir, config string) error {
 	return nil
 }
 
-func GetAccountFromDir(dir string) (*wallet.Account, error) {
-	secretsManager, err := secretsHelper.SetupLocalSecretsManager(dir)
+func GetAccount(dataDir, config string) (*wallet.Account, error) {
+	// get secret manager and allow reading from local directory (true at the end)
+	secretsManager, err := polybftsecrets.GetSecretsManager(dataDir, config, true)
 	if err != nil {
 		return nil, err
 	}
 
 	return wallet.NewAccountFromSecret(secretsManager)
+}
+
+func GetAccountFromDir(dir string) (*wallet.Account, error) {
+	return GetAccount(dir, "")
 }
 
 // GetValidatorInfo queries ChildValidatorSet smart contract and retrieves validator info for given address

--- a/command/sidechain/helper.go
+++ b/command/sidechain/helper.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"os"
 
+	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
@@ -27,6 +28,18 @@ const (
 func CheckIfDirectoryExist(dir string) error {
 	if _, err := os.Stat(dir); errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("provided directory '%s' doesn't exist", dir)
+	}
+
+	return nil
+}
+
+func ValidateSecretFlags(dataDir, config string) error {
+	if config == "" {
+		if dataDir == "" {
+			return polybftsecrets.ErrInvalidParams
+		} else {
+			return CheckIfDirectoryExist(dataDir)
+		}
 	}
 
 	return nil

--- a/command/sidechain/staking/params.go
+++ b/command/sidechain/staking/params.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/0xPolygon/polygon-edge/command/helper"
-	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
+	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 )
 
 var (
@@ -14,6 +14,7 @@ var (
 
 type stakeParams struct {
 	accountDir      string
+	configPath      string
 	jsonRPC         string
 	amount          uint64
 	self            bool
@@ -21,7 +22,11 @@ type stakeParams struct {
 }
 
 func (v *stakeParams) validateFlags() error {
-	return sidechainHelper.CheckIfDirectoryExist(v.accountDir)
+	if v.accountDir == "" && v.configPath == "" {
+		return polybftsecrets.ErrInvalidParams
+	}
+
+	return nil
 }
 
 type stakeResult struct {

--- a/command/sidechain/staking/params.go
+++ b/command/sidechain/staking/params.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/0xPolygon/polygon-edge/command/helper"
-	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
+	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
 )
 
 var (
@@ -22,11 +22,7 @@ type stakeParams struct {
 }
 
 func (v *stakeParams) validateFlags() error {
-	if v.accountDir == "" && v.configPath == "" {
-		return polybftsecrets.ErrInvalidParams
-	}
-
-	return nil
+	return sidechainHelper.ValidateSecretFlags(v.accountDir, v.configPath)
 }
 
 type stakeResult struct {

--- a/command/sidechain/staking/stake.go
+++ b/command/sidechain/staking/stake.go
@@ -10,7 +10,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -87,13 +86,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	// get secret manager and allow reading from local directory (true at the end)
-	secretsManager, err := polybftsecrets.GetSecretsManager(params.accountDir, params.configPath, true)
-	if err != nil {
-		return err
-	}
-
-	validatorAccount, err := wallet.NewAccountFromSecret(secretsManager)
+	validatorAccount, err := sidechainHelper.GetAccount(params.accountDir, params.configPath)
 	if err != nil {
 		return err
 	}

--- a/command/sidechain/staking/stake.go
+++ b/command/sidechain/staking/stake.go
@@ -74,6 +74,7 @@ func setFlags(cmd *cobra.Command) {
 	)
 
 	cmd.MarkFlagsMutuallyExclusive(sidechainHelper.SelfFlag, delegateAddressFlag)
+	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.DataPathFlag, polybftsecrets.ConfigFlag)
 }
 
 func runPreRun(cmd *cobra.Command, _ []string) error {

--- a/command/sidechain/staking/stake.go
+++ b/command/sidechain/staking/stake.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/helper"
+	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -39,9 +41,16 @@ func GetCommand() *cobra.Command {
 func setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&params.accountDir,
-		sidechainHelper.AccountDirFlag,
+		polybftsecrets.DataPathFlag,
 		"",
-		"the directory path where validator key is stored",
+		polybftsecrets.DataPathFlagDesc,
+	)
+
+	cmd.Flags().StringVar(
+		&params.configPath,
+		polybftsecrets.ConfigFlag,
+		"",
+		polybftsecrets.ConfigFlagDesc,
 	)
 
 	cmd.Flags().BoolVar(
@@ -78,7 +87,13 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	validatorAccount, err := sidechainHelper.GetAccountFromDir(params.accountDir)
+	// get secret manager and allow reading from local directory (true at the end)
+	secretsManager, err := polybftsecrets.GetSecretsManager(params.accountDir, params.configPath, true)
+	if err != nil {
+		return err
+	}
+
+	validatorAccount, err := wallet.NewAccountFromSecret(secretsManager)
 	if err != nil {
 		return err
 	}

--- a/command/sidechain/unstaking/params.go
+++ b/command/sidechain/unstaking/params.go
@@ -22,7 +22,7 @@ type unstakeParams struct {
 }
 
 func (v *unstakeParams) validateFlags() error {
-	return sidechainHelper.CheckIfDirectoryExist(v.accountDir)
+	return sidechainHelper.ValidateSecretFlags(v.accountDir, v.configPath)
 }
 
 type unstakeResult struct {

--- a/command/sidechain/unstaking/params.go
+++ b/command/sidechain/unstaking/params.go
@@ -14,6 +14,7 @@ var (
 
 type unstakeParams struct {
 	accountDir        string
+	configPath        string
 	jsonRPC           string
 	amount            uint64
 	self              bool

--- a/command/sidechain/unstaking/unstake.go
+++ b/command/sidechain/unstaking/unstake.go
@@ -10,7 +10,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -87,13 +86,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	// get secret manager and allow reading from local directory (true at the end)
-	secretsManager, err := polybftsecrets.GetSecretsManager(params.accountDir, params.configPath, true)
-	if err != nil {
-		return err
-	}
-
-	validatorAccount, err := wallet.NewAccountFromSecret(secretsManager)
+	validatorAccount, err := sidechainHelper.GetAccount(params.accountDir, params.configPath)
 	if err != nil {
 		return err
 	}

--- a/command/sidechain/unstaking/unstake.go
+++ b/command/sidechain/unstaking/unstake.go
@@ -74,6 +74,7 @@ func setFlags(cmd *cobra.Command) {
 	)
 
 	cmd.MarkFlagsMutuallyExclusive(sidechainHelper.SelfFlag, undelegateAddressFlag)
+	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.DataPathFlag, polybftsecrets.ConfigFlag)
 }
 
 func runPreRun(cmd *cobra.Command, _ []string) error {

--- a/command/sidechain/validators/params.go
+++ b/command/sidechain/validators/params.go
@@ -15,7 +15,7 @@ type validatorInfoParams struct {
 }
 
 func (v *validatorInfoParams) validateFlags() error {
-	return sidechainHelper.CheckIfDirectoryExist(v.accountDir)
+	return sidechainHelper.ValidateSecretFlags(v.accountDir, v.configPath)
 }
 
 type validatorsInfoResult struct {

--- a/command/sidechain/validators/params.go
+++ b/command/sidechain/validators/params.go
@@ -10,6 +10,7 @@ import (
 
 type validatorInfoParams struct {
 	accountDir string
+	configPath string
 	jsonRPC    string
 }
 

--- a/command/sidechain/validators/validator_info.go
+++ b/command/sidechain/validators/validator_info.go
@@ -7,7 +7,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/spf13/cobra"
 )
@@ -56,13 +55,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	// get secret manager and allow reading from local directory (true at the end)
-	secretsManager, err := polybftsecrets.GetSecretsManager(params.accountDir, params.configPath, true)
-	if err != nil {
-		return err
-	}
-
-	validatorAccount, err := wallet.NewAccountFromSecret(secretsManager)
+	validatorAccount, err := sidechainHelper.GetAccount(params.accountDir, params.configPath)
 	if err != nil {
 		return err
 	}

--- a/command/sidechain/validators/validator_info.go
+++ b/command/sidechain/validators/validator_info.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/helper"
+	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/spf13/cobra"
 )
@@ -31,9 +33,16 @@ func GetCommand() *cobra.Command {
 func setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&params.accountDir,
-		sidechainHelper.AccountDirFlag,
+		polybftsecrets.DataPathFlag,
 		"",
-		"the directory path where validator key is stored",
+		polybftsecrets.DataPathFlagDesc,
+	)
+
+	cmd.Flags().StringVar(
+		&params.configPath,
+		polybftsecrets.ConfigFlag,
+		"",
+		polybftsecrets.ConfigFlagDesc,
 	)
 }
 
@@ -47,7 +56,13 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	validatorAccount, err := sidechainHelper.GetAccountFromDir(params.accountDir)
+	// get secret manager and allow reading from local directory (true at the end)
+	secretsManager, err := polybftsecrets.GetSecretsManager(params.accountDir, params.configPath, true)
+	if err != nil {
+		return err
+	}
+
+	validatorAccount, err := wallet.NewAccountFromSecret(secretsManager)
 	if err != nil {
 		return err
 	}

--- a/command/sidechain/validators/validator_info.go
+++ b/command/sidechain/validators/validator_info.go
@@ -43,6 +43,8 @@ func setFlags(cmd *cobra.Command) {
 		"",
 		polybftsecrets.ConfigFlagDesc,
 	)
+
+	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.DataPathFlag, polybftsecrets.ConfigFlag)
 }
 
 func runPreRun(cmd *cobra.Command, _ []string) error {

--- a/command/sidechain/withdraw/params.go
+++ b/command/sidechain/withdraw/params.go
@@ -20,7 +20,7 @@ type withdrawParams struct {
 }
 
 func (v *withdrawParams) validateFlags() error {
-	return sidechainHelper.CheckIfDirectoryExist(v.accountDir)
+	return sidechainHelper.ValidateSecretFlags(v.accountDir, v.configPath)
 }
 
 type withdrawResult struct {

--- a/command/sidechain/withdraw/params.go
+++ b/command/sidechain/withdraw/params.go
@@ -14,6 +14,7 @@ var (
 
 type withdrawParams struct {
 	accountDir string
+	configPath string
 	jsonRPC    string
 	addressTo  string
 }

--- a/command/sidechain/withdraw/withdraw.go
+++ b/command/sidechain/withdraw/withdraw.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/helper"
+	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -37,9 +39,16 @@ func GetCommand() *cobra.Command {
 func setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&params.accountDir,
-		sidechainHelper.AccountDirFlag,
+		polybftsecrets.DataPathFlag,
 		"",
-		"the directory path where validator key is stored",
+		polybftsecrets.DataPathFlagDesc,
+	)
+
+	cmd.Flags().StringVar(
+		&params.configPath,
+		polybftsecrets.ConfigFlag,
+		"",
+		polybftsecrets.ConfigFlagDesc,
 	)
 
 	cmd.Flags().StringVar(
@@ -62,7 +71,13 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	validatorAccount, err := sidechainHelper.GetAccountFromDir(params.accountDir)
+	// get secret manager and allow reading from local directory (true at the end)
+	secretsManager, err := polybftsecrets.GetSecretsManager(params.accountDir, params.configPath, true)
+	if err != nil {
+		return err
+	}
+
+	validatorAccount, err := wallet.NewAccountFromSecret(secretsManager)
 	if err != nil {
 		return err
 	}

--- a/command/sidechain/withdraw/withdraw.go
+++ b/command/sidechain/withdraw/withdraw.go
@@ -57,6 +57,7 @@ func setFlags(cmd *cobra.Command) {
 		"address where to withdraw withdrawable amount",
 	)
 
+	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.DataPathFlag, polybftsecrets.ConfigFlag)
 	helper.RegisterJSONRPCFlag(cmd)
 }
 

--- a/command/sidechain/withdraw/withdraw.go
+++ b/command/sidechain/withdraw/withdraw.go
@@ -10,7 +10,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -71,13 +70,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	// get secret manager and allow reading from local directory (true at the end)
-	secretsManager, err := polybftsecrets.GetSecretsManager(params.accountDir, params.configPath, true)
-	if err != nil {
-		return err
-	}
-
-	validatorAccount, err := wallet.NewAccountFromSecret(secretsManager)
+	validatorAccount, err := sidechainHelper.GetAccount(params.accountDir, params.configPath)
 	if err != nil {
 		return err
 	}

--- a/e2e-polybft/framework/test-server.go
+++ b/e2e-polybft/framework/test-server.go
@@ -161,7 +161,7 @@ func (t *TestServer) Stake(amount uint64) error {
 	args := []string{
 		"polybft",
 		"stake",
-		"--account", t.config.DataDir,
+		"--data-dir", t.config.DataDir,
 		"--jsonrpc", t.JSONRPCAddr(),
 		"--amount", strconv.FormatUint(amount, 10),
 		"--self",
@@ -175,7 +175,7 @@ func (t *TestServer) Unstake(amount uint64) error {
 	args := []string{
 		"polybft",
 		"unstake",
-		"--account", t.config.DataDir,
+		"--data-dir", t.config.DataDir,
 		"--jsonrpc", t.JSONRPCAddr(),
 		"--amount", strconv.FormatUint(amount, 10),
 		"--self",
@@ -204,7 +204,7 @@ func (t *TestServer) Delegate(amount uint64, secrets string, validatorAddr ethgo
 	args := []string{
 		"polybft",
 		"stake",
-		"--account", secrets,
+		"--data-dir", secrets,
 		"--jsonrpc", t.JSONRPCAddr(),
 		"--delegate", validatorAddr.String(),
 		"--amount", strconv.FormatUint(amount, 10),
@@ -218,7 +218,7 @@ func (t *TestServer) Undelegate(amount uint64, secrets string, validatorAddr eth
 	args := []string{
 		"polybft",
 		"unstake",
-		"--account", secrets,
+		"--data-dir", secrets,
 		"--undelegate", validatorAddr.String(),
 		"--amount", strconv.FormatUint(amount, 10),
 		"--jsonrpc", t.JSONRPCAddr(),
@@ -232,7 +232,7 @@ func (t *TestServer) Withdraw(secrets string, recipient ethgo.Address) error {
 	args := []string{
 		"polybft",
 		"withdraw",
-		"--account", secrets,
+		"--data-dir", secrets,
 		"--to", recipient.String(),
 		"--jsonrpc", t.JSONRPCAddr(),
 	}

--- a/e2e-polybft/framework/test-server.go
+++ b/e2e-polybft/framework/test-server.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	"github.com/0xPolygon/polygon-edge/server/proto"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -114,7 +115,7 @@ func (t *TestServer) Start() {
 	args := []string{
 		"server",
 		// add data dir
-		"--data-dir", config.DataDir,
+		"--" + polybftsecrets.DataPathFlag, config.DataDir,
 		// add custom chain
 		"--chain", config.Chain,
 		// enable p2p port
@@ -161,7 +162,7 @@ func (t *TestServer) Stake(amount uint64) error {
 	args := []string{
 		"polybft",
 		"stake",
-		"--data-dir", t.config.DataDir,
+		"--" + polybftsecrets.DataPathFlag, t.config.DataDir,
 		"--jsonrpc", t.JSONRPCAddr(),
 		"--amount", strconv.FormatUint(amount, 10),
 		"--self",
@@ -175,7 +176,7 @@ func (t *TestServer) Unstake(amount uint64) error {
 	args := []string{
 		"polybft",
 		"unstake",
-		"--data-dir", t.config.DataDir,
+		"--" + polybftsecrets.DataPathFlag, t.config.DataDir,
 		"--jsonrpc", t.JSONRPCAddr(),
 		"--amount", strconv.FormatUint(amount, 10),
 		"--self",
@@ -189,7 +190,7 @@ func (t *TestServer) RegisterValidator(secrets string, balance string, stake str
 	args := []string{
 		"polybft",
 		"register-validator",
-		"--data-dir", path.Join(t.clusterConfig.TmpDir, secrets),
+		"--" + polybftsecrets.DataPathFlag, path.Join(t.clusterConfig.TmpDir, secrets),
 		"--registrator-data-dir", path.Join(t.clusterConfig.TmpDir, "test-chain-1"),
 		"--jsonrpc", t.JSONRPCAddr(),
 		"--balance", balance,
@@ -204,7 +205,7 @@ func (t *TestServer) Delegate(amount uint64, secrets string, validatorAddr ethgo
 	args := []string{
 		"polybft",
 		"stake",
-		"--data-dir", secrets,
+		"--" + polybftsecrets.DataPathFlag, secrets,
 		"--jsonrpc", t.JSONRPCAddr(),
 		"--delegate", validatorAddr.String(),
 		"--amount", strconv.FormatUint(amount, 10),
@@ -218,7 +219,7 @@ func (t *TestServer) Undelegate(amount uint64, secrets string, validatorAddr eth
 	args := []string{
 		"polybft",
 		"unstake",
-		"--data-dir", secrets,
+		"--" + polybftsecrets.DataPathFlag, secrets,
 		"--undelegate", validatorAddr.String(),
 		"--amount", strconv.FormatUint(amount, 10),
 		"--jsonrpc", t.JSONRPCAddr(),
@@ -232,7 +233,7 @@ func (t *TestServer) Withdraw(secrets string, recipient ethgo.Address) error {
 	args := []string{
 		"polybft",
 		"withdraw",
-		"--data-dir", secrets,
+		"--" + polybftsecrets.DataPathFlag, secrets,
 		"--to", recipient.String(),
 		"--jsonrpc", t.JSONRPCAddr(),
 	}


### PR DESCRIPTION
# Description
Commands stake, unstake, withdraw, validator info use secret manager to provide access to cloud secret storage or local disc.
Naming of the flags are standardized for all commands: 
        DataPathFlag = "data-dir"  - for local storage
	ConfigFlag   = "config"       - cloud config

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests
