### PR TITLE
Disable console precompile for prod networks

### DIFF
--- a/state/runtime/precompiled/precompiled.go
+++ b/state/runtime/precompiled/precompiled.go
@@ -77,7 +77,7 @@ func (p *Precompiled) setupContracts() {
 	p.register(contracts.BLSAggSigsVerificationPrecompile.String(), &blsAggSignsVerification{})
 
 	// Console precompile
-	p.register(contracts.ConsolePrecompile.String(), &console{})
+	// p.register(contracts.ConsolePrecompile.String(), &console{})
 }
 
 func (p *Precompiled) register(addrStr string, b contract) {

--- a/state/runtime/precompiled/precompiled.go
+++ b/state/runtime/precompiled/precompiled.go
@@ -73,11 +73,11 @@ func (p *Precompiled) setupContracts() {
 	// Native transfer precompile
 	p.register(contracts.NativeTransferPrecompile.String(), &nativeTransfer{})
 
-	// BLS aggregated signatures verification precompile
-	p.register(contracts.BLSAggSigsVerificationPrecompile.String(), &blsAggSignsVerification{})
-
 	// Console precompile
 	// p.register(contracts.ConsolePrecompile.String(), &console{})
+
+	// BLS aggregated signatures verification precompile
+	p.register(contracts.BLSAggSigsVerificationPrecompile.String(), &blsAggSignsVerification{})
 }
 
 func (p *Precompiled) register(addrStr string, b contract) {


### PR DESCRIPTION
# Description

Only local development networks have a use case to deploy the `console.log` utilities, but, in the production scenarios in which `Edge` is meant to run, this precompile is not necessary and could introduce attack vectors (i.e. Ddos the logs). This PR disables the precompile altogether. I would propose discussing two options to follow this up:
- To introduce a `--console` flag that enables the precompile. This could only run in local networks and not distributed networks since it would break consensus (some nodes logging and others not and consuming gas).
- To leave it like this and uncomment the line in the cases where we need to debug something from the local smart contracts.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
