### PR TITLE
EVM-475 create a relayer microservice additional

### DIFF
--- a/command/aarelayer/params.go
+++ b/command/aarelayer/params.go
@@ -7,7 +7,6 @@ import (
 	"path"
 
 	"github.com/0xPolygon/polygon-edge/command"
-	"github.com/0xPolygon/polygon-edge/command/aarelayer/service"
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
@@ -46,6 +45,10 @@ func (rp *aarelayerParams) validateFlags() error {
 
 	if fn == "" {
 		return errors.New("file name for boltdb not specified")
+	}
+
+	if rp.invokerAddr == "" {
+		return errors.New("address of invoker smart contract not specified")
 	}
 
 	return sidechainHelper.ValidateSecretFlags(rp.accountDir, rp.configPath)
@@ -90,7 +93,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&params.invokerAddr,
 		invokerAddrFlag,
-		service.DefaultAAInvokerAddress.String(),
+		"",
 		"address of invoker smart contract",
 	)
 

--- a/command/aarelayer/params_test.go
+++ b/command/aarelayer/params_test.go
@@ -24,7 +24,7 @@ func Test_validateFlags_ErrorValidateIPPort(t *testing.T) {
 func Test_validateFlags_InvokerAddressNotSpecified(t *testing.T) {
 	t.Parallel()
 
-	tmpFilePath, err := os.MkdirTemp("/tmp", "aa_test_test_happy_path")
+	tmpFilePath, err := os.MkdirTemp("", "aa_test_test_happy_path")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpFilePath)
@@ -40,7 +40,7 @@ func Test_validateFlags_InvokerAddressNotSpecified(t *testing.T) {
 func Test_validateFlags_SecretsError(t *testing.T) {
 	t.Parallel()
 
-	tmpFilePath, err := os.MkdirTemp("/tmp", "aa_test_test_happy_path")
+	tmpFilePath, err := os.MkdirTemp("", "aa_test_test_happy_path")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpFilePath)
@@ -58,7 +58,7 @@ func Test_validateFlags_ErrorValidateDbPath(t *testing.T) {
 	t.Parallel()
 
 	p := aarelayerParams{
-		dbPath: "/tmp/non_existing_path_to/non_existing_file.db",
+		dbPath: "/non_existing_path_to/non_existing_file.db",
 		addr:   "127.0.0.1:8289",
 	}
 
@@ -71,7 +71,7 @@ func Test_validateFlags_ErrorValidateDbPath(t *testing.T) {
 func Test_validateFlags_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	tmpFilePath, err := os.MkdirTemp("/tmp", "aa_test_test_happy_path")
+	tmpFilePath, err := os.MkdirTemp("", "aa_test_test_happy_path")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpFilePath)

--- a/command/aarelayer/params_test.go
+++ b/command/aarelayer/params_test.go
@@ -21,7 +21,7 @@ func Test_validateFlags_ErrorValidateIPPort(t *testing.T) {
 	assert.ErrorContains(t, p.validateFlags(), "invalid address:")
 }
 
-func Test_validateFlags_SecretsError(t *testing.T) {
+func Test_validateFlags_InvokerAddressNotSpecified(t *testing.T) {
 	t.Parallel()
 
 	tmpFilePath, err := os.MkdirTemp("/tmp", "aa_test_test_happy_path")
@@ -32,6 +32,23 @@ func Test_validateFlags_SecretsError(t *testing.T) {
 	p := aarelayerParams{
 		addr:   "127.0.0.1:8289",
 		dbPath: path.Join(tmpFilePath, "e.db"),
+	}
+
+	assert.ErrorContains(t, p.validateFlags(), "address of invoker smart contract not specified")
+}
+
+func Test_validateFlags_SecretsError(t *testing.T) {
+	t.Parallel()
+
+	tmpFilePath, err := os.MkdirTemp("/tmp", "aa_test_test_happy_path")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(tmpFilePath)
+
+	p := aarelayerParams{
+		addr:        "127.0.0.1:8289",
+		dbPath:      path.Join(tmpFilePath, "e.db"),
+		invokerAddr: "0x445",
 	}
 
 	assert.ErrorContains(t, p.validateFlags(), "no config file or data directory passed in")
@@ -60,9 +77,10 @@ func Test_validateFlags_HappyPath(t *testing.T) {
 	defer os.RemoveAll(tmpFilePath)
 
 	p := aarelayerParams{
-		addr:       "127.0.0.1:8289",
-		dbPath:     path.Join(tmpFilePath, "e.db"),
-		configPath: "something",
+		addr:        "127.0.0.1:8289",
+		dbPath:      path.Join(tmpFilePath, "e.db"),
+		configPath:  "something",
+		invokerAddr: "0x88FF",
 	}
 
 	assert.NoError(t, p.validateFlags())

--- a/command/aarelayer/service/aa_config.go
+++ b/command/aarelayer/service/aa_config.go
@@ -16,7 +16,7 @@ type AAConfig struct {
 	ReceiptNumRetries     int           `json:"receiptNumRetries"`
 }
 
-func (c *AAConfig) IsValidAddress(address types.Address) bool {
+func (c *AAConfig) IsAddressAllowed(address types.Address) bool {
 	addressStr := strings.TrimPrefix(address.String(), "0x")
 
 	for _, v := range c.DenyList {

--- a/command/aarelayer/service/aa_config_test.go
+++ b/command/aarelayer/service/aa_config_test.go
@@ -21,7 +21,7 @@ func Test_AAConfig(t *testing.T) {
 
 		config := AAConfig{DenyList: []string{"0000000000000000000000000000000000000000"}}
 
-		assert.False(t, config.IsValidAddress(types.ZeroAddress))
+		assert.False(t, config.IsAddressAllowed(types.ZeroAddress))
 	})
 
 	t.Run("WhiteListEmpty", func(t *testing.T) {
@@ -30,7 +30,7 @@ func Test_AAConfig(t *testing.T) {
 		config := AAConfig{DenyList: []string{"0000000000000000000000000000000000000000"}}
 
 		address := types.Address{1, 2}
-		assert.True(t, config.IsValidAddress(address))
+		assert.True(t, config.IsAddressAllowed(address))
 	})
 
 	t.Run("NotInWhiteList", func(t *testing.T) {
@@ -39,7 +39,7 @@ func Test_AAConfig(t *testing.T) {
 		config := AAConfig{AllowList: []string{"1000000000000000000000000000000000000000"}}
 
 		address := types.Address{1, 2}
-		assert.False(t, config.IsValidAddress(address))
+		assert.False(t, config.IsAddressAllowed(address))
 	})
 
 	t.Run("InWhiteList", func(t *testing.T) {
@@ -48,7 +48,7 @@ func Test_AAConfig(t *testing.T) {
 		config := AAConfig{AllowList: []string{"0101000000000000000000000000000000000000"}}
 
 		address := types.Address{1, 1}
-		assert.True(t, config.IsValidAddress(address))
+		assert.True(t, config.IsAddressAllowed(address))
 	})
 
 	t.Run("JSONConfig", func(t *testing.T) {
@@ -65,7 +65,7 @@ func Test_AAConfig(t *testing.T) {
 		address1 := types.StringToAddress("0x71C7656EC7ab88b098defB751B7401B5f6d8976F")
 		address2 := types.StringToAddress("0x71C7656EC7ab88b098defB751B7401B5f6d8976C")
 
-		assert.True(t, config.IsValidAddress(address1))
-		assert.False(t, config.IsValidAddress(address2))
+		assert.True(t, config.IsAddressAllowed(address1))
+		assert.False(t, config.IsAddressAllowed(address2))
 	})
 }

--- a/command/aarelayer/service/aa_types.go
+++ b/command/aarelayer/service/aa_types.go
@@ -37,8 +37,8 @@ var (
 		"tuple(bytes32 typeHash, bytes32 name, bytes32 version, uint256 chainId, address verifyingContract)",
 	)
 
-	// default address of invoker smart contract
-	DefaultAAInvokerAddress = types.StringToAddress("3001")
+	//  aaInvokerNoncesAbiType is mapping(address => uint256) public nonces;
+	aaInvokerNoncesAbiType = abi.MustNewMethod("function nonces(address) returns (uint256)")
 )
 
 // AATransaction represents an AA transaction

--- a/command/aarelayer/service/aa_verification.go
+++ b/command/aarelayer/service/aa_verification.go
@@ -55,7 +55,7 @@ func (p *aaVerification) Validate(tx *AATransaction) error {
 		}
 	}
 
-	if !p.config.IsValidAddress(tx.Transaction.From) {
+	if !p.config.IsAddressAllowed(tx.Transaction.From) {
 		return fmt.Errorf("tx has from which is not allowed: %s", tx.Transaction.From)
 	}
 


### PR DESCRIPTION
# Description

Updates for EVM-475:
-  optimization for AA tx pool: Pop does not push transaction from the same address with the next nonce into the main (`timeHeap aaPoolTimeHeap`) binary heap; that is the job for `Update` function.
 - optimization for AA service regarding transaction retrieving from AA tx pool (`getFirstValidTx` function).
 - AA service should detect tx status from receipt.
 - AA service should have `aaInvokerAddress` as as field.
-  invoker address flag should be mandatory.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [X] I have tested this code manually

### Manual tests

Execute e2e test from https://github.com/0xPolygon/polygon-edge/pull/1284

