### PR TITLE
Simplify state transactions function in FSM

### DIFF
--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -195,7 +195,7 @@ func (f *fsm) applyBridgeCommitmentTx() error {
 	if f.proposerCommitmentToRegister != nil {
 		bridgeCommitmentTx, err := f.createBridgeCommitmentTx()
 		if err != nil {
-			return err
+			return fmt.Errorf("creation of bridge commitment transaction failed: %w", err)
 		}
 
 		if err := f.blockBuilder.WriteTx(bridgeCommitmentTx); err != nil {

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -208,10 +208,6 @@ func (f *fsm) applyBridgeCommitmentTx() error {
 
 // createBridgeCommitmentTx builds bridge commitment registration transaction
 func (f *fsm) createBridgeCommitmentTx() (*types.Transaction, error) {
-	if f.proposerCommitmentToRegister == nil {
-		return nil, errors.New("unable to create bridge commitment transaction, since commitment instance is undefined")
-	}
-
 	inputData, err := f.proposerCommitmentToRegister.EncodeAbi()
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode input data for bridge commitment registration: %w", err)

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -552,7 +552,8 @@ func TestFSM_VerifyStateTransactions_StateTransactionQuorumNotReached(t *testing
 		logger:                       hclog.NewNullLogger(),
 	}
 
-	bridgeCommitmentTx := fsm.getBridgeCommitmentTx()
+	bridgeCommitmentTx, err := fsm.createBridgeCommitmentTx()
+	require.NoError(t, err)
 
 	// add commit epoch commitEpochTx to the end of transactions list
 	commitEpochTx, err := fsm.createCommitEpochTx()
@@ -593,13 +594,14 @@ func TestFSM_VerifyStateTransactions_StateTransactionInvalidSignature(t *testing
 		logger:                       hclog.NewNullLogger(),
 	}
 
-	bridgeCommitmentTx := fsm.getBridgeCommitmentTx()
-
-	// add commit epoch tx to the end of transactions list
-	tx, err := fsm.createCommitEpochTx()
+	bridgeCommitmentTx, err := fsm.createBridgeCommitmentTx()
 	require.NoError(t, err)
 
-	err = fsm.VerifyStateTransactions([]*types.Transaction{tx, bridgeCommitmentTx})
+	// add commit epoch commitEpochTx to the end of transactions list
+	commitEpochTx, err := fsm.createCommitEpochTx()
+	require.NoError(t, err)
+
+	err = fsm.VerifyStateTransactions([]*types.Transaction{commitEpochTx, bridgeCommitmentTx})
 	require.ErrorContains(t, err, "invalid signature")
 }
 
@@ -1013,7 +1015,8 @@ func TestFSM_DecodeCommitmentStateTxs(t *testing.T) {
 		logger:                       hclog.NewNullLogger(),
 	}
 
-	bridgeCommitmentTx := f.getBridgeCommitmentTx()
+	bridgeCommitmentTx, err := f.createBridgeCommitmentTx()
+	require.NoError(t, err)
 
 	decodedData, err := decodeStateTransaction(bridgeCommitmentTx.Input)
 	require.NoError(t, err)


### PR DESCRIPTION
# Description

As `stateTransactions` function returns only single transaction, which is the one for bridge commitment registration, it is renamed and it's signature is changed, so it returns only single instance instead of slice.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
