### PR TITLE
Initialize rootchain config instance before deploying contracts

### DIFF
--- a/command/output.go
+++ b/command/output.go
@@ -36,5 +36,10 @@ func InitializeOutputter(cmd *cobra.Command) OutputFormatter {
 }
 
 func shouldOutputJSON(baseCmd *cobra.Command) bool {
-	return baseCmd.Flag(JSONOutputFlag).Changed
+	jsonOutputFlag := baseCmd.Flag(JSONOutputFlag)
+	if jsonOutputFlag == nil {
+		return false
+	}
+
+	return jsonOutputFlag.Changed
 }

--- a/command/rootchain/initcontracts/init_contracts.go
+++ b/command/rootchain/initcontracts/init_contracts.go
@@ -238,6 +238,9 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 		}
 	}
 
+	rootchainConfig := &polybft.RootchainConfig{}
+	manifest.RootchainConfig = rootchainConfig
+
 	type contractInfo struct {
 		name     string
 		artifact *artifact.Artifact
@@ -295,9 +298,6 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 		// deploy MockERC20 as default root chain ERC20 token
 		deployContracts = append(deployContracts, &contractInfo{name: "RootERC20", artifact: contractsapi.RootERC20})
 	}
-
-	rootchainConfig := &polybft.RootchainConfig{}
-	manifest.RootchainConfig = rootchainConfig
 
 	for _, contract := range deployContracts {
 		txn := &ethgo.Transaction{

--- a/command/rootchain/initcontracts/init_contracts_test.go
+++ b/command/rootchain/initcontracts/init_contracts_test.go
@@ -1,6 +1,7 @@
 package initcontracts
 
 import (
+	"os"
 	"testing"
 
 	"github.com/0xPolygon/polygon-edge/command"
@@ -15,6 +16,12 @@ func TestDeployContracts_NoPanics(t *testing.T) {
 	t.Parallel()
 
 	server := testutil.DeployTestServer(t, nil)
+	t.Cleanup(func() {
+		err := os.RemoveAll(params.manifestPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	client, err := jsonrpc.NewClient(server.HTTPAddr())
 	require.NoError(t, err)

--- a/command/rootchain/initcontracts/init_contracts_test.go
+++ b/command/rootchain/initcontracts/init_contracts_test.go
@@ -1,0 +1,35 @@
+package initcontracts
+
+import (
+	"testing"
+
+	"github.com/0xPolygon/polygon-edge/command"
+	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft"
+	"github.com/stretchr/testify/require"
+	"github.com/umbracle/ethgo/jsonrpc"
+	"github.com/umbracle/ethgo/testutil"
+)
+
+func TestDeployContracts_NoPanics(t *testing.T) {
+	t.Parallel()
+
+	server := testutil.DeployTestServer(t, nil)
+
+	client, err := jsonrpc.NewClient(server.HTTPAddr())
+	require.NoError(t, err)
+
+	testKey, err := helper.GetRootchainTestPrivKey()
+	require.NoError(t, err)
+
+	receipt, err := server.Fund(testKey.Address())
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), receipt.Status)
+
+	outputter := command.InitializeOutputter(GetCommand())
+
+	require.NotPanics(t, func() {
+		err = deployContracts(outputter, client, &polybft.Manifest{}, testKey)
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
# Description

This PR fixes the segmentation fault error when deploying root chain contracts with provided root erc20 token address.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
