### PR TITLE
Fix polygon-edge.sh typos and shellcheck

### DIFF
--- a/docker/local/polygon-edge.sh
+++ b/docker/local/polygon-edge.sh
@@ -20,18 +20,19 @@ case "$1" in
          "ibft")
          if [ -f "$GENESIS_PATH" ]; then
               echo "Secrets have already been generated."
-          else
+         else
               echo "Generating secrets..."
               secrets=$("$POLYGON_EDGE_BIN" secrets init --insecure --num 4 --data-dir /data/data- --json)
               echo "Secrets have been successfully generated"
               echo "Generating IBFT Genesis file..."
-              cd /data && /polygon-edge/polygon-edge genesis  $CHAIN_CUSTOM_OPTIONS \
+              cd /data && /polygon-edge/polygon-edge genesis $CHAIN_CUSTOM_OPTIONS \
                 --dir genesis.json \
                 --consensus ibft \
                 --ibft-validators-prefix-path data- \
                 --validator-set-size=4 \
-                --bootnode /dns4/node-1/tcp/1478/p2p/$(echo $secrets | jq -r '.[0] | .node_id') \
-                --bootnode /dns4/node-2/tcp/1478/p2p/$(echo $secrets | jq -r '.[1] | .node_id') \
+                --bootnode "/dns4/node-1/tcp/1478/p2p/$(echo "$secrets" | jq -r '.[0] | .node_id')" \
+                --bootnode "/dns4/node-2/tcp/1478/p2p/$(echo "$secrets" | jq -r '.[1] | .node_id')"
+         fi
               ;;
           "polybft")
               echo "Generating PolyBFT secrets..."
@@ -47,8 +48,8 @@ case "$1" in
                 --consensus polybft \
                 --manifest /data/manifest.json \
                 --validator-set-size=4 \
-                --bootnode /dns4/node-1/tcp/1478/p2p/$(echo $secrets | jq -r '.[0] | .node_id') \
-                --bootnode /dns4/node-2/tcp/1478/p2p/$(echo $secrets | jq -r '.[1] | .node_id')
+                --bootnode "/dns4/node-1/tcp/1478/p2p/$(echo "$secrets" | jq -r '.[0] | .node_id')" \
+                --bootnode "/dns4/node-2/tcp/1478/p2p/$(echo "$secrets" | jq -r '.[1] | .node_id')"
               ;;
       esac
       ;;


### PR DESCRIPTION
polygon-edge.sh is missing a `fi` and has an erroneous trailing `\` around line 34.

shellcheck complains about globbing unquoted vars.