### PR TITLE
Provide hex encoded private key

### DIFF
--- a/command/bridge/README.md
+++ b/command/bridge/README.md
@@ -7,28 +7,28 @@ This is a helper command, which allows sending deposits from root to child chain
 This is a helper command which deposits ERC20 tokens from the root chain to the child chain
 
 ```bash
-$ polygon-edge bridge deposit-erc20
-    --sender-key <hex_encoded_depositor_private_key>
-    --receivers <receivers_addresses>
-    --amounts <amounts>
-    --root-token <root_erc20_token_address>
-    --root-predicate <root_erc20_predicate_address>
+$ polygon-edge bridge deposit-erc20 \
+    --sender-key <hex_encoded_depositor_private_key> \
+    --receivers <receivers_addresses> \
+    --amounts <amounts> \
+    --root-token <root_erc20_token_address> \
+    --root-predicate <root_erc20_predicate_address> \
     --json-rpc <root_chain_json_rpc_endpoint>
 ```
 
-**Note:** for using test account provided by Geth dev instance, use `--test` flag. In that case `--data-dir` and `--config` flags can be omitted and test account is used as depositor.
+**Note:** for using test account provided by Geth dev instance, use `--test` flag. In that case `--sender-key` flag can be omitted and test account is used as a depositor.
 
 ## Withdraw ERC20
 
 This is a helper command which withdraws ERC20 tokens from the child chain to the root chain
 
 ```bash
-$ polygon-edge bridge withdraw-erc20
-    --data-dir <local_storage_secrets_path> | [--config <cloud_secrets_manager_config_path>]
-    --receivers <receivers_addresses>
-    --amounts <amounts>
-    --child-predicate <rchild_erc20_predicate_address>
-    [--child-token <child_erc20_token_address>]
+$ polygon-edge bridge withdraw-erc20 \
+    --sender-key <hex_encoded_txn_sender_private_key> \
+    --receivers <receivers_addresses> \
+    --amounts <amounts> \
+    --child-predicate <rchild_erc20_predicate_address> \
+    [--child-token <child_erc20_token_address>] \
     --json-rpc <child_chain_json_rpc_endpoint>
 ```
 
@@ -37,12 +37,12 @@ $ polygon-edge bridge withdraw-erc20
 This is a helper command which qeuries child chain for exit event proof and sends an exit transaction to ExitHelper smart contract.
 
 ```bash
-$ polygon-edge bridge exit
-    --sender-key <hex_encoded_txn_sender_private_key>
-    --exit-helper <exit_helper_address>
-    --exit-id <exit_event_id>
-    --root-json-rpc <root_chain_json_rpc_endpoint>
+$ polygon-edge bridge exit \
+    --sender-key <hex_encoded_txn_sender_private_key> \
+    --exit-helper <exit_helper_address> \
+    --exit-id <exit_event_id> \
+    --root-json-rpc <root_chain_json_rpc_endpoint> \
     --child-json-rpc <child_chain_json_rpc_endpoint>
 ```
 
-**Note:** for using test account provided by Geth dev instance, use `--test` flag. In that case `--data-dir` and `--config` flags can be omitted and test account is used as an exit transaction sender.
+**Note:** for using test account provided by Geth dev instance, use `--test` flag. In that case `--sender-key` flag can be omitted and test account is used as an exit transaction sender.

--- a/command/bridge/README.md
+++ b/command/bridge/README.md
@@ -8,7 +8,7 @@ This is a helper command which deposits ERC20 tokens from the root chain to the 
 
 ```bash
 $ polygon-edge bridge deposit-erc20
-    --data-dir <local_storage_secrets_path> | [--config <cloud_secrets_manager_config_path>]
+    --sender-key <hex_encoded_depositor_private_key>
     --receivers <receivers_addresses>
     --amounts <amounts>
     --root-token <root_erc20_token_address>
@@ -38,7 +38,7 @@ This is a helper command which qeuries child chain for exit event proof and send
 
 ```bash
 $ polygon-edge bridge exit
-    --data-dir <local_storage_secrets_path> | [--config <cloud_secrets_manager_config_path>]
+    --sender-key <hex_encoded_txn_sender_private_key>
     --exit-helper <exit_helper_address>
     --exit-id <exit_event_id>
     --root-json-rpc <root_chain_json_rpc_endpoint>

