### PR TITLE
Lower log level of the `ProposerCalculator` logs

### DIFF
--- a/consensus/polybft/proposer_calculator.go
+++ b/consensus/polybft/proposer_calculator.go
@@ -209,6 +209,7 @@ func (pc *ProposerCalculator) PostBlock(req *PostBlockRequest) error {
 		if err := pc.updatePerBlock(height); err != nil {
 			return err
 		}
+
 		pc.logger.Debug("Proposers snapshot has been updated", "current block", blockNumber+1,
 			"validators count", len(pc.snapshot.Validators))
 	}
@@ -225,7 +226,8 @@ func (pc *ProposerCalculator) PostBlock(req *PostBlockRequest) error {
 // Updates ProposerSnapshot to block block with number `blockNumber`
 func (pc *ProposerCalculator) updatePerBlock(blockNumber uint64) error {
 	if pc.snapshot.Height != blockNumber {
-		return fmt.Errorf("proposers snapshot update wrong block=%d, snapshot block number = %d", blockNumber, pc.snapshot.Height)
+		return fmt.Errorf("proposers snapshot update called for wrong block. block number=%d, snapshot block number=%d",
+			blockNumber, pc.snapshot.Height)
 	}
 
 	_, extra, err := getBlockData(blockNumber, pc.config.blockchain)

--- a/tracker/event_tracker_store.go
+++ b/tracker/event_tracker_store.go
@@ -171,7 +171,7 @@ func (b *EventTrackerStore) onNewBlock(filterHash, blockData string) error {
 		b.subscriber.AddLog(log)
 	}
 
-	b.logger.Info("event logs have been notified to a subscriber", "len", len(logs), "next", nextToProcessIdx)
+	b.logger.Debug("Event logs have been notified to a subscriber", "len", len(logs), "next", nextToProcessIdx)
 
 	return nil
 }


### PR DESCRIPTION
# Description

This PR lowers the log level of `ProposerCalculator` logs from `info` to `debug` level. It also rewords some of them.

The rationale for doing it is that info is the default logging level and these logs are reported per block, so probably no need to output them on the info level for each block.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually