### PR TITLE
Provide multi addresses instead of p2p peer ids to the manifest file

### DIFF
--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -152,8 +152,7 @@ func (p *genesisParams) generatePolyBftChainConfig() error {
 
 		// set genesis validators as boot nodes if boot nodes not provided via CLI
 		if len(p.bootnodes) == 0 {
-			bootNodeMultiAddr := fmt.Sprintf("/ip4/%s/tcp/%d/p2p/%s", "127.0.0.1", bootnodePortStart+i, validator.NodeID)
-			chainConfig.Bootnodes = append(chainConfig.Bootnodes, bootNodeMultiAddr)
+			chainConfig.Bootnodes = append(chainConfig.Bootnodes, validator.MultiAddr)
 		}
 	}
 

--- a/command/genesis/utils.go
+++ b/command/genesis/utils.go
@@ -147,7 +147,7 @@ func ReadValidatorsByPrefix(dir, prefix string) ([]*polybft.Validator, error) {
 			BlsPrivateKey: account.Bls,
 			BlsKey:        hex.EncodeToString(account.Bls.PublicKey().Marshal()),
 			BlsSignature:  blsSignature,
-			NodeID:        nodeID,
+			MultiAddr:     fmt.Sprintf("/ip4/%s/tcp/%d/p2p/%s", "127.0.0.1", bootnodePortStart+int64(i), nodeID),
 		}
 	}
 

--- a/command/polybftmanifest/manifest_init.go
+++ b/command/polybftmanifest/manifest_init.go
@@ -163,11 +163,13 @@ func (p *manifestInitParams) getValidatorAccounts() ([]*polybft.Validator, error
 				return nil, fmt.Errorf("invalid P2P multi address '%s' provided: %w ", parts[0], err)
 			}
 
-			if len(strings.TrimPrefix(parts[1], "0x")) != ecdsaAddressLength {
+			trimmedAddress := strings.TrimPrefix(parts[1], "0x")
+			if len(trimmedAddress) != ecdsaAddressLength {
 				return nil, fmt.Errorf("invalid ECDSA address: %s", parts[1])
 			}
 
-			if len(strings.TrimPrefix(parts[2], "0x")) != blsKeyLength {
+			trimmedBLSKey := strings.TrimPrefix(parts[2], "0x")
+			if len(trimmedBLSKey) != blsKeyLength {
 				return nil, fmt.Errorf("invalid BLS key: %s", parts[2])
 			}
 
@@ -177,8 +179,8 @@ func (p *manifestInitParams) getValidatorAccounts() ([]*polybft.Validator, error
 
 			validators[i] = &polybft.Validator{
 				MultiAddr:    parts[0],
-				Address:      types.StringToAddress(parts[1]),
-				BlsKey:       parts[2],
+				Address:      types.StringToAddress(trimmedAddress),
+				BlsKey:       trimmedBLSKey,
 				BlsSignature: parts[3],
 				Balance:      balance,
 			}

--- a/consensus/polybft/README.md
+++ b/consensus/polybft/README.md
@@ -18,7 +18,7 @@ In order to do so, run `make compile-core-contracts`.
     go build -o polygon-edge .
     ```
 
-2. Init secrets - this command is used to generate private keys (ECDSA, BLS as well as P2P networking node id). `--data-dir` denotes folder prefix names and `--num` how many accounts need to be created. **This command is for testing purposes only.**
+2. Init secrets - this command is used to generate account secrets (ECDSA, BLS as well as P2P networking node id). `--data-dir` denotes folder prefix names and `--num` how many accounts need to be created. **This command is for testing purposes only.**
 
     ```bash
     polygon-edge polybft-secrets --data-dir test-chain- --num 4
@@ -42,12 +42,13 @@ In order to do so, run `make compile-core-contracts`.
         ```
 
     - validators information are scafollded on multiple hosts and therefore necessary information are supplied using `--validators` flag. Validator information needs to be supplied in the strictly following format:
-    `<p2p node id>:<public ECDSA address>:<public BLS key>:<BLS signature>`.
+    `<multi address>:<public ECDSA address>:<public BLS key>:<BLS signature>`.
+    **Note:** when specifying validators via validators flag, entire multi address must be specified.
 
         ```bash
         polygon-edge manifest 
-        --validators 16Uiu2HAmTkqGixWVxshMbbgtXhTUP8zLCZZiG1UyCNtxLhCkZJuv:0xDcBe0024206ec42b0Ef4214Ac7B71aeae1A11af0:1cf134e02c6b2afb2ceda50bf2c9a01da367ac48f7783ee6c55444e1cab418ec0f52837b90a4d8cf944814073fc6f2bd96f35366a3846a8393e3cb0b19197cde23e2b40c6401fa27ff7d0c36779d9d097d1393cab6fc1d332f92fb3df850b78703b2989d567d1344e219f0667a1863f52f7663092276770cf513f9704b5351c4:11b18bde524f4b02258a8d196b687f8d8e9490d536718666dc7babca14eccb631c238fb79aa2b44a5a4dceccad2dd797f537008dda185d952226a814c1acf7c2
-        [--validators 16Uiu2HAm1kVEh4uVw41WuhDfreCaVuj3kiWZy44kbnJrZnwnMKDW:0x2da750eD4AE1D5A7F7c996Faec592F3d44060e90:088d92c25b5f278750534e8a902da604a1aa39b524b4511f5f47c3a386374ca3031b667beb424faef068a01cee3428a1bc8c1c8bab826f30a1ee03fbe90cb5f01abcf4abd7af3bbe83eaed6f82179b9cbdc417aad65d919b802d91c2e1aaefec27ba747158bc18a0556e39bfc9175c099dd77517a85731894bbea3d191a622bc:08dc3006352fdc01b331907fd3a68d4d68ed40329032598c1c0faa260421d66720965ace3ba29c6d6608ec1facdbf4624bca72df36c34afd4bdd753c4dfe049c]
+        --validators /ip4/127.0.0.1/tcp/30301/p2p/16Uiu2HAmV5hqAp77untfJRorxqKmyUxgaVn8YHFjBJm9gKMms3mr:0xDcBe0024206ec42b0Ef4214Ac7B71aeae1A11af0:1cf134e02c6b2afb2ceda50bf2c9a01da367ac48f7783ee6c55444e1cab418ec0f52837b90a4d8cf944814073fc6f2bd96f35366a3846a8393e3cb0b19197cde23e2b40c6401fa27ff7d0c36779d9d097d1393cab6fc1d332f92fb3df850b78703b2989d567d1344e219f0667a1863f52f7663092276770cf513f9704b5351c4:11b18bde524f4b02258a8d196b687f8d8e9490d536718666dc7babca14eccb631c238fb79aa2b44a5a4dceccad2dd797f537008dda185d952226a814c1acf7c2
+        [--validators /ip4/127.0.0.1/tcp/30302/p2p/16Uiu2HAmGmidRQY5BGJPGVRF8p1pYFdfzuf1StHzXGLDizuxJxex:0x2da750eD4AE1D5A7F7c996Faec592F3d44060e90:088d92c25b5f278750534e8a902da604a1aa39b524b4511f5f47c3a386374ca3031b667beb424faef068a01cee3428a1bc8c1c8bab826f30a1ee03fbe90cb5f01abcf4abd7af3bbe83eaed6f82179b9cbdc417aad65d919b802d91c2e1aaefec27ba747158bc18a0556e39bfc9175c099dd77517a85731894bbea3d191a622bc:08dc3006352fdc01b331907fd3a68d4d68ed40329032598c1c0faa260421d66720965ace3ba29c6d6608ec1facdbf4624bca72df36c34afd4bdd753c4dfe049c]
         [--path ./manifest.json] [--premine-validators 100]
         ```
 

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -82,7 +82,7 @@ type Validator struct {
 	BlsKey        string
 	BlsSignature  string
 	Balance       *big.Int
-	NodeID        string
+	MultiAddr     string
 }
 
 type validatorRaw struct {
@@ -90,11 +90,11 @@ type validatorRaw struct {
 	BlsKey       string        `json:"blsKey"`
 	BlsSignature string        `json:"blsSignature"`
 	Balance      *string       `json:"balance"`
-	NodeID       string        `json:"nodeId"`
+	MultiAddr    string        `json:"multiAddr"`
 }
 
 func (v *Validator) MarshalJSON() ([]byte, error) {
-	raw := &validatorRaw{Address: v.Address, BlsKey: v.BlsKey, NodeID: v.NodeID, BlsSignature: v.BlsSignature}
+	raw := &validatorRaw{Address: v.Address, BlsKey: v.BlsKey, MultiAddr: v.MultiAddr, BlsSignature: v.BlsSignature}
 	raw.Balance = types.EncodeBigInt(v.Balance)
 
 	return json.Marshal(raw)
@@ -112,7 +112,7 @@ func (v *Validator) UnmarshalJSON(data []byte) error {
 	v.Address = raw.Address
 	v.BlsKey = raw.BlsKey
 	v.BlsSignature = raw.BlsSignature
-	v.NodeID = raw.NodeID
+	v.MultiAddr = raw.MultiAddr
 	v.Balance, err = types.ParseUint256orHex(raw.Balance)
 
 	if err != nil {

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -341,15 +341,13 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 		require.NoError(t, err)
 
 		if cluster.Config.BootnodeCount > 0 {
-			cnt := cluster.Config.BootnodeCount
-			if len(validators) < cnt {
-				cnt = len(validators)
+			bootNodesCnt := cluster.Config.BootnodeCount
+			if len(validators) < bootNodesCnt {
+				bootNodesCnt = len(validators)
 			}
 
-			for i := 0; i < cnt; i++ {
-				maddr := fmt.Sprintf("/ip4/%s/tcp/%d/p2p/%s",
-					"127.0.0.1", cluster.initialPort+int64(i+1), validators[i].NodeID)
-				args = append(args, "--bootnode", maddr)
+			for i := 0; i < bootNodesCnt; i++ {
+				args = append(args, "--bootnode", validators[i].MultiAddr)
 			}
 		}
 


### PR DESCRIPTION
# Description

This PR changes the way we are expecting validators' network parameters to be specified when creating the manifest file. Prior to this, when specifying validators via CLI flags, only P2P peer id was expected, and then when genesis configuration was generated multi-address was assuming the local host IP address.

Now manifest generation expects entire multi-address to be provided if case genesis validators are being specified via CLI flag. Otherwise, if secrets are provided on local file storage, multi addresses are being constructed with localhost IP addresses.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
