### PR TITLE
Remove smart contracts path flags

### DIFF
--- a/.github/workflows/e2e-polybft.yml
+++ b/.github/workflows/e2e-polybft.yml
@@ -22,8 +22,6 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
-      - name: Compile core contracts
-        run: make compile-core-contracts
       - name: Run tests
         run: make test-e2e-polybft
       - name: Archive test logs

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -7,7 +7,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/genesis/predeploy"
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/consensus/ibft"
-	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/validators"
 	"github.com/spf13/cobra"
@@ -176,13 +175,6 @@ func setFlags(cmd *cobra.Command) {
 			blockTimeFlag,
 			defaultBlockTime,
 			"the predefined period which determines block creation frequency",
-		)
-
-		cmd.Flags().StringVar(
-			&params.smartContractsRootPath,
-			smartContractsRootPathFlag,
-			contracts.ContractsRootFolder,
-			"the smart contracts folder",
 		)
 
 		cmd.Flags().StringVar(

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -78,13 +78,12 @@ type genesisParams struct {
 	genesisConfig *chain.Chain
 
 	// PolyBFT
-	manifestPath           string
-	smartContractsRootPath string
-	validatorSetSize       int
-	sprintSize             uint64
-	blockTime              time.Duration
-	bridgeJSONRPCAddr      string
-	epochReward            uint64
+	manifestPath      string
+	validatorSetSize  int
+	sprintSize        uint64
+	blockTime         time.Duration
+	bridgeJSONRPCAddr string
+	epochReward       uint64
 }
 
 func (p *genesisParams) validateFlags() error {

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -23,12 +23,11 @@ import (
 )
 
 const (
-	smartContractsRootPathFlag = "contracts-path"
-	manifestPathFlag           = "manifest"
-	validatorSetSizeFlag       = "validator-set-size"
-	sprintSizeFlag             = "sprint-size"
-	blockTimeFlag              = "block-time"
-	bridgeFlag                 = "bridge-json-rpc"
+	manifestPathFlag     = "manifest"
+	validatorSetSizeFlag = "validator-set-size"
+	sprintSizeFlag       = "sprint-size"
+	blockTimeFlag        = "block-time"
+	bridgeFlag           = "bridge-json-rpc"
 
 	defaultManifestPath     = "./manifest.json"
 	defaultEpochSize        = uint64(10)

--- a/command/rootchain/initcontracts/init_contracts.go
+++ b/command/rootchain/initcontracts/init_contracts.go
@@ -17,7 +17,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
-	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 )
@@ -71,13 +70,6 @@ func GetCommand() *cobra.Command {
 }
 
 func setFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(
-		&params.contractsPath,
-		contractsPathFlag,
-		contracts.ContractsRootFolder,
-		"Root directory path containing POS smart contracts",
-	)
-
 	cmd.Flags().StringVar(
 		&params.manifestPath,
 		manifestPathFlag,

--- a/command/rootchain/initcontracts/params.go
+++ b/command/rootchain/initcontracts/params.go
@@ -7,26 +7,20 @@ import (
 )
 
 const (
-	contractsPathFlag = "path"
-	manifestPathFlag  = "manifest"
-	jsonRPCFlag       = "json-rpc"
-	adminKeyFlag      = "admin-key"
+	manifestPathFlag = "manifest"
+	jsonRPCFlag      = "json-rpc"
+	adminKeyFlag     = "admin-key"
 
 	defaultManifestPath = "./manifest.json"
 )
 
 type initContractsParams struct {
-	contractsPath  string
 	manifestPath   string
 	adminKey       string
 	jsonRPCAddress string
 }
 
 func (ip *initContractsParams) validateFlags() error {
-	if _, err := os.Stat(ip.contractsPath); errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("provided smart contracts directory '%s' doesn't exist", ip.contractsPath)
-	}
-
 	if _, err := os.Stat(ip.manifestPath); errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("provided manifest path '%s' doesn't exist", ip.manifestPath)
 	}

--- a/consensus/polybft/README.md
+++ b/consensus/polybft/README.md
@@ -54,7 +54,7 @@ In order to do so, run `make compile-core-contracts`.
 5. Deploy and initialize rootchain contracts - this command deploys rootchain smart contracts and initializes them. It also updates manifest configuration with rootchain contract addresses and rootchain default sender address.
 
     ```bash
-    polygon-edge rootchain init-contracts [--manifest ./manifest.json] [--contracts-path ./core-contracts/artifacts]
+    polygon-edge rootchain init-contracts [--manifest ./manifest.json]
     [--json-rpc http://127.0.0.1:8545] [--admin-key <hex_encoded_private_key>]
     ```
 

--- a/consensus/polybft/README.md
+++ b/consensus/polybft/README.md
@@ -62,7 +62,7 @@ In order to do so, run `make compile-core-contracts`.
 
     ```bash
     polygon-edge genesis --consensus polybft --block-gas-limit 10000000 --epoch-size 10
-    [--bridge-json-rpc <rootchain_ip_address>] [--contracts-path ./core-contracts/artifacts] [--manifest ./manifest.json]
+    [--bridge-json-rpc <rootchain_ip_address>] [--manifest ./manifest.json]
     ```
 
 7. Fund validators on rootchain - in order for validators to be able to send transactions to Ethereum, they need to be funded in order to be able to cover gas cost. **This command is for testing purposes only.**

--- a/contracts/constants.go
+++ b/contracts/constants.go
@@ -1,6 +1,0 @@
-package contracts
-
-const (
-	// ContractsRootFolder is a relative path of the core smart contracts
-	ContractsRootFolder = "./core-contracts/artifacts/contracts/"
-)

--- a/e2e-polybft/framework/test-bridge.go
+++ b/e2e-polybft/framework/test-bridge.go
@@ -60,7 +60,6 @@ func (t *TestBridge) deployRootchainContracts(manifestPath string) error {
 	args := []string{
 		"rootchain",
 		"init-contracts",
-		"--path", t.clusterConfig.ContractsDir,
 		"--manifest", manifestPath,
 	}
 

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -42,9 +42,6 @@ const (
 )
 
 const (
-	// path to core contracts
-	defaultContractsPath = "./../core-contracts/artifacts/contracts/"
-
 	// prefix for validator directory
 	defaultValidatorPrefix = "test-chain-"
 )
@@ -78,7 +75,6 @@ type TestClusterConfig struct {
 	LogsDir           string
 	TmpDir            string
 	BlockGasLimit     uint64
-	ContractsDir      string
 	ValidatorPrefix   string
 	Binary            string
 	ValidatorSetSize  uint64
@@ -244,10 +240,6 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 		PremineValidators: command.DefaultPremineBalance,
 	}
 
-	if config.ContractsDir == "" {
-		config.ContractsDir = defaultContractsPath
-	}
-
 	if config.ValidatorPrefix == "" {
 		config.ValidatorPrefix = defaultValidatorPrefix
 	}
@@ -319,7 +311,6 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 			"--manifest", manifestPath,
 			"--consensus", "polybft",
 			"--dir", path.Join(config.TmpDir, "genesis.json"),
-			"--contracts-path", defaultContractsPath,
 			"--block-gas-limit", strconv.FormatUint(cluster.Config.BlockGasLimit, 10),
 			"--epoch-size", strconv.Itoa(cluster.Config.EpochSize),
 			"--epoch-reward", strconv.Itoa(cluster.Config.EpochReward),


### PR DESCRIPTION
# Description

Since Edge is using embedded smart contracts definition, there is no need to specify smart contract root directory via CLI commands. This PR removes deprecated flags and `make compile-core-contracts` step when executing polybft e2e tests.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually