### PR TITLE
Incorrect block number for epoch ending exit events

### DIFF
--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -272,15 +272,20 @@ func (c *checkpointManager) isCheckpointBlock(blockNumber uint64, isEpochEndingB
 // PostBlock is called on every insert of finalized block (either from consensus or syncer)
 // It will read any exit event that happened in block and insert it to state boltDb
 func (c *checkpointManager) PostBlock(req *PostBlockRequest) error {
-	epoch := req.Epoch
+	var (
+		epoch = req.Epoch
+		block = req.FullBlock.Block.Number()
+	)
+
 	if req.IsEpochEndingBlock {
 		// exit events that happened in epoch ending blocks,
 		// should be added to the tree of the next epoch
 		epoch++
+		block++
 	}
 
 	// commit exit events only when we finalize a block
-	events, err := getExitEventsFromReceipts(epoch, req.FullBlock.Block.Number(), req.FullBlock.Receipts)
+	events, err := getExitEventsFromReceipts(epoch, block, req.FullBlock.Receipts)
 	if err != nil {
 		return err
 	}

--- a/consensus/polybft/checkpoint_manager_test.go
+++ b/consensus/polybft/checkpoint_manager_test.go
@@ -325,11 +325,12 @@ func TestCheckpointManager_PostBlock(t *testing.T) {
 		require.NoError(t, checkpointManager.PostBlock(req))
 
 		exitEvents, err := state.CheckpointStore.getExitEvents(epoch+1, func(exitEvent *ExitEvent) bool {
-			return exitEvent.BlockNumber == block
+			return exitEvent.BlockNumber == block+1
 		})
 
 		require.NoError(t, err)
 		require.Len(t, exitEvents, numOfReceipts)
+		require.Equal(t, uint64(block+1), exitEvents[0].BlockNumber)
 		require.Equal(t, uint64(epoch+1), exitEvents[0].EpochNumber)
 	})
 }

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
-	"github.com/0xPolygon/polygon-edge/merkle-tree"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 
@@ -950,23 +949,6 @@ func (c *consensusRuntime) getFirstBlockOfEpoch(epochNumber uint64, latestHeader
 	}
 
 	return firstBlockInEpoch, nil
-}
-
-// createExitTree creates an exit event merkle tree from provided exit events
-func createExitTree(exitEvents []*ExitEvent) (*merkle.MerkleTree, error) {
-	numOfEvents := len(exitEvents)
-	data := make([][]byte, numOfEvents)
-
-	for i := 0; i < numOfEvents; i++ {
-		b, err := ExitEventInputsABIType.Encode(exitEvents[i])
-		if err != nil {
-			return nil, err
-		}
-
-		data[i] = b
-	}
-
-	return merkle.NewMerkleTree(data)
 }
 
 // getSealersForBlock checks who sealed a given block and updates the counter


### PR DESCRIPTION
# Description

If an exit event happens on the epoch-ending block, it is propagated to the next epoch, due to security concerns and exit event finalization. However, its block number remains incorrectly set in the storage. Therefore when Edge is providing exit proof for such an event, it is not valid, because such an event is not going to be submitted with the current checkpoint block, but the next one in fact.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually