### PR TITLE
Print output of cluster bash script to both terminal and file

### DIFF
--- a/scripts/cluster
+++ b/scripts/cluster
@@ -27,10 +27,18 @@ function createGenesis() {
 }
 
 function startServerFromBinary() {
-  ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 --num-block-confirmations 2 --seal --log-level DEBUG &
-  ./polygon-edge server --data-dir ./test-chain-2 --chain genesis.json --grpc-address :20000 --libp2p :30302 --jsonrpc :20002 --num-block-confirmations 2 --seal --log-level DEBUG &
-  ./polygon-edge server --data-dir ./test-chain-3 --chain genesis.json --grpc-address :30000 --libp2p :30303 --jsonrpc :30002 --num-block-confirmations 2 --seal --log-level DEBUG &
-  ./polygon-edge server --data-dir ./test-chain-4 --chain genesis.json --grpc-address :40000 --libp2p :30304 --jsonrpc :40002 --num-block-confirmations 2 --seal --log-level DEBUG &
+  ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json \
+    --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 \
+    --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-1.log &
+  ./polygon-edge server --data-dir ./test-chain-2 --chain genesis.json \
+    --grpc-address :20000 --libp2p :30302 --jsonrpc :20002 \
+    --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-2.log &
+  ./polygon-edge server --data-dir ./test-chain-3 --chain genesis.json \
+    --grpc-address :30000 --libp2p :30303 --jsonrpc :30002 \
+    --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-3.log &
+  ./polygon-edge server --data-dir ./test-chain-4 --chain genesis.json \
+    --grpc-address :40000 --libp2p :30304 --jsonrpc :40002 \
+    --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-4.log &
   wait
 }
 

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -27,19 +27,36 @@ function createGenesis() {
 }
 
 function startServerFromBinary() {
-  ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json \
-    --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 \
-    --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-1.log &
-  ./polygon-edge server --data-dir ./test-chain-2 --chain genesis.json \
-    --grpc-address :20000 --libp2p :30302 --jsonrpc :20002 \
-    --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-2.log &
-  ./polygon-edge server --data-dir ./test-chain-3 --chain genesis.json \
-    --grpc-address :30000 --libp2p :30303 --jsonrpc :30002 \
-    --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-3.log &
-  ./polygon-edge server --data-dir ./test-chain-4 --chain genesis.json \
-    --grpc-address :40000 --libp2p :30304 --jsonrpc :40002 \
-    --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-4.log &
-  wait
+  if [ "$1" == "write-logs" ]; then
+    echo "Writing validators logs to the files..."
+    ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json \
+      --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 \
+      --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-1.log &
+    ./polygon-edge server --data-dir ./test-chain-2 --chain genesis.json \
+      --grpc-address :20000 --libp2p :30302 --jsonrpc :20002 \
+      --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-2.log &
+    ./polygon-edge server --data-dir ./test-chain-3 --chain genesis.json \
+      --grpc-address :30000 --libp2p :30303 --jsonrpc :30002 \
+      --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-3.log &
+    ./polygon-edge server --data-dir ./test-chain-4 --chain genesis.json \
+      --grpc-address :40000 --libp2p :30304 --jsonrpc :40002 \
+      --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-4.log &
+      wait
+  else
+    ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json \
+      --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 \
+      --num-block-confirmations 2 --seal --log-level DEBUG &
+    ./polygon-edge server --data-dir ./test-chain-2 --chain genesis.json \
+      --grpc-address :20000 --libp2p :30302 --jsonrpc :20002 \
+      --num-block-confirmations 2 --seal --log-level DEBUG &
+    ./polygon-edge server --data-dir ./test-chain-3 --chain genesis.json \
+      --grpc-address :30000 --libp2p :30303 --jsonrpc :30002 \
+      --num-block-confirmations 2 --seal --log-level DEBUG &
+    ./polygon-edge server --data-dir ./test-chain-4 --chain genesis.json \
+      --grpc-address :40000 --libp2p :30304 --jsonrpc :40002 \
+      --num-block-confirmations 2 --seal --log-level DEBUG &
+      wait
+  fi
 }
 
 function startServerFromDockerCompose() {
@@ -103,14 +120,14 @@ case "$2" in
       initIbftConsensus
       # Create genesis file and start the server from binary
       createGenesis
-      startServerFromBinary
+      startServerFromBinary $2
       exit 0;
     elif [ "$1" == "polybft" ]; then
       # Initialize polybft consensus
       initPolybftConsensus
       # Create genesis file and start the server from binary
       createGenesis
-      startServerFromBinary
+      startServerFromBinary $2
       exit 0;
     else
       echo "Unsupported consensus mode. Supported modes are: ibft and polybft "


### PR DESCRIPTION
# Description

This PR changes the helper cluster script to print the output of both `stdout` and `stderr` to both terminal and file for each validator node.

**Note:** would be nice to maybe group it somehow to a folder because currently files are written to the root folder of the project and it gets overwritten if cluster script is run multiple times.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
