### PR TITLE
Forbid premining validators in the genesis cmd

### DIFF
--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -341,13 +341,13 @@ func (p *genesisParams) initGenesisConfig() error {
 	}
 
 	for _, premineRaw := range p.premine {
-		premineInfo, err := parsePremineInfo(premineRaw)
+		premineInfo, err := ParsePremineInfo(premineRaw)
 		if err != nil {
 			return err
 		}
 
-		chainConfig.Genesis.Alloc[premineInfo.address] = &chain.GenesisAccount{
-			Balance: premineInfo.balance,
+		chainConfig.Genesis.Alloc[premineInfo.Address] = &chain.GenesisAccount{
+			Balance: premineInfo.Balance,
 		}
 	}
 

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -139,9 +139,9 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 		// genesis validators balances must be defined in manifest file and should not be changed in the genesis
 		if _, ok := genesisValidators[premineInfo.Address]; ok {
 			premineValidatorsAddrs = append(premineValidatorsAddrs, premineInfo.Address.String())
+		} else {
+			premineInfos[i] = premineInfo
 		}
-
-		premineInfos[i] = premineInfo
 	}
 
 	// if there are any premined validators in the genesis command, consider it as an error

--- a/command/genesis/utils.go
+++ b/command/genesis/utils.go
@@ -62,13 +62,13 @@ func verifyGenesisExistence(genesisPath string) *GenesisGenError {
 	return nil
 }
 
-type premineInfo struct {
-	address types.Address
-	balance *big.Int
+type PremineInfo struct {
+	Address types.Address
+	Balance *big.Int
 }
 
-// parsePremineInfo parses provided premine information and returns premine address and premine balance
-func parsePremineInfo(premineInfoRaw string) (*premineInfo, error) {
+// ParsePremineInfo parses provided premine information and returns premine address and premine balance
+func ParsePremineInfo(premineInfoRaw string) (*PremineInfo, error) {
 	var (
 		address types.Address
 		val     = command.DefaultPremineBalance
@@ -87,7 +87,7 @@ func parsePremineInfo(premineInfoRaw string) (*premineInfo, error) {
 		return nil, fmt.Errorf("failed to parse amount %s: %w", val, err)
 	}
 
-	return &premineInfo{address: address, balance: amount}, nil
+	return &PremineInfo{Address: address, Balance: amount}, nil
 }
 
 // parseTrackerStartBlocks parses provided event tracker start blocks configuration.

--- a/consensus/polybft/extra.go
+++ b/consensus/polybft/extra.go
@@ -417,7 +417,7 @@ func (d *ValidatorSetDelta) Copy() *ValidatorSetDelta {
 
 // fmt.Stringer interface implementation
 func (d *ValidatorSetDelta) String() string {
-	return fmt.Sprintf("Added: \n%v Removed: %v\n Updated: \n%v\n", d.Added, d.Removed, d.Updated)
+	return fmt.Sprintf("Added: \n%v Removed: %v\n Updated: \n%v", d.Added, d.Removed, d.Updated)
 }
 
 // Signature represents aggregated signatures of signers accompanied with a bitmap

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -121,7 +121,12 @@ func TestE2E_Consensus_RegisterValidator(t *testing.T) {
 	cluster := framework.NewTestCluster(t, validatorSize,
 		framework.WithEpochSize(epochSize),
 		framework.WithEpochReward(epochReward),
-		framework.WithPremineValidators(premineBalance))
+		framework.WithSecretsCallback(func(addresses []types.Address, config *framework.TestClusterConfig) {
+			for _, a := range addresses {
+				config.PremineValidators = append(config.PremineValidators, fmt.Sprintf("%s:%s", a, premineBalance))
+			}
+		}),
+	)
 	defer cluster.Stop()
 
 	// first validator is the owner of ChildValidator set smart contract
@@ -327,8 +332,13 @@ func TestE2E_Consensus_Delegation_Undelegation(t *testing.T) {
 
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithEpochReward(100000),
-		framework.WithPremineValidators(premineBalance),
-		framework.WithEpochSize(epochSize))
+		framework.WithEpochSize(epochSize),
+		framework.WithSecretsCallback(func(addresses []types.Address, config *framework.TestClusterConfig) {
+			for _, a := range addresses {
+				config.PremineValidators = append(config.PremineValidators, fmt.Sprintf("%s:%s", a, premineBalance))
+			}
+		}),
+	)
 	defer cluster.Stop()
 
 	// init delegator account
@@ -428,11 +438,18 @@ func TestE2E_Consensus_Delegation_Undelegation(t *testing.T) {
 }
 
 func TestE2E_Consensus_Validator_Unstake(t *testing.T) {
+	const premineAmount = "10000000000000000000" // 10 native tokens
+
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithBridge(),
 		framework.WithEpochReward(10000),
 		framework.WithEpochSize(5),
-		framework.WithPremineValidators("10000000000000000000")) // 10 native tokens
+		framework.WithSecretsCallback(func(addresses []types.Address, config *framework.TestClusterConfig) {
+			for _, a := range addresses {
+				config.PremineValidators = append(config.PremineValidators, fmt.Sprintf("%s:%s", a, premineAmount))
+			}
+		}),
+	)
 	validatorSecrets := path.Join(cluster.Config.TmpDir, "test-chain-1")
 	srv := cluster.Servers[0]
 
@@ -532,7 +549,6 @@ func TestE2E_Consensus_CorrectnessOfExtraValidatorsShouldNotDependOnDelegate(t *
 
 	cluster := framework.NewTestCluster(t, validatorCount,
 		framework.WithEpochReward(100000),
-		framework.WithPremineValidators(premineBalance),
 		framework.WithEpochSize(epochSize))
 	defer cluster.Stop()
 

--- a/e2e-polybft/property/property_test.go
+++ b/e2e-polybft/property/property_test.go
@@ -38,7 +38,7 @@ func TestProperty_DifferentVotingPower(t *testing.T) {
 			framework.WithEpochSize(epochSize),
 			framework.WithSecretsCallback(func(adresses []types.Address, config *framework.TestClusterConfig) {
 				for i, a := range adresses {
-					config.Premine = append(config.Premine, fmt.Sprintf("%s:%d", a, premine[i]))
+					config.PremineValidators = append(config.PremineValidators, fmt.Sprintf("%s:%d", a, premine[i]))
 				}
 			}))
 		defer cluster.Stop()

--- a/state/runtime/evm/evm_test.go
+++ b/state/runtime/evm/evm_test.go
@@ -42,7 +42,7 @@ func (m *mockHost) SetState(
 	key types.Hash,
 	value types.Hash,
 ) {
-	panic("Not implemented in tests")
+	panic("Not implemented in tests") //nolint:gocritic
 }
 
 func (m *mockHost) SetStorage(

--- a/state/runtime/precompiled/native_transfer_test.go
+++ b/state/runtime/precompiled/native_transfer_test.go
@@ -93,7 +93,7 @@ func (d dummyHost) SetState(
 	key types.Hash,
 	value types.Hash,
 ) {
-	panic("Not implemented in tests")
+	d.t.Fatalf("SetState is not implemented")
 }
 
 func (d dummyHost) SetStorage(addr types.Address, key types.Hash, value types.Hash, config *chain.ForksInTime) runtime.StorageStatus {


### PR DESCRIPTION
# Description

This PR forbids premining genesis validators in the genesis command and allows providing premine information in a more granular way in the manifest command (`<validator address>:<balance>)`.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
