### PR TITLE
Some SyncPeerStatus messages were not published

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -928,6 +928,7 @@ func (b *Blockchain) WriteFullBlock(fblock *types.FullBlock, source string) erro
 		"txs", len(block.Transactions),
 		"hash", header.Hash,
 		"parent", header.ParentHash,
+		"source", source,
 	}
 
 	if prevHeader, ok := b.GetHeaderByNumber(header.Number - 1); ok {
@@ -992,6 +993,7 @@ func (b *Blockchain) WriteBlock(block *types.Block, source string) error {
 		"txs", len(block.Transactions),
 		"hash", header.Hash,
 		"parent", header.ParentHash,
+		"source", source,
 	}
 
 	if prevHeader, ok := b.GetHeaderByNumber(header.Number - 1); ok {

--- a/blockchain/subscription.go
+++ b/blockchain/subscription.go
@@ -19,49 +19,19 @@ type Subscription interface {
 // FOR TESTING PURPOSES //
 
 type MockSubscription struct {
-	updateCh chan *Event // Channel for update information
-	closeCh  chan void   // Channel for close signals
+	*subscription
 }
 
 func NewMockSubscription() *MockSubscription {
 	return &MockSubscription{
-		updateCh: make(chan *Event),
-		closeCh:  make(chan void),
+		subscription: &subscription{
+			updateCh: make(chan *Event),
+			closeCh:  make(chan void),
+		},
 	}
 }
-
 func (m *MockSubscription) Push(e *Event) {
 	m.updateCh <- e
-}
-
-func (m *MockSubscription) GetEventCh() chan *Event {
-	eventCh := make(chan *Event)
-
-	go func() {
-		for {
-			evnt := m.GetEvent()
-			if evnt == nil {
-				return
-			}
-			eventCh <- evnt
-		}
-	}()
-
-	return eventCh
-}
-
-func (m *MockSubscription) GetEvent() *Event {
-	// Wait for an update
-	select {
-	case ev := <-m.updateCh:
-		return ev
-	case <-m.closeCh:
-		return nil
-	}
-}
-
-func (m *MockSubscription) Close() {
-	close(m.closeCh)
 }
 
 // subscription is the Blockchain event subscription object

--- a/blockchain/subscription.go
+++ b/blockchain/subscription.go
@@ -51,14 +51,12 @@ func (m *MockSubscription) GetEventCh() chan *Event {
 }
 
 func (m *MockSubscription) GetEvent() *Event {
-	for {
-		// Wait for an update
-		select {
-		case ev := <-m.updateCh:
-			return ev
-		case <-m.closeCh:
-			return nil
-		}
+	// Wait for an update
+	select {
+	case ev := <-m.updateCh:
+		return ev
+	case <-m.closeCh:
+		return nil
 	}
 }
 
@@ -91,14 +89,12 @@ func (s *subscription) GetEventCh() chan *Event {
 
 // GetEvent returns the event from the subscription (BLOCKING)
 func (s *subscription) GetEvent() *Event {
-	for {
-		// Wait for an update
-		select {
-		case ev := <-s.updateCh:
-			return ev
-		case <-s.closeCh:
-			return nil
-		}
+	// Wait for an update
+	select {
+	case ev := <-s.updateCh:
+		return ev
+	case <-s.closeCh:
+		return nil
 	}
 }
 

--- a/syncer/client.go
+++ b/syncer/client.go
@@ -226,6 +226,7 @@ func (m *syncPeerClient) handleStatusUpdate(obj interface{}, from peer.ID) {
 // startNewBlockProcess starts blockchain event subscription
 func (m *syncPeerClient) startNewBlockProcess() {
 	m.subscription = m.blockchain.SubscribeEvents()
+	eventCh := m.subscription.GetEventCh()
 
 	for {
 		var event *blockchain.Event
@@ -233,7 +234,7 @@ func (m *syncPeerClient) startNewBlockProcess() {
 		select {
 		case <-m.closeCh:
 			return
-		case event = <-m.subscription.GetEventCh():
+		case event = <-eventCh:
 		}
 
 		if !m.shouldEmitBlocks {

--- a/syncer/client_test.go
+++ b/syncer/client_test.go
@@ -524,3 +524,102 @@ func Test_syncPeerClient_GetBlocks(t *testing.T) {
 
 	assert.Equal(t, expected, blocks)
 }
+
+func Test_EmitMultipleBlocks(t *testing.T) {
+	t.Parallel()
+
+	var (
+		// network layer
+		clientSrv = newTestNetwork(t)
+		peerSrv   = newTestNetwork(t)
+
+		clientLatest = uint64(10)
+
+		subscription = blockchain.NewMockSubscription()
+
+		client = newTestSyncPeerClient(clientSrv, &mockBlockchain{
+			subscription:  subscription,
+			headerHandler: newSimpleHeaderHandler(clientLatest),
+		})
+	)
+
+	t.Cleanup(func() {
+		clientSrv.Close()
+		peerSrv.Close()
+		client.Close()
+	})
+
+	err := network.JoinAndWaitMultiple(
+		network.DefaultJoinTimeout,
+		clientSrv,
+		peerSrv,
+	)
+
+	assert.NoError(t, err)
+
+	// start gossip
+	assert.NoError(t, client.startGossip())
+
+	// start to subscribe blockchain events
+	go client.startNewBlockProcess()
+
+	// push latest block number to blockchain subscription
+	pushSubscription := func(sub *blockchain.MockSubscription, latest uint64) {
+		sub.Push(&blockchain.Event{
+			NewChain: []*types.Header{
+				{
+					Number: latest,
+				},
+			},
+		})
+	}
+
+	waitForGossip := func(wg *sync.WaitGroup) bool {
+		c := make(chan struct{})
+		go func() {
+			defer close(c)
+			wg.Wait()
+		}()
+		select {
+		case <-c:
+			return true
+		case <-time.After(5 * time.Second):
+			return false
+		}
+	}
+
+	// create topic & subscribe in peer
+	topic, err := peerSrv.NewTopic(statusTopicName, &proto.SyncPeerStatus{})
+	assert.NoError(t, err)
+
+	testGossip := func(t *testing.T, blocksNum int) {
+		t.Helper()
+
+		var wgForGossip sync.WaitGroup
+
+		wgForGossip.Add(blocksNum)
+
+		assert.NoError(t, topic.Subscribe(func(_ interface{}, id peer.ID) {
+			wgForGossip.Done()
+		}))
+
+		// need to wait for a few seconds to propagate subscribing
+		time.Sleep(2 * time.Second)
+		client.EnablePublishingPeerStatus()
+
+		go func() {
+			for i := 0; i < blocksNum; i++ {
+				pushSubscription(subscription, clientLatest+uint64(i))
+			}
+		}()
+
+		gossiped := waitForGossip(&wgForGossip)
+
+		assert.Equal(t, true, gossiped)
+	}
+
+	t.Run("should receive all blocks", func(t *testing.T) {
+		t.Parallel()
+		testGossip(t, 4)
+	})
+}

--- a/syncer/client_test.go
+++ b/syncer/client_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/0xPolygon/polygon-edge/blockchain"
 	"github.com/0xPolygon/polygon-edge/network"
@@ -555,10 +556,10 @@ func Test_EmitMultipleBlocks(t *testing.T) {
 		peerSrv,
 	)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// start gossip
-	assert.NoError(t, client.startGossip())
+	require.NoError(t, client.startGossip())
 
 	// start to subscribe blockchain events
 	go client.startNewBlockProcess()
@@ -599,7 +600,7 @@ func Test_EmitMultipleBlocks(t *testing.T) {
 
 		wgForGossip.Add(blocksNum)
 
-		assert.NoError(t, topic.Subscribe(func(_ interface{}, id peer.ID) {
+		require.NoError(t, topic.Subscribe(func(_ interface{}, _ peer.ID) {
 			wgForGossip.Done()
 		}))
 
@@ -615,7 +616,7 @@ func Test_EmitMultipleBlocks(t *testing.T) {
 
 		gossiped := waitForGossip(&wgForGossip)
 
-		assert.Equal(t, true, gossiped)
+		require.Equal(t, true, gossiped)
 	}
 
 	t.Run("should receive all blocks", func(t *testing.T) {


### PR DESCRIPTION
The problem fixed in this PR is related to publishing SyncPeerStatus. Some messages were not published because of the bug in startNewBlockProcess fn of syncPeerClient where each time after the notification is dispatched on block insertions the new channel is created for the same syncPeerClient subscription. This could be noticed on non validator nodes since they are not producing block but instead receiving them upon SyncPeerStatus is published (when syncer's newStatusCh is set). On those nodes as reproduced on the test system as well, blocks were not arriving one by one.
-The main fix is in syncer/client.go
-Unit test is written and for that purpose,  mocked subscriber is adjusted to look more like real subscriber in order to be able to test this scenario (it does not affect other test, the previous version was more simplified because it was sufficient for existing tests). 
-blockchain.go is changed because source of the block is added to the log since we have that data and it can be useful 

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually