### PR TITLE
Increase E2E polybft timeout to 45 minutes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,8 @@ test-e2e:
 test-e2e-polybft:
     # We can not build with race because of a bug in boltdb dependency
 	go build -o artifacts/polygon-edge .
-	env EDGE_BINARY=${PWD}/artifacts/polygon-edge E2E_TESTS=true E2E_LOGS=true E2E_TESTS_TYPE=integration go test -v -timeout=30m ./e2e-polybft/e2e/...
+	env EDGE_BINARY=${PWD}/artifacts/polygon-edge E2E_TESTS=true E2E_LOGS=true E2E_TESTS_TYPE=integration \
+	go test -v -timeout=45m ./e2e-polybft/e2e/...
 
 test-property-polybft:
     # We can not build with race because of a bug in boltdb dependency


### PR DESCRIPTION
# Description

This PR increases E2E polybft tests timeout to 45 minutes, as execution often lasts longer than 30 minutes and E2E polybft fails due to the timeout.

**Note:** When we revise e2e tests, we can lower timeout again to some more reasonable value. So this is a rather temporary "fix".

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually