### PR TITLE
Fix proposer logging for HasQuorum function

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -752,7 +752,9 @@ func (c *consensusRuntime) HasQuorum(
 
 		propAddress, err := c.fsm.proposerSnapshot.GetLatestProposer(messages[0].View.Round, height)
 		if err != nil {
-			c.logger.Warn("HasQuorum has been called but proposer is not set", "error", err)
+			// This can happen if e.g. node runs sequence on lower height and proposer calculator updated
+			// to a newer count as a consequence of inserting block from syncer
+			c.logger.Debug("HasQuorum has been called but proposer could not be retrieved", "error", err)
 
 			return false
 		}

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -308,6 +308,8 @@ func (p *Polybft) startConsensusProtocol() {
 				// The blockchain notification system can eventually deliver
 				// stale block notifications. These should be ignored
 				if ev.Source == "syncer" && ev.NewChain[0].Number >= p.blockchain.CurrentHeader().Number {
+					p.logger.Info("sync block notification received", "block height", ev.NewChain[0].Number,
+						"current height", p.blockchain.CurrentHeader().Number)
 					syncerBlockCh <- struct{}{}
 				}
 			}


### PR DESCRIPTION
In HasQuorum fn, if the view(height or round) from the message does not match the view from the proposer calculator, that will be logged as debug instead of warning and false should be returned. This is valid case because node can run the sequence for the height lower than the height from calculator since the calculator is updated on block insertion (which can come from the syncer as well and thus the proposer calculator can have different height that message). 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually