### PR TITLE
Send approve transaction on each deposit

### DIFF
--- a/command/bridge/deposit/deposit_erc20.go
+++ b/command/bridge/deposit/deposit_erc20.go
@@ -196,7 +196,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 				}
 
 				// approve root erc20 predicate
-				txn, err := createApproveERC20PredicateTxn(amountBig,
+				txn, err := createApproveERC20PredicateTxn(amountBig.Add(amountBig, big.NewInt(1e18)),
 					types.StringToAddress(dp.rootPredicateAddr),
 					types.StringToAddress(dp.rootTokenAddr))
 

--- a/command/bridge/deposit/deposit_erc20.go
+++ b/command/bridge/deposit/deposit_erc20.go
@@ -153,9 +153,69 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		depositorKey = rootchainKey
 	}
 
+	depositorAddr := depositorKey.Address()
+
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(dp.jsonRPCAddress))
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to initialize rootchain tx relayer: %w", err))
+
+		return
+	}
+
+	amounts := make([]*big.Int, len(dp.Amounts))
+	aggregateAmount := new(big.Int)
+
+	for i, amountRaw := range dp.Amounts {
+		amountRaw := amountRaw
+
+		amount, err := types.ParseUint256orHex(&amountRaw)
+		if err != nil {
+			outputter.SetError(fmt.Errorf("failed to decode provided amount %s: %w", amount, err))
+
+			return
+		}
+
+		amounts[i] = amount
+		aggregateAmount.Add(aggregateAmount, amount)
+	}
+
+	if dp.testMode {
+		// mint tokens to depositor, so he is able to send them
+		mintTxn, err := createMintTxn(types.Address(depositorAddr), types.Address(depositorAddr), aggregateAmount)
+		if err != nil {
+			outputter.SetError(fmt.Errorf("mint transaction creation failed: %w", err))
+
+			return
+		}
+
+		receipt, err := txRelayer.SendTransaction(mintTxn, depositorKey)
+		if err != nil {
+			outputter.SetError(fmt.Errorf("failed to send mint transaction to depositor %s", depositorAddr))
+
+			return
+		}
+
+		if receipt.Status == uint64(types.ReceiptFailed) {
+			outputter.SetError(fmt.Errorf("failed to mint tokens to depositor %s", depositorAddr))
+
+			return
+		}
+	}
+
+	// approve root erc20 predicate
+	approveTxn, err := createApproveERC20PredicateTxn(aggregateAmount,
+		types.StringToAddress(dp.rootPredicateAddr),
+		types.StringToAddress(dp.rootTokenAddr))
+
+	receipt, err := txRelayer.SendTransaction(approveTxn, depositorKey)
+	if err != nil {
+		outputter.SetError(fmt.Errorf("failed to send root erc20 approve transaction"))
+
+		return
+	}
+
+	if receipt.Status == uint64(types.ReceiptFailed) {
+		outputter.SetError(fmt.Errorf("failed to approve root erc20 predicate"))
 
 		return
 	}
@@ -164,58 +224,20 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 	for i := range dp.Receivers {
 		receiver := dp.Receivers[i]
-		amount := dp.Amounts[i]
+		amount := amounts[i]
 
 		g.Go(func() error {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
 			default:
-				amountBig, err := types.ParseUint256orHex(&amount)
-				if err != nil {
-					return fmt.Errorf("failed to decode provided deposit amount %s: %w", amount, err)
-				}
-
-				if dp.testMode {
-					// mint tokens to the depositor, so he is able to deposit them
-					// Note: this works only if using test account on the rootchain,
-					// because it is expected that it is the one which deploys rootchain smart contracts as well
-					txn, err := createMintTxn(types.Address(depositorKey.Address()), types.Address(depositorKey.Address()), amountBig)
-					if err != nil {
-						return fmt.Errorf("mint transaction creation failed: %w", err)
-					}
-
-					receipt, err := txRelayer.SendTransaction(txn, depositorKey)
-					if err != nil {
-						return fmt.Errorf("failed to send mint transaction to depositor %s", depositorKey.Address())
-					}
-
-					if receipt.Status == uint64(types.ReceiptFailed) {
-						return fmt.Errorf("failed to mint tokens to depositor %s", depositorKey.Address())
-					}
-				}
-
-				// approve root erc20 predicate
-				txn, err := createApproveERC20PredicateTxn(amountBig.Add(amountBig, big.NewInt(1e18)),
-					types.StringToAddress(dp.rootPredicateAddr),
-					types.StringToAddress(dp.rootTokenAddr))
-
-				receipt, err := txRelayer.SendTransaction(txn, depositorKey)
-				if err != nil {
-					return fmt.Errorf("failed to send root erc20 approve transaction")
-				}
-
-				if receipt.Status == uint64(types.ReceiptFailed) {
-					return fmt.Errorf("failed to approve root erc20 predicate")
-				}
-
 				// deposit tokens
-				txn, err = createDepositTxn(types.Address(depositorKey.Address()), types.StringToAddress(receiver), amountBig)
+				depositTxn, err := createDepositTxn(types.Address(depositorAddr), types.StringToAddress(receiver), amount)
 				if err != nil {
 					return fmt.Errorf("failed to create tx input: %w", err)
 				}
 
-				receipt, err = txRelayer.SendTransaction(txn, depositorKey)
+				receipt, err = txRelayer.SendTransaction(depositTxn, depositorKey)
 				if err != nil {
 					return fmt.Errorf("receiver: %s, amount: %s, error: %w", receiver, amount, err)
 				}
@@ -236,7 +258,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	outputter.SetCommandResult(&depositERC20Result{
-		Sender:    depositorKey.Address().String(),
+		Sender:    depositorAddr.String(),
 		Receivers: dp.Receivers,
 		Amounts:   dp.Amounts,
 	})

--- a/command/rootchain/initcontracts/init_contracts.go
+++ b/command/rootchain/initcontracts/init_contracts.go
@@ -33,12 +33,6 @@ const (
 	rootERC20PredicateName = "RootERC20Predicate"
 	rootERC20Name          = "RootERC20"
 	erc20TemplateName      = "ERC20Template"
-
-	// defaultAllowanceValue is value which is assigned to the RootERC20Predicate spender
-	defaultAllowanceValue = uint64(1e19)
-
-	// defaultFundAmount is value which is sent to rootchain contracts deployer account
-	defaultFundAmount = uint64(1e19)
 )
 
 var (
@@ -328,18 +322,6 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 		Message: fmt.Sprintf("%s %s contract is initialized", contractsDeploymentTitle, rootERC20PredicateName),
 	})
 
-	if params.isTestMode {
-		// approve RootERC20Predicate
-		if err := approveERC20Predicate(txRelayer, rootchainConfig, deployerKey); err != nil {
-			return err
-		}
-
-		outputter.WriteCommandResult(&messageResult{
-			Message: fmt.Sprintf("%s %s contract is approved for spender of %s",
-				contractsDeploymentTitle, rootERC20PredicateName, rootERC20Name),
-		})
-	}
-
 	return nil
 }
 
@@ -415,28 +397,6 @@ func initializeRootERC20Predicate(txRelayer txrelayer.TxRelayer, rootchainConfig
 	}
 
 	return sendTransaction(txRelayer, txn, rootERC20PredicateName, deployerKey)
-}
-
-// approveERC20Predicate sends approve transaction to ERC20 token so that it is able to spend given root ERC20 token
-func approveERC20Predicate(txRelayer txrelayer.TxRelayer, config *polybft.RootchainConfig,
-	deployerKey ethgo.Key) error {
-	approveFnParams := &contractsapi.ApproveFunction{
-		Spender: config.RootERC20PredicateAddress,
-		Amount:  new(big.Int).SetUint64(defaultAllowanceValue),
-	}
-
-	input, err := approveFnParams.EncodeAbi()
-	if err != nil {
-		return fmt.Errorf("failed to encode parameters for RootERC20.approve. error: %w", err)
-	}
-
-	addr := ethgo.Address(config.RootNativeERC20Address)
-	txn := &ethgo.Transaction{
-		To:    &addr,
-		Input: input,
-	}
-
-	return sendTransaction(txRelayer, txn, rootERC20Name, deployerKey)
 }
 
 // sendTransaction sends provided transaction

--- a/command/rootchain/initcontracts/init_contracts.go
+++ b/command/rootchain/initcontracts/init_contracts.go
@@ -38,6 +38,8 @@ const (
 var (
 	params initContractsParams
 
+	defaultFundAmount, _ = new(big.Int).SetString(command.DefaultPremineBalance, 16)
+
 	// metadataPopulatorMap maps rootchain contract names to callback
 	// which populates appropriate field in the RootchainMetadata
 	metadataPopulatorMap = map[string]func(*polybft.RootchainConfig, types.Address){
@@ -217,7 +219,7 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 		// fund account
 		deployerAddress := deployerKey.Address()
 
-		txn := &ethgo.Transaction{To: &deployerAddress, Value: new(big.Int).SetUint64(defaultFundAmount)}
+		txn := &ethgo.Transaction{To: &deployerAddress, Value: defaultFundAmount}
 		if _, err := txRelayer.SendTransactionLocal(txn); err != nil {
 			return err
 		}

--- a/command/rootchain/initcontracts/init_contracts.go
+++ b/command/rootchain/initcontracts/init_contracts.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/umbracle/ethgo"
@@ -38,7 +39,7 @@ const (
 var (
 	params initContractsParams
 
-	defaultFundAmount, _ = new(big.Int).SetString(command.DefaultPremineBalance, 16)
+	defaultFundAmount, _ = new(big.Int).SetString(strings.TrimPrefix(command.DefaultPremineBalance, "0x"), 16)
 
 	// metadataPopulatorMap maps rootchain contract names to callback
 	// which populates appropriate field in the RootchainMetadata


### PR DESCRIPTION
# Description

This PR fixes sending approval transactions for `RootERC20Predicate`. Prior to this, it was sent only by the root chain contracts deployer, which allowed `RootERC20Predicate` to spend ERC20 tokens only on its behalf. Now approval transaction is being sent before each deposit, which is correct behavior, allowing arbitrary account to send deposit transaction and not only the root chain contracts deployer.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
