### PR TITLE
TOB-EDGE-27: RecoverPubk should validate provided hashed message

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -30,7 +30,8 @@ var (
 	one            = big.NewInt(1)
 
 	ErrInvalidBLSSignature = errors.New("invalid BLS Signature")
-	errEmptyOrZeroHash     = errors.New("can not recover public key from zero or empty message hash")
+	errZeroHash            = errors.New("can not recover public key from zero or empty message hash")
+	errHashOfInvalidLength = errors.New("message hash of invalid length")
 	errInvalidSignature    = errors.New("invalid signature")
 )
 
@@ -142,8 +143,12 @@ func Ecrecover(hash, sig []byte) ([]byte, error) {
 // RecoverPubkey verifies the compact signature "signature" of "hash" for the
 // secp256k1 curve.
 func RecoverPubkey(signature, hash []byte) (*ecdsa.PublicKey, error) {
-	if len(hash) == 0 || types.BytesToHash(hash) == types.ZeroHash {
-		return nil, errEmptyOrZeroHash
+	if len(hash) != types.HashLength {
+		return nil, errHashOfInvalidLength
+	}
+
+	if types.BytesToHash(hash) == types.ZeroHash {
+		return nil, errZeroHash
 	}
 
 	size := len(signature)

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -30,6 +30,7 @@ var (
 	one            = big.NewInt(1)
 
 	ErrInvalidBLSSignature = errors.New("invalid BLS Signature")
+	ErrEmptyOrZeroHash     = errors.New("can not recover public key from zero or empty message hash")
 )
 
 type KeyType string
@@ -144,6 +145,10 @@ func Ecrecover(hash, sig []byte) ([]byte, error) {
 // RecoverPubkey verifies the compact signature "signature" of "hash" for the
 // secp256k1 curve.
 func RecoverPubkey(signature, hash []byte) (*ecdsa.PublicKey, error) {
+	if len(hash) == 0 || types.BytesToHash(hash) == types.ZeroHash {
+		return nil, ErrEmptyOrZeroHash
+	}
+
 	size := len(signature)
 	term := byte(27)
 

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -30,7 +30,8 @@ var (
 	one            = big.NewInt(1)
 
 	ErrInvalidBLSSignature = errors.New("invalid BLS Signature")
-	ErrEmptyOrZeroHash     = errors.New("can not recover public key from zero or empty message hash")
+	errEmptyOrZeroHash     = errors.New("can not recover public key from zero or empty message hash")
+	errInvalidSignature    = errors.New("invalid signature")
 )
 
 type KeyType string
@@ -38,10 +39,6 @@ type KeyType string
 const (
 	KeyECDSA KeyType = "ecdsa"
 	KeyBLS   KeyType = "bls"
-)
-
-var (
-	errInvalidSignature = errors.New("invalid signature")
 )
 
 // KeccakState wraps sha3.state. In addition to the usual hash methods, it also supports
@@ -146,7 +143,7 @@ func Ecrecover(hash, sig []byte) ([]byte, error) {
 // secp256k1 curve.
 func RecoverPubkey(signature, hash []byte) (*ecdsa.PublicKey, error) {
 	if len(hash) == 0 || types.BytesToHash(hash) == types.ZeroHash {
-		return nil, ErrEmptyOrZeroHash
+		return nil, errEmptyOrZeroHash
 	}
 
 	size := len(signature)

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -446,17 +446,17 @@ func TestRecoverPublicKey(t *testing.T) {
 		t.Parallel()
 
 		_, err := RecoverPubkey(testSignature, []byte{})
-		require.ErrorIs(t, err, ErrEmptyOrZeroHash)
+		require.ErrorIs(t, err, errEmptyOrZeroHash)
 	})
 
 	t.Run("Zero hash", func(t *testing.T) {
 		t.Parallel()
 
 		_, err := RecoverPubkey(testSignature, types.ZeroHash[:])
-		require.ErrorIs(t, err, ErrEmptyOrZeroHash)
+		require.ErrorIs(t, err, errEmptyOrZeroHash)
 	})
 
-	t.Run("Ok signature", func(t *testing.T) {
+	t.Run("Ok signature and hash", func(t *testing.T) {
 		t.Parallel()
 
 		hash := []byte{0, 1, 2}

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -446,28 +446,35 @@ func TestRecoverPublicKey(t *testing.T) {
 		t.Parallel()
 
 		_, err := RecoverPubkey(testSignature, []byte{})
-		require.ErrorIs(t, err, errEmptyOrZeroHash)
+		require.ErrorIs(t, err, errHashOfInvalidLength)
+	})
+
+	t.Run("Hash of non appropriate length", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := RecoverPubkey(testSignature, []byte{0, 1})
+		require.ErrorIs(t, err, errHashOfInvalidLength)
 	})
 
 	t.Run("Zero hash", func(t *testing.T) {
 		t.Parallel()
 
 		_, err := RecoverPubkey(testSignature, types.ZeroHash[:])
-		require.ErrorIs(t, err, errEmptyOrZeroHash)
+		require.ErrorIs(t, err, errZeroHash)
 	})
 
 	t.Run("Ok signature and hash", func(t *testing.T) {
 		t.Parallel()
 
-		hash := []byte{0, 1, 2}
+		hash := types.BytesToHash([]byte{0, 1, 2})
 
 		privateKey, err := GenerateECDSAKey()
 		require.NoError(t, err)
 
-		signature, err := Sign(privateKey, hash)
+		signature, err := Sign(privateKey, hash.Bytes())
 		require.NoError(t, err)
 
-		publicKey, err := RecoverPubkey(signature, hash)
+		publicKey, err := RecoverPubkey(signature, hash.Bytes())
 		require.NoError(t, err)
 
 		require.True(t, privateKey.PublicKey.Equal(publicKey))


### PR DESCRIPTION
# Description

`crypto` package provides a way to recover the public from provided signature and hashed message, but before this PR, it did not validate the provided hashed message, meaning the function will return an arbitrary public key and then a malicious signer could impersonate other parties even without knowledge of their secret keys.

For example:
An attacker Eve finds a component inside of Polygon Edge that was changed recently and does not properly validate messages and submits a signature on an empty message that results in the `RecoverPubkey` function returning the public key for another user Bob. Eve is then able to impersonate Bob.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually