### PR TITLE
Additional block metrics

### DIFF
--- a/consensus/polybft/consensus_metrics.go
+++ b/consensus/polybft/consensus_metrics.go
@@ -33,7 +33,7 @@ func updateBlockMetrics(currentBlock *types.Block, parentHeader *types.Header) e
 	// number of rounds needed to seal a block
 	metrics.SetGauge([]string{consensusMetricsPrefix, "rounds"}, float32(extra.Checkpoint.BlockRound))
 	metrics.SetGauge([]string{consensusMetricsPrefix, "block_transactions"}, float32(len(currentBlock.Transactions)))
-	metrics.SetGauge([]string{consensusMetricsPrefix, "current_block"}, float32(currentBlock.Number()))
+	metrics.SetGauge([]string{consensusMetricsPrefix, "chain_head"}, float32(currentBlock.Number()))
 	metrics.IncrCounter([]string{consensusMetricsPrefix, "insert_block"}, float32(1))
 
 	return nil

--- a/consensus/polybft/consensus_metrics.go
+++ b/consensus/polybft/consensus_metrics.go
@@ -34,7 +34,7 @@ func updateBlockMetrics(currentBlock *types.Block, parentHeader *types.Header) e
 	metrics.SetGauge([]string{consensusMetricsPrefix, "rounds"}, float32(extra.Checkpoint.BlockRound))
 	metrics.SetGauge([]string{consensusMetricsPrefix, "block_transactions"}, float32(len(currentBlock.Transactions)))
 	metrics.SetGauge([]string{consensusMetricsPrefix, "chain_head"}, float32(currentBlock.Number()))
-	metrics.IncrCounter([]string{consensusMetricsPrefix, "insert_block"}, float32(1))
+	metrics.IncrCounter([]string{consensusMetricsPrefix, "block_counter"}, float32(1))
 
 	return nil
 }

--- a/consensus/polybft/consensus_metrics.go
+++ b/consensus/polybft/consensus_metrics.go
@@ -32,7 +32,6 @@ func updateBlockMetrics(currentBlock *types.Block, parentHeader *types.Header) e
 
 	// number of rounds needed to seal a block
 	metrics.SetGauge([]string{consensusMetricsPrefix, "rounds"}, float32(extra.Checkpoint.BlockRound))
-	metrics.SetGauge([]string{consensusMetricsPrefix, "block_transactions"}, float32(len(currentBlock.Transactions)))
 	metrics.SetGauge([]string{consensusMetricsPrefix, "current_block"}, float32(currentBlock.Number()))
 	metrics.IncrCounter([]string{consensusMetricsPrefix, "insert_block"}, float32(1))
 

--- a/consensus/polybft/consensus_metrics.go
+++ b/consensus/polybft/consensus_metrics.go
@@ -23,7 +23,7 @@ func updateBlockMetrics(currentBlock *types.Block, parentHeader *types.Header) e
 	}
 
 	// update the number of transactions in the block metric
-	metrics.SetGauge([]string{consensusMetricsPrefix, "num_txs"}, float32(len(currentBlock.Body().Transactions)))
+	metrics.SetGauge([]string{consensusMetricsPrefix, "num_txs"}, float32(len(currentBlock.Transactions)))
 
 	extra, err := GetIbftExtra(currentBlock.Header.ExtraData)
 	if err != nil {

--- a/consensus/polybft/consensus_metrics.go
+++ b/consensus/polybft/consensus_metrics.go
@@ -32,6 +32,9 @@ func updateBlockMetrics(currentBlock *types.Block, parentHeader *types.Header) e
 
 	// number of rounds needed to seal a block
 	metrics.SetGauge([]string{consensusMetricsPrefix, "rounds"}, float32(extra.Checkpoint.BlockRound))
+	metrics.SetGauge([]string{consensusMetricsPrefix, "block_transactions"}, float32(len(currentBlock.Transactions)))
+	metrics.SetGauge([]string{consensusMetricsPrefix, "current_block"}, float32(currentBlock.Number()))
+	metrics.IncrCounter([]string{consensusMetricsPrefix, "insert_block"}, float32(1))
 
 	return nil
 }


### PR DESCRIPTION
# Description

This PR adds two more metrics to the polybft consensus:
1. `chain-head` - indicates the latest block number inserted into the blockchain
2. `block-counter` - can indicate the frequency of blocks being created per time unit.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
