### PR TITLE
EVM-553: Enable generating of functions with same names in contracts api

### DIFF
--- a/command/bridge/deposit/deposit_erc20.go
+++ b/command/bridge/deposit/deposit_erc20.go
@@ -271,7 +271,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 // createDepositTxn encodes parameters for deposit function on rootchain predicate contract
 func createDepositTxn(sender, receiver types.Address, amount *big.Int) (*ethgo.Transaction, error) {
-	depositToFn := &contractsapi.DepositToFunction{
+	depositToFn := &contractsapi.DepositToRootERC20PredicateFn{
 		RootToken: types.StringToAddress(dp.rootTokenAddr),
 		Receiver:  receiver,
 		Amount:    amount,
@@ -293,7 +293,7 @@ func createDepositTxn(sender, receiver types.Address, amount *big.Int) (*ethgo.T
 
 // createMintTxn encodes parameters for mint function on rootchain token contract
 func createMintTxn(sender, receiver types.Address, amount *big.Int) (*ethgo.Transaction, error) {
-	mintFn := &contractsapi.MintFunction{
+	mintFn := &contractsapi.MintRootERC20Fn{
 		To:     receiver,
 		Amount: amount,
 	}
@@ -316,7 +316,7 @@ func createMintTxn(sender, receiver types.Address, amount *big.Int) (*ethgo.Tran
 // to ERC20 token for ERC20 predicate so that it is able to spend given tokens
 func createApproveERC20PredicateTxn(amount *big.Int,
 	rootERC20Predicate, rootERC20Token types.Address) (*ethgo.Transaction, error) {
-	approveFnParams := &contractsapi.ApproveFunction{
+	approveFnParams := &contractsapi.ApproveRootERC20Fn{
 		Spender: rootERC20Predicate,
 		Amount:  amount,
 	}

--- a/command/bridge/exit/exit.go
+++ b/command/bridge/exit/exit.go
@@ -248,7 +248,7 @@ func createExitTxn(sender ethgo.Address, proof types.Proof) (*ethgo.Transaction,
 		return nil, nil, errors.New("failed to convert proof checkpoint block")
 	}
 
-	exitFn := &contractsapi.ExitFunction{
+	exitFn := &contractsapi.ExitExitHelperFn{
 		BlockNumber:  new(big.Int).SetUint64(uint64(checkpointBlock)),
 		LeafIndex:    new(big.Int).SetUint64(uint64(leafIndex)),
 		UnhashedLeaf: exitEventEncoded,

--- a/command/bridge/withdraw/withdraw_erc20.go
+++ b/command/bridge/withdraw/withdraw_erc20.go
@@ -190,7 +190,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 // createWithdrawTxn encodes parameters for withdraw function on child chain predicate contract
 func createWithdrawTxn(receiver types.Address, amount *big.Int) (*ethgo.Transaction, error) {
-	withdrawToFn := &contractsapi.WithdrawToFunction{
+	withdrawToFn := &contractsapi.WithdrawToChildERC20PredicateFn{
 		ChildToken: types.StringToAddress(wp.childTokenAddr),
 		Receiver:   receiver,
 		Amount:     amount,

--- a/command/rootchain/initcontracts/init_contracts.go
+++ b/command/rootchain/initcontracts/init_contracts.go
@@ -361,7 +361,7 @@ func initializeCheckpointManager(
 		return fmt.Errorf("failed to convert validators to map: %w", err)
 	}
 
-	initialize := contractsapi.InitializeCheckpointManagerFunction{
+	initialize := contractsapi.InitializeCheckpointManagerFn{
 		ChainID_:        big.NewInt(manifest.ChainID),
 		NewBls:          manifest.RootchainConfig.BLSAddress,
 		NewBn256G2:      manifest.RootchainConfig.BN256G2Address,
@@ -403,7 +403,7 @@ func initializeExitHelper(txRelayer txrelayer.TxRelayer, rootchainConfig *polybf
 // initializeRootERC20Predicate invokes initialize function on "RootERC20Predicate" smart contract
 func initializeRootERC20Predicate(txRelayer txrelayer.TxRelayer, rootchainConfig *polybft.RootchainConfig,
 	deployerKey ethgo.Key) error {
-	rootERC20PredicateParams := &contractsapi.InitializeRootERC20PredicateFunction{
+	rootERC20PredicateParams := &contractsapi.InitializeRootERC20PredicateFn{
 		NewStateSender:         rootchainConfig.StateSenderAddress,
 		NewExitHelper:          rootchainConfig.ExitHelperAddress,
 		NewChildERC20Predicate: contracts.ChildERC20PredicateContract,

--- a/command/sidechain/registration/register_validator.go
+++ b/command/sidechain/registration/register_validator.go
@@ -219,7 +219,7 @@ func registerValidator(sender txrelayer.TxRelayer, account *wallet.Account,
 		return nil, fmt.Errorf("register validator failed: %w", err)
 	}
 
-	registerFn := &contractsapi.RegisterFunction{
+	registerFn := &contractsapi.RegisterChildValidatorSetFn{
 		Signature: sigMarshal,
 		Pubkey:    account.Bls.PublicKey().ToBigInt(),
 	}

--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -243,7 +243,7 @@ func (c *checkpointManager) abiEncodeCheckpointBlock(blockNumber uint64, blockHa
 		return nil, err
 	}
 
-	submit := &contractsapi.SubmitFunction{
+	submit := &contractsapi.SubmitCheckpointManagerFn{
 		CheckpointMetadata: &contractsapi.CheckpointMetadata{
 			BlockHash:               blockHash,
 			BlockRound:              new(big.Int).SetUint64(extra.Checkpoint.BlockRound),
@@ -344,7 +344,7 @@ func (c *checkpointManager) GenerateExitProof(exitID uint64) (types.Proof, error
 		return types.Proof{}, err
 	}
 
-	getCheckpointBlockFn := &contractsapi.GetCheckpointBlockFunction{
+	getCheckpointBlockFn := &contractsapi.GetCheckpointBlockCheckpointManagerFn{
 		BlockNumber: new(big.Int).SetUint64(exitEvent.BlockNumber),
 	}
 

--- a/consensus/polybft/checkpoint_manager_test.go
+++ b/consensus/polybft/checkpoint_manager_test.go
@@ -166,7 +166,7 @@ func TestCheckpointManager_abiEncodeCheckpointBlock(t *testing.T) {
 	checkpointDataEncoded, err := c.abiEncodeCheckpointBlock(header.Number, header.Hash, extra, nextValidators.getPublicIdentities())
 	require.NoError(t, err)
 
-	submit := &contractsapi.SubmitFunction{}
+	submit := &contractsapi.SubmitCheckpointManagerFn{}
 	require.NoError(t, submit.DecodeAbi(checkpointDataEncoded))
 
 	require.Equal(t, new(big.Int).SetUint64(checkpoint.EpochNumber), submit.Checkpoint.Epoch)
@@ -389,7 +389,7 @@ func TestCheckpointManager_GenerateExitProof(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	getCheckpointBlockFn := &contractsapi.GetCheckpointBlockFunction{
+	getCheckpointBlockFn := &contractsapi.GetCheckpointBlockCheckpointManagerFn{
 		BlockNumber: new(big.Int).SetUint64(correctBlockToGetExit),
 	}
 
@@ -510,7 +510,7 @@ func (d *dummyTxRelayer) SendTransactionLocal(txn *ethgo.Transaction) (*ethgo.Re
 func getBlockNumberCheckpointSubmitInput(t *testing.T, input []byte) uint64 {
 	t.Helper()
 
-	submit := &contractsapi.SubmitFunction{}
+	submit := &contractsapi.SubmitCheckpointManagerFn{}
 	require.NoError(t, submit.DecodeAbi(input))
 
 	return submit.Checkpoint.BlockNumber.Uint64()

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -451,7 +451,7 @@ func (c *consensusRuntime) restartEpoch(header *types.Header) (*epochMetadata, e
 // in the current epoch, and ending at the last block of previous epoch
 func (c *consensusRuntime) calculateCommitEpochInput(
 	currentBlock *types.Header,
-	epoch *epochMetadata) (*contractsapi.CommitEpochFunction, error) {
+	epoch *epochMetadata) (*contractsapi.CommitEpochChildValidatorSetFn, error) {
 	uptimeCounter := map[types.Address]int64{}
 	blockHeader := currentBlock
 	epochID := epoch.Number
@@ -529,7 +529,7 @@ func (c *consensusRuntime) calculateCommitEpochInput(
 		uptime.AddValidatorUptime(addr, uptimeCounter[addr])
 	}
 
-	commitEpoch := &contractsapi.CommitEpochFunction{
+	commitEpoch := &contractsapi.CommitEpochChildValidatorSetFn{
 		ID: new(big.Int).SetUint64(epochID),
 		Epoch: &contractsapi.Epoch{
 			StartBlock: new(big.Int).SetUint64(epoch.FirstBlockInEpoch),

--- a/consensus/polybft/contracts_initializer.go
+++ b/consensus/polybft/contracts_initializer.go
@@ -36,7 +36,7 @@ func getInitChildValidatorSetInput(polyBFTConfig PolyBFTConfig) ([]byte, error) 
 		apiValidators[i] = validatorData
 	}
 
-	params := &contractsapi.InitializeChildValidatorSetFunction{
+	params := &contractsapi.InitializeChildValidatorSetFn{
 		Init: &contractsapi.InitStruct{
 			EpochReward:   new(big.Int).SetUint64(polyBFTConfig.EpochReward),
 			MinStake:      big.NewInt(minStake),
@@ -62,7 +62,7 @@ func getInitChildERC20PredicateInput(config *BridgeConfig) ([]byte, error) {
 		rootERC20Addr = config.RootNativeERC20Addr
 	}
 
-	params := &contractsapi.InitializeChildERC20PredicateFunction{
+	params := &contractsapi.InitializeChildERC20PredicateFn{
 		NewL2StateSender:          contracts.L2StateSenderContract,
 		NewStateReceiver:          contracts.StateReceiverContract,
 		NewRootERC20Predicate:     rootERC20PredicateAddr,

--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -19,7 +19,7 @@ import (
 const (
 	abiTypeNameFormat  = "var %sABIType = abi.MustNewType(\"%s\")"
 	eventNameFormat    = "%sEvent"
-	functionNameFormat = "%sFunction"
+	functionNameFormat = "%sFn"
 )
 
 type generatedData struct {
@@ -358,15 +358,7 @@ func ({{.Sig}} *{{.TName}}) ParseLog(log *ethgo.Log) error {
 
 // generateFunction generates code for smart contract function and its parameters
 func generateFunction(generatedData *generatedData, contractName string, method *abi.Method) error {
-	methodName := method.Name
-	if methodName == "initialize" {
-		// most of the contracts have initialize function, which differ in params
-		// so make them unique somehow
-		methodName = strings.Title(methodName + contractName)
-	}
-
-	methodName = fmt.Sprintf(functionNameFormat, methodName)
-
+	methodName := fmt.Sprintf(functionNameFormat, strings.Title(method.Name+contractName))
 	res := []string{}
 
 	_, err := generateType(generatedData, methodName, method.Inputs, &res)

--- a/consensus/polybft/contractsapi/contractsapi.go
+++ b/consensus/polybft/contractsapi/contractsapi.go
@@ -25,17 +25,17 @@ func (s *StateSyncCommitment) DecodeAbi(buf []byte) error {
 	return decodeStruct(StateSyncCommitmentABIType, buf, &s)
 }
 
-type CommitFunction struct {
+type CommitStateReceiverFn struct {
 	Commitment *StateSyncCommitment `abi:"commitment"`
 	Signature  []byte               `abi:"signature"`
 	Bitmap     []byte               `abi:"bitmap"`
 }
 
-func (c *CommitFunction) EncodeAbi() ([]byte, error) {
+func (c *CommitStateReceiverFn) EncodeAbi() ([]byte, error) {
 	return StateReceiver.Abi.Methods["commit"].Encode(c)
 }
 
-func (c *CommitFunction) DecodeAbi(buf []byte) error {
+func (c *CommitStateReceiverFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(StateReceiver.Abi.Methods["commit"], buf, c)
 }
 
@@ -56,16 +56,16 @@ func (s *StateSync) DecodeAbi(buf []byte) error {
 	return decodeStruct(StateSyncABIType, buf, &s)
 }
 
-type ExecuteFunction struct {
+type ExecuteStateReceiverFn struct {
 	Proof []types.Hash `abi:"proof"`
 	Obj   *StateSync   `abi:"obj"`
 }
 
-func (e *ExecuteFunction) EncodeAbi() ([]byte, error) {
+func (e *ExecuteStateReceiverFn) EncodeAbi() ([]byte, error) {
 	return StateReceiver.Abi.Methods["execute"].Encode(e)
 }
 
-func (e *ExecuteFunction) DecodeAbi(buf []byte) error {
+func (e *ExecuteStateReceiverFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(StateReceiver.Abi.Methods["execute"], buf, e)
 }
 
@@ -136,17 +136,17 @@ func (u *Uptime) DecodeAbi(buf []byte) error {
 	return decodeStruct(UptimeABIType, buf, &u)
 }
 
-type CommitEpochFunction struct {
+type CommitEpochChildValidatorSetFn struct {
 	ID     *big.Int `abi:"id"`
 	Epoch  *Epoch   `abi:"epoch"`
 	Uptime *Uptime  `abi:"uptime"`
 }
 
-func (c *CommitEpochFunction) EncodeAbi() ([]byte, error) {
+func (c *CommitEpochChildValidatorSetFn) EncodeAbi() ([]byte, error) {
 	return ChildValidatorSet.Abi.Methods["commitEpoch"].Encode(c)
 }
 
-func (c *CommitEpochFunction) DecodeAbi(buf []byte) error {
+func (c *CommitEpochChildValidatorSetFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(ChildValidatorSet.Abi.Methods["commitEpoch"], buf, c)
 }
 
@@ -184,56 +184,56 @@ func (v *ValidatorInit) DecodeAbi(buf []byte) error {
 	return decodeStruct(ValidatorInitABIType, buf, &v)
 }
 
-type InitializeChildValidatorSetFunction struct {
+type InitializeChildValidatorSetFn struct {
 	Init       *InitStruct      `abi:"init"`
 	Validators []*ValidatorInit `abi:"validators"`
 	NewBls     types.Address    `abi:"newBls"`
 	Governance types.Address    `abi:"governance"`
 }
 
-func (i *InitializeChildValidatorSetFunction) EncodeAbi() ([]byte, error) {
+func (i *InitializeChildValidatorSetFn) EncodeAbi() ([]byte, error) {
 	return ChildValidatorSet.Abi.Methods["initialize"].Encode(i)
 }
 
-func (i *InitializeChildValidatorSetFunction) DecodeAbi(buf []byte) error {
+func (i *InitializeChildValidatorSetFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(ChildValidatorSet.Abi.Methods["initialize"], buf, i)
 }
 
-type AddToWhitelistFunction struct {
+type AddToWhitelistChildValidatorSetFn struct {
 	WhitelistAddreses []ethgo.Address `abi:"whitelistAddreses"`
 }
 
-func (a *AddToWhitelistFunction) EncodeAbi() ([]byte, error) {
+func (a *AddToWhitelistChildValidatorSetFn) EncodeAbi() ([]byte, error) {
 	return ChildValidatorSet.Abi.Methods["addToWhitelist"].Encode(a)
 }
 
-func (a *AddToWhitelistFunction) DecodeAbi(buf []byte) error {
+func (a *AddToWhitelistChildValidatorSetFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(ChildValidatorSet.Abi.Methods["addToWhitelist"], buf, a)
 }
 
-type RegisterFunction struct {
+type RegisterChildValidatorSetFn struct {
 	Signature [2]*big.Int `abi:"signature"`
 	Pubkey    [4]*big.Int `abi:"pubkey"`
 }
 
-func (r *RegisterFunction) EncodeAbi() ([]byte, error) {
+func (r *RegisterChildValidatorSetFn) EncodeAbi() ([]byte, error) {
 	return ChildValidatorSet.Abi.Methods["register"].Encode(r)
 }
 
-func (r *RegisterFunction) DecodeAbi(buf []byte) error {
+func (r *RegisterChildValidatorSetFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(ChildValidatorSet.Abi.Methods["register"], buf, r)
 }
 
-type SyncStateFunction struct {
+type SyncStateStateSenderFn struct {
 	Receiver types.Address `abi:"receiver"`
 	Data     []byte        `abi:"data"`
 }
 
-func (s *SyncStateFunction) EncodeAbi() ([]byte, error) {
+func (s *SyncStateStateSenderFn) EncodeAbi() ([]byte, error) {
 	return StateSender.Abi.Methods["syncState"].Encode(s)
 }
 
-func (s *SyncStateFunction) DecodeAbi(buf []byte) error {
+func (s *SyncStateStateSenderFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(StateSender.Abi.Methods["syncState"], buf, s)
 }
 
@@ -307,7 +307,7 @@ func (v *Validator) DecodeAbi(buf []byte) error {
 	return decodeStruct(ValidatorABIType, buf, &v)
 }
 
-type SubmitFunction struct {
+type SubmitCheckpointManagerFn struct {
 	CheckpointMetadata *CheckpointMetadata `abi:"checkpointMetadata"`
 	Checkpoint         *Checkpoint         `abi:"checkpoint"`
 	Signature          [2]*big.Int         `abi:"signature"`
@@ -315,57 +315,57 @@ type SubmitFunction struct {
 	Bitmap             []byte              `abi:"bitmap"`
 }
 
-func (s *SubmitFunction) EncodeAbi() ([]byte, error) {
+func (s *SubmitCheckpointManagerFn) EncodeAbi() ([]byte, error) {
 	return CheckpointManager.Abi.Methods["submit"].Encode(s)
 }
 
-func (s *SubmitFunction) DecodeAbi(buf []byte) error {
+func (s *SubmitCheckpointManagerFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(CheckpointManager.Abi.Methods["submit"], buf, s)
 }
 
-type InitializeCheckpointManagerFunction struct {
+type InitializeCheckpointManagerFn struct {
 	NewBls          types.Address `abi:"newBls"`
 	NewBn256G2      types.Address `abi:"newBn256G2"`
 	ChainID_        *big.Int      `abi:"chainId_"`
 	NewValidatorSet []*Validator  `abi:"newValidatorSet"`
 }
 
-func (i *InitializeCheckpointManagerFunction) EncodeAbi() ([]byte, error) {
+func (i *InitializeCheckpointManagerFn) EncodeAbi() ([]byte, error) {
 	return CheckpointManager.Abi.Methods["initialize"].Encode(i)
 }
 
-func (i *InitializeCheckpointManagerFunction) DecodeAbi(buf []byte) error {
+func (i *InitializeCheckpointManagerFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(CheckpointManager.Abi.Methods["initialize"], buf, i)
 }
 
-type GetCheckpointBlockFunction struct {
+type GetCheckpointBlockCheckpointManagerFn struct {
 	BlockNumber *big.Int `abi:"blockNumber"`
 }
 
-func (g *GetCheckpointBlockFunction) EncodeAbi() ([]byte, error) {
+func (g *GetCheckpointBlockCheckpointManagerFn) EncodeAbi() ([]byte, error) {
 	return CheckpointManager.Abi.Methods["getCheckpointBlock"].Encode(g)
 }
 
-func (g *GetCheckpointBlockFunction) DecodeAbi(buf []byte) error {
+func (g *GetCheckpointBlockCheckpointManagerFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(CheckpointManager.Abi.Methods["getCheckpointBlock"], buf, g)
 }
 
-type ExitFunction struct {
+type ExitExitHelperFn struct {
 	BlockNumber  *big.Int     `abi:"blockNumber"`
 	LeafIndex    *big.Int     `abi:"leafIndex"`
 	UnhashedLeaf []byte       `abi:"unhashedLeaf"`
 	Proof        []types.Hash `abi:"proof"`
 }
 
-func (e *ExitFunction) EncodeAbi() ([]byte, error) {
+func (e *ExitExitHelperFn) EncodeAbi() ([]byte, error) {
 	return ExitHelper.Abi.Methods["exit"].Encode(e)
 }
 
-func (e *ExitFunction) DecodeAbi(buf []byte) error {
+func (e *ExitExitHelperFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(ExitHelper.Abi.Methods["exit"], buf, e)
 }
 
-type InitializeChildERC20PredicateFunction struct {
+type InitializeChildERC20PredicateFn struct {
 	NewL2StateSender          types.Address `abi:"newL2StateSender"`
 	NewStateReceiver          types.Address `abi:"newStateReceiver"`
 	NewRootERC20Predicate     types.Address `abi:"newRootERC20Predicate"`
@@ -373,29 +373,29 @@ type InitializeChildERC20PredicateFunction struct {
 	NewNativeTokenRootAddress types.Address `abi:"newNativeTokenRootAddress"`
 }
 
-func (i *InitializeChildERC20PredicateFunction) EncodeAbi() ([]byte, error) {
+func (i *InitializeChildERC20PredicateFn) EncodeAbi() ([]byte, error) {
 	return ChildERC20Predicate.Abi.Methods["initialize"].Encode(i)
 }
 
-func (i *InitializeChildERC20PredicateFunction) DecodeAbi(buf []byte) error {
+func (i *InitializeChildERC20PredicateFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(ChildERC20Predicate.Abi.Methods["initialize"], buf, i)
 }
 
-type WithdrawToFunction struct {
+type WithdrawToChildERC20PredicateFn struct {
 	ChildToken types.Address `abi:"childToken"`
 	Receiver   types.Address `abi:"receiver"`
 	Amount     *big.Int      `abi:"amount"`
 }
 
-func (w *WithdrawToFunction) EncodeAbi() ([]byte, error) {
+func (w *WithdrawToChildERC20PredicateFn) EncodeAbi() ([]byte, error) {
 	return ChildERC20Predicate.Abi.Methods["withdrawTo"].Encode(w)
 }
 
-func (w *WithdrawToFunction) DecodeAbi(buf []byte) error {
+func (w *WithdrawToChildERC20PredicateFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(ChildERC20Predicate.Abi.Methods["withdrawTo"], buf, w)
 }
 
-type InitializeNativeERC20Function struct {
+type InitializeNativeERC20Fn struct {
 	Predicate_ types.Address `abi:"predicate_"`
 	RootToken_ types.Address `abi:"rootToken_"`
 	Name_      string        `abi:"name_"`
@@ -403,15 +403,15 @@ type InitializeNativeERC20Function struct {
 	Decimals_  uint8         `abi:"decimals_"`
 }
 
-func (i *InitializeNativeERC20Function) EncodeAbi() ([]byte, error) {
+func (i *InitializeNativeERC20Fn) EncodeAbi() ([]byte, error) {
 	return NativeERC20.Abi.Methods["initialize"].Encode(i)
 }
 
-func (i *InitializeNativeERC20Function) DecodeAbi(buf []byte) error {
+func (i *InitializeNativeERC20Fn) DecodeAbi(buf []byte) error {
 	return decodeMethod(NativeERC20.Abi.Methods["initialize"], buf, i)
 }
 
-type InitializeNativeERC20MintableFunction struct {
+type InitializeNativeERC20MintableFn struct {
 	Predicate_ types.Address `abi:"predicate_"`
 	Owner_     types.Address `abi:"owner_"`
 	RootToken_ types.Address `abi:"rootToken_"`
@@ -420,15 +420,15 @@ type InitializeNativeERC20MintableFunction struct {
 	Decimals_  uint8         `abi:"decimals_"`
 }
 
-func (i *InitializeNativeERC20MintableFunction) EncodeAbi() ([]byte, error) {
+func (i *InitializeNativeERC20MintableFn) EncodeAbi() ([]byte, error) {
 	return NativeERC20Mintable.Abi.Methods["initialize"].Encode(i)
 }
 
-func (i *InitializeNativeERC20MintableFunction) DecodeAbi(buf []byte) error {
+func (i *InitializeNativeERC20MintableFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(NativeERC20Mintable.Abi.Methods["initialize"], buf, i)
 }
 
-type InitializeRootERC20PredicateFunction struct {
+type InitializeRootERC20PredicateFn struct {
 	NewStateSender         types.Address `abi:"newStateSender"`
 	NewExitHelper          types.Address `abi:"newExitHelper"`
 	NewChildERC20Predicate types.Address `abi:"newChildERC20Predicate"`
@@ -436,50 +436,50 @@ type InitializeRootERC20PredicateFunction struct {
 	NativeTokenRootAddress types.Address `abi:"nativeTokenRootAddress"`
 }
 
-func (i *InitializeRootERC20PredicateFunction) EncodeAbi() ([]byte, error) {
+func (i *InitializeRootERC20PredicateFn) EncodeAbi() ([]byte, error) {
 	return RootERC20Predicate.Abi.Methods["initialize"].Encode(i)
 }
 
-func (i *InitializeRootERC20PredicateFunction) DecodeAbi(buf []byte) error {
+func (i *InitializeRootERC20PredicateFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(RootERC20Predicate.Abi.Methods["initialize"], buf, i)
 }
 
-type DepositToFunction struct {
+type DepositToRootERC20PredicateFn struct {
 	RootToken types.Address `abi:"rootToken"`
 	Receiver  types.Address `abi:"receiver"`
 	Amount    *big.Int      `abi:"amount"`
 }
 
-func (d *DepositToFunction) EncodeAbi() ([]byte, error) {
+func (d *DepositToRootERC20PredicateFn) EncodeAbi() ([]byte, error) {
 	return RootERC20Predicate.Abi.Methods["depositTo"].Encode(d)
 }
 
-func (d *DepositToFunction) DecodeAbi(buf []byte) error {
+func (d *DepositToRootERC20PredicateFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(RootERC20Predicate.Abi.Methods["depositTo"], buf, d)
 }
 
-type ApproveFunction struct {
+type ApproveRootERC20Fn struct {
 	Spender types.Address `abi:"spender"`
 	Amount  *big.Int      `abi:"amount"`
 }
 
-func (a *ApproveFunction) EncodeAbi() ([]byte, error) {
+func (a *ApproveRootERC20Fn) EncodeAbi() ([]byte, error) {
 	return RootERC20.Abi.Methods["approve"].Encode(a)
 }
 
-func (a *ApproveFunction) DecodeAbi(buf []byte) error {
+func (a *ApproveRootERC20Fn) DecodeAbi(buf []byte) error {
 	return decodeMethod(RootERC20.Abi.Methods["approve"], buf, a)
 }
 
-type MintFunction struct {
+type MintRootERC20Fn struct {
 	To     types.Address `abi:"to"`
 	Amount *big.Int      `abi:"amount"`
 }
 
-func (m *MintFunction) EncodeAbi() ([]byte, error) {
+func (m *MintRootERC20Fn) EncodeAbi() ([]byte, error) {
 	return RootERC20.Abi.Methods["mint"].Encode(m)
 }
 
-func (m *MintFunction) DecodeAbi(buf []byte) error {
+func (m *MintRootERC20Fn) DecodeAbi(buf []byte) error {
 	return decodeMethod(RootERC20.Abi.Methods["mint"], buf, m)
 }

--- a/consensus/polybft/contractsapi/contractsapi_test.go
+++ b/consensus/polybft/contractsapi/contractsapi_test.go
@@ -19,7 +19,7 @@ func TestEncoding_Method(t *testing.T) {
 
 	cases := []method{
 		// empty commit
-		&CommitFunction{
+		&CommitStateReceiverFn{
 			Commitment: &StateSyncCommitment{
 				StartID: big.NewInt(1),
 				EndID:   big.NewInt(1),
@@ -29,7 +29,7 @@ func TestEncoding_Method(t *testing.T) {
 			Bitmap:    []byte{},
 		},
 		// empty commit epoch
-		&CommitEpochFunction{
+		&CommitEpochChildValidatorSetFn{
 			ID: big.NewInt(1),
 			Epoch: &Epoch{
 				StartBlock: big.NewInt(1),

--- a/consensus/polybft/contractsapi/helper.go
+++ b/consensus/polybft/contractsapi/helper.go
@@ -38,4 +38,4 @@ func (u *Uptime) AddValidatorUptime(address types.Address, count int64) {
 	})
 }
 
-var _ StateTransactionInput = &CommitEpochFunction{}
+var _ StateTransactionInput = &CommitEpochChildValidatorSetFn{}

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -63,7 +63,7 @@ type fsm struct {
 	// commitEpochInput holds info about validators performance during single epoch
 	// (namely how many times each validator signed block during epoch).
 	// It is populated only for epoch-ending blocks.
-	commitEpochInput *contractsapi.CommitEpochFunction
+	commitEpochInput *contractsapi.CommitEpochChildValidatorSetFn
 
 	// isEndOfEpoch indicates if epoch reached its end
 	isEndOfEpoch bool
@@ -440,7 +440,7 @@ func (f *fsm) VerifyStateTransactions(transactions []*types.Transaction) error {
 			if !verified {
 				return fmt.Errorf("invalid signature for tx = %v", tx.Hash)
 			}
-		case *contractsapi.CommitEpochFunction:
+		case *contractsapi.CommitEpochChildValidatorSetFn:
 			if commitEpochTxExists {
 				// if we already validated commit epoch tx,
 				// that means someone added more than one commit epoch tx to block,

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -1038,7 +1038,7 @@ func TestFSM_DecodeCommitEpochStateTx(t *testing.T) {
 	decodedInputData, err := decodeStateTransaction(tx.Input)
 	require.NoError(t, err)
 
-	decodedCommitEpoch, ok := decodedInputData.(*contractsapi.CommitEpochFunction)
+	decodedCommitEpoch, ok := decodedInputData.(*contractsapi.CommitEpochChildValidatorSetFn)
 	require.True(t, ok)
 	require.True(t, commitEpoch.ID.Cmp(decodedCommitEpoch.ID) == 0)
 	require.NotNil(t, decodedCommitEpoch.Epoch)

--- a/consensus/polybft/helpers_test.go
+++ b/consensus/polybft/helpers_test.go
@@ -57,7 +57,8 @@ func createSignature(t *testing.T, accounts []*wallet.Account, hash types.Hash) 
 	return &Signature{AggregatedSignature: aggs, Bitmap: bmp}
 }
 
-func createTestCommitEpochInput(t *testing.T, epochID uint64, validatorSet AccountSet, epochSize uint64) *contractsapi.CommitEpochFunction {
+func createTestCommitEpochInput(t *testing.T, epochID uint64,
+	validatorSet AccountSet, epochSize uint64) *contractsapi.CommitEpochChildValidatorSetFn {
 	t.Helper()
 
 	if validatorSet == nil {
@@ -75,7 +76,7 @@ func createTestCommitEpochInput(t *testing.T, epochID uint64, validatorSet Accou
 		TotalBlocks: new(big.Int).SetUint64(epochSize),
 	}
 
-	commitEpoch := &contractsapi.CommitEpochFunction{
+	commitEpoch := &contractsapi.CommitEpochChildValidatorSetFn{
 		ID: uptime.EpochID,
 		Epoch: &contractsapi.Epoch{
 			StartBlock: new(big.Int).SetUint64(startBlock + 1),

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -145,7 +145,7 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 
 		if polyBFTConfig.MintableERC20Token {
 			// initialize NativeERC20Mintable SC
-			params := &contractsapi.InitializeNativeERC20MintableFunction{
+			params := &contractsapi.InitializeNativeERC20MintableFn{
 				Predicate_: contracts.ChildERC20PredicateContract,
 				Owner_:     polyBFTConfig.Governance,
 				RootToken_: rootNativeERC20Token,
@@ -164,7 +164,7 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 			}
 		} else {
 			// initialize NativeERC20 SC
-			params := &contractsapi.InitializeNativeERC20Function{
+			params := &contractsapi.InitializeNativeERC20Fn{
 				Name_:      nativeTokenName,
 				Symbol_:    nativeTokenSymbol,
 				Decimals_:  nativeTokenDecimals,

--- a/consensus/polybft/sc_integration_test.go
+++ b/consensus/polybft/sc_integration_test.go
@@ -56,7 +56,7 @@ func TestIntegratoin_PerformExit(t *testing.T) {
 	}
 
 	checkpointManagerInit := func() ([]byte, error) {
-		initialize := contractsapi.InitializeCheckpointManagerFunction{
+		initialize := contractsapi.InitializeCheckpointManagerFn{
 			NewBls:          contracts.BLSContract,
 			NewBn256G2:      bn256Addr,
 			NewValidatorSet: accSet.ToAPIBinding(),

--- a/consensus/polybft/state_transaction.go
+++ b/consensus/polybft/state_transaction.go
@@ -107,7 +107,7 @@ func (cm *CommitmentMessageSigned) EncodeAbi() ([]byte, error) {
 		return nil, err
 	}
 
-	commit := &contractsapi.CommitFunction{
+	commit := &contractsapi.CommitStateReceiverFn{
 		Commitment: cm.Message,
 		Signature:  cm.AggSignature.AggregatedSignature,
 		Bitmap:     blsVerificationPart,
@@ -122,7 +122,7 @@ func (cm *CommitmentMessageSigned) DecodeAbi(txData []byte) error {
 		return fmt.Errorf("invalid commitment data, len = %d", len(txData))
 	}
 
-	commit := contractsapi.CommitFunction{}
+	commit := contractsapi.CommitStateReceiverFn{}
 
 	err := commit.DecodeAbi(txData)
 	if err != nil {
@@ -175,7 +175,7 @@ func decodeStateTransaction(txData []byte) (contractsapi.StateTransactionInput, 
 		obj = &CommitmentMessageSigned{}
 	} else if bytes.Equal(sig, contractsapi.ChildValidatorSet.Abi.Methods["commitEpoch"].ID()) {
 		// commit epoch
-		obj = &contractsapi.CommitEpochFunction{}
+		obj = &contractsapi.CommitEpochChildValidatorSetFn{}
 	} else {
 		return nil, fmt.Errorf("unknown state transaction")
 	}

--- a/consensus/polybft/state_transaction_test.go
+++ b/consensus/polybft/state_transaction_test.go
@@ -99,7 +99,7 @@ func TestCommitmentMessage_VerifyProof(t *testing.T) {
 		proof, err := commitment.MerkleTree.GenerateProof(leaf)
 		require.NoError(t, err)
 
-		execute := &contractsapi.ExecuteFunction{
+		execute := &contractsapi.ExecuteStateReceiverFn{
 			Proof: proof,
 			Obj:   (*contractsapi.StateSync)(stateSync),
 		}
@@ -107,7 +107,7 @@ func TestCommitmentMessage_VerifyProof(t *testing.T) {
 		inputData, err := execute.EncodeAbi()
 		require.NoError(t, err)
 
-		executionStateSync := &contractsapi.ExecuteFunction{}
+		executionStateSync := &contractsapi.ExecuteStateReceiverFn{}
 		require.NoError(t, executionStateSync.DecodeAbi(inputData))
 		require.Equal(t, stateSync.ID.Uint64(), executionStateSync.Obj.ID.Uint64())
 		require.Equal(t, stateSync.Sender, executionStateSync.Obj.Sender)
@@ -200,7 +200,7 @@ func TestStateTransaction_Encoding(t *testing.T) {
 	t.Parallel()
 
 	cases := []contractsapi.StateTransactionInput{
-		&contractsapi.CommitEpochFunction{
+		&contractsapi.CommitEpochChildValidatorSetFn{
 			ID: big.NewInt(1),
 			Epoch: &contractsapi.Epoch{
 				StartBlock: big.NewInt(1),

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer.go
@@ -199,7 +199,7 @@ func (r *StateSyncRelayer) executeStateSync(proof *types.Proof) error {
 		return fmt.Errorf("failed to unmarshal state sync event from JSON. Error: %w", err)
 	}
 
-	execute := &contractsapi.ExecuteFunction{
+	execute := &contractsapi.ExecuteStateReceiverFn{
 		Proof: proof.Data,
 		Obj:   sse,
 	}


### PR DESCRIPTION
# Description

We have a situation where 2 separate contracts have functions with same name. For example: `mint` function in `NativeERC20Mintable` and `NativeERC20` contracts.

This PR now generates go stubs for contract functions, where their name is `NameOfFunction + ContractName + Fn` (e.g., `InitializeNativeERC20MintableFn` and `MintRootERC20Fn`).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually