### PR TITLE
Simplify tokens amount providing in e2e tests

### DIFF
--- a/command/rootchain/initcontracts/init_contracts.go
+++ b/command/rootchain/initcontracts/init_contracts.go
@@ -3,7 +3,6 @@ package initcontracts
 import (
 	"fmt"
 	"math/big"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/umbracle/ethgo"
@@ -220,17 +219,10 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 
 	// if running in test mode, we need to fund deployer account
 	if params.isTestMode {
-		fundAmountRaw := strings.TrimPrefix(command.DefaultPremineBalance, "0x")
-
-		fundAmount, ok := new(big.Int).SetString(fundAmountRaw, 16)
-		if !ok {
-			return fmt.Errorf("failed to parse provided fund amount: %s", fundAmountRaw)
-		}
-
 		// fund account
 		deployerAddress := deployerKey.Address()
 
-		txn := &ethgo.Transaction{To: &deployerAddress, Value: fundAmount}
+		txn := &ethgo.Transaction{To: &deployerAddress, Value: ethgo.Ether(1e6)}
 		if _, err := txRelayer.SendTransactionLocal(txn); err != nil {
 			return err
 		}


### PR DESCRIPTION
# Description

This PR uses helper functions from `ethgo`, which enables tests to be more verbose, by using `ethgo.Ether` and `ethgo.Gwei,` instead of specifying huge strings representing token amounts, which are hard for understanding.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
