### PR TITLE
Integrate secrets manager to bridge commands and rootchain init-contracts commands

### DIFF
--- a/command/bridge/README.md
+++ b/command/bridge/README.md
@@ -7,7 +7,7 @@ This is a helper command which deposits ERC20 tokens from the root chain to the 
 
 ```bash
 $ polygon-edge bridge deposit-erc20
-    --sender-key <hex_encoded_depositor_private_key>
+    --data-dir <local_storage_secrets_path> | [--config <cloud_secrets_manager_config_path>]
     --receivers <receivers_addresses>
     --amounts <amounts>
     --root-token <root_erc20_token_address>
@@ -15,12 +15,14 @@ $ polygon-edge bridge deposit-erc20
     --json-rpc <root_chain_json_rpc_endpoint>
 ```
 
+**Note:** for using test account provided by Geth dev instance, use `--test` flag. In that case `--data-dir` and `--config` flags can be omitted and test account is used as depositor.
+
 ## Withdraw ERC20
 This is a helper command which withdraws ERC20 tokens from the child chain to the root chain
 
 ```bash
 $ polygon-edge bridge withdraw-erc20
-    --sender-key <hex_encoded_withdraw_sender_private_key>
+    --data-dir <local_storage_secrets_path> | [--config <cloud_secrets_manager_config_path>]
     --receivers <receivers_addresses>
     --amounts <amounts>
     --child-predicate <rchild_erc20_predicate_address>
@@ -33,7 +35,7 @@ This is a helper command which qeuries child chain for exit event proof and send
 
 ```bash
 $ polygon-edge bridge exit
-    --sender-key <hex_encoded_withdraw_sender_private_key>
+    --data-dir <local_storage_secrets_path> | [--config <cloud_secrets_manager_config_path>]
     --exit-helper <exit_helper_address>
     --event-id <exit_event_id>
     --epoch <epoch_in_which_exit_event_got_processed>
@@ -41,3 +43,5 @@ $ polygon-edge bridge exit
     --root-json-rpc <root_chain_json_rpc_endpoint>
     --child-json-rpc <child_chain_json_rpc_endpoint>
 ```
+
+**Note:** for using test account provided by Geth dev instance, use `--test` flag. In that case `--data-dir` and `--config` flags can be omitted and test account is used as an exit transaction sender.

--- a/command/bridge/README.md
+++ b/command/bridge/README.md
@@ -3,6 +3,7 @@
 This is a helper command, which allows sending deposits from root to child chain and make withdrawals from child chain to root chain.
 
 ## Deposit ERC20
+
 This is a helper command which deposits ERC20 tokens from the root chain to the child chain
 
 ```bash
@@ -18,6 +19,7 @@ $ polygon-edge bridge deposit-erc20
 **Note:** for using test account provided by Geth dev instance, use `--test` flag. In that case `--data-dir` and `--config` flags can be omitted and test account is used as depositor.
 
 ## Withdraw ERC20
+
 This is a helper command which withdraws ERC20 tokens from the child chain to the root chain
 
 ```bash
@@ -31,6 +33,7 @@ $ polygon-edge bridge withdraw-erc20
 ```
 
 ## Exit
+
 This is a helper command which qeuries child chain for exit event proof and sends an exit transaction to ExitHelper smart contract.
 
 ```bash

--- a/command/bridge/bridge.go
+++ b/command/bridge/bridge.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/0xPolygon/polygon-edge/command/bridge/deposit"
+	"github.com/0xPolygon/polygon-edge/command/bridge/exit"
 	"github.com/0xPolygon/polygon-edge/command/bridge/withdraw"
 )
 
@@ -24,8 +25,8 @@ func registerSubcommands(baseCmd *cobra.Command) {
 		// bridge deposit
 		deposit.GetCommand(),
 		// bridge withdraw
-		withdraw.GetWithdrawCommand(),
+		withdraw.GetCommand(),
 		// bridge exit
-		withdraw.GetExitCommand(),
+		exit.GetCommand(),
 	)
 }

--- a/command/bridge/common/bridge_erc20_params.go
+++ b/command/bridge/common/bridge_erc20_params.go
@@ -17,20 +17,20 @@ var (
 )
 
 type ERC20BridgeParams struct {
-	SecretsDataPath   string
-	SecretsConfigPath string
-	Receivers         []string
-	Amounts           []string
+	AccountDir    string
+	AccountConfig string
+	Receivers     []string
+	Amounts       []string
 }
 
 func (bp *ERC20BridgeParams) ValidateFlags(testMode bool) error {
 	// in case of test mode test rootchain account is being used as the rootchain transactions sender
 	if !testMode {
-		if err := sidechain.ValidateSecretFlags(bp.SecretsDataPath, bp.SecretsConfigPath); err != nil {
+		if err := sidechain.ValidateSecretFlags(bp.AccountDir, bp.AccountConfig); err != nil {
 			return err
 		}
 	} else {
-		if bp.SecretsDataPath != "" || bp.SecretsConfigPath != "" {
+		if bp.AccountDir != "" || bp.AccountConfig != "" {
 			return helper.ErrTestModeSecrets
 		}
 	}

--- a/command/bridge/common/bridge_erc20_params.go
+++ b/command/bridge/common/bridge_erc20_params.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
-	"github.com/0xPolygon/polygon-edge/command/sidechain"
 )
 
 const (
@@ -23,16 +22,10 @@ type ERC20BridgeParams struct {
 	Amounts       []string
 }
 
-func (bp *ERC20BridgeParams) ValidateFlags(testMode bool) error {
+func (bp *ERC20BridgeParams) ValidateFlags(isTestMode bool) error {
 	// in case of test mode test rootchain account is being used as the rootchain transactions sender
-	if !testMode {
-		if err := sidechain.ValidateSecretFlags(bp.AccountDir, bp.AccountConfig); err != nil {
-			return err
-		}
-	} else {
-		if bp.AccountDir != "" || bp.AccountConfig != "" {
-			return helper.ErrTestModeSecrets
-		}
+	if err := helper.ValidateSecretFlags(isTestMode, bp.AccountDir, bp.AccountConfig); err != nil {
+		return err
 	}
 
 	if len(bp.Receivers) != len(bp.Amounts) {

--- a/command/bridge/common/bridge_erc20_params.go
+++ b/command/bridge/common/bridge_erc20_params.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"errors"
+
+	"github.com/0xPolygon/polygon-edge/command/sidechain"
 )
 
 const (
@@ -15,12 +17,20 @@ var (
 )
 
 type ERC20BridgeParams struct {
-	TxnSenderKey string
-	Receivers    []string
-	Amounts      []string
+	SecretsDataPath   string
+	SecretsConfigPath string
+	Receivers         []string
+	Amounts           []string
 }
 
-func (bp *ERC20BridgeParams) ValidateFlags() error {
+func (bp *ERC20BridgeParams) ValidateFlags(testMode bool) error {
+	// in case of test mode test rootchain account is being used as the rootchain transactions sender
+	if !testMode {
+		if err := sidechain.ValidateSecretFlags(bp.SecretsDataPath, bp.SecretsConfigPath); err != nil {
+			return err
+		}
+	}
+
 	if len(bp.Receivers) != len(bp.Amounts) {
 		return errInconsistentAccounts
 	}

--- a/command/bridge/common/bridge_erc20_params.go
+++ b/command/bridge/common/bridge_erc20_params.go
@@ -3,11 +3,11 @@ package common
 import (
 	"errors"
 
+	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
 	"github.com/0xPolygon/polygon-edge/command/sidechain"
 )
 
 const (
-	SenderKeyFlag = "sender-key"
 	ReceiversFlag = "receivers"
 	AmountsFlag   = "amounts"
 )
@@ -28,6 +28,10 @@ func (bp *ERC20BridgeParams) ValidateFlags(testMode bool) error {
 	if !testMode {
 		if err := sidechain.ValidateSecretFlags(bp.SecretsDataPath, bp.SecretsConfigPath); err != nil {
 			return err
+		}
+	} else {
+		if bp.SecretsDataPath != "" || bp.SecretsConfigPath != "" {
+			return helper.ErrTestModeSecrets
 		}
 	}
 

--- a/command/bridge/deposit/deposit_erc20.go
+++ b/command/bridge/deposit/deposit_erc20.go
@@ -13,8 +13,10 @@ import (
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/bridge/common"
 	cmdHelper "github.com/0xPolygon/polygon-edge/command/helper"
+	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 )
@@ -25,16 +27,17 @@ const (
 	jsonRPCFlag       = "json-rpc"
 )
 
-type depositParams struct {
+type depositERC20Params struct {
 	*common.ERC20BridgeParams
 	rootTokenAddr     string
 	rootPredicateAddr string
 	jsonRPCAddress    string
+	testMode          bool
 }
 
 var (
 	// depositParams is abstraction for provided bridge parameter values
-	dp *depositParams = &depositParams{ERC20BridgeParams: &common.ERC20BridgeParams{}}
+	dp *depositERC20Params = &depositERC20Params{ERC20BridgeParams: &common.ERC20BridgeParams{}}
 )
 
 // GetCommand returns the bridge deposit command
@@ -47,10 +50,17 @@ func GetCommand() *cobra.Command {
 	}
 
 	depositCmd.Flags().StringVar(
-		&dp.TxnSenderKey,
-		common.SenderKeyFlag,
-		helper.DefaultPrivateKeyRaw,
-		"hex encoded private key of the account which sends rootchain deposit transactions",
+		&dp.SecretsDataPath,
+		polybftsecrets.DataPathFlag,
+		"",
+		polybftsecrets.DataPathFlagDesc,
+	)
+
+	depositCmd.Flags().StringVar(
+		&dp.SecretsConfigPath,
+		polybftsecrets.ConfigFlag,
+		"",
+		polybftsecrets.ConfigFlagDesc,
 	)
 
 	depositCmd.Flags().StringSliceVar(
@@ -71,14 +81,14 @@ func GetCommand() *cobra.Command {
 		&dp.rootTokenAddr,
 		rootTokenFlag,
 		"",
-		"ERC20 root chain token address",
+		"root ERC20 token address",
 	)
 
 	depositCmd.Flags().StringVar(
 		&dp.rootPredicateAddr,
 		rootPredicateFlag,
 		"",
-		"ERC20 root chain predicate address",
+		"root ERC20 token predicate address",
 	)
 
 	depositCmd.Flags().StringVar(
@@ -88,16 +98,28 @@ func GetCommand() *cobra.Command {
 		"the JSON RPC root chain endpoint",
 	)
 
+	depositCmd.Flags().BoolVar(
+		&dp.testMode,
+		helper.TestModeFlag,
+		false,
+		"test indicates whether depositor is hardcoded test account "+
+			"(in that case tokens are minted to it, so it is able to make deposits)",
+	)
+
 	depositCmd.MarkFlagRequired(common.ReceiversFlag)
 	depositCmd.MarkFlagRequired(common.AmountsFlag)
 	depositCmd.MarkFlagRequired(rootTokenFlag)
 	depositCmd.MarkFlagRequired(rootPredicateFlag)
 
+	depositCmd.MarkFlagsMutuallyExclusive(polybftsecrets.DataPathFlag, polybftsecrets.ConfigFlag)
+	depositCmd.MarkFlagsMutuallyExclusive(helper.TestModeFlag, polybftsecrets.DataPathFlag)
+	depositCmd.MarkFlagsMutuallyExclusive(helper.TestModeFlag, polybftsecrets.ConfigFlag)
+
 	return depositCmd
 }
 
 func runPreRun(cmd *cobra.Command, _ []string) error {
-	if err := dp.ValidateFlags(); err != nil {
+	if err := dp.ValidateFlags(dp.testMode); err != nil {
 		return err
 	}
 
@@ -108,15 +130,37 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	if err := helper.InitRootchainPrivateKey(dp.TxnSenderKey); err != nil {
-		outputter.SetError(err)
+	var depositorKey ethgo.Key
 
-		return
+	if !dp.testMode {
+		secretsManager, err := polybftsecrets.GetSecretsManager(dp.SecretsDataPath, dp.SecretsConfigPath, true)
+		if err != nil {
+			outputter.SetError(err)
+
+			return
+		}
+
+		depositorAccount, err := wallet.NewAccountFromSecret(secretsManager)
+		if err != nil {
+			outputter.SetError(err)
+
+			return
+		}
+
+		depositorKey = depositorAccount.Ecdsa
+	} else {
+		if err := helper.InitRootchainPrivateKey(""); err != nil {
+			outputter.SetError(fmt.Errorf("failed to initialize root chain private key: %w", err))
+
+			return
+		}
+
+		depositorKey = helper.GetRootchainPrivateKey()
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(dp.jsonRPCAddress))
 	if err != nil {
-		outputter.SetError(fmt.Errorf("could not create rootchain tx relayer: %w", err))
+		outputter.SetError(fmt.Errorf("failed not initialize rootchain tx relayer: %w", err))
 
 		return
 	}
@@ -134,15 +178,18 @@ func runCommand(cmd *cobra.Command, _ []string) {
 			default:
 				amountBig, err := types.ParseUint256orHex(&amount)
 				if err != nil {
-					return fmt.Errorf("failed to decode provided amount %s: %w", amount, err)
+					return fmt.Errorf("failed to decode provided deposit amount %s: %w", amount, err)
 				}
 
-				if helper.IsTestMode(dp.TxnSenderKey) {
-					// mint tokens to depositor, so he is able to send them
-					txn, err := createMintTxn(types.Address(helper.GetRootchainPrivateKey().Address()), amountBig)
+				if dp.testMode {
+					// mint tokens to the depositor, so he is able to deposit them
+					// Note: this works only if using test account on the rootchain,
+					// because it is expected that it is the one which deploys rootchain smart contracts as well
+					txn, err := createMintTxn(types.Address(depositorKey.Address()), types.Address(depositorKey.Address()), amountBig)
 					if err != nil {
 						return fmt.Errorf("mint transaction creation failed: %w", err)
 					}
+
 					receipt, err := txRelayer.SendTransaction(txn, helper.GetRootchainPrivateKey())
 					if err != nil {
 						return fmt.Errorf("failed to send mint transaction to depositor %s", helper.GetRootchainPrivateKey().Address())
@@ -154,20 +201,18 @@ func runCommand(cmd *cobra.Command, _ []string) {
 				}
 
 				// deposit tokens
-				txn, err := createDepositTxn(types.StringToAddress(receiver), amountBig)
+				txn, err := createDepositTxn(types.Address(depositorKey.Address()), types.StringToAddress(receiver), amountBig)
 				if err != nil {
 					return fmt.Errorf("failed to create tx input: %w", err)
 				}
 
-				receipt, err := txRelayer.SendTransaction(txn, helper.GetRootchainPrivateKey())
+				receipt, err := txRelayer.SendTransaction(txn, depositorKey)
 				if err != nil {
-					return fmt.Errorf("receiver: %s, amount: %s, error: %w",
-						receiver, amount, err)
+					return fmt.Errorf("receiver: %s, amount: %s, error: %w", receiver, amount, err)
 				}
 
 				if receipt.Status == uint64(types.ReceiptFailed) {
-					return fmt.Errorf("receiver: %s, amount: %s",
-						receiver, amount)
+					return fmt.Errorf("receiver: %s, amount: %s", receiver, amount)
 				}
 
 				return nil
@@ -189,7 +234,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 }
 
 // createDepositTxn encodes parameters for deposit function on rootchain predicate contract
-func createDepositTxn(receiver types.Address, amount *big.Int) (*ethgo.Transaction, error) {
+func createDepositTxn(sender, receiver types.Address, amount *big.Int) (*ethgo.Transaction, error) {
 	depositToFn := &contractsapi.DepositToFunction{
 		RootToken: types.StringToAddress(dp.rootTokenAddr),
 		Receiver:  receiver,
@@ -210,7 +255,7 @@ func createDepositTxn(receiver types.Address, amount *big.Int) (*ethgo.Transacti
 }
 
 // createMintTxn encodes parameters for mint function on rootchain token contract
-func createMintTxn(receiver types.Address, amount *big.Int) (*ethgo.Transaction, error) {
+func createMintTxn(sender, receiver types.Address, amount *big.Int) (*ethgo.Transaction, error) {
 	mintFn := &contractsapi.MintFunction{
 		To:     receiver,
 		Amount: amount,
@@ -224,6 +269,7 @@ func createMintTxn(receiver types.Address, amount *big.Int) (*ethgo.Transaction,
 	addr := ethgo.Address(types.StringToAddress(dp.rootTokenAddr))
 
 	return &ethgo.Transaction{
+		From:  ethgo.Address(sender),
 		To:    &addr,
 		Input: input,
 	}, nil

--- a/command/bridge/deposit/deposit_erc20.go
+++ b/command/bridge/deposit/deposit_erc20.go
@@ -50,17 +50,17 @@ func GetCommand() *cobra.Command {
 	}
 
 	depositCmd.Flags().StringVar(
-		&dp.SecretsDataPath,
-		polybftsecrets.DataPathFlag,
+		&dp.AccountDir,
+		polybftsecrets.AccountDirFlag,
 		"",
-		polybftsecrets.DataPathFlagDesc,
+		polybftsecrets.AccountDirFlagDesc,
 	)
 
 	depositCmd.Flags().StringVar(
-		&dp.SecretsConfigPath,
-		polybftsecrets.ConfigFlag,
+		&dp.AccountConfig,
+		polybftsecrets.AccountConfigFlag,
 		"",
-		polybftsecrets.ConfigFlagDesc,
+		polybftsecrets.AccountConfigFlagDesc,
 	)
 
 	depositCmd.Flags().StringSliceVar(
@@ -111,7 +111,10 @@ func GetCommand() *cobra.Command {
 	depositCmd.MarkFlagRequired(rootTokenFlag)
 	depositCmd.MarkFlagRequired(rootPredicateFlag)
 
-	depositCmd.MarkFlagsMutuallyExclusive(helper.TestModeFlag, polybftsecrets.DataPathFlag, polybftsecrets.ConfigFlag)
+	depositCmd.MarkFlagsMutuallyExclusive(
+		helper.TestModeFlag,
+		polybftsecrets.AccountDirFlag,
+		polybftsecrets.AccountConfigFlag)
 
 	return depositCmd
 }
@@ -131,7 +134,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	var depositorKey ethgo.Key
 
 	if !dp.testMode {
-		secretsManager, err := polybftsecrets.GetSecretsManager(dp.SecretsDataPath, dp.SecretsConfigPath, true)
+		secretsManager, err := polybftsecrets.GetSecretsManager(dp.AccountDir, dp.AccountConfig, true)
 		if err != nil {
 			outputter.SetError(err)
 

--- a/command/bridge/deposit/deposit_erc20.go
+++ b/command/bridge/deposit/deposit_erc20.go
@@ -15,8 +15,8 @@ import (
 	cmdHelper "github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
+	"github.com/0xPolygon/polygon-edge/command/sidechain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 )
@@ -134,14 +134,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	var depositorKey ethgo.Key
 
 	if !dp.testMode {
-		secretsManager, err := polybftsecrets.GetSecretsManager(dp.AccountDir, dp.AccountConfig, true)
-		if err != nil {
-			outputter.SetError(err)
-
-			return
-		}
-
-		depositorAccount, err := wallet.NewAccountFromSecret(secretsManager)
+		depositorAccount, err := sidechain.GetAccount(dp.AccountDir, dp.AccountConfig)
 		if err != nil {
 			outputter.SetError(err)
 

--- a/command/bridge/exit/exit.go
+++ b/command/bridge/exit/exit.go
@@ -1,4 +1,4 @@
-package withdraw
+package exit
 
 import (
 	"bytes"
@@ -64,13 +64,13 @@ var (
 	ep *exitParams = &exitParams{}
 )
 
-// GetExitCommand returns the bridge exit command
-func GetExitCommand() *cobra.Command {
+// GetCommand returns the bridge exit command
+func GetCommand() *cobra.Command {
 	exitCmd := &cobra.Command{
 		Use:     "exit",
 		Short:   "Sends exit transaction to the Exit helper contract on the root chain",
-		Run:     runExitCommand,
-		PreRunE: runExitPreRun,
+		PreRunE: preRun,
+		Run:     run,
 	}
 
 	exitCmd.Flags().StringVar(
@@ -144,7 +144,7 @@ func GetExitCommand() *cobra.Command {
 	return exitCmd
 }
 
-func runExitCommand(cmd *cobra.Command, _ []string) {
+func run(cmd *cobra.Command, _ []string) {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
@@ -236,8 +236,8 @@ func runExitCommand(cmd *cobra.Command, _ []string) {
 	})
 }
 
-// runExitPreRun is used to validate input values
-func runExitPreRun(_ *cobra.Command, _ []string) error {
+// preRun is used to validate input values
+func preRun(_ *cobra.Command, _ []string) error {
 	if err := ep.validateFlags(); err != nil {
 		return err
 	}

--- a/command/bridge/exit/exit.go
+++ b/command/bridge/exit/exit.go
@@ -38,8 +38,8 @@ const (
 )
 
 type exitParams struct {
-	secretsDataPath   string
-	secretsConfigPath string
+	accountDir        string
+	accountConfig     string
 	exitHelperAddrRaw string
 	exitID            uint64
 	epochNumber       uint64
@@ -52,11 +52,11 @@ type exitParams struct {
 // validateFlags validates input values
 func (ep *exitParams) validateFlags() error {
 	if !ep.isTestMode {
-		if err := sidechain.ValidateSecretFlags(ep.secretsDataPath, ep.secretsConfigPath); err != nil {
+		if err := sidechain.ValidateSecretFlags(ep.accountDir, ep.accountConfig); err != nil {
 			return err
 		}
 	} else {
-		if ep.secretsDataPath != "" || ep.secretsConfigPath != "" {
+		if ep.accountDir != "" || ep.accountConfig != "" {
 			return helper.ErrTestModeSecrets
 		}
 	}
@@ -79,17 +79,17 @@ func GetCommand() *cobra.Command {
 	}
 
 	exitCmd.Flags().StringVar(
-		&ep.secretsDataPath,
-		polybftsecrets.DataPathFlag,
+		&ep.accountDir,
+		polybftsecrets.AccountDirFlag,
 		"",
-		polybftsecrets.DataPathFlagDesc,
+		polybftsecrets.AccountDirFlagDesc,
 	)
 
 	exitCmd.Flags().StringVar(
-		&ep.secretsConfigPath,
-		polybftsecrets.ConfigFlag,
+		&ep.accountConfig,
+		polybftsecrets.AccountConfigFlag,
 		"",
-		polybftsecrets.ConfigFlagDesc,
+		polybftsecrets.AccountConfigFlagDesc,
 	)
 
 	exitCmd.Flags().StringVar(
@@ -142,7 +142,10 @@ func GetCommand() *cobra.Command {
 	)
 
 	exitCmd.MarkFlagRequired(exitHelperFlag)
-	exitCmd.MarkFlagsMutuallyExclusive(helper.TestModeFlag, polybftsecrets.DataPathFlag, polybftsecrets.ConfigFlag)
+	exitCmd.MarkFlagsMutuallyExclusive(
+		helper.TestModeFlag,
+		polybftsecrets.AccountDirFlag,
+		polybftsecrets.AccountConfigFlag)
 
 	return exitCmd
 }
@@ -154,7 +157,7 @@ func run(cmd *cobra.Command, _ []string) {
 	var senderKey ethgo.Key
 
 	if !ep.isTestMode {
-		secretsManager, err := polybftsecrets.GetSecretsManager(ep.secretsDataPath, ep.secretsConfigPath, true)
+		secretsManager, err := polybftsecrets.GetSecretsManager(ep.accountDir, ep.accountConfig, true)
 		if err != nil {
 			outputter.SetError(err)
 

--- a/command/bridge/exit/exit.go
+++ b/command/bridge/exit/exit.go
@@ -16,7 +16,6 @@ import (
 	cmdHelper "github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
-	"github.com/0xPolygon/polygon-edge/command/sidechain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
@@ -51,17 +50,7 @@ type exitParams struct {
 
 // validateFlags validates input values
 func (ep *exitParams) validateFlags() error {
-	if !ep.isTestMode {
-		if err := sidechain.ValidateSecretFlags(ep.accountDir, ep.accountConfig); err != nil {
-			return err
-		}
-	} else {
-		if ep.accountDir != "" || ep.accountConfig != "" {
-			return helper.ErrTestModeSecrets
-		}
-	}
-
-	return nil
+	return helper.ValidateSecretFlags(ep.isTestMode, ep.accountDir, ep.accountConfig)
 }
 
 var (

--- a/command/bridge/withdraw/withdraw_erc20.go
+++ b/command/bridge/withdraw/withdraw_erc20.go
@@ -41,12 +41,12 @@ var (
 )
 
 // GetCommand returns the bridge withdraw command
-func GetWithdrawCommand() *cobra.Command {
+func GetCommand() *cobra.Command {
 	withdrawCmd := &cobra.Command{
 		Use:     "withdraw-erc20",
 		Short:   "Withdraws tokens from the child chain to the root chain",
-		PreRunE: runPreRunWithdraw,
-		Run:     runCommand,
+		PreRunE: preRun,
+		Run:     run,
 	}
 
 	withdrawCmd.Flags().StringVar(
@@ -106,7 +106,7 @@ func GetWithdrawCommand() *cobra.Command {
 	return withdrawCmd
 }
 
-func runPreRunWithdraw(cmd *cobra.Command, _ []string) error {
+func preRun(cmd *cobra.Command, _ []string) error {
 	if err := wp.ValidateFlags(false); err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func runPreRunWithdraw(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func runCommand(cmd *cobra.Command, _ []string) {
+func run(cmd *cobra.Command, _ []string) {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 

--- a/command/bridge/withdraw/withdraw_erc20.go
+++ b/command/bridge/withdraw/withdraw_erc20.go
@@ -50,17 +50,17 @@ func GetCommand() *cobra.Command {
 	}
 
 	withdrawCmd.Flags().StringVar(
-		&wp.SecretsDataPath,
-		polybftsecrets.DataPathFlag,
+		&wp.AccountDir,
+		polybftsecrets.AccountDirFlag,
 		"",
-		polybftsecrets.DataPathFlagDesc,
+		polybftsecrets.AccountDirFlagDesc,
 	)
 
 	withdrawCmd.Flags().StringVar(
-		&wp.SecretsConfigPath,
-		polybftsecrets.ConfigFlag,
+		&wp.AccountConfig,
+		polybftsecrets.AccountConfigFlag,
 		"",
-		polybftsecrets.ConfigFlagDesc,
+		polybftsecrets.AccountConfigFlagDesc,
 	)
 
 	withdrawCmd.Flags().StringSliceVar(
@@ -101,7 +101,7 @@ func GetCommand() *cobra.Command {
 	withdrawCmd.MarkFlagRequired(common.ReceiversFlag)
 	withdrawCmd.MarkFlagRequired(common.AmountsFlag)
 
-	withdrawCmd.MarkFlagsMutuallyExclusive(polybftsecrets.DataPathFlag, polybftsecrets.ConfigFlag)
+	withdrawCmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
 
 	return withdrawCmd
 }
@@ -118,7 +118,7 @@ func run(cmd *cobra.Command, _ []string) {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	secretsManager, err := polybftsecrets.GetSecretsManager(wp.SecretsDataPath, wp.SecretsConfigPath, true)
+	secretsManager, err := polybftsecrets.GetSecretsManager(wp.AccountDir, wp.AccountConfig, true)
 	if err != nil {
 		outputter.SetError(err)
 

--- a/command/bridge/withdraw/withdraw_erc20.go
+++ b/command/bridge/withdraw/withdraw_erc20.go
@@ -15,9 +15,9 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/bridge/common"
 	cmdHelper "github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
+	"github.com/0xPolygon/polygon-edge/command/sidechain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -118,14 +118,7 @@ func run(cmd *cobra.Command, _ []string) {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	secretsManager, err := polybftsecrets.GetSecretsManager(wp.AccountDir, wp.AccountConfig, true)
-	if err != nil {
-		outputter.SetError(err)
-
-		return
-	}
-
-	senderAccount, err := wallet.NewAccountFromSecret(secretsManager)
+	senderAccount, err := sidechain.GetAccount(wp.AccountDir, wp.AccountConfig)
 	if err != nil {
 		outputter.SetError(err)
 

--- a/command/polybftsecrets/params.go
+++ b/command/polybftsecrets/params.go
@@ -27,8 +27,8 @@ const (
 )
 
 type initParams struct {
-	dataPath   string
-	configPath string
+	accountDir    string
+	accountConfig string
 
 	generatesAccount bool
 	generatesNetwork bool
@@ -49,7 +49,7 @@ func (ip *initParams) validateFlags() error {
 		return ErrInvalidNum
 	}
 
-	if ip.dataPath == "" && ip.configPath == "" {
+	if ip.accountDir == "" && ip.accountConfig == "" {
 		return ErrInvalidParams
 	}
 
@@ -58,17 +58,17 @@ func (ip *initParams) validateFlags() error {
 
 func (ip *initParams) setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
-		&ip.dataPath,
-		DataPathFlag,
+		&ip.accountDir,
+		AccountDirFlag,
 		"",
-		DataPathFlagDesc,
+		AccountDirFlagDesc,
 	)
 
 	cmd.Flags().StringVar(
-		&ip.configPath,
-		ConfigFlag,
+		&ip.accountConfig,
+		AccountConfigFlag,
 		"",
-		ConfigFlagDesc,
+		AccountConfigFlagDesc,
 	)
 
 	cmd.Flags().IntVar(
@@ -80,10 +80,10 @@ func (ip *initParams) setFlags(cmd *cobra.Command) {
 
 	// Don't accept data-dir and config flags because they are related to different secrets managers.
 	// data-dir is about the local FS as secrets storage, config is about remote secrets manager.
-	cmd.MarkFlagsMutuallyExclusive(DataPathFlag, ConfigFlag)
+	cmd.MarkFlagsMutuallyExclusive(AccountDirFlag, AccountConfigFlag)
 
 	// num flag should be used with data-dir flag only so it should not be used with config flag.
-	cmd.MarkFlagsMutuallyExclusive(numFlag, ConfigFlag)
+	cmd.MarkFlagsMutuallyExclusive(numFlag, AccountConfigFlag)
 
 	cmd.Flags().BoolVar(
 		&ip.generatesAccount,
@@ -132,14 +132,14 @@ func (ip *initParams) Execute() (Results, error) {
 	results := make(Results, ip.numberOfSecrets)
 
 	for i := 0; i < ip.numberOfSecrets; i++ {
-		configDir, dataDir := ip.configPath, ip.dataPath
+		configDir, dataDir := ip.accountConfig, ip.accountDir
 
 		if ip.numberOfSecrets > 1 {
-			dataDir = fmt.Sprintf("%s%d", ip.dataPath, i+1)
+			dataDir = fmt.Sprintf("%s%d", ip.accountDir, i+1)
 		}
 
 		if configDir != "" && ip.numberOfSecrets > 1 {
-			configDir = fmt.Sprintf("%s%d", ip.configPath, i+1)
+			configDir = fmt.Sprintf("%s%d", ip.accountConfig, i+1)
 		}
 
 		secretManager, err := GetSecretsManager(dataDir, configDir, ip.insecureLocalStore)

--- a/command/polybftsecrets/utils.go
+++ b/command/polybftsecrets/utils.go
@@ -10,11 +10,11 @@ import (
 
 // common flags for all polybft commands
 const (
-	DataPathFlag = "data-dir"
-	ConfigFlag   = "config"
+	AccountDirFlag    = "data-dir"
+	AccountConfigFlag = "config"
 
-	DataPathFlagDesc = "the directory for the Polygon Edge data if the local FS is used"
-	ConfigFlagDesc   = "the path to the SecretsManager config file, if omitted, the local FS secrets manager is used"
+	AccountDirFlagDesc    = "the directory for the Polygon Edge data if the local FS is used"
+	AccountConfigFlagDesc = "the path to the SecretsManager config file, if omitted, the local FS secrets manager is used"
 )
 
 // common errors for all polybft commands

--- a/command/polybftsecrets/utils.go
+++ b/command/polybftsecrets/utils.go
@@ -35,7 +35,7 @@ func GetSecretsManager(dataPath, configPath string, insecureLocalStore bool) (se
 	if configPath != "" {
 		secretsConfig, readErr := secrets.ReadConfig(configPath)
 		if readErr != nil {
-			return nil, errors.New(ErrInvalidConfig.Error() + ": " + readErr.Error())
+			return nil, fmt.Errorf("%w: %w", ErrInvalidConfig, readErr)
 		}
 
 		if !secrets.SupportedServiceManager(secretsConfig.Type) {

--- a/command/rootchain/README.md
+++ b/command/rootchain/README.md
@@ -30,5 +30,8 @@ This command deploys and initializes rootchain contracts. Transactions are being
 $ polygon-edge rootchain init-contracts 
     --manifest <manifest_file_path> 
     --json-rpc <json_rpc_endpoint> 
-    --adminKey <hex_encoded_rootchain_admin_private_key>
+    --data-dir <local_storage_secrets_path> | [--config <cloud_secrets_manager_config_path>]
+    [--test]
 ```
+
+**Note:** In case `test` flag is provided, it engages test mode, which uses predefined test account private key to send transactions to the rootchain.

--- a/command/rootchain/helper/metadata.go
+++ b/command/rootchain/helper/metadata.go
@@ -13,42 +13,24 @@ import (
 )
 
 const (
-	DefaultPrivateKeyRaw = "aa75e9a7d427efc732f8e4f1a5b7646adcc61fd5bae40f80d13c8419c9f43d6d"
-	TestModeFlag         = "test"
+	testAccountPrivKey = "aa75e9a7d427efc732f8e4f1a5b7646adcc61fd5bae40f80d13c8419c9f43d6d"
+	TestModeFlag       = "test"
 )
 
 var (
 	ErrRootchainNotFound = errors.New("rootchain not found")
 	ErrRootchainPortBind = errors.New("port 8545 is not bind with localhost")
-
-	// rootchainAccountKey is a private key of account which is used for different actions on rootchain
-	// (smart contracts deployment, deposits etc.)
-	rootchainAccountKey *wallet.Key
+	ErrTestModeSecrets   = errors.New("rootchain test mode does not imply specifying secrets parameters")
 )
 
-// InitRootchainPrivateKey initializes a private key instance from provided hex encoded private key
-func InitRootchainPrivateKey(rawKey string) error {
-	privateKeyRaw := DefaultPrivateKeyRaw
-	if rawKey != "" {
-		privateKeyRaw = rawKey
-	}
-
-	dec, err := hex.DecodeString(privateKeyRaw)
+// GetRootchainTestPrivKey initializes a private key instance from hardcoded test account hex encoded private key
+func GetRootchainTestPrivKey() (ethgo.Key, error) {
+	testAccPrivKeyRaw, err := hex.DecodeString(testAccountPrivKey)
 	if err != nil {
-		return fmt.Errorf("failed to decode private key string '%s': %w", privateKeyRaw, err)
+		return nil, fmt.Errorf("failed to decode private key string '%s': %w", testAccountPrivKey, err)
 	}
 
-	rootchainAccountKey, err = wallet.NewWalletFromPrivKey(dec)
-	if err != nil {
-		return fmt.Errorf("failed to initialize key from provided private key '%s': %w", privateKeyRaw, err)
-	}
-
-	return nil
-}
-
-// GetRootchainPrivateKey returns rootchain account private key
-func GetRootchainPrivateKey() ethgo.Key {
-	return rootchainAccountKey
+	return wallet.NewWalletFromPrivKey(testAccPrivKeyRaw)
 }
 
 func GetRootchainID() (string, error) {
@@ -93,9 +75,4 @@ func ReadRootchainIP() (string, error) {
 	}
 
 	return fmt.Sprintf("http://%s:%s", ports[0].HostIP, ports[0].HostPort), nil
-}
-
-// IsTestMode returns true in case provided rootchain private key is the same as DefaultPrivateKey one
-func IsTestMode(rootchainPrivKey string) bool {
-	return rootchainPrivKey == DefaultPrivateKeyRaw
 }

--- a/command/rootchain/helper/metadata.go
+++ b/command/rootchain/helper/metadata.go
@@ -12,7 +12,10 @@ import (
 	"github.com/umbracle/ethgo/wallet"
 )
 
-const DefaultPrivateKeyRaw = "aa75e9a7d427efc732f8e4f1a5b7646adcc61fd5bae40f80d13c8419c9f43d6d"
+const (
+	DefaultPrivateKeyRaw = "aa75e9a7d427efc732f8e4f1a5b7646adcc61fd5bae40f80d13c8419c9f43d6d"
+	TestModeFlag         = "test"
+)
 
 var (
 	ErrRootchainNotFound = errors.New("rootchain not found")

--- a/command/rootchain/initcontracts/init_contracts.go
+++ b/command/rootchain/initcontracts/init_contracts.go
@@ -91,17 +91,17 @@ func GetCommand() *cobra.Command {
 	)
 
 	cmd.Flags().StringVar(
-		&params.secretsConfigPath,
-		polybftsecrets.ConfigFlag,
+		&params.accountDir,
+		polybftsecrets.AccountDirFlag,
 		"",
-		polybftsecrets.ConfigFlagDesc,
+		polybftsecrets.AccountDirFlagDesc,
 	)
 
 	cmd.Flags().StringVar(
-		&params.secretsDataPath,
-		polybftsecrets.DataPathFlag,
+		&params.accountConfig,
+		polybftsecrets.AccountConfigFlag,
 		"",
-		polybftsecrets.DataPathFlagDesc,
+		polybftsecrets.AccountConfigFlagDesc,
 	)
 
 	cmd.Flags().StringVar(
@@ -119,7 +119,10 @@ func GetCommand() *cobra.Command {
 			" (otherwise provided secrets are used to resolve deployer account)",
 	)
 
-	cmd.MarkFlagsMutuallyExclusive(helper.TestModeFlag, polybftsecrets.DataPathFlag, polybftsecrets.ConfigFlag)
+	cmd.MarkFlagsMutuallyExclusive(
+		helper.TestModeFlag,
+		polybftsecrets.AccountDirFlag,
+		polybftsecrets.AccountConfigFlag)
 
 	return cmd
 }
@@ -139,7 +142,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	var deployerKey ethgo.Key
 
 	if !params.isTestMode {
-		secretsManager, err := polybftsecrets.GetSecretsManager(params.secretsDataPath, params.secretsConfigPath, true)
+		secretsManager, err := polybftsecrets.GetSecretsManager(params.accountDir, params.accountConfig, true)
 		if err != nil {
 			outputter.SetError(err)
 

--- a/command/rootchain/initcontracts/params.go
+++ b/command/rootchain/initcontracts/params.go
@@ -4,23 +4,37 @@ import (
 	"errors"
 	"fmt"
 	"os"
+
+	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
+	"github.com/0xPolygon/polygon-edge/command/sidechain"
 )
 
 const (
 	manifestPathFlag = "manifest"
 	jsonRPCFlag      = "json-rpc"
-	adminKeyFlag     = "admin-key"
 
 	defaultManifestPath = "./manifest.json"
 )
 
 type initContractsParams struct {
-	manifestPath   string
-	adminKey       string
-	jsonRPCAddress string
+	manifestPath      string
+	secretsDataPath   string
+	secretsConfigPath string
+	jsonRPCAddress    string
+	isTestMode        bool
 }
 
 func (ip *initContractsParams) validateFlags() error {
+	if !ip.isTestMode {
+		if err := sidechain.ValidateSecretFlags(ip.secretsDataPath, ip.secretsConfigPath); err != nil {
+			return err
+		}
+	} else {
+		if ip.secretsDataPath != "" || ip.secretsConfigPath != "" {
+			return helper.ErrTestModeSecrets
+		}
+	}
+
 	if _, err := os.Stat(ip.manifestPath); errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("provided manifest path '%s' doesn't exist", ip.manifestPath)
 	}

--- a/command/rootchain/initcontracts/params.go
+++ b/command/rootchain/initcontracts/params.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
-	"github.com/0xPolygon/polygon-edge/command/sidechain"
 )
 
 const (
@@ -25,14 +24,8 @@ type initContractsParams struct {
 }
 
 func (ip *initContractsParams) validateFlags() error {
-	if !ip.isTestMode {
-		if err := sidechain.ValidateSecretFlags(ip.accountDir, ip.accountConfig); err != nil {
-			return err
-		}
-	} else {
-		if ip.accountDir != "" || ip.accountConfig != "" {
-			return helper.ErrTestModeSecrets
-		}
+	if err := helper.ValidateSecretFlags(ip.isTestMode, ip.accountDir, ip.accountConfig); err != nil {
+		return err
 	}
 
 	if _, err := os.Stat(ip.manifestPath); errors.Is(err, os.ErrNotExist) {

--- a/command/rootchain/initcontracts/params.go
+++ b/command/rootchain/initcontracts/params.go
@@ -17,20 +17,20 @@ const (
 )
 
 type initContractsParams struct {
-	manifestPath      string
-	secretsDataPath   string
-	secretsConfigPath string
-	jsonRPCAddress    string
-	isTestMode        bool
+	manifestPath   string
+	accountDir     string
+	accountConfig  string
+	jsonRPCAddress string
+	isTestMode     bool
 }
 
 func (ip *initContractsParams) validateFlags() error {
 	if !ip.isTestMode {
-		if err := sidechain.ValidateSecretFlags(ip.secretsDataPath, ip.secretsConfigPath); err != nil {
+		if err := sidechain.ValidateSecretFlags(ip.accountDir, ip.accountConfig); err != nil {
 			return err
 		}
 	} else {
-		if ip.secretsDataPath != "" || ip.secretsConfigPath != "" {
+		if ip.accountDir != "" || ip.accountConfig != "" {
 			return helper.ErrTestModeSecrets
 		}
 	}

--- a/command/sidechain/helper.go
+++ b/command/sidechain/helper.go
@@ -44,9 +44,10 @@ func ValidateSecretFlags(dataDir, config string) error {
 	return nil
 }
 
-func GetAccount(dataDir, config string) (*wallet.Account, error) {
+// GetAccount resolves secrets manager and returns an account object
+func GetAccount(accountDir, accountConfig string) (*wallet.Account, error) {
 	// resolve secrets manager instance and allow usage of insecure local secrets manager
-	secretsManager, err := polybftsecrets.GetSecretsManager(dataDir, config, true)
+	secretsManager, err := polybftsecrets.GetSecretsManager(accountDir, accountConfig, true)
 	if err != nil {
 		return nil, err
 	}
@@ -54,8 +55,9 @@ func GetAccount(dataDir, config string) (*wallet.Account, error) {
 	return wallet.NewAccountFromSecret(secretsManager)
 }
 
-func GetAccountFromDir(dir string) (*wallet.Account, error) {
-	return GetAccount(dir, "")
+// GetAccountFromDir returns an account object from local secrets manager
+func GetAccountFromDir(accountDir string) (*wallet.Account, error) {
+	return GetAccount(accountDir, "")
 }
 
 // GetValidatorInfo queries ChildValidatorSet smart contract and retrieves validator info for given address

--- a/command/sidechain/registration/params.go
+++ b/command/sidechain/registration/params.go
@@ -15,15 +15,15 @@ const (
 )
 
 type registerParams struct {
-	accountDir string
-	configPath string
-	jsonRPC    string
-	stake      string
-	chainID    int64
+	accountDir    string
+	accountConfig string
+	jsonRPC       string
+	stake         string
+	chainID       int64
 }
 
 func (rp *registerParams) validateFlags() error {
-	if err := sidechainHelper.ValidateSecretFlags(rp.accountDir, rp.configPath); err != nil {
+	if err := sidechainHelper.ValidateSecretFlags(rp.accountDir, rp.accountConfig); err != nil {
 		return err
 	}
 

--- a/command/sidechain/registration/register_validator.go
+++ b/command/sidechain/registration/register_validator.go
@@ -45,16 +45,16 @@ func GetCommand() *cobra.Command {
 func setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&params.accountDir,
-		polybftsecrets.DataPathFlag,
+		polybftsecrets.AccountDirFlag,
 		"",
-		polybftsecrets.DataPathFlagDesc,
+		polybftsecrets.AccountDirFlagDesc,
 	)
 
 	cmd.Flags().StringVar(
-		&params.configPath,
-		polybftsecrets.ConfigFlag,
+		&params.accountConfig,
+		polybftsecrets.AccountConfigFlag,
 		"",
-		polybftsecrets.ConfigFlagDesc,
+		polybftsecrets.AccountConfigFlagDesc,
 	)
 
 	cmd.Flags().StringVar(
@@ -72,7 +72,7 @@ func setFlags(cmd *cobra.Command) {
 	)
 
 	helper.RegisterJSONRPCFlag(cmd)
-	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.ConfigFlag, polybftsecrets.DataPathFlag)
+	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountConfigFlag, polybftsecrets.AccountDirFlag)
 }
 
 func runPreRun(cmd *cobra.Command, _ []string) error {
@@ -85,7 +85,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	secretsManager, err := polybftsecrets.GetSecretsManager(params.accountDir, params.configPath, true)
+	secretsManager, err := polybftsecrets.GetSecretsManager(params.accountDir, params.accountConfig, true)
 	if err != nil {
 		return err
 	}

--- a/command/sidechain/staking/params.go
+++ b/command/sidechain/staking/params.go
@@ -14,7 +14,7 @@ var (
 
 type stakeParams struct {
 	accountDir      string
-	configPath      string
+	accountConfig   string
 	jsonRPC         string
 	amount          uint64
 	self            bool
@@ -22,7 +22,7 @@ type stakeParams struct {
 }
 
 func (v *stakeParams) validateFlags() error {
-	return sidechainHelper.ValidateSecretFlags(v.accountDir, v.configPath)
+	return sidechainHelper.ValidateSecretFlags(v.accountDir, v.accountConfig)
 }
 
 type stakeResult struct {

--- a/command/sidechain/staking/stake.go
+++ b/command/sidechain/staking/stake.go
@@ -40,16 +40,16 @@ func GetCommand() *cobra.Command {
 func setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&params.accountDir,
-		polybftsecrets.DataPathFlag,
+		polybftsecrets.AccountDirFlag,
 		"",
-		polybftsecrets.DataPathFlagDesc,
+		polybftsecrets.AccountDirFlagDesc,
 	)
 
 	cmd.Flags().StringVar(
-		&params.configPath,
-		polybftsecrets.ConfigFlag,
+		&params.accountConfig,
+		polybftsecrets.AccountConfigFlag,
 		"",
-		polybftsecrets.ConfigFlagDesc,
+		polybftsecrets.AccountConfigFlagDesc,
 	)
 
 	cmd.Flags().BoolVar(
@@ -74,7 +74,7 @@ func setFlags(cmd *cobra.Command) {
 	)
 
 	cmd.MarkFlagsMutuallyExclusive(sidechainHelper.SelfFlag, delegateAddressFlag)
-	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.DataPathFlag, polybftsecrets.ConfigFlag)
+	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
 }
 
 func runPreRun(cmd *cobra.Command, _ []string) error {
@@ -87,7 +87,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	validatorAccount, err := sidechainHelper.GetAccount(params.accountDir, params.configPath)
+	validatorAccount, err := sidechainHelper.GetAccount(params.accountDir, params.accountConfig)
 	if err != nil {
 		return err
 	}

--- a/command/sidechain/unstaking/params.go
+++ b/command/sidechain/unstaking/params.go
@@ -14,7 +14,7 @@ var (
 
 type unstakeParams struct {
 	accountDir        string
-	configPath        string
+	accountConfig     string
 	jsonRPC           string
 	amount            uint64
 	self              bool
@@ -22,7 +22,7 @@ type unstakeParams struct {
 }
 
 func (v *unstakeParams) validateFlags() error {
-	return sidechainHelper.ValidateSecretFlags(v.accountDir, v.configPath)
+	return sidechainHelper.ValidateSecretFlags(v.accountDir, v.accountConfig)
 }
 
 type unstakeResult struct {

--- a/command/sidechain/unstaking/unstake.go
+++ b/command/sidechain/unstaking/unstake.go
@@ -40,16 +40,16 @@ func GetCommand() *cobra.Command {
 func setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&params.accountDir,
-		polybftsecrets.DataPathFlag,
+		polybftsecrets.AccountDirFlag,
 		"",
-		polybftsecrets.DataPathFlagDesc,
+		polybftsecrets.AccountDirFlagDesc,
 	)
 
 	cmd.Flags().StringVar(
-		&params.configPath,
-		polybftsecrets.ConfigFlag,
+		&params.accountConfig,
+		polybftsecrets.AccountConfigFlag,
 		"",
-		polybftsecrets.ConfigFlagDesc,
+		polybftsecrets.AccountConfigFlagDesc,
 	)
 
 	cmd.Flags().BoolVar(
@@ -74,7 +74,7 @@ func setFlags(cmd *cobra.Command) {
 	)
 
 	cmd.MarkFlagsMutuallyExclusive(sidechainHelper.SelfFlag, undelegateAddressFlag)
-	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.DataPathFlag, polybftsecrets.ConfigFlag)
+	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
 }
 
 func runPreRun(cmd *cobra.Command, _ []string) error {
@@ -87,7 +87,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	validatorAccount, err := sidechainHelper.GetAccount(params.accountDir, params.configPath)
+	validatorAccount, err := sidechainHelper.GetAccount(params.accountDir, params.accountConfig)
 	if err != nil {
 		return err
 	}

--- a/command/sidechain/validators/params.go
+++ b/command/sidechain/validators/params.go
@@ -9,13 +9,13 @@ import (
 )
 
 type validatorInfoParams struct {
-	accountDir string
-	configPath string
-	jsonRPC    string
+	accountDir    string
+	accountConfig string
+	jsonRPC       string
 }
 
 func (v *validatorInfoParams) validateFlags() error {
-	return sidechainHelper.ValidateSecretFlags(v.accountDir, v.configPath)
+	return sidechainHelper.ValidateSecretFlags(v.accountDir, v.accountConfig)
 }
 
 type validatorsInfoResult struct {

--- a/command/sidechain/validators/validator_info.go
+++ b/command/sidechain/validators/validator_info.go
@@ -32,19 +32,19 @@ func GetCommand() *cobra.Command {
 func setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&params.accountDir,
-		polybftsecrets.DataPathFlag,
+		polybftsecrets.AccountDirFlag,
 		"",
-		polybftsecrets.DataPathFlagDesc,
+		polybftsecrets.AccountDirFlagDesc,
 	)
 
 	cmd.Flags().StringVar(
-		&params.configPath,
-		polybftsecrets.ConfigFlag,
+		&params.accountConfig,
+		polybftsecrets.AccountConfigFlag,
 		"",
-		polybftsecrets.ConfigFlagDesc,
+		polybftsecrets.AccountConfigFlagDesc,
 	)
 
-	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.DataPathFlag, polybftsecrets.ConfigFlag)
+	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
 }
 
 func runPreRun(cmd *cobra.Command, _ []string) error {
@@ -57,7 +57,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	validatorAccount, err := sidechainHelper.GetAccount(params.accountDir, params.configPath)
+	validatorAccount, err := sidechainHelper.GetAccount(params.accountDir, params.accountConfig)
 	if err != nil {
 		return err
 	}

--- a/command/sidechain/whitelist/params.go
+++ b/command/sidechain/whitelist/params.go
@@ -14,13 +14,13 @@ var (
 
 type whitelistParams struct {
 	accountDir          string
-	configPath          string
+	accountConfig       string
 	jsonRPC             string
 	newValidatorAddress string
 }
 
 func (ep *whitelistParams) validateFlags() error {
-	return sidechainHelper.ValidateSecretFlags(ep.accountDir, ep.configPath)
+	return sidechainHelper.ValidateSecretFlags(ep.accountDir, ep.accountConfig)
 }
 
 type enlistResult struct {

--- a/command/sidechain/whitelist/whitelist_validator.go
+++ b/command/sidechain/whitelist/whitelist_validator.go
@@ -39,16 +39,16 @@ func GetCommand() *cobra.Command {
 func setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&params.accountDir,
-		polybftsecrets.DataPathFlag,
+		polybftsecrets.AccountDirFlag,
 		"",
-		polybftsecrets.DataPathFlagDesc,
+		polybftsecrets.AccountDirFlagDesc,
 	)
 
 	cmd.Flags().StringVar(
-		&params.configPath,
-		polybftsecrets.ConfigFlag,
+		&params.accountConfig,
+		polybftsecrets.AccountConfigFlag,
 		"",
-		polybftsecrets.ConfigFlagDesc,
+		polybftsecrets.AccountConfigFlagDesc,
 	)
 
 	cmd.Flags().StringVar(
@@ -58,7 +58,7 @@ func setFlags(cmd *cobra.Command) {
 		"account address of a possible validator",
 	)
 
-	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.DataPathFlag, polybftsecrets.ConfigFlag)
+	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
 	helper.RegisterJSONRPCFlag(cmd)
 }
 
@@ -72,7 +72,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	ownerAccount, err := sidechainHelper.GetAccount(params.accountDir, params.configPath)
+	ownerAccount, err := sidechainHelper.GetAccount(params.accountDir, params.accountConfig)
 	if err != nil {
 		return fmt.Errorf("enlist validator failed: %w", err)
 	}

--- a/command/sidechain/withdraw/params.go
+++ b/command/sidechain/withdraw/params.go
@@ -13,14 +13,14 @@ var (
 )
 
 type withdrawParams struct {
-	accountDir string
-	configPath string
-	jsonRPC    string
-	addressTo  string
+	accountDir    string
+	accountConfig string
+	jsonRPC       string
+	addressTo     string
 }
 
 func (v *withdrawParams) validateFlags() error {
-	return sidechainHelper.ValidateSecretFlags(v.accountDir, v.configPath)
+	return sidechainHelper.ValidateSecretFlags(v.accountDir, v.accountConfig)
 }
 
 type withdrawResult struct {

--- a/command/sidechain/withdraw/withdraw.go
+++ b/command/sidechain/withdraw/withdraw.go
@@ -38,16 +38,16 @@ func GetCommand() *cobra.Command {
 func setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&params.accountDir,
-		polybftsecrets.DataPathFlag,
+		polybftsecrets.AccountDirFlag,
 		"",
-		polybftsecrets.DataPathFlagDesc,
+		polybftsecrets.AccountDirFlagDesc,
 	)
 
 	cmd.Flags().StringVar(
-		&params.configPath,
-		polybftsecrets.ConfigFlag,
+		&params.accountConfig,
+		polybftsecrets.AccountConfigFlag,
 		"",
-		polybftsecrets.ConfigFlagDesc,
+		polybftsecrets.AccountConfigFlagDesc,
 	)
 
 	cmd.Flags().StringVar(
@@ -57,7 +57,7 @@ func setFlags(cmd *cobra.Command) {
 		"address where to withdraw withdrawable amount",
 	)
 
-	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.DataPathFlag, polybftsecrets.ConfigFlag)
+	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
 	helper.RegisterJSONRPCFlag(cmd)
 }
 
@@ -71,7 +71,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	validatorAccount, err := sidechainHelper.GetAccount(params.accountDir, params.configPath)
+	validatorAccount, err := sidechainHelper.GetAccount(params.accountDir, params.accountConfig)
 	if err != nil {
 		return err
 	}

--- a/consensus/polybft/README.md
+++ b/consensus/polybft/README.md
@@ -55,8 +55,11 @@ In order to do so, run `make compile-core-contracts`.
 5. Deploy and initialize rootchain contracts - this command deploys rootchain smart contracts and initializes them. It also updates manifest configuration with rootchain contract addresses and rootchain default sender address.
 
     ```bash
-    polygon-edge rootchain init-contracts [--manifest ./manifest.json]
-    [--json-rpc http://127.0.0.1:8545] [--admin-key <hex_encoded_private_key>]
+    polygon-edge rootchain init-contracts 
+    --data-dir <local_storage_secrets_path> | [--config <cloud_secrets_manager_config_path>] 
+    [--manifest ./manifest.json]
+    [--json-rpc http://127.0.0.1:8545]
+    [--test]
     ```
 
 6. Create chain configuration - this command creates chain configuration, which is needed to run a blockchain

--- a/consensus/polybft/README.md
+++ b/consensus/polybft/README.md
@@ -9,9 +9,6 @@ It has native support for running bridge, which enables running cross-chain tran
 
 ### Precondition
 
-Smart contracts in the `core-contracts` submodule must be compiled before running following commands.
-In order to do so, run `make compile-core-contracts`.
-
 1. Build binary
 
     ```bash

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -395,8 +395,9 @@ func TestE2E_Bridge_L2toL1Exit(t *testing.T) {
 		accountAddress[i] = types.Address(key.Address())
 	}
 
-	// initialize rootchain admin key to default one
-	require.NoError(t, rootchainHelper.InitRootchainPrivateKey(""))
+	// use test account for rootchain
+	rootchainKey, err := rootchainHelper.GetRootchainTestPrivKey()
+	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithBridge(),
@@ -423,7 +424,7 @@ func TestE2E_Bridge_L2toL1Exit(t *testing.T) {
 
 	// deploy L1ExitTest contract
 	receipt, err := l1TxRelayer.SendTransaction(&ethgo.Transaction{Input: contractsapi.TestL1StateReceiver.Bytecode},
-		rootchainHelper.GetRootchainPrivateKey())
+		rootchainKey)
 	require.NoError(t, err)
 	require.Equal(t, receipt.Status, uint64(types.ReceiptSuccess))
 
@@ -467,7 +468,7 @@ func TestE2E_Bridge_L2toL1Exit(t *testing.T) {
 		proof, err = getExitProof(cluster.Servers[0].JSONRPCAddr(), exitID, checkpointEpoch, checkpointBlock)
 		require.NoError(t, err)
 
-		isProcessed, err := sendExitTransaction(sidechainKeys[i], proof, checkpointBlock, stateSenderData, l1ExitTestAddr, exitHelperAddr, l1TxRelayer, exitID)
+		isProcessed, err := sendExitTransaction(sidechainKeys[i], rootchainKey, proof, checkpointBlock, stateSenderData, l1ExitTestAddr, exitHelperAddr, l1TxRelayer, exitID)
 		require.NoError(t, err)
 		require.True(t, isProcessed)
 	}
@@ -494,8 +495,9 @@ func TestE2E_Bridge_L2toL1ExitMultiple(t *testing.T) {
 		accountAddress[i] = types.Address(key.Address())
 	}
 
-	// initialize rootchain admin key to default one
-	require.NoError(t, rootchainHelper.InitRootchainPrivateKey(""))
+	// use test account for rootchain
+	rootchainKey, err := rootchainHelper.GetRootchainTestPrivKey()
+	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithBridge(),
@@ -520,8 +522,9 @@ func TestE2E_Bridge_L2toL1ExitMultiple(t *testing.T) {
 	require.NoError(t, err)
 
 	// deploy L1ExitTest contract
-	receipt, err := l1TxRelayer.SendTransaction(&ethgo.Transaction{Input: contractsapi.TestL1StateReceiver.Bytecode},
-		rootchainHelper.GetRootchainPrivateKey())
+	receipt, err := l1TxRelayer.SendTransaction(
+		&ethgo.Transaction{Input: contractsapi.TestL1StateReceiver.Bytecode},
+		rootchainKey)
 	require.NoError(t, err)
 	require.Equal(t, receipt.Status, uint64(types.ReceiptSuccess))
 
@@ -574,14 +577,23 @@ func TestE2E_Bridge_L2toL1ExitMultiple(t *testing.T) {
 		for j := 0; j < userNumber; j++ {
 			proof, err = getExitProof(cluster.Servers[0].JSONRPCAddr(), exitEventIds[j+i*userNumber], uint64(i+1)*checkpointEpoch, uint64(i+1)*checkpointBlock)
 			require.NoError(t, err)
-			isProcessed, err := sendExitTransaction(sidechainKeys[j], proof, uint64(i+1)*checkpointBlock, stateSenderData, l1ExitTestAddr, exitHelperAddr, l1TxRelayer, exitEventIds[j+i*userNumber])
+			isProcessed, err := sendExitTransaction(sidechainKeys[j], rootchainKey, proof, uint64(i+1)*checkpointBlock, stateSenderData, l1ExitTestAddr, exitHelperAddr, l1TxRelayer, exitEventIds[j+i*userNumber])
 			require.NoError(t, err)
 			require.True(t, isProcessed)
 		}
 	}
 }
 
-func sendExitTransaction(sidechainKey *ethgow.Key, proof types.Proof, checkpointBlock uint64, stateSenderData []byte, l1ExitTestAddr, exitHelperAddr ethgo.Address, l1TxRelayer txrelayer.TxRelayer, exitEventID uint64) (bool, error) {
+func sendExitTransaction(
+	sidechainKey *ethgow.Key,
+	rootchainKey ethgo.Key,
+	proof types.Proof,
+	checkpointBlock uint64,
+	stateSenderData []byte,
+	l1ExitTestAddr,
+	exitHelperAddr ethgo.Address,
+	l1TxRelayer txrelayer.TxRelayer,
+	exitEventID uint64) (bool, error) {
 	proofExitEventEncoded, err := polybft.ExitEventInputsABIType.Encode(&polybft.ExitEvent{
 		ID:       exitEventID,
 		Sender:   sidechainKey.Address(),
@@ -597,7 +609,7 @@ func sendExitTransaction(sidechainKey *ethgow.Key, proof types.Proof, checkpoint
 		return false, fmt.Errorf("could not get leaf index from exit event proof. Leaf from proof: %v", proof.Metadata["LeafIndex"])
 	}
 
-	receipt, err := ABITransaction(l1TxRelayer, rootchainHelper.GetRootchainPrivateKey(), contractsapi.ExitHelper, exitHelperAddr,
+	receipt, err := ABITransaction(l1TxRelayer, rootchainKey, contractsapi.ExitHelper, exitHelperAddr,
 		"exit",
 		big.NewInt(int64(checkpointBlock)),
 		uint64(leafIndex),

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"bytes"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -140,14 +139,11 @@ func TestE2E_Bridge_DepositAndWithdrawERC20(t *testing.T) {
 	senderAccount, err := sidechain.GetAccountFromDir(cluster.Servers[0].DataDir())
 	require.NoError(t, err)
 
-	rawPrivateSenderKey, err := senderAccount.Ecdsa.MarshallPrivateKey()
-	require.NoError(t, err)
-
 	t.Logf("Withdraw sender: %s\n", senderAccount.Ecdsa.Address())
 
 	// send withdraw transaction
 	err = cluster.Bridge.WithdrawERC20(
-		hex.EncodeToString(rawPrivateSenderKey),
+		cluster.Servers[0].DataDir(),
 		strings.Join(receivers[:], ","),
 		strings.Join(amounts[:], ","),
 		cluster.Servers[0].JSONRPCAddr())

--- a/e2e-polybft/framework/test-bridge.go
+++ b/e2e-polybft/framework/test-bridge.go
@@ -179,6 +179,7 @@ func (t *TestBridge) deployRootchainContracts(manifestPath string) error {
 		"rootchain",
 		"init-contracts",
 		"--manifest", manifestPath,
+		"test",
 	}
 
 	if err := t.cmdRun(args...); err != nil {

--- a/e2e-polybft/framework/test-bridge.go
+++ b/e2e-polybft/framework/test-bridge.go
@@ -137,7 +137,7 @@ func (t *TestBridge) WithdrawERC20(secretsDataDir, receivers, amounts, jsonRPCEn
 	return t.cmdRun(
 		"bridge",
 		"withdraw-erc20",
-		"--"+polybftsecrets.DataPathFlag, secretsDataDir,
+		"--"+polybftsecrets.AccountDirFlag, secretsDataDir,
 		"--receivers", receivers,
 		"--amounts", amounts,
 		"--json-rpc", jsonRPCEndpoint,

--- a/e2e-polybft/framework/test-bridge.go
+++ b/e2e-polybft/framework/test-bridge.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	"github.com/0xPolygon/polygon-edge/command/rootchain/server"
 	"github.com/0xPolygon/polygon-edge/types"
 )
@@ -107,6 +108,7 @@ func (t *TestBridge) DepositERC20(rootTokenAddr, rootPredicateAddr types.Address
 	return t.cmdRun(
 		"bridge",
 		"deposit-erc20",
+		"--test",
 		"--root-token", rootTokenAddr.String(),
 		"--root-predicate", rootPredicateAddr.String(),
 		"--receivers", receivers,
@@ -115,9 +117,9 @@ func (t *TestBridge) DepositERC20(rootTokenAddr, rootPredicateAddr types.Address
 
 // WithdrawERC20 function is used to invoke bridge withdraw ERC20 tokens (from the child to the root chain)
 // with given receivers and amounts
-func (t *TestBridge) WithdrawERC20(senderKey, receivers, amounts, jsonRPCEndpoint string) error {
-	if senderKey == "" {
-		return errors.New("provide a hex-encoded sender private key")
+func (t *TestBridge) WithdrawERC20(secretsDataDir, receivers, amounts, jsonRPCEndpoint string) error {
+	if secretsDataDir == "" {
+		return errors.New("provide a data directory which holds sender secrets")
 	}
 
 	if receivers == "" {
@@ -135,7 +137,7 @@ func (t *TestBridge) WithdrawERC20(senderKey, receivers, amounts, jsonRPCEndpoin
 	return t.cmdRun(
 		"bridge",
 		"withdraw-erc20",
-		"--sender-key", senderKey,
+		"--"+polybftsecrets.DataPathFlag, secretsDataDir,
 		"--receivers", receivers,
 		"--amounts", amounts,
 		"--json-rpc", jsonRPCEndpoint,
@@ -162,6 +164,7 @@ func (t *TestBridge) SendExitTransaction(exitHelper types.Address, exitID, epoch
 		"--checkpoint-block", strconv.FormatUint(checkpointBlock, 10),
 		"--root-json-rpc", rootJSONRPCAddr,
 		"--child-json-rpc", childJSONRPCAddr,
+		"--test",
 	)
 }
 

--- a/e2e-polybft/framework/test-bridge.go
+++ b/e2e-polybft/framework/test-bridge.go
@@ -179,7 +179,7 @@ func (t *TestBridge) deployRootchainContracts(manifestPath string) error {
 		"rootchain",
 		"init-contracts",
 		"--manifest", manifestPath,
-		"test",
+		"--test",
 	}
 
 	if err := t.cmdRun(args...); err != nil {

--- a/e2e-polybft/framework/test-server.go
+++ b/e2e-polybft/framework/test-server.go
@@ -124,7 +124,7 @@ func (t *TestServer) Start() {
 	args := []string{
 		"server",
 		// add data dir
-		"--" + polybftsecrets.DataPathFlag, config.DataDir,
+		"--" + polybftsecrets.AccountDirFlag, config.DataDir,
 		// add custom chain
 		"--chain", config.Chain,
 		// enable p2p port
@@ -173,7 +173,7 @@ func (t *TestServer) Stake(amount uint64) error {
 	args := []string{
 		"polybft",
 		"stake",
-		"--" + polybftsecrets.DataPathFlag, t.config.DataDir,
+		"--" + polybftsecrets.AccountDirFlag, t.config.DataDir,
 		"--jsonrpc", t.JSONRPCAddr(),
 		"--amount", strconv.FormatUint(amount, 10),
 		"--self",
@@ -187,7 +187,7 @@ func (t *TestServer) Unstake(amount uint64) error {
 	args := []string{
 		"polybft",
 		"unstake",
-		"--" + polybftsecrets.DataPathFlag, t.config.DataDir,
+		"--" + polybftsecrets.AccountDirFlag, t.config.DataDir,
 		"--jsonrpc", t.JSONRPCAddr(),
 		"--amount", strconv.FormatUint(amount, 10),
 		"--self",
@@ -201,7 +201,7 @@ func (t *TestServer) RegisterValidator(secrets string, stake string) error {
 	args := []string{
 		"polybft",
 		"register-validator",
-		"--" + polybftsecrets.DataPathFlag, path.Join(t.clusterConfig.TmpDir, secrets),
+		"--" + polybftsecrets.AccountDirFlag, path.Join(t.clusterConfig.TmpDir, secrets),
 		"--jsonrpc", t.JSONRPCAddr(),
 	}
 
@@ -218,7 +218,7 @@ func (t *TestServer) WhitelistValidator(address, secrets string) error {
 	args := []string{
 		"polybft",
 		"whitelist-validator",
-		"--" + polybftsecrets.DataPathFlag, path.Join(t.clusterConfig.TmpDir, secrets),
+		"--" + polybftsecrets.AccountDirFlag, path.Join(t.clusterConfig.TmpDir, secrets),
 		"--address", address,
 		"--jsonrpc", t.JSONRPCAddr(),
 	}
@@ -231,7 +231,7 @@ func (t *TestServer) Delegate(amount uint64, secrets string, validatorAddr ethgo
 	args := []string{
 		"polybft",
 		"stake",
-		"--" + polybftsecrets.DataPathFlag, secrets,
+		"--" + polybftsecrets.AccountDirFlag, secrets,
 		"--jsonrpc", t.JSONRPCAddr(),
 		"--delegate", validatorAddr.String(),
 		"--amount", strconv.FormatUint(amount, 10),
@@ -245,7 +245,7 @@ func (t *TestServer) Undelegate(amount uint64, secrets string, validatorAddr eth
 	args := []string{
 		"polybft",
 		"unstake",
-		"--" + polybftsecrets.DataPathFlag, secrets,
+		"--" + polybftsecrets.AccountDirFlag, secrets,
 		"--undelegate", validatorAddr.String(),
 		"--amount", strconv.FormatUint(amount, 10),
 		"--jsonrpc", t.JSONRPCAddr(),
@@ -259,7 +259,7 @@ func (t *TestServer) Withdraw(secrets string, recipient ethgo.Address) error {
 	args := []string{
 		"polybft",
 		"withdraw",
-		"--" + polybftsecrets.DataPathFlag, secrets,
+		"--" + polybftsecrets.AccountDirFlag, secrets,
 		"--to", recipient.String(),
 		"--jsonrpc", t.JSONRPCAddr(),
 	}


### PR DESCRIPTION
# Description

PR introduces a secrets manager to bridge commands (namely `deposit-erc20`, `withdraw-erc20`, and `exit`) which is a safer way to provide secrets compared to the previous approach which was specifying hex-encoded private key via CLI flag.

It also introduces test mode to rootchain init contracts,  bridge deposit-erc20 and bridge exit commands. If a test mode flag is provided (`--test`), a predefined test account private key is used to send transactions to the rootchain.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