--- a/command/bridge/common/bridge_erc20_params.go
+++ b/command/bridge/common/bridge_erc20_params.go
@@ -21,7 +21,6 @@ type ERC20BridgeParams struct {
 }
 
 func (bp *ERC20BridgeParams) ValidateFlags() error {
-	// in case of test mode test rootchain account is being used as the rootchain transactions sender
 	if len(bp.Receivers) != len(bp.Amounts) {
 		return errInconsistentAccounts
 	}

--- a/command/bridge/common/bridge_erc20_params.go
+++ b/command/bridge/common/bridge_erc20_params.go
@@ -2,11 +2,10 @@ package common
 
 import (
 	"errors"
-
-	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
 )
 
 const (
+	SenderKeyFlag = "sender-key"
 	ReceiversFlag = "receivers"
 	AmountsFlag   = "amounts"
 )
@@ -16,18 +15,13 @@ var (
 )
 
 type ERC20BridgeParams struct {
-	AccountDir    string
-	AccountConfig string
-	Receivers     []string
-	Amounts       []string
+	SenderKey string
+	Receivers []string
+	Amounts   []string
 }
 
-func (bp *ERC20BridgeParams) ValidateFlags(isTestMode bool) error {
+func (bp *ERC20BridgeParams) ValidateFlags() error {
 	// in case of test mode test rootchain account is being used as the rootchain transactions sender
-	if err := helper.ValidateSecretFlags(isTestMode, bp.AccountDir, bp.AccountConfig); err != nil {
-		return err
-	}
-
 	if len(bp.Receivers) != len(bp.Amounts) {
 		return errInconsistentAccounts
 	}

--- a/command/bridge/exit/exit.go
+++ b/command/bridge/exit/exit.go
@@ -2,6 +2,7 @@ package exit
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,14 +12,14 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/umbracle/ethgo"
 	"github.com/umbracle/ethgo/jsonrpc"
+	"github.com/umbracle/ethgo/wallet"
 
 	"github.com/0xPolygon/polygon-edge/command"
+	"github.com/0xPolygon/polygon-edge/command/bridge/common"
 	cmdHelper "github.com/0xPolygon/polygon-edge/command/helper"
-	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 )
@@ -35,18 +36,12 @@ const (
 )
 
 type exitParams struct {
-	accountDir        string
-	accountConfig     string
+	senderKey         string
 	exitHelperAddrRaw string
 	exitID            uint64
 	rootJSONRPCAddr   string
 	childJSONRPCAddr  string
 	isTestMode        bool
-}
-
-// validateFlags validates input values
-func (ep *exitParams) validateFlags() error {
-	return helper.ValidateSecretFlags(ep.isTestMode, ep.accountDir, ep.accountConfig)
 }
 
 var (
@@ -57,24 +52,16 @@ var (
 // GetCommand returns the bridge exit command
 func GetCommand() *cobra.Command {
 	exitCmd := &cobra.Command{
-		Use:     "exit",
-		Short:   "Sends exit transaction to the Exit helper contract on the root chain",
-		PreRunE: preRun,
-		Run:     run,
+		Use:   "exit",
+		Short: "Sends exit transaction to the Exit helper contract on the root chain",
+		Run:   run,
 	}
 
 	exitCmd.Flags().StringVar(
-		&ep.accountDir,
-		polybftsecrets.AccountDirFlag,
+		&ep.senderKey,
+		common.SenderKeyFlag,
 		"",
-		polybftsecrets.AccountDirFlagDesc,
-	)
-
-	exitCmd.Flags().StringVar(
-		&ep.accountConfig,
-		polybftsecrets.AccountConfigFlag,
-		"",
-		polybftsecrets.AccountConfigFlagDesc,
+		"hex encoded private key of the account which sends exit transaction to the root chain",
 	)
 
 	exitCmd.Flags().StringVar(
@@ -112,11 +99,8 @@ func GetCommand() *cobra.Command {
 		"test indicates whether exit transaction sender is hardcoded test account",
 	)
 
-	exitCmd.MarkFlagRequired(exitHelperFlag) //nolint:errcheck
-	exitCmd.MarkFlagsMutuallyExclusive(
-		helper.TestModeFlag,
-		polybftsecrets.AccountDirFlag,
-		polybftsecrets.AccountConfigFlag)
+	_ = exitCmd.MarkFlagRequired(exitHelperFlag)
+	exitCmd.MarkFlagsMutuallyExclusive(helper.TestModeFlag, common.SenderKeyFlag)
 
 	return exitCmd
 }
@@ -125,33 +109,18 @@ func run(cmd *cobra.Command, _ []string) {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	var senderKey ethgo.Key
+	ecdsaRaw, err := hex.DecodeString(ep.senderKey)
+	if err != nil {
+		outputter.SetError(fmt.Errorf("failed to decode private key: %w", err))
 
-	if !ep.isTestMode {
-		secretsManager, err := polybftsecrets.GetSecretsManager(ep.accountDir, ep.accountConfig, true)
-		if err != nil {
-			outputter.SetError(err)
+		return
+	}
 
-			return
-		}
+	key, err := wallet.NewWalletFromPrivKey(ecdsaRaw)
+	if err != nil {
+		outputter.SetError(fmt.Errorf("failed to create wallet from private key: %w", err))
 
-		senderAccount, err := wallet.NewAccountFromSecret(secretsManager)
-		if err != nil {
-			outputter.SetError(err)
-
-			return
-		}
-
-		senderKey = senderAccount.Ecdsa
-	} else {
-		rootchainKey, err := helper.GetRootchainTestPrivKey()
-		if err != nil {
-			outputter.SetError(fmt.Errorf("failed to initialize root chain private key: %w", err))
-
-			return
-		}
-
-		senderKey = rootchainKey
+		return
 	}
 
 	rootTxRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(ep.rootJSONRPCAddr))
@@ -179,7 +148,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	// create exit transaction
-	txn, exitEvent, err := createExitTxn(senderKey.Address(), proof)
+	txn, exitEvent, err := createExitTxn(key.Address(), proof)
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to create tx input: %w", err))
 
@@ -187,7 +156,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	// send exit transaction
-	receipt, err := rootTxRelayer.SendTransaction(txn, senderKey)
+	receipt, err := rootTxRelayer.SendTransaction(txn, key)
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to send exit transaction (exit id=%d): %w", ep.exitID, err))
 
@@ -205,15 +174,6 @@ func run(cmd *cobra.Command, _ []string) {
 		Sender:   exitEvent.Sender.String(),
 		Receiver: exitEvent.Receiver.String(),
 	})
-}
-
-// preRun is used to validate input values
-func preRun(_ *cobra.Command, _ []string) error {
-	if err := ep.validateFlags(); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // createExitTxn encodes parameters for exit function on root chain ExitHelper contract

--- a/command/bridge/withdraw/withdraw_erc20.go
+++ b/command/bridge/withdraw/withdraw_erc20.go
@@ -36,7 +36,9 @@ type withdrawParams struct {
 }
 
 var (
-	wp *withdrawParams = &withdrawParams{ERC20BridgeParams: &common.ERC20BridgeParams{}}
+	wp *withdrawParams = &withdrawParams{
+		ERC20BridgeParams: &common.ERC20BridgeParams{},
+	}
 )
 
 // GetCommand returns the bridge withdraw command
@@ -90,8 +92,8 @@ func GetCommand() *cobra.Command {
 		"the JSON RPC child chain endpoint",
 	)
 
-	withdrawCmd.MarkFlagRequired(common.ReceiversFlag) //nolint:errcheck
-	withdrawCmd.MarkFlagRequired(common.AmountsFlag)   //nolint:errcheck
+	_ = withdrawCmd.MarkFlagRequired(common.ReceiversFlag)
+	_ = withdrawCmd.MarkFlagRequired(common.AmountsFlag)
 
 	return withdrawCmd
 }

--- a/command/bridge/withdraw/withdraw_erc20.go
+++ b/command/bridge/withdraw/withdraw_erc20.go
@@ -2,6 +2,7 @@ package withdraw
 
 import (
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -107,7 +108,14 @@ func run(cmd *cobra.Command, _ []string) {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	senderAccount, err := wallet.NewWalletFromPrivKey([]byte(wp.SenderKey))
+	senderKeyRaw, err := hex.DecodeString(wp.SenderKey)
+	if err != nil {
+		outputter.SetError(fmt.Errorf("failed to decode sender private key: %w", err))
+
+		return
+	}
+
+	senderAccount, err := wallet.NewWalletFromPrivKey(senderKeyRaw)
 	if err != nil {
 		outputter.SetError(err)
 

--- a/command/rootchain/README.md
+++ b/command/rootchain/README.md
@@ -29,9 +29,8 @@ This command deploys and initializes rootchain contracts. Transactions are being
 ```bash
 $ polygon-edge rootchain init-contracts 
     --manifest <manifest_file_path> 
+    --deployer-key <hex_encoded_rootchain_deployer_private_key>
     --json-rpc <json_rpc_endpoint> 
-    --data-dir <local_storage_secrets_path> | [--config <cloud_secrets_manager_config_path>]
-    [--test]
 ```
 
 **Note:** In case `test` flag is provided, it engages test mode, which uses predefined test account private key to send transactions to the rootchain.

--- a/command/rootchain/initcontracts/init_contracts_test.go
+++ b/command/rootchain/initcontracts/init_contracts_test.go
@@ -26,7 +26,7 @@ func TestDeployContracts_NoPanics(t *testing.T) {
 	client, err := jsonrpc.NewClient(server.HTTPAddr())
 	require.NoError(t, err)
 
-	testKey, err := helper.GetRootchainTestPrivKey()
+	testKey, err := helper.GetRootchainPrivateKey("")
 	require.NoError(t, err)
 
 	receipt, err := server.Fund(testKey.Address())
@@ -36,7 +36,7 @@ func TestDeployContracts_NoPanics(t *testing.T) {
 	outputter := command.InitializeOutputter(GetCommand())
 
 	require.NotPanics(t, func() {
-		err = deployContracts(outputter, client, &polybft.Manifest{}, testKey)
+		err = deployContracts(outputter, client, &polybft.Manifest{})
 	})
 	require.NoError(t, err)
 }

--- a/command/rootchain/initcontracts/params.go
+++ b/command/rootchain/initcontracts/params.go
@@ -4,12 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
-
-	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
 )
 
 const (
 	manifestPathFlag   = "manifest"
+	deployerKeyFlag    = "deployer-key"
 	jsonRPCFlag        = "json-rpc"
 	rootchainERC20Flag = "rootchain-erc20"
 
@@ -18,18 +17,13 @@ const (
 
 type initContractsParams struct {
 	manifestPath       string
-	accountDir         string
-	accountConfig      string
+	deployerKey        string
 	jsonRPCAddress     string
 	rootERC20TokenAddr string
 	isTestMode         bool
 }
 
 func (ip *initContractsParams) validateFlags() error {
-	if err := helper.ValidateSecretFlags(ip.isTestMode, ip.accountDir, ip.accountConfig); err != nil {
-		return err
-	}
-
 	if _, err := os.Stat(ip.manifestPath); errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("provided manifest path '%s' doesn't exist", ip.manifestPath)
 	}

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -371,7 +371,7 @@ func TestE2E_Bridge_L2toL1Exit(t *testing.T) {
 	}
 
 	// use test account for rootchain
-	rootchainKey, err := rootchainHelper.GetRootchainTestPrivKey()
+	rootchainKey, err := rootchainHelper.GetRootchainPrivateKey("")
 	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 5,
@@ -470,7 +470,7 @@ func TestE2E_Bridge_L2toL1ExitMultiple(t *testing.T) {
 	}
 
 	// use test account for rootchain
-	rootchainKey, err := rootchainHelper.GetRootchainTestPrivKey()
+	rootchainKey, err := rootchainHelper.GetRootchainPrivateKey("")
 	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 5,

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"path"
@@ -116,9 +117,12 @@ func TestE2E_Bridge_DepositAndWithdrawERC20(t *testing.T) {
 
 	t.Logf("Withdraw sender: %s\n", senderAccount.Ecdsa.Address())
 
+	rawKey, err := senderAccount.Ecdsa.MarshallPrivateKey()
+	require.NoError(t, err)
+
 	// send withdraw transaction
 	err = cluster.Bridge.WithdrawERC20(
-		cluster.Servers[0].DataDir(),
+		hex.EncodeToString(rawKey),
 		strings.Join(receivers[:], ","),
 		strings.Join(amounts[:], ","),
 		cluster.Servers[0].JSONRPCAddr())

--- a/e2e-polybft/framework/test-bridge.go
+++ b/e2e-polybft/framework/test-bridge.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	"github.com/0xPolygon/polygon-edge/command/rootchain/server"
 	"github.com/0xPolygon/polygon-edge/types"
 )
@@ -116,9 +115,9 @@ func (t *TestBridge) DepositERC20(rootTokenAddr, rootPredicateAddr types.Address
 
 // WithdrawERC20 function is used to invoke bridge withdraw ERC20 tokens (from the child to the root chain)
 // with given receivers and amounts
-func (t *TestBridge) WithdrawERC20(secretsDataDir, receivers, amounts, jsonRPCEndpoint string) error {
-	if secretsDataDir == "" {
-		return errors.New("provide a data directory which holds sender secrets")
+func (t *TestBridge) WithdrawERC20(senderKey, receivers, amounts, jsonRPCEndpoint string) error {
+	if senderKey == "" {
+		return errors.New("provide hex encoded sender private key")
 	}
 
 	if receivers == "" {
@@ -136,7 +135,7 @@ func (t *TestBridge) WithdrawERC20(secretsDataDir, receivers, amounts, jsonRPCEn
 	return t.cmdRun(
 		"bridge",
 		"withdraw-erc20",
-		"--"+polybftsecrets.AccountDirFlag, secretsDataDir,
+		"--sender-key", senderKey,
 		"--receivers", receivers,
 		"--amounts", amounts,
 		"--json-rpc", jsonRPCEndpoint,


### PR DESCRIPTION
# Description

This PR changes rootchain init contracts and bridge transactions helper commands to rely on hex encoded private key, instead of secrets manager since it is more streamlined to provide private key that way (and the fact that these commands are going to be used only for one time deployment and testing purposes).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
