### PR TITLE
Use wait for ready on e2e test

### DIFF
--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -83,8 +83,7 @@ func TestE2E_Bridge_DepositAndWithdrawERC20(t *testing.T) {
 		framework.WithEpochSize(epochSize))
 	defer cluster.Stop()
 
-	// wait for a couple of blocks
-	require.NoError(t, cluster.WaitForBlock(1, 10*time.Second))
+	cluster.WaitForReady(t)
 
 	manifest, err := polybft.LoadManifest(path.Join(cluster.Config.TmpDir, manifestFileName))
 	require.NoError(t, err)
@@ -235,8 +234,7 @@ func TestE2E_Bridge_MultipleCommitmentsPerEpoch(t *testing.T) {
 	manifest, err := polybft.LoadManifest(path.Join(cluster.Config.TmpDir, manifestFileName))
 	require.NoError(t, err)
 
-	// wait for a couple of blocks
-	require.NoError(t, cluster.WaitForBlock(2, 1*time.Minute))
+	cluster.WaitForReady(t)
 
 	// send two transactions to the bridge so that we have a minimal commitment
 	require.NoError(
@@ -412,8 +410,7 @@ func TestE2E_Bridge_L2toL1Exit(t *testing.T) {
 	checkpointManagerAddr := ethgo.Address(manifest.RootchainConfig.CheckpointManagerAddress)
 	exitHelperAddr := ethgo.Address(manifest.RootchainConfig.ExitHelperAddress)
 
-	// wait for a couple of blocks
-	require.NoError(t, cluster.WaitForBlock(2, 2*time.Minute))
+	cluster.WaitForReady(t)
 
 	// init rpc clients
 	l1TxRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(txrelayer.DefaultRPCAddress))
@@ -511,8 +508,7 @@ func TestE2E_Bridge_L2toL1ExitMultiple(t *testing.T) {
 	checkpointManagerAddr := ethgo.Address(manifest.RootchainConfig.CheckpointManagerAddress)
 	exitHelperAddr := ethgo.Address(manifest.RootchainConfig.ExitHelperAddress)
 
-	// wait for a couple of blocks
-	require.NoError(t, cluster.WaitForBlock(2, 2*time.Minute))
+	cluster.WaitForReady(t)
 
 	// init rpc clients
 	l1TxRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(txrelayer.DefaultRPCAddress))

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -346,8 +346,7 @@ func TestE2E_Consensus_Delegation_Undelegation(t *testing.T) {
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(srv.JSONRPCAddr()))
 	require.NoError(t, err)
 
-	// wait for consensus to start
-	require.NoError(t, cluster.WaitForBlock(1, 10*time.Second))
+	cluster.WaitForReady(t)
 
 	// extract delegator's secrets
 	delegatorSecretsPath := path.Join(cluster.Config.TmpDir, delegatorSecrets)
@@ -555,8 +554,7 @@ func TestE2E_Consensus_CorrectnessOfExtraValidatorsShouldNotDependOnDelegate(t *
 	_, err = cluster.InitSecrets(delegatorSecrets, 1)
 	require.NoError(t, err)
 
-	// wait for consensus to start
-	require.NoError(t, cluster.WaitForBlock(2, 20*time.Second))
+	cluster.WaitForReady(t)
 
 	// extract delegator's secrets
 	delegatorSecretsPath := path.Join(cluster.Config.TmpDir, delegatorSecrets)

--- a/e2e-polybft/e2e/migration_test.go
+++ b/e2e-polybft/e2e/migration_test.go
@@ -153,7 +153,7 @@ func TestMigration(t *testing.T) {
 	)
 	defer cluster.Stop()
 
-	require.NoError(t, cluster.WaitForBlock(5, 1*time.Minute))
+	cluster.WaitForReady(t)
 
 	senderBalanceAfterMigration, err := cluster.Servers[0].JSONRPC().Eth().GetBalance(userAddr, ethgo.Latest)
 	if err != nil {

--- a/e2e-polybft/e2e/txpool_test.go
+++ b/e2e-polybft/e2e/txpool_test.go
@@ -25,7 +25,7 @@ func TestE2E_TxPool_Transfer(t *testing.T) {
 	cluster := framework.NewTestCluster(t, 5, framework.WithPremine(types.Address(sender.Address())))
 	defer cluster.Stop()
 
-	require.NoError(t, cluster.WaitForBlock(2, 1*time.Minute))
+	cluster.WaitForReady(t)
 
 	client := cluster.Servers[0].JSONRPC().Eth()
 
@@ -91,7 +91,7 @@ func TestE2E_TxPool_Transfer_Linear(t *testing.T) {
 	cluster := framework.NewTestCluster(t, 5, framework.WithPremine(types.Address(premine.Address())))
 	defer cluster.Stop()
 
-	require.NoError(t, cluster.WaitForBlock(2, 1*time.Minute))
+	cluster.WaitForReady(t)
 
 	client := cluster.Servers[0].JSONRPC().Eth()
 

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -513,7 +513,7 @@ func (c *TestCluster) WaitUntil(timeout, pollFrequency time.Duration, handler fu
 func (c *TestCluster) WaitForReady(t *testing.T) {
 	t.Helper()
 
-	require.NoError(t, c.WaitForBlock(3, 1*time.Minute))
+	require.NoError(t, c.WaitForBlock(1, 30*time.Second))
 }
 
 func (c *TestCluster) WaitForBlock(n uint64, timeout time.Duration) error {


### PR DESCRIPTION
# Description

The majority of the e2e test must wait for the chain to start before any action can be performed. Currently, the tests use a utility function (`WaitForBlock`) to wait for a certain block to be created. However, it is inconsistent and up to the person writing the test to decide which block to wait for and how much time.

This PR introduces uses the `WaitForReady` function introduced in `allow-list` to standardize how much time to wait until we consider the cluster ready to perform any operation.

Note that I have not touched some tests from `consensus_test.go` that use long `WaitForBlock` numbers since the test involve having a long chain.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
