### PR TITLE
Allow usage of localstack AWS SSM Parameter Store

### DIFF
--- a/secrets/awsssm/aws_ssm.go
+++ b/secrets/awsssm/aws_ssm.go
@@ -20,6 +20,9 @@ type AwsSsmManager struct {
 	// The AWS region
 	region string
 
+	// Custom AWS endpoint, e.g. localstack
+	endpoint string
+
 	// The AWS SSM client
 	client *ssm.SSM
 
@@ -44,8 +47,9 @@ func SecretsManagerFactory(
 
 	// / Set up the base object
 	awsSsmManager := &AwsSsmManager{
-		logger: params.Logger.Named(string(secrets.AWSSSM)),
-		region: fmt.Sprintf("%v", config.Extra["region"]),
+		logger:   params.Logger.Named(string(secrets.AWSSSM)),
+		region:   fmt.Sprintf("%v", config.Extra["region"]),
+		endpoint: config.ServerURL,
 	}
 
 	// Set the base path to store the secrets in SSM
@@ -61,15 +65,19 @@ func SecretsManagerFactory(
 
 // Setup sets up the AWS SSM secrets manager
 func (a *AwsSsmManager) Setup() error {
+	cfg := aws.NewConfig().WithRegion(a.region)
+	if a.endpoint != "" {
+		cfg = cfg.WithEndpoint(a.endpoint)
+	}
 	sess, err := session.NewSessionWithOptions(session.Options{
-		Config:            aws.Config{Region: aws.String(a.region)},
+		Config:            *cfg,
 		SharedConfigState: session.SharedConfigEnable,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to initialize AWS SSM client: %w", err)
 	}
 
-	ssmsvc := ssm.New(sess, aws.NewConfig().WithRegion(a.region))
+	ssmsvc := ssm.New(sess, cfg)
 	a.client = ssmsvc
 
 	return nil

--- a/secrets/awsssm/aws_ssm.go
+++ b/secrets/awsssm/aws_ssm.go
@@ -69,6 +69,7 @@ func (a *AwsSsmManager) Setup() error {
 	if a.endpoint != "" {
 		cfg = cfg.WithEndpoint(a.endpoint)
 	}
+
 	sess, err := session.NewSessionWithOptions(session.Options{
 		Config:            *cfg,
 		SharedConfigState: session.SharedConfigEnable,


### PR DESCRIPTION
# Description

This PR adds a possibility to use Localstack instead of real AWS to create/read secrets using Parameter Store. It utilizes existing cli flag (`--server-url`) to instantiate proper aws config that targets localstack instance. If not provided it will target real AWS instead.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

I've tested it locally with Localstack instance.
