### PR TITLE
EVM-433-TOB-EDGE-35-Lack-of-domain-separation

### DIFF
--- a/consensus/polybft/checkpoint_manager_test.go
+++ b/consensus/polybft/checkpoint_manager_test.go
@@ -61,7 +61,7 @@ func TestCheckpointManager_SubmitCheckpoint(t *testing.T) {
 
 	validators.iterAcct(aliases, func(t *testValidator) {
 		bitmap.Set(idx)
-		signatures = append(signatures, t.mustSign(dummyMsg))
+		signatures = append(signatures, t.mustSign(dummyMsg, bls.DomainStateReceiver))
 		idx++
 	})
 
@@ -139,7 +139,7 @@ func TestCheckpointManager_abiEncodeCheckpointBlock(t *testing.T) {
 	var signatures bls.Signatures
 
 	currentValidators.iterAcct(nil, func(v *testValidator) {
-		signatures = append(signatures, v.mustSign(proposalHash))
+		signatures = append(signatures, v.mustSign(proposalHash, bls.DomainCheckpointManager))
 		bmp.Set(i)
 		i++
 	})

--- a/consensus/polybft/checkpoint_manager_test.go
+++ b/consensus/polybft/checkpoint_manager_test.go
@@ -61,7 +61,7 @@ func TestCheckpointManager_SubmitCheckpoint(t *testing.T) {
 
 	validators.iterAcct(aliases, func(t *testValidator) {
 		bitmap.Set(idx)
-		signatures = append(signatures, t.mustSign(dummyMsg, bls.DomainStateReceiver))
+		signatures = append(signatures, t.mustSign(dummyMsg, bls.DomainCheckpointManager))
 		idx++
 	})
 

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -863,7 +864,7 @@ func (c *consensusRuntime) BuildPrepareMessage(proposalHash []byte, view *proto.
 
 // BuildCommitMessage builds a COMMIT message based on the passed in proposal
 func (c *consensusRuntime) BuildCommitMessage(proposalHash []byte, view *proto.View) *proto.Message {
-	committedSeal, err := c.config.Key.Sign(proposalHash)
+	committedSeal, err := c.config.Key.SignWithDomain(proposalHash, bls.DomainCheckpointManager)
 	if err != nil {
 		c.logger.Error("Cannot create committed seal message.", "error", err)
 

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -335,7 +335,7 @@ func TestConsensusRuntime_FSM_NotEndOfEpoch_NotEndOfSprint(t *testing.T) {
 			EpochSize:  10,
 			SprintSize: 5,
 		},
-		Key:        wallet.NewKey(validators.getPrivateIdentities()[0], bls.DomainCheckpointManager),
+		Key:        wallet.NewKey(validators.getPrivateIdentities()[0]),
 		blockchain: blockchainMock,
 	}
 	runtime := &consensusRuntime{
@@ -686,7 +686,7 @@ func TestConsensusRuntime_TamperMessageContent(t *testing.T) {
 	}
 	sender := validatorAccounts.getValidator("A")
 	proposalHash := []byte{2, 4, 6, 8, 10}
-	proposalSignature, err := sender.Key().Sign(proposalHash)
+	proposalSignature, err := sender.Key().SignWithDomain(proposalHash, bls.DomainCheckpointManager)
 	require.NoError(t, err)
 
 	msg := &proto.Message{
@@ -999,7 +999,7 @@ func TestConsensusRuntime_BuildCommitMessage(t *testing.T) {
 		},
 	}
 
-	committedSeal, err := key.Sign(proposalHash)
+	committedSeal, err := key.SignWithDomain(proposalHash, bls.DomainCheckpointManager)
 	require.NoError(t, err)
 
 	expected := proto.Message{

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1065,18 +1065,6 @@ func TestConsensusRuntime_BuildPrepareMessage(t *testing.T) {
 	assert.Equal(t, signedMsg, runtime.BuildPrepareMessage(proposalHash, view))
 }
 
-func createTestMessageVote(t *testing.T, hash []byte, validator *testValidator) *MessageSignature {
-	t.Helper()
-
-	signature, err := validator.mustSign(hash).Marshal()
-	require.NoError(t, err)
-
-	return &MessageSignature{
-		From:      validator.Key().String(),
-		Signature: signature,
-	}
-}
-
 func createTestBlocks(t *testing.T, numberOfBlocks, defaultEpochSize uint64,
 	validatorSet AccountSet) (*types.Header, *testHeadersMap) {
 	t.Helper()

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -437,7 +437,7 @@ func (f *fsm) VerifyStateTransactions(transactions []*types.Transaction) error {
 				return err
 			}
 
-			verified := aggs.VerifyAggregated(signers.GetBlsKeys(), hash.Bytes(), bls.DomainCheckpointManager)
+			verified := aggs.VerifyAggregated(signers.GetBlsKeys(), hash.Bytes(), bls.DomainStateReceiver)
 			if !verified {
 				return fmt.Errorf("invalid signature for tx = %v", tx.Hash)
 			}

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -117,7 +117,7 @@ func TestFSM_BuildProposal_WithoutCommitEpochTxGood(t *testing.T) {
 	runtime := &consensusRuntime{
 		logger: hclog.NewNullLogger(),
 		config: &runtimeConfig{
-			Key:        wallet.NewKey(validators.getPrivateIdentities()[0], bls.DomainCheckpointManager),
+			Key:        wallet.NewKey(validators.getPrivateIdentities()[0]),
 			blockchain: blockchainMock,
 		},
 	}
@@ -192,7 +192,7 @@ func TestFSM_BuildProposal_WithCommitEpochTxGood(t *testing.T) {
 	runtime := &consensusRuntime{
 		logger: hclog.NewNullLogger(),
 		config: &runtimeConfig{
-			Key:        wallet.NewKey(validators.getPrivateIdentities()[0], bls.DomainCheckpointManager),
+			Key:        wallet.NewKey(validators.getPrivateIdentities()[0]),
 			blockchain: blockChainMock,
 		},
 	}
@@ -875,7 +875,7 @@ func TestFSM_Insert_Good(t *testing.T) {
 		seals := make([]*messages.CommittedSeal, signaturesCount)
 
 		for i := 0; i < signaturesCount; i++ {
-			sign, err := allAccounts[i].Bls.Sign(builtBlock.Block.Hash().Bytes(), bls.DomainValidatorSet)
+			sign, err := allAccounts[i].Bls.Sign(builtBlock.Block.Hash().Bytes(), bls.DomainCheckpointManager)
 			require.NoError(t, err)
 			sigRaw, err := sign.Marshal()
 			require.NoError(t, err)
@@ -1311,7 +1311,7 @@ func createTestCommitment(t *testing.T, accounts []*wallet.Account) *CommitmentM
 	var signatures bls.Signatures
 
 	for _, a := range accounts {
-		signature, err := a.Bls.Sign(hash.Bytes(), bls.DomainValidatorSet)
+		signature, err := a.Bls.Sign(hash.Bytes(), bls.DomainStateReceiver)
 		assert.NoError(t, err)
 
 		signatures = append(signatures, signature)

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -571,7 +571,7 @@ func TestFSM_VerifyStateTransactions_StateTransactionInvalidSignature(t *testing
 	aggregatedSigs := bls.Signatures{}
 
 	nonValidators.iterAcct(nil, func(t *testValidator) {
-		aggregatedSigs = append(aggregatedSigs, t.mustSign([]byte("dummyHash")))
+		aggregatedSigs = append(aggregatedSigs, t.mustSign([]byte("dummyHash"), bls.DomainStateReceiver))
 	})
 
 	sig, err := aggregatedSigs.Aggregate().Marshal()
@@ -653,7 +653,7 @@ func TestFSM_ValidateCommit_InvalidHash(t *testing.T) {
 	require.NoError(t, err)
 
 	nonValidatorAcc := newTestValidator(t, "non_validator", 1)
-	wrongSignature, err := nonValidatorAcc.mustSign([]byte("Foo")).Marshal()
+	wrongSignature, err := nonValidatorAcc.mustSign([]byte("Foo"), bls.DomainCheckpointManager).Marshal()
 	require.NoError(t, err)
 
 	err = fsm.ValidateCommit(validators.getValidator("0").Address().Bytes(), wrongSignature, []byte{})
@@ -687,7 +687,7 @@ func TestFSM_ValidateCommit_Good(t *testing.T) {
 	require.NoError(t, block.UnmarshalRLP(proposal))
 
 	validator := validators.getValidator("A")
-	seal, err := validator.mustSign(block.Hash().Bytes()).Marshal()
+	seal, err := validator.mustSign(block.Hash().Bytes(), bls.DomainCheckpointManager).Marshal()
 	require.NoError(t, err)
 	err = fsm.ValidateCommit(validator.Key().Address().Bytes(), seal, block.Hash().Bytes())
 	require.NoError(t, err)
@@ -959,15 +959,15 @@ func TestFSM_Insert_InvalidNode(t *testing.T) {
 	validatorA := validators.getValidator("A")
 	validatorB := validators.getValidator("B")
 	proposalHash := buildBlock.Block.Hash().Bytes()
-	sigA, err := validatorA.mustSign(proposalHash).Marshal()
+	sigA, err := validatorA.mustSign(proposalHash, bls.DomainCheckpointManager).Marshal()
 	require.NoError(t, err)
 
-	sigB, err := validatorB.mustSign(proposalHash).Marshal()
+	sigB, err := validatorB.mustSign(proposalHash, bls.DomainCheckpointManager).Marshal()
 	require.NoError(t, err)
 
 	// create test account outside of validator set
 	nonValidatorAccount := newTestValidator(t, "non_validator", 1)
-	nonValidatorSignature, err := nonValidatorAccount.mustSign(proposalHash).Marshal()
+	nonValidatorSignature, err := nonValidatorAccount.mustSign(proposalHash, bls.DomainCheckpointManager).Marshal()
 	require.NoError(t, err)
 
 	commitedSeals := []*messages.CommittedSeal{
@@ -1059,7 +1059,7 @@ func TestFSM_VerifyStateTransaction_ValidBothTypesOfStateTransactions(t *testing
 			// add register commitment state transaction
 			hash, err := sc.Hash()
 			require.NoError(t, err)
-			signature := createSignature(t, validators.getPrivateIdentities(aliases...), hash)
+			signature := createSignature(t, validators.getPrivateIdentities(aliases...), hash, bls.DomainStateReceiver)
 			sc.AggSignature = *signature
 		}
 
@@ -1116,7 +1116,7 @@ func TestFSM_VerifyStateTransaction_QuorumNotReached(t *testing.T) {
 
 	var txns []*types.Transaction
 
-	signature := createSignature(t, validators.getPrivateIdentities("A", "B"), hash)
+	signature := createSignature(t, validators.getPrivateIdentities("A", "B"), hash, bls.DomainStateReceiver)
 	commitmentMessageSigned.AggSignature = *signature
 
 	inputData, err := commitmentMessageSigned.EncodeAbi()
@@ -1144,9 +1144,9 @@ func TestFSM_VerifyStateTransaction_InvalidSignature(t *testing.T) {
 
 	var txns []*types.Transaction
 
-	signature := createSignature(t, validators.getPrivateIdentities("A", "B", "C", "D"), hash)
+	signature := createSignature(t, validators.getPrivateIdentities("A", "B", "C", "D"), hash, bls.DomainStateReceiver)
 	invalidValidator := newTestValidator(t, "G", 1)
-	invalidSignature, err := invalidValidator.mustSign([]byte("malicious message")).Marshal()
+	invalidSignature, err := invalidValidator.mustSign([]byte("malicious message"), bls.DomainStateReceiver).Marshal()
 	require.NoError(t, err)
 
 	commitmentMessageSigned.AggSignature = Signature{
@@ -1182,7 +1182,7 @@ func TestFSM_VerifyStateTransaction_TwoCommitmentMessages(t *testing.T) {
 
 	var txns []*types.Transaction
 
-	signature := createSignature(t, validators.getPrivateIdentities("A", "B", "C", "D"), hash)
+	signature := createSignature(t, validators.getPrivateIdentities("A", "B", "C", "D"), hash, bls.DomainStateReceiver)
 	commitmentMessageSigned.AggSignature = *signature
 
 	inputData, err := commitmentMessageSigned.EncodeAbi()

--- a/consensus/polybft/hash_test.go
+++ b/consensus/polybft/hash_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
+	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/assert"
@@ -12,7 +13,7 @@ import (
 func Test_setupHeaderHashFunc(t *testing.T) {
 	extra := &Extra{
 		Validators: &ValidatorSetDelta{Removed: bitmap.Bitmap{1}},
-		Parent:     createSignature(t, []*wallet.Account{generateTestAccount(t)}, types.ZeroHash),
+		Parent:     createSignature(t, []*wallet.Account{generateTestAccount(t)}, types.ZeroHash, bls.DomainCheckpointManager),
 		Checkpoint: &CheckpointData{},
 		Seal:       []byte{},
 		Committed:  &Signature{},
@@ -28,7 +29,7 @@ func Test_setupHeaderHashFunc(t *testing.T) {
 	notFullExtraHash := types.HeaderHash(header)
 
 	extra.Seal = []byte{1, 2, 3, 255}
-	extra.Committed = createSignature(t, []*wallet.Account{generateTestAccount(t)}, types.ZeroHash)
+	extra.Committed = createSignature(t, []*wallet.Account{generateTestAccount(t)}, types.ZeroHash, bls.DomainCheckpointManager)
 	header.ExtraData = append(make([]byte, ExtraVanity), extra.MarshalRLPTo(nil)...)
 	fullExtraHash := types.HeaderHash(header)
 

--- a/consensus/polybft/helpers_test.go
+++ b/consensus/polybft/helpers_test.go
@@ -21,7 +21,7 @@ import (
 func createTestKey(t *testing.T) *wallet.Key {
 	t.Helper()
 
-	return wallet.NewKey(generateTestAccount(t), bls.DomainCheckpointManager)
+	return wallet.NewKey(generateTestAccount(t))
 }
 
 func createRandomTestKeys(t *testing.T, numberOfKeys int) []*wallet.Key {
@@ -30,7 +30,7 @@ func createRandomTestKeys(t *testing.T, numberOfKeys int) []*wallet.Key {
 	result := make([]*wallet.Key, numberOfKeys, numberOfKeys)
 
 	for i := 0; i < numberOfKeys; i++ {
-		result[i] = wallet.NewKey(generateTestAccount(t), bls.DomainCheckpointManager)
+		result[i] = wallet.NewKey(generateTestAccount(t))
 	}
 
 	return result

--- a/consensus/polybft/helpers_test.go
+++ b/consensus/polybft/helpers_test.go
@@ -36,7 +36,7 @@ func createRandomTestKeys(t *testing.T, numberOfKeys int) []*wallet.Key {
 	return result
 }
 
-func createSignature(t *testing.T, accounts []*wallet.Account, hash types.Hash) *Signature {
+func createSignature(t *testing.T, accounts []*wallet.Account, hash types.Hash, domain []byte) *Signature {
 	t.Helper()
 
 	var signatures bls.Signatures
@@ -45,7 +45,7 @@ func createSignature(t *testing.T, accounts []*wallet.Account, hash types.Hash) 
 	for i, x := range accounts {
 		bmp.Set(uint64(i))
 
-		src, err := x.Bls.Sign(hash[:], bls.DomainCheckpointManager)
+		src, err := x.Bls.Sign(hash[:], domain)
 		require.NoError(t, err)
 
 		signatures = append(signatures, src)

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -438,8 +438,8 @@ func (v *testValidator) ValidatorMetadata() *ValidatorMetadata {
 	}
 }
 
-func (v *testValidator) mustSign(hash []byte) *bls.Signature {
-	signature, err := v.account.Bls.Sign(hash, bls.DomainCheckpointManager)
+func (v *testValidator) mustSign(hash, domain []byte) *bls.Signature {
+	signature, err := v.account.Bls.Sign(hash, domain)
 	if err != nil {
 		panic(fmt.Sprintf("BUG: failed to sign: %v", err)) //nolint:gocritic
 	}

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -416,7 +416,7 @@ func (v *testValidator) Address() types.Address {
 }
 
 func (v *testValidator) Key() *wallet.Key {
-	return wallet.NewKey(v.account, bls.DomainCheckpointManager)
+	return wallet.NewKey(v.account)
 }
 
 func (v *testValidator) paramsValidator() *Validator {

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -197,7 +197,7 @@ func (p *Polybft) Initialize() error {
 	}
 
 	// set key
-	p.key = wallet.NewKey(account, bls.DomainCheckpointManager)
+	p.key = wallet.NewKey(account)
 
 	// create and set syncer
 	p.syncer = syncer.NewSyncer(

--- a/consensus/polybft/polybft_test.go
+++ b/consensus/polybft/polybft_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/consensus"
 	"github.com/0xPolygon/polygon-edge/consensus/ibft/signer"
+	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/helper/progress"
 	"github.com/0xPolygon/polygon-edge/txpool"
@@ -54,7 +55,7 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 			checkpointHash, err := extra.Checkpoint.Hash(0, header.Number, header.Hash)
 			require.NoError(t, err)
 
-			extra.Committed = createSignature(t, committedAccounts, checkpointHash)
+			extra.Committed = createSignature(t, committedAccounts, checkpointHash, bls.DomainCheckpointManager)
 			header.ExtraData = append(make([]byte, signer.IstanbulExtraVanity), extra.MarshalRLPTo(nil)...)
 		}
 

--- a/consensus/polybft/sc_integration_test.go
+++ b/consensus/polybft/sc_integration_test.go
@@ -125,7 +125,7 @@ func TestIntegratoin_PerformExit(t *testing.T) {
 	var signatures bls.Signatures
 
 	currentValidators.iterAcct(nil, func(v *testValidator) {
-		signatures = append(signatures, v.mustSign(checkpointHash[:]))
+		signatures = append(signatures, v.mustSign(checkpointHash[:], bls.DomainCheckpointManager))
 		bmp.Set(i)
 		i++
 	})

--- a/consensus/polybft/signer/common.go
+++ b/consensus/polybft/signer/common.go
@@ -27,8 +27,8 @@ var (
 	// domain used to map hash to G1 used by child checkpoint manager
 	DomainCheckpointManager = pcrypto.Keccak256([]byte("DOMAIN_CHECKPOINT_MANAGER"))
 
-	DomainTransactionSigning = pcrypto.Keccak256([]byte("DOMAIN_TRANSACTIONS"))
-	DomainStateReceiver      = pcrypto.Keccak256([]byte("DOMAIN_STATE_RECEIVER"))
+	DomainCommonSigning = pcrypto.Keccak256([]byte("DOMAIN_COMMON_SIGNING"))
+	DomainStateReceiver = pcrypto.Keccak256([]byte("DOMAIN_STATE_RECEIVER"))
 )
 
 func mustG2Point(str string) *bn256.G2 {

--- a/consensus/polybft/signer/common.go
+++ b/consensus/polybft/signer/common.go
@@ -26,6 +26,9 @@ var (
 
 	// domain used to map hash to G1 used by child checkpoint manager
 	DomainCheckpointManager = pcrypto.Keccak256([]byte("DOMAIN_CHECKPOINT_MANAGER"))
+
+	DomainTransactionSigning = pcrypto.Keccak256([]byte("DOMAIN_TRANSACTIONS"))
+	DomainStateReceiver      = pcrypto.Keccak256([]byte("DOMAIN_STATE_RECEIVER"))
 )
 
 func mustG2Point(str string) *bn256.G2 {

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -217,7 +217,7 @@ func (s *stateSyncManager) verifyVoteSignature(valSet ValidatorSet, signer types
 		return fmt.Errorf("failed to unmarshal signature from signer %s, %w", signer.String(), err)
 	}
 
-	if !unmarshaledSignature.Verify(validator.BlsKey, hash, bls.DomainCheckpointManager) {
+	if !unmarshaledSignature.Verify(validator.BlsKey, hash, bls.DomainStateReceiver) {
 		return fmt.Errorf("incorrect signature from %s", signer)
 	}
 
@@ -534,7 +534,7 @@ func (s *stateSyncManager) buildCommitment() error {
 
 	hashBytes := hash.Bytes()
 
-	signature, err := s.config.key.Sign(hashBytes)
+	signature, err := s.config.key.SignWithDomain(hashBytes, bls.DomainStateReceiver)
 	if err != nil {
 		return fmt.Errorf("failed to sign commitment message. Error: %w", err)
 	}

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/merkle-tree"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
@@ -116,8 +117,8 @@ func (m *mockMsg) WithHash(hash []byte) *mockMsg {
 	return m
 }
 
-func (m *mockMsg) sign(val *testValidator) (*TransportMessage, error) {
-	signature, err := val.mustSign(m.hash).Marshal()
+func (m *mockMsg) sign(val *testValidator, domain []byte) (*TransportMessage, error) {
+	signature, err := val.mustSign(m.hash, domain).Marshal()
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +138,7 @@ func TestStateSyncManager_MessagePool_SenderIsNoValidator(t *testing.T) {
 	s.validatorSet = vals.toValidatorSet()
 
 	badVal := newTestValidator(t, "a", 0)
-	msg, err := newMockMsg().sign(badVal)
+	msg, err := newMockMsg().sign(badVal, bls.DomainStateReceiver)
 	require.NoError(t, err)
 
 	require.Error(t, s.saveVote(msg))
@@ -152,7 +153,7 @@ func TestStateSyncManager_MessagePool_InvalidEpoch(t *testing.T) {
 	s.validatorSet = vals.toValidatorSet()
 
 	val := newMockMsg()
-	msg, err := val.sign(vals.getValidator("0"))
+	msg, err := val.sign(vals.getValidator("0"), bls.DomainStateReceiver)
 	require.NoError(t, err)
 
 	msg.EpochNumber = 1
@@ -179,7 +180,7 @@ func TestStateSyncManager_MessagePool_SenderAndSignatureMissmatch(t *testing.T) 
 
 	// validator signs the msg in behalf of another validator
 	val := newMockMsg()
-	msg, err := val.sign(vals.getValidator("0"))
+	msg, err := val.sign(vals.getValidator("0"), bls.DomainStateReceiver)
 	require.NoError(t, err)
 
 	msg.From = vals.getValidator("1").Address().String()
@@ -187,7 +188,7 @@ func TestStateSyncManager_MessagePool_SenderAndSignatureMissmatch(t *testing.T) 
 
 	// non validator signs the msg in behalf of a validator
 	badVal := newTestValidator(t, "a", 0)
-	msg, err = newMockMsg().sign(badVal)
+	msg, err = newMockMsg().sign(badVal, bls.DomainStateReceiver)
 	require.NoError(t, err)
 
 	msg.From = vals.getValidator("1").Address().String()
@@ -201,10 +202,10 @@ func TestStateSyncManager_MessagePool_SenderVotes(t *testing.T) {
 	s.validatorSet = vals.toValidatorSet()
 
 	msg := newMockMsg()
-	val1signed, err := msg.sign(vals.getValidator("1"))
+	val1signed, err := msg.sign(vals.getValidator("1"), bls.DomainStateReceiver)
 	require.NoError(t, err)
 
-	val2signed, err := msg.sign(vals.getValidator("2"))
+	val2signed, err := msg.sign(vals.getValidator("2"), bls.DomainStateReceiver)
 	require.NoError(t, err)
 
 	// vote with validator 1
@@ -257,10 +258,10 @@ func TestStateSyncManager_BuildCommitment(t *testing.T) {
 
 	// validators 0 and 1 vote for the proposal, there is not enough
 	// voting power for the proposal
-	signedMsg1, err := msg.sign(vals.getValidator("0"))
+	signedMsg1, err := msg.sign(vals.getValidator("0"), bls.DomainStateReceiver)
 	require.NoError(t, err)
 
-	signedMsg2, err := msg.sign(vals.getValidator("1"))
+	signedMsg2, err := msg.sign(vals.getValidator("1"), bls.DomainStateReceiver)
 	require.NoError(t, err)
 
 	require.NoError(t, s.saveVote(signedMsg1))
@@ -272,10 +273,10 @@ func TestStateSyncManager_BuildCommitment(t *testing.T) {
 
 	// validator 2 and 3 vote for the proposal, there is enough voting power now
 
-	signedMsg1, err = msg.sign(vals.getValidator("2"))
+	signedMsg1, err = msg.sign(vals.getValidator("2"), bls.DomainStateReceiver)
 	require.NoError(t, err)
 
-	signedMsg2, err = msg.sign(vals.getValidator("3"))
+	signedMsg2, err = msg.sign(vals.getValidator("3"), bls.DomainStateReceiver)
 	require.NoError(t, err)
 
 	require.NoError(t, s.saveVote(signedMsg1))

--- a/consensus/polybft/wallet/key.go
+++ b/consensus/polybft/wallet/key.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/0xPolygon/go-ibft/messages/proto"
+	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/umbracle/ethgo"
@@ -11,14 +12,12 @@ import (
 )
 
 type Key struct {
-	raw    *Account
-	domain []byte
+	raw *Account
 }
 
-func NewKey(raw *Account, domain []byte) *Key {
+func NewKey(raw *Account) *Key {
 	return &Key{
-		raw:    raw,
-		domain: domain,
+		raw: raw,
 	}
 }
 
@@ -33,8 +32,14 @@ func (k *Key) Address() ethgo.Address {
 }
 
 // Sign signs the provided digest with BLS key
+// Used only to sign transactions
 func (k *Key) Sign(digest []byte) ([]byte, error) {
-	signature, err := k.raw.Bls.Sign(digest, k.domain)
+	return k.SignWithDomain(digest, bls.DomainTransactionSigning)
+}
+
+// SignWithDomain signs the provided digest with BLS key and provided domain
+func (k *Key) SignWithDomain(digest, domain []byte) ([]byte, error) {
+	signature, err := k.raw.Bls.Sign(digest, domain)
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/polybft/wallet/key.go
+++ b/consensus/polybft/wallet/key.go
@@ -34,7 +34,7 @@ func (k *Key) Address() ethgo.Address {
 // Sign signs the provided digest with BLS key
 // Used only to sign transactions
 func (k *Key) Sign(digest []byte) ([]byte, error) {
-	return k.SignWithDomain(digest, bls.DomainTransactionSigning)
+	return k.SignWithDomain(digest, bls.DomainCommonSigning)
 }
 
 // SignWithDomain signs the provided digest with BLS key and provided domain

--- a/consensus/polybft/wallet/key_test.go
+++ b/consensus/polybft/wallet/key_test.go
@@ -13,7 +13,7 @@ func Test_RecoverAddressFromSignature(t *testing.T) {
 	t.Parallel()
 
 	for _, account := range []*Account{generateTestAccount(t), generateTestAccount(t), generateTestAccount(t)} {
-		key := NewKey(account, bls.DomainCheckpointManager)
+		key := NewKey(account)
 		msgNoSig := &proto.Message{
 			From:    key.Address().Bytes(),
 			Type:    proto.MessageType_COMMIT,
@@ -38,8 +38,8 @@ func Test_Sign(t *testing.T) {
 	msg := []byte("some message")
 
 	for _, account := range []*Account{generateTestAccount(t), generateTestAccount(t)} {
-		key := NewKey(account, bls.DomainCheckpointManager)
-		ser, err := key.Sign(msg)
+		key := NewKey(account)
+		ser, err := key.SignWithDomain(msg, bls.DomainCheckpointManager)
 
 		require.NoError(t, err)
 
@@ -54,7 +54,7 @@ func Test_String(t *testing.T) {
 	t.Parallel()
 
 	for _, account := range []*Account{generateTestAccount(t), generateTestAccount(t), generateTestAccount(t)} {
-		key := NewKey(account, bls.DomainCheckpointManager)
+		key := NewKey(account)
 		assert.Equal(t, key.Address().String(), key.String())
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -20,7 +20,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/blockchain"
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/consensus"
-	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/statesyncrelayer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
@@ -549,7 +548,7 @@ func (s *Server) setupRelayer() error {
 		ethgo.Address(contracts.StateReceiverContract),
 		trackerStartBlockConfig[contracts.StateReceiverContract],
 		s.logger.Named("relayer"),
-		wallet.NewEcdsaSigner(wallet.NewKey(account, bls.DomainCheckpointManager)),
+		wallet.NewEcdsaSigner(wallet.NewKey(account)),
 	)
 
 	// start relayer

--- a/state/runtime/precompiled/bls_agg_sigs_verification.go
+++ b/state/runtime/precompiled/bls_agg_sigs_verification.go
@@ -99,7 +99,7 @@ func (c *blsAggSignsVerification) run(input []byte, caller types.Address, host r
 		blsPubKeys[i] = blsPubKey
 	}
 
-	if sig.VerifyAggregated(blsPubKeys, types.Hash(msg).Bytes(), bls.DomainCheckpointManager) {
+	if sig.VerifyAggregated(blsPubKeys, types.Hash(msg).Bytes(), bls.DomainStateReceiver) {
 		return abiBoolTrue, nil
 	}
 

--- a/state/runtime/precompiled/bls_agg_sigs_verification_test.go
+++ b/state/runtime/precompiled/bls_agg_sigs_verification_test.go
@@ -67,7 +67,7 @@ func generatePubKeysAndSignature(t *testing.T, numKeys int, messageRaw []byte) (
 	signatures := make(bls.Signatures, len(validators))
 
 	for i, validator := range validators {
-		sign, err := validator.Sign(message[:], bls.DomainCheckpointManager)
+		sign, err := validator.Sign(message[:], bls.DomainStateReceiver)
 		require.NoError(t, err)
 
 		pubKeys[i] = validator.PublicKey().Marshal()


### PR DESCRIPTION
# Description

This PR introduces two new domains for hash `bls` signing, so that we have a better domain separation:
- `DomainStateReceiver` - for signing commitment messages and commitment votes.
- `DomainTransactionSigning` - for signing regular transactions.

There are also two pre-existing domains:
- `DomainValidatorSet` - for signing validator set.
- `DomainCheckpointManager` - for signing checkpoint data and block proposals (since block proposal hash is also checkpoint hash).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually