### PR TITLE
Fix var name in Loadtest workflow to allow on-demand triggers

### DIFF
--- a/.github/workflows/deploy.devnet.eph.yml
+++ b/.github/workflows/deploy.devnet.eph.yml
@@ -211,6 +211,7 @@ jobs:
             }
 
   loadtest:
+    needs: deploy_eph_devnet
     uses: ./.github/workflows/loadtest.yml
     name: Load Test
     secrets:

--- a/.github/workflows/deploy.devnet.yml
+++ b/.github/workflows/deploy.devnet.yml
@@ -211,6 +211,7 @@ jobs:
             }
 
   loadtest:
+    needs: deploy_devnet
     uses: ./.github/workflows/loadtest.yml
     name: Load Test
     secrets:

--- a/.github/workflows/deploy.testnet.yml
+++ b/.github/workflows/deploy.testnet.yml
@@ -201,6 +201,7 @@ jobs:
             }
 
   loadtest:
+    needs: deploy_testnet
     uses: ./.github/workflows/loadtest.yml
     name: Load Test
     secrets:

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -19,6 +19,11 @@
           default: 'simple'
           description: The scenario to run
           type: string
+        duration:
+          default: '2m'
+          description: Duration of the test
+          required: false
+          type: string
     workflow_call:
       inputs:
         environment:
@@ -32,6 +37,11 @@
         scenario:
           required: true
           description: The mode for the stress test
+          type: string
+        duration:
+          default: '2m'
+          description: Duration of the test
+          required: false
           type: string
       secrets:
         SLACK_PERFORMANCE_WEBHOOK_URL:
@@ -88,6 +98,7 @@
             RPC_URL: ${{ secrets.LOADTEST_RPC_URL }}
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
             LOADTEST_MNEMONIC: ${{ secrets.LOADTEST_MNEMONIC }}
+            LOADTEST_DURATION: ${{ inputs.duration }}
         
         - name: Notify Slack
           uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -38,7 +38,7 @@
           required: true
         DD_API_KEY:
           required: true
-        RPC_URL:
+        LOADTEST_RPC_URL:
           required: true
         LOADTEST_MNEMONIC:
           required: true
@@ -85,7 +85,7 @@
             echo "gas_max=$(cat summary.json | jq -r '.metrics.ethereum_gas_used.values.max')" >> $GITHUB_OUTPUT
           env:
             K6_STATSD_ENABLE_TAGS: true
-            RPC_URL: ${{ secrets.RPC_URL }}
+            RPC_URL: ${{ secrets.LOADTEST_RPC_URL }}
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PERFORMANCE_WEBHOOK_URL }}
             LOADTEST_MNEMONIC: ${{ secrets.LOADTEST_MNEMONIC }}
         
@@ -124,7 +124,7 @@
                         },
                         {
                           "type": "mrkdwn",
-                          "text": "JSON-RPC Endpoint: ${{ secrets.RPC_URL }}"
+                          "text": "JSON-RPC Endpoint: ${{ secrets.LOADTEST_RPC_URL }}"
                         },
                         {
                           "type": "mrkdwn",

--- a/loadtest/scenarios/multiple_EOA.js
+++ b/loadtest/scenarios/multiple_EOA.js
@@ -10,9 +10,9 @@ export const options = {
       executor: 'constant-arrival-rate',
       rate: 300,
       timeUnit: '1s',
-      duration: '1m',
-      preAllocatedVUs: 10,
-      maxVUs: 10,
+      duration: '5m',
+      preAllocatedVUs: 20,
+      maxVUs: 20,
     },
   },
 };

--- a/loadtest/scenarios/multiple_EOA.js
+++ b/loadtest/scenarios/multiple_EOA.js
@@ -10,7 +10,7 @@ export const options = {
       executor: 'constant-arrival-rate',
       rate: 300,
       timeUnit: '1s',
-      duration: '5m',
+      duration: '10m',
       preAllocatedVUs: 20,
       maxVUs: 20,
     },

--- a/loadtest/scenarios/multiple_EOA.js
+++ b/loadtest/scenarios/multiple_EOA.js
@@ -3,6 +3,11 @@ import exec from 'k6/execution';
 import { fundTestAccounts } from '../helpers/init.js';
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 
+let duration = __ENV.LOADTEST_DURATION;
+if (duration == undefined) {
+    duration = "2m";
+}
+
 export const options = {
   setupTimeout: '220s',
   scenarios: {
@@ -10,7 +15,7 @@ export const options = {
       executor: 'constant-arrival-rate',
       rate: 300,
       timeUnit: '1s',
-      duration: '10m',
+      duration: duration,
       preAllocatedVUs: 20,
       maxVUs: 20,
     },

--- a/loadtest/scenarios/multiple_EOA.js
+++ b/loadtest/scenarios/multiple_EOA.js
@@ -50,7 +50,7 @@ export default function (data) {
 
   const tx = {
     to: "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
-    value: Number(0.0001 * 1e18),
+    value: Number(0.00000001 * 1e18),
     gas_price: client.gasPrice(),
     nonce: nonce,
   };

--- a/loadtest/scenarios/multiple_EOA.js
+++ b/loadtest/scenarios/multiple_EOA.js
@@ -8,7 +8,7 @@ export const options = {
   scenarios: {
     constant_request_rate: {
       executor: 'constant-arrival-rate',
-      rate: 200,
+      rate: 300,
       timeUnit: '1s',
       duration: '1m',
       preAllocatedVUs: 10,

--- a/loadtest/scenarios/multiple_ERC20.js
+++ b/loadtest/scenarios/multiple_ERC20.js
@@ -3,6 +3,11 @@ import exec from 'k6/execution';
 import { fundTestAccounts } from '../helpers/init.js';
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 
+let duration = __ENV.LOADTEST_DURATION;
+if (duration == undefined) {
+    duration = "2m";
+}
+
 export const options = {
     setupTimeout: '220s',
     scenarios: {
@@ -10,7 +15,7 @@ export const options = {
             executor: 'constant-arrival-rate',
             rate: 200,
             timeUnit: '1s',
-            duration: '1m',
+            duration: duration,
             preAllocatedVUs: 10,
             maxVUs: 10,
         },
@@ -22,7 +27,7 @@ const root_address = "0x1AB8C3df809b85012a009c0264eb92dB04eD6EFa";
 const mnemonic = __ENV.LOADTEST_MNEMONIC;
 let rpc_url = __ENV.RPC_URL;
 if (rpc_url == undefined) {
-    rpc_url = "http://localhost:10002"
+    rpc_url = "http://localhost:10002";
 }
 
 const ZexCoin = JSON.parse(open("../contracts/ZexCoinERC20.json"));


### PR DESCRIPTION
# Description

- Fix var name to be able to run manually https://github.com/0xPolygon/polygon-edge/actions/workflows/loadtest.yml
- Add `duration` var to allow different duration.
- Require deployment before loadtest

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Run the workflow
