### PR TITLE
EVM-535: Use contractsapi bindings throught code

### DIFF
--- a/command/bridge/exit/exit.go
+++ b/command/bridge/exit/exit.go
@@ -233,7 +233,8 @@ func createExitTxn(sender ethgo.Address, proof types.Proof) (*ethgo.Transaction,
 		return nil, nil, fmt.Errorf("failed to unmarshal exit event from JSON. Error: %w", err)
 	}
 
-	exitEventEncoded, err := polybft.ExitEventInputsABIType.Encode(exitEvent)
+	var exitEventApi contractsapi.L2StateSyncedEvent
+	exitEventEncoded, err := exitEventApi.Encode(exitEvent)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to encode exit event: %w", err)
 	}

--- a/command/bridge/exit/exit.go
+++ b/command/bridge/exit/exit.go
@@ -233,8 +233,9 @@ func createExitTxn(sender ethgo.Address, proof types.Proof) (*ethgo.Transaction,
 		return nil, nil, fmt.Errorf("failed to unmarshal exit event from JSON. Error: %w", err)
 	}
 
-	var exitEventApi contractsapi.L2StateSyncedEvent
-	exitEventEncoded, err := exitEventApi.Encode(exitEvent)
+	var exitEventAPI contractsapi.L2StateSyncedEvent
+
+	exitEventEncoded, err := exitEventAPI.Encode(exitEvent)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to encode exit event: %w", err)
 	}

--- a/command/bridge/withdraw/withdraw_erc20.go
+++ b/command/bridge/withdraw/withdraw_erc20.go
@@ -16,7 +16,6 @@ import (
 	cmdHelper "github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	"github.com/0xPolygon/polygon-edge/command/sidechain"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
@@ -211,13 +210,14 @@ func createWithdrawTxn(receiver types.Address, amount *big.Int) (*ethgo.Transact
 
 // extractExitEventID tries to extract exit event id from provided receipt
 func extractExitEventID(receipt *ethgo.Receipt) (*big.Int, error) {
+	var exitEvent contractsapi.L2StateSyncedEvent
 	for _, log := range receipt.Logs {
-		if !polybft.ExitEventABI.Match(log) {
+		doesMatch, err := exitEvent.ParseLog(log)
+		if !doesMatch {
 			continue
 		}
 
-		exitEvent := &contractsapi.L2StateSyncedEvent{}
-		if err := exitEvent.ParseLog(log); err != nil {
+		if err != nil {
 			return nil, err
 		}
 

--- a/command/sidechain/registration/register_validator.go
+++ b/command/sidechain/registration/register_validator.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/big"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/helper"
@@ -21,10 +20,8 @@ import (
 )
 
 var (
-	stakeManager         = contracts.ValidatorSetContract
-	stakeFn              = contractsapi.ChildValidatorSet.Abi.Methods["stake"]
-	newValidatorEventABI = contractsapi.ChildValidatorSet.Abi.Events["NewValidator"]
-	stakeEventABI        = contractsapi.ChildValidatorSet.Abi.Events["Staked"]
+	stakeManager = contracts.ValidatorSetContract
+	stakeFn      = contractsapi.ChildValidatorSet.Abi.Methods["stake"]
 )
 
 var params registerParams
@@ -127,20 +124,23 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	result := &registerResult{}
 	foundLog := false
 
+	var newValidatorEvent contractsapi.NewValidatorEvent
 	for _, log := range receipt.Logs {
-		if newValidatorEventABI.Match(log) {
-			event, err := newValidatorEventABI.ParseLog(log)
-			if err != nil {
-				return err
-			}
-
-			result.validatorAddress = event["validator"].(ethgo.Address).String() //nolint:forcetypeassert
-			result.stakeResult = "No stake parameters have been submitted"
-			result.amount = 0
-			foundLog = true
-
-			break
+		doesMatch, err := newValidatorEvent.ParseLog(log)
+		if !doesMatch {
+			continue
 		}
+
+		if err != nil {
+			return err
+		}
+
+		result.validatorAddress = newValidatorEvent.Validator.String()
+		result.stakeResult = "No stake parameters have been submitted"
+		result.amount = 0
+		foundLog = true
+
+		break
 	}
 
 	if !foundLog {
@@ -193,20 +193,23 @@ func populateStakeResults(receipt *ethgo.Receipt, result *registerResult) {
 	}
 
 	// check the logs to verify stake
+	var stakedEvent contractsapi.StakedEvent
 	for _, log := range receipt.Logs {
-		if stakeEventABI.Match(log) {
-			event, err := stakeEventABI.ParseLog(log)
-			if err != nil {
-				result.stakeResult = "Failed to parse stake log"
+		doesMatch, err := stakedEvent.ParseLog(log)
+		if !doesMatch {
+			continue
+		}
 
-				return
-			}
-
-			result.amount = event["amount"].(*big.Int).Uint64() //nolint:forcetypeassert
-			result.stakeResult = "Stake succeeded"
+		if err != nil {
+			result.stakeResult = "Failed to parse stake log"
 
 			return
 		}
+
+		result.amount = stakedEvent.Amount.Uint64()
+		result.stakeResult = "Stake succeeded"
+
+		return
 	}
 
 	result.stakeResult = "Could not find an appropriate log in receipt that stake happened"

--- a/command/sidechain/whitelist/whitelist_validator.go
+++ b/command/sidechain/whitelist/whitelist_validator.go
@@ -78,7 +78,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("enlist validator failed: %w", err)
 	}
 
-	whitelistFn := &contractsapi.AddToWhitelistFunction{
+	whitelistFn := &contractsapi.AddToWhitelistChildValidatorSetFn{
 		WhitelistAddreses: []ethgo.Address{ethgo.Address(types.StringToAddress(params.newValidatorAddress))},
 	}
 

--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -396,7 +396,8 @@ func (c *checkpointManager) GenerateExitProof(exitID uint64) (types.Proof, error
 		return types.Proof{}, fmt.Errorf("checkpoint block not found for exit ID %d", exitID)
 	}
 
-	e, err := ExitEventInputsABIType.Encode(exitEvent)
+	var exitEventApi contractsapi.L2StateSyncedEvent
+	e, err := exitEventApi.Encode(exitEvent)
 	if err != nil {
 		return types.Proof{}, err
 	}
@@ -474,8 +475,9 @@ func createExitTree(exitEvents []*ExitEvent) (*merkle.MerkleTree, error) {
 	numOfEvents := len(exitEvents)
 	data := make([][]byte, numOfEvents)
 
+	var exitEventApi contractsapi.L2StateSyncedEvent
 	for i := 0; i < numOfEvents; i++ {
-		b, err := ExitEventInputsABIType.Encode(exitEvents[i])
+		b, err := exitEventApi.Encode(exitEvents[i])
 		if err != nil {
 			return nil, err
 		}

--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -396,8 +396,9 @@ func (c *checkpointManager) GenerateExitProof(exitID uint64) (types.Proof, error
 		return types.Proof{}, fmt.Errorf("checkpoint block not found for exit ID %d", exitID)
 	}
 
-	var exitEventApi contractsapi.L2StateSyncedEvent
-	e, err := exitEventApi.Encode(exitEvent)
+	var exitEventAPI contractsapi.L2StateSyncedEvent
+
+	e, err := exitEventAPI.Encode(exitEvent)
 	if err != nil {
 		return types.Proof{}, err
 	}
@@ -475,9 +476,9 @@ func createExitTree(exitEvents []*ExitEvent) (*merkle.MerkleTree, error) {
 	numOfEvents := len(exitEvents)
 	data := make([][]byte, numOfEvents)
 
-	var exitEventApi contractsapi.L2StateSyncedEvent
+	var exitEventAPI contractsapi.L2StateSyncedEvent
 	for i := 0; i < numOfEvents; i++ {
-		b, err := exitEventApi.Encode(exitEvents[i])
+		b, err := exitEventAPI.Encode(exitEvents[i])
 		if err != nil {
 			return nil, err
 		}

--- a/consensus/polybft/checkpoint_manager_test.go
+++ b/consensus/polybft/checkpoint_manager_test.go
@@ -519,8 +519,10 @@ func getBlockNumberCheckpointSubmitInput(t *testing.T, input []byte) uint64 {
 func createTestLogForExitEvent(t *testing.T, exitEventID uint64) *types.Log {
 	t.Helper()
 
+	var exitEvent contractsapi.L2StateSyncedEvent
+
 	topics := make([]types.Hash, 4)
-	topics[0] = types.Hash(contractsapi.L2StateSender.Abi.Events["L2StateSynced"].ID())
+	topics[0] = types.Hash(exitEvent.Sig())
 	topics[1] = types.BytesToHash(common.EncodeUint64ToBytes(exitEventID))
 	topics[2] = types.BytesToHash(types.StringToAddress("0x1111").Bytes())
 	topics[3] = types.BytesToHash(types.StringToAddress("0x2222").Bytes())

--- a/consensus/polybft/checkpoint_manager_test.go
+++ b/consensus/polybft/checkpoint_manager_test.go
@@ -520,7 +520,7 @@ func createTestLogForExitEvent(t *testing.T, exitEventID uint64) *types.Log {
 	t.Helper()
 
 	topics := make([]types.Hash, 4)
-	topics[0] = types.Hash(ExitEventABI.ID())
+	topics[0] = types.Hash(contractsapi.L2StateSender.Abi.Events["L2StateSynced"].ID())
 	topics[1] = types.BytesToHash(common.EncodeUint64ToBytes(exitEventID))
 	topics[2] = types.BytesToHash(types.StringToAddress("0x1111").Bytes())
 	topics[3] = types.BytesToHash(types.StringToAddress("0x2222").Bytes())

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -157,8 +157,8 @@ func (c *consensusRuntime) close() {
 func (c *consensusRuntime) initStateSyncManager(logger hcf.Logger) error {
 	if c.IsBridgeEnabled() {
 		stateSenderAddr := c.config.PolyBFTConfig.Bridge.BridgeAddr
-		stateSyncManager, err := NewStateSyncManager(
-			logger,
+		stateSyncManager, err := newStateSyncManager(
+			logger.Named("state-sync-manager"),
 			c.config.State,
 			&stateSyncConfig{
 				key:                   c.config.Key,

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/0xPolygon/go-ibft/messages/proto"
 	"github.com/0xPolygon/polygon-edge/consensus"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
@@ -1175,8 +1176,9 @@ func encodeExitEvents(t *testing.T, exitEvents []*ExitEvent) [][]byte {
 
 	encodedEvents := make([][]byte, len(exitEvents))
 
+	var exitEventApi contractsapi.L2StateSyncedEvent
 	for i, e := range exitEvents {
-		encodedEvent, err := ExitEventInputsABIType.Encode(e)
+		encodedEvent, err := exitEventApi.Encode(e)
 		require.NoError(t, err)
 
 		encodedEvents[i] = encodedEvent

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1176,9 +1176,9 @@ func encodeExitEvents(t *testing.T, exitEvents []*ExitEvent) [][]byte {
 
 	encodedEvents := make([][]byte, len(exitEvents))
 
-	var exitEventApi contractsapi.L2StateSyncedEvent
+	var exitEventAPI contractsapi.L2StateSyncedEvent
 	for i, e := range exitEvents {
-		encodedEvent, err := exitEventApi.Encode(e)
+		encodedEvent, err := exitEventAPI.Encode(e)
 		require.NoError(t, err)
 
 		encodedEvents[i] = encodedEvent

--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -55,7 +55,15 @@ func main() {
 				"addToWhitelist",
 				"register",
 			},
-			[]string{},
+			[]string{
+				"NewValidator",
+				"Staked",
+				"Delegated",
+				"Unstaked",
+				"Undelegated",
+				"AddedToWhitelist",
+				"Withdrawal",
+			},
 		},
 		{
 			"StateSender",
@@ -334,8 +342,16 @@ func generateEvent(generatedData *generatedData, contractName string, event *abi
 	{{.}}
 {{ end }}
 
-func ({{.Sig}} *{{.TName}}) ParseLog(log *ethgo.Log) error {
-	return decodeEvent({{.ContractName}}.Abi.Events["{{.Name}}"], log, {{.Sig}})
+func ({{.Sig}} *{{.TName}}) Encode(inputs interface{}) ([]byte, error) {
+	return {{.ContractName}}.Abi.Events["{{.Name}}"].Inputs.Encode(inputs)
+}
+
+func ({{.Sig}} *{{.TName}}) ParseLog(log *ethgo.Log) (bool, error) {
+	if (!{{.ContractName}}.Abi.Events["{{.Name}}"].Match(log)) {
+		return false, nil
+	}
+
+	return true, decodeEvent({{.ContractName}}.Abi.Events["{{.Name}}"], log, {{.Sig}})
 }`
 
 	inputs := map[string]interface{}{

--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -342,11 +342,11 @@ func generateEvent(generatedData *generatedData, contractName string, event *abi
 	{{.}}
 {{ end }}
 
-func ({{.Sig}} *{{.TName}}) Sig() ethgo.Hash {
+func (*{{.TName}}) Sig() ethgo.Hash {
 	return {{.ContractName}}.Abi.Events["{{.Name}}"].ID()
 }
 
-func ({{.Sig}} *{{.TName}}) Encode(inputs interface{}) ([]byte, error) {
+func (*{{.TName}}) Encode(inputs interface{}) ([]byte, error) {
 	return {{.ContractName}}.Abi.Events["{{.Name}}"].Inputs.Encode(inputs)
 }
 

--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -342,6 +342,10 @@ func generateEvent(generatedData *generatedData, contractName string, event *abi
 	{{.}}
 {{ end }}
 
+func ({{.Sig}} *{{.TName}}) Sig() ethgo.Hash {
+	return {{.ContractName}}.Abi.Events["{{.Name}}"].ID()
+}
+
 func ({{.Sig}} *{{.TName}}) Encode(inputs interface{}) ([]byte, error) {
 	return {{.ContractName}}.Abi.Events["{{.Name}}"].Inputs.Encode(inputs)
 }
@@ -387,6 +391,10 @@ func generateFunction(generatedData *generatedData, contractName string, method 
 {{range .Structs}}
 	{{.}}
 {{ end }}
+
+func ({{.Sig}} *{{.TName}}) Sig() []byte {
+	return {{.ContractName}}.Abi.Methods["{{.Name}}"].ID()
+}
 
 func ({{.Sig}} *{{.TName}}) EncodeAbi() ([]byte, error) {
 	return {{.ContractName}}.Abi.Methods["{{.Name}}"].Encode({{.Sig}})

--- a/consensus/polybft/contractsapi/contractsapi.go
+++ b/consensus/polybft/contractsapi/contractsapi.go
@@ -75,6 +75,10 @@ type StateSyncResultEvent struct {
 	Message []byte   `abi:"message"`
 }
 
+func (s *StateSyncResultEvent) Sig() ethgo.Hash {
+	return StateReceiver.Abi.Events["StateSyncResult"].ID()
+}
+
 func (s *StateSyncResultEvent) Encode(inputs interface{}) ([]byte, error) {
 	return StateReceiver.Abi.Events["StateSyncResult"].Inputs.Encode(inputs)
 }
@@ -91,6 +95,10 @@ type NewCommitmentEvent struct {
 	StartID *big.Int   `abi:"startId"`
 	EndID   *big.Int   `abi:"endId"`
 	Root    types.Hash `abi:"root"`
+}
+
+func (n *NewCommitmentEvent) Sig() ethgo.Hash {
+	return StateReceiver.Abi.Events["NewCommitment"].ID()
 }
 
 func (n *NewCommitmentEvent) Encode(inputs interface{}) ([]byte, error) {
@@ -260,6 +268,10 @@ type StateSyncedEvent struct {
 	Data     []byte        `abi:"data"`
 }
 
+func (s *StateSyncedEvent) Sig() ethgo.Hash {
+	return StateSender.Abi.Events["StateSynced"].ID()
+}
+
 func (s *StateSyncedEvent) Encode(inputs interface{}) ([]byte, error) {
 	return StateSender.Abi.Events["StateSynced"].Inputs.Encode(inputs)
 }
@@ -277,6 +289,10 @@ type L2StateSyncedEvent struct {
 	Sender   types.Address `abi:"sender"`
 	Receiver types.Address `abi:"receiver"`
 	Data     []byte        `abi:"data"`
+}
+
+func (l *L2StateSyncedEvent) Sig() ethgo.Hash {
+	return L2StateSender.Abi.Events["L2StateSynced"].ID()
 }
 
 func (l *L2StateSyncedEvent) Encode(inputs interface{}) ([]byte, error) {

--- a/consensus/polybft/contractsapi/contractsapi.go
+++ b/consensus/polybft/contractsapi/contractsapi.go
@@ -75,8 +75,16 @@ type StateSyncResultEvent struct {
 	Message []byte   `abi:"message"`
 }
 
-func (s *StateSyncResultEvent) ParseLog(log *ethgo.Log) error {
-	return decodeEvent(StateReceiver.Abi.Events["StateSyncResult"], log, s)
+func (s *StateSyncResultEvent) Encode(inputs interface{}) ([]byte, error) {
+	return StateReceiver.Abi.Events["StateSyncResult"].Inputs.Encode(inputs)
+}
+
+func (s *StateSyncResultEvent) ParseLog(log *ethgo.Log) (bool, error) {
+	if !StateReceiver.Abi.Events["StateSyncResult"].Match(log) {
+		return false, nil
+	}
+
+	return true, decodeEvent(StateReceiver.Abi.Events["StateSyncResult"], log, s)
 }
 
 type NewCommitmentEvent struct {
@@ -85,8 +93,16 @@ type NewCommitmentEvent struct {
 	Root    types.Hash `abi:"root"`
 }
 
-func (n *NewCommitmentEvent) ParseLog(log *ethgo.Log) error {
-	return decodeEvent(StateReceiver.Abi.Events["NewCommitment"], log, n)
+func (n *NewCommitmentEvent) Encode(inputs interface{}) ([]byte, error) {
+	return StateReceiver.Abi.Events["NewCommitment"].Inputs.Encode(inputs)
+}
+
+func (n *NewCommitmentEvent) ParseLog(log *ethgo.Log) (bool, error) {
+	if !StateReceiver.Abi.Events["NewCommitment"].Match(log) {
+		return false, nil
+	}
+
+	return true, decodeEvent(StateReceiver.Abi.Events["NewCommitment"], log, n)
 }
 
 type Epoch struct {
@@ -244,8 +260,16 @@ type StateSyncedEvent struct {
 	Data     []byte        `abi:"data"`
 }
 
-func (s *StateSyncedEvent) ParseLog(log *ethgo.Log) error {
-	return decodeEvent(StateSender.Abi.Events["StateSynced"], log, s)
+func (s *StateSyncedEvent) Encode(inputs interface{}) ([]byte, error) {
+	return StateSender.Abi.Events["StateSynced"].Inputs.Encode(inputs)
+}
+
+func (s *StateSyncedEvent) ParseLog(log *ethgo.Log) (bool, error) {
+	if !StateSender.Abi.Events["StateSynced"].Match(log) {
+		return false, nil
+	}
+
+	return true, decodeEvent(StateSender.Abi.Events["StateSynced"], log, s)
 }
 
 type L2StateSyncedEvent struct {
@@ -255,8 +279,16 @@ type L2StateSyncedEvent struct {
 	Data     []byte        `abi:"data"`
 }
 
-func (l *L2StateSyncedEvent) ParseLog(log *ethgo.Log) error {
-	return decodeEvent(L2StateSender.Abi.Events["L2StateSynced"], log, l)
+func (l *L2StateSyncedEvent) Encode(inputs interface{}) ([]byte, error) {
+	return L2StateSender.Abi.Events["L2StateSynced"].Inputs.Encode(inputs)
+}
+
+func (l *L2StateSyncedEvent) ParseLog(log *ethgo.Log) (bool, error) {
+	if !L2StateSender.Abi.Events["L2StateSynced"].Match(log) {
+		return false, nil
+	}
+
+	return true, decodeEvent(L2StateSender.Abi.Events["L2StateSynced"], log, l)
 }
 
 type CheckpointMetadata struct {

--- a/consensus/polybft/contractsapi/contractsapi.go
+++ b/consensus/polybft/contractsapi/contractsapi.go
@@ -83,11 +83,11 @@ type StateSyncResultEvent struct {
 	Message []byte   `abi:"message"`
 }
 
-func (s *StateSyncResultEvent) Sig() ethgo.Hash {
+func (*StateSyncResultEvent) Sig() ethgo.Hash {
 	return StateReceiver.Abi.Events["StateSyncResult"].ID()
 }
 
-func (s *StateSyncResultEvent) Encode(inputs interface{}) ([]byte, error) {
+func (*StateSyncResultEvent) Encode(inputs interface{}) ([]byte, error) {
 	return StateReceiver.Abi.Events["StateSyncResult"].Inputs.Encode(inputs)
 }
 
@@ -105,11 +105,11 @@ type NewCommitmentEvent struct {
 	Root    types.Hash `abi:"root"`
 }
 
-func (n *NewCommitmentEvent) Sig() ethgo.Hash {
+func (*NewCommitmentEvent) Sig() ethgo.Hash {
 	return StateReceiver.Abi.Events["NewCommitment"].ID()
 }
 
-func (n *NewCommitmentEvent) Encode(inputs interface{}) ([]byte, error) {
+func (*NewCommitmentEvent) Encode(inputs interface{}) ([]byte, error) {
 	return StateReceiver.Abi.Events["NewCommitment"].Inputs.Encode(inputs)
 }
 
@@ -277,11 +277,11 @@ type NewValidatorEvent struct {
 	BlsKey    [4]*big.Int   `abi:"blsKey"`
 }
 
-func (n *NewValidatorEvent) Sig() ethgo.Hash {
+func (*NewValidatorEvent) Sig() ethgo.Hash {
 	return ChildValidatorSet.Abi.Events["NewValidator"].ID()
 }
 
-func (n *NewValidatorEvent) Encode(inputs interface{}) ([]byte, error) {
+func (*NewValidatorEvent) Encode(inputs interface{}) ([]byte, error) {
 	return ChildValidatorSet.Abi.Events["NewValidator"].Inputs.Encode(inputs)
 }
 
@@ -298,11 +298,11 @@ type StakedEvent struct {
 	Amount    *big.Int      `abi:"amount"`
 }
 
-func (s *StakedEvent) Sig() ethgo.Hash {
+func (*StakedEvent) Sig() ethgo.Hash {
 	return ChildValidatorSet.Abi.Events["Staked"].ID()
 }
 
-func (s *StakedEvent) Encode(inputs interface{}) ([]byte, error) {
+func (*StakedEvent) Encode(inputs interface{}) ([]byte, error) {
 	return ChildValidatorSet.Abi.Events["Staked"].Inputs.Encode(inputs)
 }
 
@@ -320,11 +320,11 @@ type DelegatedEvent struct {
 	Amount    *big.Int      `abi:"amount"`
 }
 
-func (d *DelegatedEvent) Sig() ethgo.Hash {
+func (*DelegatedEvent) Sig() ethgo.Hash {
 	return ChildValidatorSet.Abi.Events["Delegated"].ID()
 }
 
-func (d *DelegatedEvent) Encode(inputs interface{}) ([]byte, error) {
+func (*DelegatedEvent) Encode(inputs interface{}) ([]byte, error) {
 	return ChildValidatorSet.Abi.Events["Delegated"].Inputs.Encode(inputs)
 }
 
@@ -341,11 +341,11 @@ type UnstakedEvent struct {
 	Amount    *big.Int      `abi:"amount"`
 }
 
-func (u *UnstakedEvent) Sig() ethgo.Hash {
+func (*UnstakedEvent) Sig() ethgo.Hash {
 	return ChildValidatorSet.Abi.Events["Unstaked"].ID()
 }
 
-func (u *UnstakedEvent) Encode(inputs interface{}) ([]byte, error) {
+func (*UnstakedEvent) Encode(inputs interface{}) ([]byte, error) {
 	return ChildValidatorSet.Abi.Events["Unstaked"].Inputs.Encode(inputs)
 }
 
@@ -363,11 +363,11 @@ type UndelegatedEvent struct {
 	Amount    *big.Int      `abi:"amount"`
 }
 
-func (u *UndelegatedEvent) Sig() ethgo.Hash {
+func (*UndelegatedEvent) Sig() ethgo.Hash {
 	return ChildValidatorSet.Abi.Events["Undelegated"].ID()
 }
 
-func (u *UndelegatedEvent) Encode(inputs interface{}) ([]byte, error) {
+func (*UndelegatedEvent) Encode(inputs interface{}) ([]byte, error) {
 	return ChildValidatorSet.Abi.Events["Undelegated"].Inputs.Encode(inputs)
 }
 
@@ -383,11 +383,11 @@ type AddedToWhitelistEvent struct {
 	Validator types.Address `abi:"validator"`
 }
 
-func (a *AddedToWhitelistEvent) Sig() ethgo.Hash {
+func (*AddedToWhitelistEvent) Sig() ethgo.Hash {
 	return ChildValidatorSet.Abi.Events["AddedToWhitelist"].ID()
 }
 
-func (a *AddedToWhitelistEvent) Encode(inputs interface{}) ([]byte, error) {
+func (*AddedToWhitelistEvent) Encode(inputs interface{}) ([]byte, error) {
 	return ChildValidatorSet.Abi.Events["AddedToWhitelist"].Inputs.Encode(inputs)
 }
 
@@ -405,11 +405,11 @@ type WithdrawalEvent struct {
 	Amount  *big.Int      `abi:"amount"`
 }
 
-func (w *WithdrawalEvent) Sig() ethgo.Hash {
+func (*WithdrawalEvent) Sig() ethgo.Hash {
 	return ChildValidatorSet.Abi.Events["Withdrawal"].ID()
 }
 
-func (w *WithdrawalEvent) Encode(inputs interface{}) ([]byte, error) {
+func (*WithdrawalEvent) Encode(inputs interface{}) ([]byte, error) {
 	return ChildValidatorSet.Abi.Events["Withdrawal"].Inputs.Encode(inputs)
 }
 
@@ -445,11 +445,11 @@ type StateSyncedEvent struct {
 	Data     []byte        `abi:"data"`
 }
 
-func (s *StateSyncedEvent) Sig() ethgo.Hash {
+func (*StateSyncedEvent) Sig() ethgo.Hash {
 	return StateSender.Abi.Events["StateSynced"].ID()
 }
 
-func (s *StateSyncedEvent) Encode(inputs interface{}) ([]byte, error) {
+func (*StateSyncedEvent) Encode(inputs interface{}) ([]byte, error) {
 	return StateSender.Abi.Events["StateSynced"].Inputs.Encode(inputs)
 }
 
@@ -468,11 +468,11 @@ type L2StateSyncedEvent struct {
 	Data     []byte        `abi:"data"`
 }
 
-func (l *L2StateSyncedEvent) Sig() ethgo.Hash {
+func (*L2StateSyncedEvent) Sig() ethgo.Hash {
 	return L2StateSender.Abi.Events["L2StateSynced"].ID()
 }
 
-func (l *L2StateSyncedEvent) Encode(inputs interface{}) ([]byte, error) {
+func (*L2StateSyncedEvent) Encode(inputs interface{}) ([]byte, error) {
 	return L2StateSender.Abi.Events["L2StateSynced"].Inputs.Encode(inputs)
 }
 

--- a/consensus/polybft/contractsapi/contractsapi.go
+++ b/consensus/polybft/contractsapi/contractsapi.go
@@ -31,6 +31,10 @@ type CommitStateReceiverFn struct {
 	Bitmap     []byte               `abi:"bitmap"`
 }
 
+func (c *CommitStateReceiverFn) Sig() []byte {
+	return StateReceiver.Abi.Methods["commit"].ID()
+}
+
 func (c *CommitStateReceiverFn) EncodeAbi() ([]byte, error) {
 	return StateReceiver.Abi.Methods["commit"].Encode(c)
 }
@@ -59,6 +63,10 @@ func (s *StateSync) DecodeAbi(buf []byte) error {
 type ExecuteStateReceiverFn struct {
 	Proof []types.Hash `abi:"proof"`
 	Obj   *StateSync   `abi:"obj"`
+}
+
+func (e *ExecuteStateReceiverFn) Sig() []byte {
+	return StateReceiver.Abi.Methods["execute"].ID()
 }
 
 func (e *ExecuteStateReceiverFn) EncodeAbi() ([]byte, error) {
@@ -166,6 +174,10 @@ type CommitEpochChildValidatorSetFn struct {
 	Uptime *Uptime  `abi:"uptime"`
 }
 
+func (c *CommitEpochChildValidatorSetFn) Sig() []byte {
+	return ChildValidatorSet.Abi.Methods["commitEpoch"].ID()
+}
+
 func (c *CommitEpochChildValidatorSetFn) EncodeAbi() ([]byte, error) {
 	return ChildValidatorSet.Abi.Methods["commitEpoch"].Encode(c)
 }
@@ -215,6 +227,10 @@ type InitializeChildValidatorSetFn struct {
 	Governance types.Address    `abi:"governance"`
 }
 
+func (i *InitializeChildValidatorSetFn) Sig() []byte {
+	return ChildValidatorSet.Abi.Methods["initialize"].ID()
+}
+
 func (i *InitializeChildValidatorSetFn) EncodeAbi() ([]byte, error) {
 	return ChildValidatorSet.Abi.Methods["initialize"].Encode(i)
 }
@@ -225,6 +241,10 @@ func (i *InitializeChildValidatorSetFn) DecodeAbi(buf []byte) error {
 
 type AddToWhitelistChildValidatorSetFn struct {
 	WhitelistAddreses []ethgo.Address `abi:"whitelistAddreses"`
+}
+
+func (a *AddToWhitelistChildValidatorSetFn) Sig() []byte {
+	return ChildValidatorSet.Abi.Methods["addToWhitelist"].ID()
 }
 
 func (a *AddToWhitelistChildValidatorSetFn) EncodeAbi() ([]byte, error) {
@@ -240,6 +260,10 @@ type RegisterChildValidatorSetFn struct {
 	Pubkey    [4]*big.Int `abi:"pubkey"`
 }
 
+func (r *RegisterChildValidatorSetFn) Sig() []byte {
+	return ChildValidatorSet.Abi.Methods["register"].ID()
+}
+
 func (r *RegisterChildValidatorSetFn) EncodeAbi() ([]byte, error) {
 	return ChildValidatorSet.Abi.Methods["register"].Encode(r)
 }
@@ -248,9 +272,162 @@ func (r *RegisterChildValidatorSetFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(ChildValidatorSet.Abi.Methods["register"], buf, r)
 }
 
+type NewValidatorEvent struct {
+	Validator types.Address `abi:"validator"`
+	BlsKey    [4]*big.Int   `abi:"blsKey"`
+}
+
+func (n *NewValidatorEvent) Sig() ethgo.Hash {
+	return ChildValidatorSet.Abi.Events["NewValidator"].ID()
+}
+
+func (n *NewValidatorEvent) Encode(inputs interface{}) ([]byte, error) {
+	return ChildValidatorSet.Abi.Events["NewValidator"].Inputs.Encode(inputs)
+}
+
+func (n *NewValidatorEvent) ParseLog(log *ethgo.Log) (bool, error) {
+	if !ChildValidatorSet.Abi.Events["NewValidator"].Match(log) {
+		return false, nil
+	}
+
+	return true, decodeEvent(ChildValidatorSet.Abi.Events["NewValidator"], log, n)
+}
+
+type StakedEvent struct {
+	Validator types.Address `abi:"validator"`
+	Amount    *big.Int      `abi:"amount"`
+}
+
+func (s *StakedEvent) Sig() ethgo.Hash {
+	return ChildValidatorSet.Abi.Events["Staked"].ID()
+}
+
+func (s *StakedEvent) Encode(inputs interface{}) ([]byte, error) {
+	return ChildValidatorSet.Abi.Events["Staked"].Inputs.Encode(inputs)
+}
+
+func (s *StakedEvent) ParseLog(log *ethgo.Log) (bool, error) {
+	if !ChildValidatorSet.Abi.Events["Staked"].Match(log) {
+		return false, nil
+	}
+
+	return true, decodeEvent(ChildValidatorSet.Abi.Events["Staked"], log, s)
+}
+
+type DelegatedEvent struct {
+	Delegator types.Address `abi:"delegator"`
+	Validator types.Address `abi:"validator"`
+	Amount    *big.Int      `abi:"amount"`
+}
+
+func (d *DelegatedEvent) Sig() ethgo.Hash {
+	return ChildValidatorSet.Abi.Events["Delegated"].ID()
+}
+
+func (d *DelegatedEvent) Encode(inputs interface{}) ([]byte, error) {
+	return ChildValidatorSet.Abi.Events["Delegated"].Inputs.Encode(inputs)
+}
+
+func (d *DelegatedEvent) ParseLog(log *ethgo.Log) (bool, error) {
+	if !ChildValidatorSet.Abi.Events["Delegated"].Match(log) {
+		return false, nil
+	}
+
+	return true, decodeEvent(ChildValidatorSet.Abi.Events["Delegated"], log, d)
+}
+
+type UnstakedEvent struct {
+	Validator types.Address `abi:"validator"`
+	Amount    *big.Int      `abi:"amount"`
+}
+
+func (u *UnstakedEvent) Sig() ethgo.Hash {
+	return ChildValidatorSet.Abi.Events["Unstaked"].ID()
+}
+
+func (u *UnstakedEvent) Encode(inputs interface{}) ([]byte, error) {
+	return ChildValidatorSet.Abi.Events["Unstaked"].Inputs.Encode(inputs)
+}
+
+func (u *UnstakedEvent) ParseLog(log *ethgo.Log) (bool, error) {
+	if !ChildValidatorSet.Abi.Events["Unstaked"].Match(log) {
+		return false, nil
+	}
+
+	return true, decodeEvent(ChildValidatorSet.Abi.Events["Unstaked"], log, u)
+}
+
+type UndelegatedEvent struct {
+	Delegator types.Address `abi:"delegator"`
+	Validator types.Address `abi:"validator"`
+	Amount    *big.Int      `abi:"amount"`
+}
+
+func (u *UndelegatedEvent) Sig() ethgo.Hash {
+	return ChildValidatorSet.Abi.Events["Undelegated"].ID()
+}
+
+func (u *UndelegatedEvent) Encode(inputs interface{}) ([]byte, error) {
+	return ChildValidatorSet.Abi.Events["Undelegated"].Inputs.Encode(inputs)
+}
+
+func (u *UndelegatedEvent) ParseLog(log *ethgo.Log) (bool, error) {
+	if !ChildValidatorSet.Abi.Events["Undelegated"].Match(log) {
+		return false, nil
+	}
+
+	return true, decodeEvent(ChildValidatorSet.Abi.Events["Undelegated"], log, u)
+}
+
+type AddedToWhitelistEvent struct {
+	Validator types.Address `abi:"validator"`
+}
+
+func (a *AddedToWhitelistEvent) Sig() ethgo.Hash {
+	return ChildValidatorSet.Abi.Events["AddedToWhitelist"].ID()
+}
+
+func (a *AddedToWhitelistEvent) Encode(inputs interface{}) ([]byte, error) {
+	return ChildValidatorSet.Abi.Events["AddedToWhitelist"].Inputs.Encode(inputs)
+}
+
+func (a *AddedToWhitelistEvent) ParseLog(log *ethgo.Log) (bool, error) {
+	if !ChildValidatorSet.Abi.Events["AddedToWhitelist"].Match(log) {
+		return false, nil
+	}
+
+	return true, decodeEvent(ChildValidatorSet.Abi.Events["AddedToWhitelist"], log, a)
+}
+
+type WithdrawalEvent struct {
+	Account types.Address `abi:"account"`
+	To      types.Address `abi:"to"`
+	Amount  *big.Int      `abi:"amount"`
+}
+
+func (w *WithdrawalEvent) Sig() ethgo.Hash {
+	return ChildValidatorSet.Abi.Events["Withdrawal"].ID()
+}
+
+func (w *WithdrawalEvent) Encode(inputs interface{}) ([]byte, error) {
+	return ChildValidatorSet.Abi.Events["Withdrawal"].Inputs.Encode(inputs)
+}
+
+func (w *WithdrawalEvent) ParseLog(log *ethgo.Log) (bool, error) {
+	if !ChildValidatorSet.Abi.Events["Withdrawal"].Match(log) {
+		return false, nil
+	}
+
+	return true, decodeEvent(ChildValidatorSet.Abi.Events["Withdrawal"], log, w)
+}
+
 type SyncStateStateSenderFn struct {
 	Receiver types.Address `abi:"receiver"`
 	Data     []byte        `abi:"data"`
+}
+
+func (s *SyncStateStateSenderFn) Sig() []byte {
+	return StateSender.Abi.Methods["syncState"].ID()
 }
 
 func (s *SyncStateStateSenderFn) EncodeAbi() ([]byte, error) {
@@ -363,6 +540,10 @@ type SubmitCheckpointManagerFn struct {
 	Bitmap             []byte              `abi:"bitmap"`
 }
 
+func (s *SubmitCheckpointManagerFn) Sig() []byte {
+	return CheckpointManager.Abi.Methods["submit"].ID()
+}
+
 func (s *SubmitCheckpointManagerFn) EncodeAbi() ([]byte, error) {
 	return CheckpointManager.Abi.Methods["submit"].Encode(s)
 }
@@ -378,6 +559,10 @@ type InitializeCheckpointManagerFn struct {
 	NewValidatorSet []*Validator  `abi:"newValidatorSet"`
 }
 
+func (i *InitializeCheckpointManagerFn) Sig() []byte {
+	return CheckpointManager.Abi.Methods["initialize"].ID()
+}
+
 func (i *InitializeCheckpointManagerFn) EncodeAbi() ([]byte, error) {
 	return CheckpointManager.Abi.Methods["initialize"].Encode(i)
 }
@@ -388,6 +573,10 @@ func (i *InitializeCheckpointManagerFn) DecodeAbi(buf []byte) error {
 
 type GetCheckpointBlockCheckpointManagerFn struct {
 	BlockNumber *big.Int `abi:"blockNumber"`
+}
+
+func (g *GetCheckpointBlockCheckpointManagerFn) Sig() []byte {
+	return CheckpointManager.Abi.Methods["getCheckpointBlock"].ID()
 }
 
 func (g *GetCheckpointBlockCheckpointManagerFn) EncodeAbi() ([]byte, error) {
@@ -403,6 +592,10 @@ type ExitExitHelperFn struct {
 	LeafIndex    *big.Int     `abi:"leafIndex"`
 	UnhashedLeaf []byte       `abi:"unhashedLeaf"`
 	Proof        []types.Hash `abi:"proof"`
+}
+
+func (e *ExitExitHelperFn) Sig() []byte {
+	return ExitHelper.Abi.Methods["exit"].ID()
 }
 
 func (e *ExitExitHelperFn) EncodeAbi() ([]byte, error) {
@@ -421,6 +614,10 @@ type InitializeChildERC20PredicateFn struct {
 	NewNativeTokenRootAddress types.Address `abi:"newNativeTokenRootAddress"`
 }
 
+func (i *InitializeChildERC20PredicateFn) Sig() []byte {
+	return ChildERC20Predicate.Abi.Methods["initialize"].ID()
+}
+
 func (i *InitializeChildERC20PredicateFn) EncodeAbi() ([]byte, error) {
 	return ChildERC20Predicate.Abi.Methods["initialize"].Encode(i)
 }
@@ -433,6 +630,10 @@ type WithdrawToChildERC20PredicateFn struct {
 	ChildToken types.Address `abi:"childToken"`
 	Receiver   types.Address `abi:"receiver"`
 	Amount     *big.Int      `abi:"amount"`
+}
+
+func (w *WithdrawToChildERC20PredicateFn) Sig() []byte {
+	return ChildERC20Predicate.Abi.Methods["withdrawTo"].ID()
 }
 
 func (w *WithdrawToChildERC20PredicateFn) EncodeAbi() ([]byte, error) {
@@ -449,6 +650,10 @@ type InitializeNativeERC20Fn struct {
 	Name_      string        `abi:"name_"`
 	Symbol_    string        `abi:"symbol_"`
 	Decimals_  uint8         `abi:"decimals_"`
+}
+
+func (i *InitializeNativeERC20Fn) Sig() []byte {
+	return NativeERC20.Abi.Methods["initialize"].ID()
 }
 
 func (i *InitializeNativeERC20Fn) EncodeAbi() ([]byte, error) {
@@ -468,6 +673,10 @@ type InitializeNativeERC20MintableFn struct {
 	Decimals_  uint8         `abi:"decimals_"`
 }
 
+func (i *InitializeNativeERC20MintableFn) Sig() []byte {
+	return NativeERC20Mintable.Abi.Methods["initialize"].ID()
+}
+
 func (i *InitializeNativeERC20MintableFn) EncodeAbi() ([]byte, error) {
 	return NativeERC20Mintable.Abi.Methods["initialize"].Encode(i)
 }
@@ -484,6 +693,10 @@ type InitializeRootERC20PredicateFn struct {
 	NativeTokenRootAddress types.Address `abi:"nativeTokenRootAddress"`
 }
 
+func (i *InitializeRootERC20PredicateFn) Sig() []byte {
+	return RootERC20Predicate.Abi.Methods["initialize"].ID()
+}
+
 func (i *InitializeRootERC20PredicateFn) EncodeAbi() ([]byte, error) {
 	return RootERC20Predicate.Abi.Methods["initialize"].Encode(i)
 }
@@ -496,6 +709,10 @@ type DepositToRootERC20PredicateFn struct {
 	RootToken types.Address `abi:"rootToken"`
 	Receiver  types.Address `abi:"receiver"`
 	Amount    *big.Int      `abi:"amount"`
+}
+
+func (d *DepositToRootERC20PredicateFn) Sig() []byte {
+	return RootERC20Predicate.Abi.Methods["depositTo"].ID()
 }
 
 func (d *DepositToRootERC20PredicateFn) EncodeAbi() ([]byte, error) {
@@ -511,6 +728,10 @@ type ApproveRootERC20Fn struct {
 	Amount  *big.Int      `abi:"amount"`
 }
 
+func (a *ApproveRootERC20Fn) Sig() []byte {
+	return RootERC20.Abi.Methods["approve"].ID()
+}
+
 func (a *ApproveRootERC20Fn) EncodeAbi() ([]byte, error) {
 	return RootERC20.Abi.Methods["approve"].Encode(a)
 }
@@ -522,6 +743,10 @@ func (a *ApproveRootERC20Fn) DecodeAbi(buf []byte) error {
 type MintRootERC20Fn struct {
 	To     types.Address `abi:"to"`
 	Amount *big.Int      `abi:"amount"`
+}
+
+func (m *MintRootERC20Fn) Sig() []byte {
+	return RootERC20.Abi.Methods["mint"].ID()
 }
 
 func (m *MintRootERC20Fn) EncodeAbi() ([]byte, error) {

--- a/consensus/polybft/contractsapi/contractsapi_test.go
+++ b/consensus/polybft/contractsapi/contractsapi_test.go
@@ -90,8 +90,13 @@ func TestEncoding_Struct(t *testing.T) {
 func TestEncodingAndParsingEvent(t *testing.T) {
 	t.Parallel()
 
+	var (
+		exitEventAPI      L2StateSyncedEvent
+		stateSyncEventAPI StateSyncedEvent
+	)
+
 	topics := make([]ethgo.Hash, 4)
-	topics[0] = L2StateSender.Abi.Events["L2StateSynced"].ID()
+	topics[0] = exitEventAPI.Sig()
 	topics[1] = ethgo.BytesToHash(common.EncodeUint64ToBytes(11))
 	topics[2] = ethgo.BytesToHash(types.StringToAddress("0x1111").Bytes())
 	topics[3] = ethgo.BytesToHash(types.StringToAddress("0x2222").Bytes())
@@ -121,13 +126,13 @@ func TestEncodingAndParsingEvent(t *testing.T) {
 	require.Equal(t, uint64(22), exitEvent.ID.Uint64())
 
 	// log does not match event
-	log.Topics[0] = StateSender.Abi.Events["StateSynced"].ID()
+	log.Topics[0] = stateSyncEventAPI.Sig()
 	doesMatch, err = exitEvent.ParseLog(log)
 	require.False(t, doesMatch)
 	require.NoError(t, err)
 
 	// error on parsing log
-	log.Topics[0] = L2StateSender.Abi.Events["L2StateSynced"].ID()
+	log.Topics[0] = exitEventAPI.Sig()
 	log.Topics = log.Topics[:3]
 	doesMatch, err = exitEvent.ParseLog(log)
 	require.True(t, doesMatch)

--- a/consensus/polybft/contractsapi/contractsapi_test.go
+++ b/consensus/polybft/contractsapi/contractsapi_test.go
@@ -5,8 +5,12 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/require"
+	"github.com/umbracle/ethgo"
+	"github.com/umbracle/ethgo/abi"
 )
 
 type method interface {
@@ -75,10 +79,57 @@ func TestEncoding_Struct(t *testing.T) {
 	encoding, err := commitment.EncodeAbi()
 	require.NoError(t, err)
 
-	commitmentDecoded := &StateSyncCommitment{}
+	var commitmentDecoded StateSyncCommitment
 
 	require.NoError(t, commitmentDecoded.DecodeAbi(encoding))
 	require.Equal(t, commitment.StartID, commitmentDecoded.StartID)
 	require.Equal(t, commitment.EndID, commitmentDecoded.EndID)
 	require.Equal(t, commitment.Root, commitmentDecoded.Root)
+}
+
+func TestEncodingAndParsingEvent(t *testing.T) {
+	t.Parallel()
+
+	topics := make([]ethgo.Hash, 4)
+	topics[0] = ethgo.Hash(L2StateSender.Abi.Events["L2StateSynced"].ID())
+	topics[1] = ethgo.BytesToHash(common.EncodeUint64ToBytes(11))
+	topics[2] = ethgo.BytesToHash(types.StringToAddress("0x1111").Bytes())
+	topics[3] = ethgo.BytesToHash(types.StringToAddress("0x2222").Bytes())
+	someType := abi.MustNewType("tuple(string firstName, string lastName)")
+	encodedData, err := someType.Encode(map[string]string{"firstName": "John", "lastName": "Doe"})
+	require.NoError(t, err)
+
+	log := &ethgo.Log{
+		Address: ethgo.Address(contracts.L2StateSenderContract),
+		Topics:  topics,
+		Data:    encodedData,
+	}
+
+	var exitEvent L2StateSyncedEvent
+
+	// log matches event
+	doesMatch, err := exitEvent.ParseLog(log)
+	require.True(t, doesMatch)
+	require.NoError(t, err)
+	require.Equal(t, uint64(11), exitEvent.ID.Uint64())
+
+	// change exit event id
+	log.Topics[1] = ethgo.BytesToHash(common.EncodeUint64ToBytes(22))
+	doesMatch, err = exitEvent.ParseLog(log)
+	require.True(t, doesMatch)
+	require.NoError(t, err)
+	require.Equal(t, uint64(22), exitEvent.ID.Uint64())
+
+	// log does not match event
+	log.Topics[0] = ethgo.Hash(StateSender.Abi.Events["StateSynced"].ID())
+	doesMatch, err = exitEvent.ParseLog(log)
+	require.False(t, doesMatch)
+	require.NoError(t, err)
+
+	// error on parsing log
+	log.Topics[0] = ethgo.Hash(L2StateSender.Abi.Events["L2StateSynced"].ID())
+	log.Topics = log.Topics[:3]
+	doesMatch, err = exitEvent.ParseLog(log)
+	require.True(t, doesMatch)
+	require.Error(t, err)
 }

--- a/consensus/polybft/contractsapi/contractsapi_test.go
+++ b/consensus/polybft/contractsapi/contractsapi_test.go
@@ -91,7 +91,7 @@ func TestEncodingAndParsingEvent(t *testing.T) {
 	t.Parallel()
 
 	topics := make([]ethgo.Hash, 4)
-	topics[0] = ethgo.Hash(L2StateSender.Abi.Events["L2StateSynced"].ID())
+	topics[0] = L2StateSender.Abi.Events["L2StateSynced"].ID()
 	topics[1] = ethgo.BytesToHash(common.EncodeUint64ToBytes(11))
 	topics[2] = ethgo.BytesToHash(types.StringToAddress("0x1111").Bytes())
 	topics[3] = ethgo.BytesToHash(types.StringToAddress("0x2222").Bytes())
@@ -121,13 +121,13 @@ func TestEncodingAndParsingEvent(t *testing.T) {
 	require.Equal(t, uint64(22), exitEvent.ID.Uint64())
 
 	// log does not match event
-	log.Topics[0] = ethgo.Hash(StateSender.Abi.Events["StateSynced"].ID())
+	log.Topics[0] = StateSender.Abi.Events["StateSynced"].ID()
 	doesMatch, err = exitEvent.ParseLog(log)
 	require.False(t, doesMatch)
 	require.NoError(t, err)
 
 	// error on parsing log
-	log.Topics[0] = ethgo.Hash(L2StateSender.Abi.Events["L2StateSynced"].ID())
+	log.Topics[0] = L2StateSender.Abi.Events["L2StateSynced"].ID()
 	log.Topics = log.Topics[:3]
 	doesMatch, err = exitEvent.ParseLog(log)
 	require.True(t, doesMatch)

--- a/consensus/polybft/sc_integration_test.go
+++ b/consensus/polybft/sc_integration_test.go
@@ -156,7 +156,8 @@ func TestIntegratoin_PerformExit(t *testing.T) {
 	res := getField(exitHelperContractAddress, contractsapi.ExitHelper.Abi, "processedExits", exits[0].ID)
 	require.Equal(t, int(res[31]), 0)
 
-	proofExitEvent, err := ExitEventInputsABIType.Encode(exits[0])
+	var exitEventApi contractsapi.L2StateSyncedEvent
+	proofExitEvent, err := exitEventApi.Encode(exits[0])
 	require.NoError(t, err)
 
 	proof, err := exitTrie.GenerateProof(proofExitEvent)

--- a/consensus/polybft/sc_integration_test.go
+++ b/consensus/polybft/sc_integration_test.go
@@ -156,8 +156,8 @@ func TestIntegratoin_PerformExit(t *testing.T) {
 	res := getField(exitHelperContractAddress, contractsapi.ExitHelper.Abi, "processedExits", exits[0].ID)
 	require.Equal(t, int(res[31]), 0)
 
-	var exitEventApi contractsapi.L2StateSyncedEvent
-	proofExitEvent, err := exitEventApi.Encode(exits[0])
+	var exitEventAPI contractsapi.L2StateSyncedEvent
+	proofExitEvent, err := exitEventAPI.Encode(exits[0])
 	require.NoError(t, err)
 
 	proof, err := exitTrie.GenerateProof(proofExitEvent)

--- a/consensus/polybft/state_store_checkpoint.go
+++ b/consensus/polybft/state_store_checkpoint.go
@@ -17,9 +17,6 @@ var (
 	// bucket to store exit contract events
 	exitEventsBucket             = []byte("exitEvent")
 	exitEventToEpochLookupBucket = []byte("exitIdToEpochLookup")
-
-	ExitEventABI           = contractsapi.L2StateSender.Abi.Events["L2StateSynced"]
-	ExitEventInputsABIType = ExitEventABI.Inputs
 )
 
 type exitEventNotFoundError struct {
@@ -173,13 +170,13 @@ func (s *CheckpointStore) getExitEvents(epoch uint64, filter func(exitEvent *Exi
 
 // decodeExitEvent tries to decode exit event from the provided log
 func decodeExitEvent(log *ethgo.Log, epoch, block uint64) (*ExitEvent, error) {
-	if !ExitEventABI.Match(log) {
-		// valid case, not an exit event
+	var l2StateSyncedEvent contractsapi.L2StateSyncedEvent
+	doesMatch, err := l2StateSyncedEvent.ParseLog(log)
+	if !doesMatch {
 		return nil, nil
 	}
 
-	l2StateSyncedEvent := &contractsapi.L2StateSyncedEvent{}
-	if err := l2StateSyncedEvent.ParseLog(log); err != nil {
+	if err != nil {
 		return nil, err
 	}
 

--- a/consensus/polybft/state_store_checkpoint.go
+++ b/consensus/polybft/state_store_checkpoint.go
@@ -171,6 +171,7 @@ func (s *CheckpointStore) getExitEvents(epoch uint64, filter func(exitEvent *Exi
 // decodeExitEvent tries to decode exit event from the provided log
 func decodeExitEvent(log *ethgo.Log, epoch, block uint64) (*ExitEvent, error) {
 	var l2StateSyncedEvent contractsapi.L2StateSyncedEvent
+
 	doesMatch, err := l2StateSyncedEvent.ParseLog(log)
 	if !doesMatch {
 		return nil, nil

--- a/consensus/polybft/state_store_checkpoint_test.go
+++ b/consensus/polybft/state_store_checkpoint_test.go
@@ -122,8 +122,10 @@ func TestState_decodeExitEvent(t *testing.T) {
 
 	state := newTestState(t)
 
+	var exitEvent contractsapi.L2StateSyncedEvent
+
 	topics := make([]ethgo.Hash, 4)
-	topics[0] = contractsapi.L2StateSender.Abi.Events["L2StateSynced"].ID()
+	topics[0] = exitEvent.Sig()
 	topics[1] = ethgo.BytesToHash([]byte{exitID})
 	topics[2] = ethgo.BytesToHash(ethgo.HexToAddress("0x1111").Bytes())
 	topics[3] = ethgo.BytesToHash(ethgo.HexToAddress("0x2222").Bytes())
@@ -149,8 +151,10 @@ func TestState_decodeExitEvent(t *testing.T) {
 func TestState_decodeExitEvent_NotAnExitEvent(t *testing.T) {
 	t.Parallel()
 
+	var stateSyncedEvent contractsapi.StateSyncedEvent
+
 	topics := make([]ethgo.Hash, 4)
-	topics[0] = contractsapi.StateSender.Abi.Events["StateSynced"].ID()
+	topics[0] = stateSyncedEvent.Sig()
 
 	log := &ethgo.Log{
 		Address: ethgo.ZeroAddress,

--- a/consensus/polybft/state_store_checkpoint_test.go
+++ b/consensus/polybft/state_store_checkpoint_test.go
@@ -3,6 +3,7 @@ package polybft
 import (
 	"testing"
 
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -122,7 +123,7 @@ func TestState_decodeExitEvent(t *testing.T) {
 	state := newTestState(t)
 
 	topics := make([]ethgo.Hash, 4)
-	topics[0] = ExitEventABI.ID()
+	topics[0] = contractsapi.L2StateSender.Abi.Events["L2StateSynced"].ID()
 	topics[1] = ethgo.BytesToHash([]byte{exitID})
 	topics[2] = ethgo.BytesToHash(ethgo.HexToAddress("0x1111").Bytes())
 	topics[3] = ethgo.BytesToHash(ethgo.HexToAddress("0x2222").Bytes())
@@ -149,7 +150,7 @@ func TestState_decodeExitEvent_NotAnExitEvent(t *testing.T) {
 	t.Parallel()
 
 	topics := make([]ethgo.Hash, 4)
-	topics[0] = stateTransferEventABI.ID()
+	topics[0] = contractsapi.StateSender.Abi.Events["StateSynced"].ID()
 
 	log := &ethgo.Log{
 		Address: ethgo.ZeroAddress,

--- a/consensus/polybft/state_store_state_sync.go
+++ b/consensus/polybft/state_store_state_sync.go
@@ -26,8 +26,6 @@ var (
 	errCommitmentNotBuilt = errors.New("there is no built commitment to register")
 	// errNoCommitmentForStateSync error message
 	errNoCommitmentForStateSync = errors.New("no commitment found for given state sync event")
-
-	stateTransferEventABI = contractsapi.StateSender.Abi.Events["StateSynced"]
 )
 
 /*

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -30,7 +30,7 @@ func newTestStateSyncManager(t *testing.T, key *testValidator) *stateSyncManager
 
 	topic := &mockTopic{}
 
-	s, err := NewStateSyncManager(hclog.NewNullLogger(), state,
+	s, err := newStateSyncManager(hclog.NewNullLogger(), state,
 		&stateSyncConfig{
 			stateSenderAddr:   types.Address{},
 			jsonrpcAddr:       "",
@@ -340,8 +340,10 @@ func TestStateSyncerManager_AddLog_BuildCommitments(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, stateSyncs, 0)
 
+	stateSyncEventID := contractsapi.StateSender.Abi.Events["StateSynced"].ID()
+
 	// log with the state sync topic but incorrect content
-	s.AddLog(&ethgo.Log{Topics: []ethgo.Hash{stateTransferEventABI.ID()}})
+	s.AddLog(&ethgo.Log{Topics: []ethgo.Hash{stateSyncEventID}})
 	stateSyncs, err = s.state.StateSyncStore.list()
 
 	require.NoError(t, err)
@@ -353,7 +355,7 @@ func TestStateSyncerManager_AddLog_BuildCommitments(t *testing.T) {
 
 	goodLog := &ethgo.Log{
 		Topics: []ethgo.Hash{
-			stateTransferEventABI.ID(),
+			stateSyncEventID,
 			ethgo.BytesToHash([]byte{0x0}), // state sync index 0
 			ethgo.ZeroHash,
 			ethgo.ZeroHash,

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -340,7 +340,9 @@ func TestStateSyncerManager_AddLog_BuildCommitments(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, stateSyncs, 0)
 
-	stateSyncEventID := contractsapi.StateSender.Abi.Events["StateSynced"].ID()
+	var stateSyncedEvent contractsapi.StateSyncedEvent
+
+	stateSyncEventID := stateSyncedEvent.Sig()
 
 	// log with the state sync topic but incorrect content
 	s.AddLog(&ethgo.Log{Topics: []ethgo.Hash{stateSyncEventID}})

--- a/consensus/polybft/state_transaction.go
+++ b/consensus/polybft/state_transaction.go
@@ -168,12 +168,16 @@ func decodeStateTransaction(txData []byte) (contractsapi.StateTransactionInput, 
 
 	sig := txData[:abiMethodIDLength]
 
-	var obj contractsapi.StateTransactionInput
+	var (
+		commitFn      contractsapi.CommitFunction
+		commitEpochFn contractsapi.CommitEpochFunction
+		obj           contractsapi.StateTransactionInput
+	)
 
-	if bytes.Equal(sig, contractsapi.StateReceiver.Abi.Methods["commit"].ID()) {
+	if bytes.Equal(sig, commitFn.Sig()) {
 		// bridge commitment
 		obj = &CommitmentMessageSigned{}
-	} else if bytes.Equal(sig, contractsapi.ChildValidatorSet.Abi.Methods["commitEpoch"].ID()) {
+	} else if bytes.Equal(sig, commitEpochFn.Sig()) {
 		// commit epoch
 		obj = &contractsapi.CommitEpochChildValidatorSetFn{}
 	} else {
@@ -188,11 +192,12 @@ func decodeStateTransaction(txData []byte) (contractsapi.StateTransactionInput, 
 }
 
 func getCommitmentMessageSignedTx(txs []*types.Transaction) (*CommitmentMessageSigned, error) {
+	var commitFn contractsapi.CommitFunction
 	for _, tx := range txs {
 		// skip non state CommitmentMessageSigned transactions
 		if tx.Type != types.StateTx ||
 			len(tx.Input) < abiMethodIDLength ||
-			!bytes.Equal(tx.Input[:abiMethodIDLength], contractsapi.StateReceiver.Abi.Methods["commit"].ID()) {
+			!bytes.Equal(tx.Input[:abiMethodIDLength], commitFn.Sig()) {
 			continue
 		}
 

--- a/consensus/polybft/state_transaction.go
+++ b/consensus/polybft/state_transaction.go
@@ -169,8 +169,8 @@ func decodeStateTransaction(txData []byte) (contractsapi.StateTransactionInput, 
 	sig := txData[:abiMethodIDLength]
 
 	var (
-		commitFn      contractsapi.CommitFunction
-		commitEpochFn contractsapi.CommitEpochFunction
+		commitFn      contractsapi.CommitStateReceiverFn
+		commitEpochFn contractsapi.CommitEpochChildValidatorSetFn
 		obj           contractsapi.StateTransactionInput
 	)
 
@@ -192,7 +192,7 @@ func decodeStateTransaction(txData []byte) (contractsapi.StateTransactionInput, 
 }
 
 func getCommitmentMessageSignedTx(txs []*types.Transaction) (*CommitmentMessageSigned, error) {
-	var commitFn contractsapi.CommitFunction
+	var commitFn contractsapi.CommitStateReceiverFn
 	for _, tx := range txs {
 		// skip non state CommitmentMessageSigned transactions
 		if tx.Type != types.StateTx ||

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/big"
 	"net"
 	"path"
 	"strings"
@@ -20,8 +19,6 @@ import (
 	"github.com/umbracle/ethgo"
 	"github.com/umbracle/ethgo/jsonrpc"
 )
-
-var commitEvent = contractsapi.StateReceiver.Abi.Events["NewCommitment"]
 
 type StateSyncRelayer struct {
 	dataDir                string
@@ -113,37 +110,24 @@ func (r *StateSyncRelayer) Stop() {
 func (r *StateSyncRelayer) AddLog(log *ethgo.Log) {
 	r.logger.Debug("Received a log", "log", log)
 
-	if !commitEvent.Match(log) {
+	var commitEvent contractsapi.NewCommitmentEvent
+	doesMatch, err := commitEvent.ParseLog(log)
+	if !doesMatch {
 		return
 	}
 
-	vals, err := commitEvent.ParseLog(log)
 	if err != nil {
 		r.logger.Error("Failed to parse log", "err", err)
 
 		return
 	}
 
-	var (
-		startID, endID *big.Int
-		ok             bool
-	)
-
-	if startID, ok = vals["startId"].(*big.Int); !ok {
-		r.logger.Error("Failed to parse startId")
-
-		return
-	}
-
-	if endID, ok = vals["endId"].(*big.Int); !ok {
-		r.logger.Error("Failed to parse endId")
-
-		return
-	}
+	startID := commitEvent.StartID.Uint64()
+	endID := commitEvent.EndID.Uint64()
 
 	r.logger.Info("Execute commitment", "Block", log.BlockNumber, "StartID", startID, "EndID", endID)
 
-	for i := startID.Uint64(); i <= endID.Uint64(); i++ {
+	for i := startID; i <= endID; i++ {
 		// query the state sync proof
 		stateSyncProof, err := r.queryStateSyncProof(fmt.Sprintf("0x%x", i))
 		if err != nil {

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer.go
@@ -111,6 +111,7 @@ func (r *StateSyncRelayer) AddLog(log *ethgo.Log) {
 	r.logger.Debug("Received a log", "log", log)
 
 	var commitEvent contractsapi.NewCommitmentEvent
+
 	doesMatch, err := commitEvent.ParseLog(log)
 	if !doesMatch {
 		return

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -45,9 +45,11 @@ func checkStateSyncResultLogs(
 	t.Helper()
 	require.Len(t, logs, expectedCount)
 
+	var stateSyncResultEvent contractsapi.StateSyncResultEvent
 	for _, log := range logs {
-		stateSyncResultEvent := &contractsapi.StateSyncResultEvent{}
-		require.NoError(t, stateSyncResultEvent.ParseLog(log))
+		doesMatch, err := stateSyncResultEvent.ParseLog(log)
+		require.True(t, doesMatch)
+		require.NoError(t, err)
 
 		t.Logf("Block Number=%d, Decoded Log=%+v\n", log.BlockNumber, stateSyncResultEvent)
 
@@ -589,7 +591,8 @@ func sendExitTransaction(
 	exitHelperAddr ethgo.Address,
 	l1TxRelayer txrelayer.TxRelayer,
 	exitEventID uint64) (bool, error) {
-	proofExitEventEncoded, err := polybft.ExitEventInputsABIType.Encode(&polybft.ExitEvent{
+	var exitEventApi contractsapi.L2StateSyncedEvent
+	proofExitEventEncoded, err := exitEventApi.Encode(&polybft.ExitEvent{
 		ID:       exitEventID,
 		Sender:   sidechainKey.Address(),
 		Receiver: l1ExitTestAddr,

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -106,7 +106,9 @@ func TestE2E_Bridge_DepositAndWithdrawERC20(t *testing.T) {
 	require.NoError(t, cluster.WaitForBlock(35, 2*time.Minute))
 
 	// the transactions are processed and there should be a success events
-	id := contractsapi.StateReceiver.Abi.Events["StateSyncResult"].ID()
+	var stateSyncedResult contractsapi.StateSyncResultEvent
+
+	id := stateSyncedResult.Sig()
 	filter := &ethgo.LogFilter{
 		Topics: [][]*ethgo.Hash{
 			{&id},
@@ -292,7 +294,9 @@ func TestE2E_Bridge_MultipleCommitmentsPerEpoch(t *testing.T) {
 
 	// the transactions are mined and state syncs should be executed by the relayer
 	// and there should be a success events
-	id := contractsapi.StateReceiver.Abi.Events["StateSyncResult"].ID()
+	var stateSyncedResult contractsapi.StateSyncResultEvent
+
+	id := stateSyncedResult.Sig()
 	filter := &ethgo.LogFilter{
 		Topics: [][]*ethgo.Hash{
 			{&id},

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -591,8 +591,9 @@ func sendExitTransaction(
 	exitHelperAddr ethgo.Address,
 	l1TxRelayer txrelayer.TxRelayer,
 	exitEventID uint64) (bool, error) {
-	var exitEventApi contractsapi.L2StateSyncedEvent
-	proofExitEventEncoded, err := exitEventApi.Encode(&polybft.ExitEvent{
+	var exitEventAPI contractsapi.L2StateSyncedEvent
+
+	proofExitEventEncoded, err := exitEventAPI.Encode(&polybft.ExitEvent{
 		ID:       exitEventID,
 		Sender:   sidechainKey.Address(),
 		Receiver: l1ExitTestAddr,


### PR DESCRIPTION
# Description

This PR uses the `contractsapi` package and generated `go` stubs from contract functions and events, on places where it was missing.

PR expanded the `ParseLog` function on generated `go` stubs for contract events, so that the function returns two values:
- `boolean` - indicating if the given log matches the given event.
- `error` - if a log matches the event, but its parsing fails for some reason.

This simplifies the code on client that first matched the events with log, and then parsed it, shortening the code, and removing the manually added references to an event abi.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually