### PR TITLE
Reuse chain id from manifest when creating genesis configuration

### DIFF
--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -209,7 +209,7 @@ func setLegacyFlags(cmd *cobra.Command) {
 		&params.chainID,
 		chainIDFlagLEGACY,
 		command.DefaultChainID,
-		"the ID of the chain",
+		"the ID of the chain (not-applicable for Polybft consensus protocol as chain id is defined in manifest.json)",
 	)
 
 	_ = cmd.Flags().MarkHidden(chainIDFlagLEGACY)

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -87,7 +87,7 @@ func (p *genesisParams) generatePolyBftChainConfig() error {
 	chainConfig := &chain.Chain{
 		Name: p.name,
 		Params: &chain.Params{
-			ChainID: int64(p.chainID),
+			ChainID: manifest.ChainID,
 			Forks:   chain.AllForksEnabled,
 			Engine: map[string]interface{}{
 				string(server.PolyBFTConsensus): polyBftConfig,


### PR DESCRIPTION
# Description

This PR reuses the chain id defined in manifest.json when creating the genesis configuration. This is important, because if chain ids provided to the root chain `CheckpointManager` SC doesn't match with the ones used by the child chain, then checkpoints are not being submitted successfully (due to mismatches of checkpoint hashes).

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually