### PR TITLE
Event tracker starting block support

### DIFF
--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -193,7 +193,7 @@ func setFlags(cmd *cobra.Command) {
 
 		cmd.Flags().StringArrayVar(
 			&params.eventTrackerStartBlocks,
-			trackerStartBlockFlag,
+			trackerStartBlocksFlag,
 			[]string{},
 			"event tracker starting block configuration, which is specified per contract address "+
 				"(format: <contract address>:<start block>)",

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -190,6 +190,14 @@ func setFlags(cmd *cobra.Command) {
 			defaultEpochReward,
 			"reward size for block sealing",
 		)
+
+		cmd.Flags().StringArrayVar(
+			&params.eventTrackerStartBlocks,
+			trackerStartBlockFlag,
+			[]string{},
+			"event tracker starting block configuration, which is specified per contract address "+
+				"(format: <contract address>:<start block>)",
+		)
 	}
 }
 

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -78,12 +78,13 @@ type genesisParams struct {
 	genesisConfig *chain.Chain
 
 	// PolyBFT
-	manifestPath      string
-	validatorSetSize  int
-	sprintSize        uint64
-	blockTime         time.Duration
-	bridgeJSONRPCAddr string
-	epochReward       uint64
+	manifestPath            string
+	validatorSetSize        int
+	sprintSize              uint64
+	blockTime               time.Duration
+	bridgeJSONRPCAddr       string
+	epochReward             uint64
+	eventTrackerStartBlocks []string
 }
 
 func (p *genesisParams) validateFlags() error {

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -23,11 +23,12 @@ import (
 )
 
 const (
-	manifestPathFlag     = "manifest"
-	validatorSetSizeFlag = "validator-set-size"
-	sprintSizeFlag       = "sprint-size"
-	blockTimeFlag        = "block-time"
-	bridgeFlag           = "bridge-json-rpc"
+	manifestPathFlag      = "manifest"
+	validatorSetSizeFlag  = "validator-set-size"
+	sprintSizeFlag        = "sprint-size"
+	blockTimeFlag         = "block-time"
+	bridgeFlag            = "bridge-json-rpc"
+	trackerStartBlockFlag = "tracker-start-block"
 
 	defaultManifestPath     = "./manifest.json"
 	defaultEpochSize        = uint64(10)
@@ -56,12 +57,18 @@ func (p *genesisParams) generatePolyBftChainConfig() error {
 		return errNoGenesisValidators
 	}
 
+	eventTrackerStartBlock, err := parseTrackerStartBlocks(params.eventTrackerStartBlocks)
+	if err != nil {
+		return err
+	}
+
 	var bridge *polybft.BridgeConfig
 
 	// populate bridge configuration
 	if p.bridgeJSONRPCAddr != "" && manifest.RootchainConfig != nil {
 		bridge = manifest.RootchainConfig.ToBridgeConfig()
 		bridge.JSONRPCEndpoint = p.bridgeJSONRPCAddr
+		bridge.EventTrackerStartBlocks = eventTrackerStartBlock
 	}
 
 	polyBftConfig := &polybft.PolyBFTConfig{

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -23,12 +23,12 @@ import (
 )
 
 const (
-	manifestPathFlag      = "manifest"
-	validatorSetSizeFlag  = "validator-set-size"
-	sprintSizeFlag        = "sprint-size"
-	blockTimeFlag         = "block-time"
-	bridgeFlag            = "bridge-json-rpc"
-	trackerStartBlockFlag = "tracker-start-block"
+	manifestPathFlag       = "manifest"
+	validatorSetSizeFlag   = "validator-set-size"
+	sprintSizeFlag         = "sprint-size"
+	blockTimeFlag          = "block-time"
+	bridgeFlag             = "bridge-json-rpc"
+	trackerStartBlocksFlag = "tracker-start-blocks"
 
 	defaultManifestPath     = "./manifest.json"
 	defaultEpochSize        = uint64(10)

--- a/command/genesis/utils.go
+++ b/command/genesis/utils.go
@@ -42,11 +42,6 @@ func (g *GenesisGenError) GetType() string {
 	return g.errorType
 }
 
-type premineInfo struct {
-	address types.Address
-	balance *big.Int
-}
-
 // verifyGenesisExistence checks if the genesis file at the specified path is present
 func verifyGenesisExistence(genesisPath string) *GenesisGenError {
 	_, err := os.Stat(genesisPath)
@@ -65,6 +60,11 @@ func verifyGenesisExistence(genesisPath string) *GenesisGenError {
 	}
 
 	return nil
+}
+
+type premineInfo struct {
+	address types.Address
+	balance *big.Int
 }
 
 // parsePremineInfo parses provided premine information and returns premine address and premine balance
@@ -86,6 +86,33 @@ func parsePremineInfo(premineInfoRaw string) (*premineInfo, error) {
 	}
 
 	return &premineInfo{address: address, balance: amount}, nil
+}
+
+// parseTrackerStartBlocks parses provided event tracker start blocks configuration.
+// It is set in a following format: <contractAddress>:<startBlock>.
+// In case smart contract address isn't provided in the string, it is assumed its starting block is 0 implicitly.
+func parseTrackerStartBlocks(trackerStartBlocksRaw []string) (map[types.Address]uint64, error) {
+	trackerStartBlocksConfig := make(map[types.Address]uint64, len(trackerStartBlocksRaw))
+
+	for _, startBlockRawConfig := range trackerStartBlocksRaw {
+		delimiterIdx := strings.Index(startBlockRawConfig, ":")
+		if delimiterIdx == -1 {
+			return nil, fmt.Errorf("invalid event tracker start block configuration provided: %s", trackerStartBlocksRaw)
+		}
+
+		// <contractAddress>:<startBlock>
+		address := types.StringToAddress(startBlockRawConfig[:delimiterIdx])
+		startBlockRaw := startBlockRawConfig[delimiterIdx+1:]
+
+		startBlock, err := strconv.ParseUint(startBlockRaw, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse provided start block %s: %w", startBlockRaw, err)
+		}
+
+		trackerStartBlocksConfig[address] = startBlock
+	}
+
+	return trackerStartBlocksConfig, nil
 }
 
 // GetValidatorKeyFiles returns file names which has validator secrets

--- a/command/genesis/utils.go
+++ b/command/genesis/utils.go
@@ -94,15 +94,15 @@ func parsePremineInfo(premineInfoRaw string) (*premineInfo, error) {
 func parseTrackerStartBlocks(trackerStartBlocksRaw []string) (map[types.Address]uint64, error) {
 	trackerStartBlocksConfig := make(map[types.Address]uint64, len(trackerStartBlocksRaw))
 
-	for _, startBlockRawConfig := range trackerStartBlocksRaw {
-		delimiterIdx := strings.Index(startBlockRawConfig, ":")
+	for _, startBlockRaw := range trackerStartBlocksRaw {
+		delimiterIdx := strings.Index(startBlockRaw, ":")
 		if delimiterIdx == -1 {
 			return nil, fmt.Errorf("invalid event tracker start block configuration provided: %s", trackerStartBlocksRaw)
 		}
 
 		// <contractAddress>:<startBlock>
-		address := types.StringToAddress(startBlockRawConfig[:delimiterIdx])
-		startBlockRaw := startBlockRawConfig[delimiterIdx+1:]
+		address := types.StringToAddress(startBlockRaw[:delimiterIdx])
+		startBlockRaw := startBlockRaw[delimiterIdx+1:]
 
 		startBlock, err := strconv.ParseUint(startBlockRaw, 10, 64)
 		if err != nil {

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -157,12 +157,14 @@ func (c *consensusRuntime) close() {
 // if bridge is not enabled, then a dummy state sync manager will be used
 func (c *consensusRuntime) initStateSyncManager(logger hcf.Logger) error {
 	if c.IsBridgeEnabled() {
+		stateSenderAddr := c.config.PolyBFTConfig.Bridge.BridgeAddr
 		stateSyncManager, err := NewStateSyncManager(
 			logger,
 			c.config.State,
 			&stateSyncConfig{
 				key:                   c.config.Key,
-				stateSenderAddr:       c.config.PolyBFTConfig.Bridge.BridgeAddr,
+				stateSenderAddr:       stateSenderAddr,
+				stateSenderStartBlock: c.config.PolyBFTConfig.Bridge.EventTrackerStartBlocks[stateSenderAddr],
 				jsonrpcAddr:           c.config.PolyBFTConfig.Bridge.JSONRPCEndpoint,
 				dataDir:               c.config.DataDir,
 				topic:                 c.config.bridgeTopic,

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -64,11 +64,12 @@ func GetPolyBFTConfig(chainConfig *chain.Chain) (PolyBFTConfig, error) {
 
 // BridgeConfig is the rootchain bridge configuration
 type BridgeConfig struct {
-	BridgeAddr             types.Address `json:"stateSenderAddr"`
-	CheckpointAddr         types.Address `json:"checkpointAddr"`
-	RootERC20PredicateAddr types.Address `json:"rootERC20PredicateAddr"`
-	RootNativeERC20Addr    types.Address `json:"rootNativeERC20Addr"`
-	JSONRPCEndpoint        string        `json:"jsonRPCEndpoint"`
+	BridgeAddr              types.Address            `json:"stateSenderAddr"`
+	CheckpointAddr          types.Address            `json:"checkpointAddr"`
+	RootERC20PredicateAddr  types.Address            `json:"rootERC20PredicateAddr"`
+	RootNativeERC20Addr     types.Address            `json:"rootNativeERC20Addr"`
+	JSONRPCEndpoint         string                   `json:"jsonRPCEndpoint"`
+	EventTrackerStartBlocks map[types.Address]uint64 `json:"eventTrackerStartBlocks"`
 }
 
 func (p *PolyBFTConfig) IsBridgeEnabled() bool {

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -60,6 +60,7 @@ func (n *dummyStateSyncManager) GetStateSyncProof(stateSyncID uint64) (types.Pro
 // stateSyncConfig holds the configuration data of state sync manager
 type stateSyncConfig struct {
 	stateSenderAddr       types.Address
+	stateSenderStartBlock uint64
 	jsonrpcAddr           string
 	dataDir               string
 	topic                 topic
@@ -132,6 +133,7 @@ func (s *stateSyncManager) initTracker() error {
 		ethgo.Address(s.config.stateSenderAddr),
 		s,
 		s.config.numBlockConfirmations,
+		s.config.stateSenderStartBlock,
 		s.logger)
 
 	go func() {

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer_test.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer_test.go
@@ -115,7 +115,7 @@ func TestStateSyncRelayer_Stop(t *testing.T) {
 	key, err := wallet.GenerateKey()
 	require.NoError(t, err)
 
-	r := NewRelayer("test-chain-1", "http://127.0.0.1:8545", ethgo.Address(contracts.StateReceiverContract), hclog.NewNullLogger(), key)
+	r := NewRelayer("test-chain-1", "http://127.0.0.1:8545", ethgo.Address(contracts.StateReceiverContract), 0, hclog.NewNullLogger(), key)
 
 	require.NotPanics(t, func() { r.Stop() })
 }

--- a/server/server.go
+++ b/server/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/blockchain"
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/consensus"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/statesyncrelayer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
@@ -459,10 +460,21 @@ func (s *Server) setupRelayer() error {
 		return fmt.Errorf("failed to create account from secret: %w", err)
 	}
 
+	polyBFTConfig, err := polybft.GetPolyBFTConfig(s.config.Chain)
+	if err != nil {
+		return fmt.Errorf("failed to extract polybft config: %w", err)
+	}
+
+	trackerStartBlockConfig := map[types.Address]uint64{}
+	if polyBFTConfig.Bridge != nil {
+		trackerStartBlockConfig = polyBFTConfig.Bridge.EventTrackerStartBlocks
+	}
+
 	relayer := statesyncrelayer.NewRelayer(
 		s.config.DataDir,
 		s.config.JSONRPC.JSONRPCAddr.String(),
 		ethgo.Address(contracts.StateReceiverContract),
+		trackerStartBlockConfig[contracts.StateReceiverContract],
 		s.logger.Named("relayer"),
 		wallet.NewEcdsaSigner(wallet.NewKey(account, bls.DomainCheckpointManager)),
 	)


### PR DESCRIPTION
# Description

This PR exposes a new flag to the genesis command `--tracker-start-blocks`. It adds the possibility to configure starting blocks for each smart contract that the event tracker listens to. Flag expects the value to be provided in the following format "<contract address>:<starting block number>".

Example:
```go
polygon-edge genesis --block-gas-limit 10000000 \ 
--validator-set-size=4 --consensus polybft --epoch-size 10 \
--bridge-json-rpc http://localhost:8545 \
--tracker-start-blocks 0x6FE03c2768C9d800AF3Dedf1878b5687FE120a27:10
```

For contracts that are not specified in the mapping, the event tracker will start capturing events from block 0.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually