### PR TITLE
Add rootchain ERC20 token flag

### DIFF
--- a/command/rootchain/initcontracts/init_contracts.go
+++ b/command/rootchain/initcontracts/init_contracts.go
@@ -298,7 +298,6 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 	manifest.RootchainConfig = rootchainConfig
 
 	for _, contract := range deployContracts {
-
 		txn := &ethgo.Transaction{
 			To:    nil, // contract deployment
 			Input: contract.artifact.Bytecode,

--- a/command/rootchain/initcontracts/params.go
+++ b/command/rootchain/initcontracts/params.go
@@ -9,18 +9,20 @@ import (
 )
 
 const (
-	manifestPathFlag = "manifest"
-	jsonRPCFlag      = "json-rpc"
+	manifestPathFlag   = "manifest"
+	jsonRPCFlag        = "json-rpc"
+	rootchainERC20Flag = "rootchain-erc20"
 
 	defaultManifestPath = "./manifest.json"
 )
 
 type initContractsParams struct {
-	manifestPath   string
-	accountDir     string
-	accountConfig  string
-	jsonRPCAddress string
-	isTestMode     bool
+	manifestPath       string
+	accountDir         string
+	accountConfig      string
+	jsonRPCAddress     string
+	rootERC20TokenAddr string
+	isTestMode         bool
 }
 
 func (ip *initContractsParams) validateFlags() error {


### PR DESCRIPTION
# Description

The PR introduces `--rootchain-erc20` flag, which allows specifying an address of the existing root chain ERC20 token. If the value is not specified, `MockERC20` is deployed and acts as the root chain ERC20 token.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
