### PR TITLE
EVM-476 Add persistence to the Relayer

### DIFF
--- a/command/aarelayer/aa_relayer.go
+++ b/command/aarelayer/aa_relayer.go
@@ -28,7 +28,12 @@ func runPreRun(cmd *cobra.Command, _ []string) error {
 }
 
 func runCommand(cmd *cobra.Command, _ []string) error {
-	state, err := service.NewAATxState()
+	state, err := service.NewAATxState(params.dbPath)
+	if err != nil {
+		return err
+	}
+
+	pending, err := state.GetAllPending()
 	if err != nil {
 		return err
 	}
@@ -46,6 +51,8 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	pool := service.NewAAPool()
+	pool.Init(pending)
+
 	verification := service.NewAAVerification(
 		config,
 		types.Address(account.Ecdsa.Address()),

--- a/command/aarelayer/params_test.go
+++ b/command/aarelayer/params_test.go
@@ -1,9 +1,12 @@
 package aarelayer
 
 import (
+	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_validateFlags_ErrorValidateIPPort(t *testing.T) {
@@ -21,20 +24,49 @@ func Test_validateFlags_ErrorValidateIPPort(t *testing.T) {
 func Test_validateFlags_SecretsError(t *testing.T) {
 	t.Parallel()
 
+	tmpFilePath, err := os.MkdirTemp("/tmp", "aa_test_test_happy_path")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(tmpFilePath)
+
 	p := aarelayerParams{
-		addr: "127.0.0.1:8289",
+		addr:   "127.0.0.1:8289",
+		dbPath: path.Join(tmpFilePath, "e.db"),
 	}
 
 	assert.ErrorContains(t, p.validateFlags(), "no config file or data directory passed in")
 }
 
-func Test_validateFlags_HappyPath(t *testing.T) {
+func Test_validateFlags_ErrorValidateDbPath(t *testing.T) {
 	t.Parallel()
 
 	p := aarelayerParams{
+		dbPath: "/tmp/non_existing_path_to/non_existing_file.db",
+		addr:   "127.0.0.1:8289",
+	}
+
+	assert.ErrorContains(t, p.validateFlags(), "no such file or directory")
+
+	p.dbPath = ""
+	assert.ErrorContains(t, p.validateFlags(), "file name for boltdb not specified")
+}
+
+func Test_validateFlags_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	tmpFilePath, err := os.MkdirTemp("/tmp", "aa_test_test_happy_path")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(tmpFilePath)
+
+	p := aarelayerParams{
 		addr:       "127.0.0.1:8289",
+		dbPath:     path.Join(tmpFilePath, "e.db"),
 		configPath: "something",
 	}
 
+	assert.NoError(t, p.validateFlags())
+
+	p.dbPath = "dummy.db"
 	assert.NoError(t, p.validateFlags())
 }

--- a/command/aarelayer/service/aa_pool.go
+++ b/command/aarelayer/service/aa_pool.go
@@ -6,7 +6,7 @@ import (
 
 // AAPool defines the interface for a pool of Account Abstraction (AA) transactions
 type AAPool interface {
-	// Push adds an AA transaction to the pool, associating it with the given account ID
+	// Push adds an AA state transaction to the pool, associating it with the given account ID
 	Push(*AAStateTransaction)
 	// Pop removes the next transaction from the pool and returns a wrapper object containing the transaction
 	Pop() *AAStateTransaction
@@ -49,5 +49,11 @@ func (p *aaPool) Pop() *AAStateTransaction {
 	return item
 }
 
-func (p *aaPool) Init([]*AAStateTransaction) {
+func (p *aaPool) Init(txs []*AAStateTransaction) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	for _, tx := range txs {
+		p.pool = append(p.pool, tx)
+	}
 }

--- a/command/aarelayer/service/aa_server_test.go
+++ b/command/aarelayer/service/aa_server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -36,11 +37,12 @@ func Test_AAServer(t *testing.T) {
 	aaServer := getServer(t, types.Address(invoker.Ecdsa.Address()), dbpath)
 
 	go func() {
-		aaServer.ListenAndServe(baseURL)
+		err := aaServer.ListenAndServe(baseURL)
+		require.True(t, err == nil || errors.Is(err, http.ErrServerClosed))
 	}()
 
 	t.Cleanup(func() {
-		aaServer.Shutdown(context.Background())
+		require.NoError(t, aaServer.Shutdown(context.Background()))
 	})
 
 	time.Sleep(time.Millisecond * 100) // wait for server to start

--- a/command/aarelayer/service/aa_state.go
+++ b/command/aarelayer/service/aa_state.go
@@ -1,10 +1,12 @@
 package service
 
 import (
-	"fmt"
-	"sync"
+	"bytes"
+	"encoding/json"
+	"time"
 
 	"github.com/google/uuid"
+	bolt "go.etcd.io/bbolt"
 )
 
 // AATxState defines the interface for a stateful representation of Account Abstraction (AA) transactions
@@ -13,58 +15,164 @@ type AATxState interface {
 	Add(*AATransaction) (*AAStateTransaction, error)
 	// Get retrieves the metadata for the AA transaction with the specified ID from the state
 	Get(string) (*AAStateTransaction, error)
-	// Update modifies the metadata for the AA transaction with the specified ID in the state
-	Update(string, func(tx *AAStateTransaction)) error
+	// Get all pending transactions
+	GetAllPending() ([]*AAStateTransaction, error)
+	// Get all queued transactions
+	GetAllQueued() ([]*AAStateTransaction, error)
+	// Update modifies the metadata for the AA transaction
+	Update(stateTx *AAStateTransaction) error
 }
+
+var (
+	pendingBucket  = []byte("pending")
+	queuedBucket   = []byte("queued")
+	finishedBucket = []byte("finished")
+
+	allBuckets        = [][]byte{pendingBucket, queuedBucket, finishedBucket}
+	statusToBucketMap = map[string][]byte{
+		StatusPending:   pendingBucket,
+		StatusQueued:    queuedBucket,
+		StatusCompleted: finishedBucket,
+		StatusFailed:    finishedBucket,
+	}
+)
 
 var _ AATxState = (*aaTxState)(nil)
 
 type aaTxState struct {
-	// TODO: will be replaced with boldDB in next PR/task
-	mutex sync.RWMutex
-	items map[string]*AAStateTransaction
+	db *bolt.DB
 }
 
-func NewAATxState() (*aaTxState, error) {
-	return &aaTxState{
-		items: make(map[string]*AAStateTransaction),
-	}, nil
+func NewAATxState(dbFilePath string) (*aaTxState, error) {
+	state := &aaTxState{}
+
+	if err := state.init(dbFilePath); err != nil {
+		return nil, err
+	}
+
+	return state, nil
 }
 
 func (s *aaTxState) Add(tx *AATransaction) (*AAStateTransaction, error) {
-	s.mutex.Lock()
-	s.mutex.Unlock()
-
-	// TODO: bolDB implementation will be in next PR/task
-	id := uuid.NewString()
 	ntx := &AAStateTransaction{
-		ID:     id,
+		ID:     uuid.NewString(),
 		Tx:     tx,
 		Status: StatusPending,
+		Time:   time.Now().Unix(),
 	}
-	s.items[id] = ntx
+
+	value, err := json.Marshal(ntx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(pendingBucket).Put([]byte(ntx.ID), value)
+	}); err != nil {
+		return nil, err
+	}
 
 	return ntx, nil
 }
 
-func (s *aaTxState) Get(id string) (*AAStateTransaction, error) {
-	s.mutex.RLock()
-	s.mutex.RUnlock()
+func (s *aaTxState) Get(id string) (result *AAStateTransaction, err error) {
+	if err := s.db.View(func(tx *bolt.Tx) error {
+		idb := []byte(id)
 
-	// TODO: bolDB implementation will be in next PR/task
-	return s.items[id], nil
-}
+		for _, bucket := range allBuckets {
+			value := tx.Bucket(bucket).Get(idb)
+			if value != nil {
+				return json.Unmarshal(value, &result)
+			}
+		}
 
-func (s *aaTxState) Update(id string, fn func(tx *AAStateTransaction)) error {
-	s.mutex.Lock()
-	s.mutex.Unlock()
-
-	// TODO: bolDB implementation will be in next PR/task
-	if s.items[id] == nil {
-		return fmt.Errorf("tx does not exist: %s", id)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
-	fn(s.items[id])
+	return result, nil
+}
 
-	return nil
+func (s *aaTxState) GetAllPending() ([]*AAStateTransaction, error) {
+	return s.getAllFromBucket(pendingBucket)
+}
+
+func (s *aaTxState) GetAllQueued() ([]*AAStateTransaction, error) {
+	return s.getAllFromBucket(queuedBucket)
+}
+
+func (s *aaTxState) Update(stateTx *AAStateTransaction) error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		idb := []byte(stateTx.ID)
+		newStatusBacket := statusToBucketMap[stateTx.Status]
+
+		// check if item exist in another bucket, and if it is, delete item from the old bucket
+		for _, bucket := range allBuckets {
+			if !bytes.Equal(newStatusBacket, bucket) {
+				if value := tx.Bucket(bucket).Get(idb); value != nil {
+					// delete item from old bucket
+					if err := tx.Bucket(bucket).Delete(idb); err != nil {
+						return err
+					}
+
+					// update time
+					switch stateTx.Status {
+					case StatusQueued:
+						stateTx.TimeQueued = time.Now().Unix()
+					case StatusCompleted, StatusFailed:
+						stateTx.TimeFinished = time.Now().Unix()
+					}
+
+					break
+				}
+			}
+		}
+
+		bytesStateTx, err := json.Marshal(stateTx)
+		if err != nil {
+			return err
+		}
+
+		// put new value into new backet. Overwrite if already exists
+		return tx.Bucket(newStatusBacket).Put(idb, bytesStateTx)
+	})
+}
+
+func (s *aaTxState) init(dbFilePath string) (err error) {
+	if s.db, err = bolt.Open(dbFilePath, 0666, nil); err != nil {
+		return err
+	}
+
+	return s.db.Update(func(tx *bolt.Tx) error {
+		for _, bucket := range allBuckets {
+			if _, err := tx.CreateBucketIfNotExists(bucket); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+func (s *aaTxState) getAllFromBucket(bucketName []byte) ([]*AAStateTransaction, error) {
+	var result []*AAStateTransaction
+
+	if err := s.db.View(func(tx *bolt.Tx) error {
+		return tx.Bucket(bucketName).ForEach(func(key, value []byte) error {
+			stateTx := &AAStateTransaction{}
+
+			if err := json.Unmarshal(value, stateTx); err != nil {
+				return err
+			}
+
+			result = append(result, stateTx)
+
+			return nil
+		})
+	}); err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }

--- a/command/aarelayer/service/aa_state_test.go
+++ b/command/aarelayer/service/aa_state_test.go
@@ -1,0 +1,151 @@
+package service
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_AAState_AddGetUpdate(t *testing.T) {
+	t.Parallel()
+
+	dbpath, err := os.MkdirTemp("", "aa_server_state_db")
+	require.NoError(t, err)
+
+	t.Cleanup(func() { os.RemoveAll(dbpath) })
+
+	state, err := NewAATxState(path.Join(dbpath, "k.db"))
+	require.NoError(t, err)
+
+	stateTxs := [5]*AAStateTransaction{}
+
+	// add 5 items
+	for i := range stateTxs {
+		stateTxs[i], err = state.Add(&AATransaction{Transaction: Transaction{Nonce: 10 + uint64(i)}})
+
+		require.NoError(t, err)
+		assert.True(t, len(stateTxs[i].ID) >= 5)
+		assert.Equal(t, StatusPending, stateTxs[i].Status)
+	}
+
+	// retrieve
+	for i, tx := range stateTxs {
+		rtx, err := state.Get(tx.ID)
+
+		require.NoError(t, err)
+		assert.Equal(t, rtx.Tx.Transaction.Nonce, uint64(i)+10)
+	}
+
+	rtx, err := state.Get("not_existing_key")
+	require.NoError(t, err)
+	assert.Nil(t, rtx)
+
+	// move some of txs to different bucket
+	stateTxs[0].Status = StatusQueued
+	require.NoError(t, state.Update(stateTxs[0]))
+
+	stateTxs[1].Status = StatusFailed
+	require.NoError(t, state.Update(stateTxs[0]))
+
+	stateTxs[2].Status = StatusCompleted
+	require.NoError(t, state.Update(stateTxs[0]))
+
+	// retrieve should still work
+	for i, tx := range stateTxs {
+		rtx, err := state.Get(tx.ID)
+
+		require.NoError(t, err)
+		assert.Equal(t, rtx.Tx.Transaction.Nonce, uint64(i)+10)
+	}
+}
+
+func Test_AAState_UpdateGetQueuedGetPending(t *testing.T) {
+	t.Parallel()
+
+	dbpath, err := os.MkdirTemp("", "aa_server_state_db")
+	require.NoError(t, err)
+
+	t.Cleanup(func() { os.RemoveAll(dbpath) })
+
+	state, err := NewAATxState(path.Join(dbpath, "k.db"))
+	require.NoError(t, err)
+
+	stateTxs := [8]*AAStateTransaction{}
+
+	// add 8 pending items
+	for i := range stateTxs {
+		stateTxs[i], err = state.Add(&AATransaction{Transaction: Transaction{Nonce: 10 + uint64(i)}})
+
+		require.NoError(t, err)
+		assert.True(t, len(stateTxs[i].ID) >= 5)
+		assert.Equal(t, StatusPending, stateTxs[i].Status)
+	}
+
+	// update second and third to queued
+	for i := 1; i <= 2; i++ {
+		stateTxs[i].Status = StatusQueued
+		require.NoError(t, state.Update(stateTxs[i]))
+	}
+
+	// update forth to completed
+	stateTxs[3].Status = StatusCompleted
+	require.NoError(t, state.Update(stateTxs[3]))
+
+	// update sixt to failed
+	stateTxs[5].Status = StatusFailed
+	require.NoError(t, state.Update(stateTxs[5]))
+
+	// retrieve
+	txsQueued, err1 := state.GetAllQueued()
+	txsPending, err2 := state.GetAllPending()
+
+	assert.NoError(t, err1)
+	assert.Len(t, txsPending, 4)
+	assert.NoError(t, err2)
+	assert.Len(t, txsQueued, 2)
+
+	// update second to completed
+	stateTxs[1].Status = StatusCompleted
+	require.NoError(t, state.Update(stateTxs[1]))
+
+	// retrieve again
+	txsQueued, err1 = state.GetAllQueued()
+	txsPending, err2 = state.GetAllPending()
+
+	assert.NoError(t, err1)
+	assert.Len(t, txsPending, 4)
+	assert.NoError(t, err2)
+	assert.Len(t, txsQueued, 1)
+
+	// update third to failed
+	stateTxs[2].Status = StatusFailed
+	require.NoError(t, state.Update(stateTxs[2]))
+
+	// retrieve again
+	txsQueued, err1 = state.GetAllQueued()
+	txsPending, err2 = state.GetAllPending()
+
+	assert.NoError(t, err1)
+	assert.Len(t, txsPending, 4)
+	assert.NoError(t, err2)
+	assert.Len(t, txsQueued, 0)
+
+	// queue all pending
+	for i := range txsPending {
+		txsPending[i].Status = StatusQueued
+
+		require.NoError(t, state.Update(txsPending[i]))
+	}
+
+	// retrieve again
+	txsQueued, err1 = state.GetAllQueued()
+	txsPending, err2 = state.GetAllPending()
+
+	assert.NoError(t, err1)
+	assert.Len(t, txsPending, 0)
+	assert.NoError(t, err2)
+	assert.Len(t, txsQueued, 4)
+}


### PR DESCRIPTION
# Description

To store account abstraction transactions in a persistent database, we will use Bolt DB with three buckets: one for pending transactions, another for queued transactions, and a third for completed or failed transactions.

There are 4 functions in interface:
-  `Get` will search across all three buckets when retrieving a transaction by ID
-  `Add` function will assign a unique ID and place it in the pending transactions bucket
- `GetAllPending` returns all pending transactions
-  `Update`  modifies a transaction and move it to a different bucket if necessary

The path to the Bolt DB can be specified using the `--db-path` flag within the `aarelayer` command.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually


