### PR TITLE
Fix `bridge-json-rpc` flag in genesis command

### DIFF
--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -181,7 +181,7 @@ func setFlags(cmd *cobra.Command) {
 			&params.bridgeJSONRPCAddr,
 			bridgeFlag,
 			"",
-			"the rootchain JSON RPC IP address. If present, node is running in bridge mode.",
+			"the rootchain JSON RPC endpoint",
 		)
 
 		cmd.Flags().Uint64Var(
@@ -190,8 +190,6 @@ func setFlags(cmd *cobra.Command) {
 			defaultEpochReward,
 			"reward size for block sealing",
 		)
-
-		cmd.Flags().Lookup(bridgeFlag).NoOptDefVal = "http://127.0.0.1:8545"
 	}
 }
 

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -120,7 +120,7 @@ func (p *genesisParams) generatePolyBftChainConfig() error {
 		if i, ok := validatorPreminesMap[premineInfo.address]; ok {
 			premineInfos[i] = premineInfo
 		} else {
-			premineInfos = append(premineInfos, premineInfo) //nolint:makezero
+			premineInfos = append(premineInfos, premineInfo)
 		}
 	}
 

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -120,7 +120,7 @@ func (p *genesisParams) generatePolyBftChainConfig() error {
 		if i, ok := validatorPreminesMap[premineInfo.address]; ok {
 			premineInfos[i] = premineInfo
 		} else {
-			premineInfos = append(premineInfos, premineInfo)
+			premineInfos = append(premineInfos, premineInfo) //nolint:makezero
 		}
 	}
 


### PR DESCRIPTION
# Description

This PR fixes `bridge-json-rpc` flag behavior. Prior to this, there was obscure behavior meant to allow specifying this flag, without providing a value and it should then assign the default value. However, this resulted in not being possible to provide some different value than the default one.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually
