### PR TITLE
Fix the limit for TX pool contract creation size

### DIFF
--- a/state/executor.go
+++ b/state/executor.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	SpuriousDragonMaxCodeSize = 24576
+	TxPoolMaxInitCodeSize     = 2 * SpuriousDragonMaxCodeSize
 
 	TxGas                 uint64 = 21000 // Per transaction not creating a contract
 	TxGasContractCreation uint64 = 53000 // Per transaction that creates a contract

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -616,7 +616,7 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 			return ErrSmartContractRestricted
 		}
 
-		if p.forks.EIP158 && len(tx.Input) > state.SpuriousDragonMaxCodeSize {
+		if p.forks.EIP158 && len(tx.Input) > state.TxPoolMaxInitCodeSize {
 			return runtime.ErrMaxCodeSizeExceeded
 		}
 	}

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -1750,7 +1750,7 @@ func TestPermissionSmartContractDeployment(t *testing.T) {
 		)
 	})
 
-	t.Run("Input larger then the TxPoolMaxInitCodeSize", func(t *testing.T) {
+	t.Run("Input larger than the TxPoolMaxInitCodeSize", func(t *testing.T) {
 		t.Parallel()
 		pool := setupPool()
 		pool.forks.EIP158 = true

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -1774,7 +1774,7 @@ func TestPermissionSmartContractDeployment(t *testing.T) {
 		pool := setupPool()
 		pool.forks.EIP158 = true
 
-		input := make([]byte, state.SpuriousDragonMaxCodeSize)
+		input := make([]byte, state.TxPoolMaxInitCodeSize)
 		_, err := rand.Read(input)
 		require.NoError(t, err)
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -1769,7 +1769,7 @@ func TestPermissionSmartContractDeployment(t *testing.T) {
 		)
 	})
 
-	t.Run("Input the same as MaxInitCodeSize", func(t *testing.T) {
+	t.Run("Input the same as TxPoolMaxInitCodeSize", func(t *testing.T) {
 		t.Parallel()
 		pool := setupPool()
 		pool.forks.EIP158 = true

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -1750,12 +1750,12 @@ func TestPermissionSmartContractDeployment(t *testing.T) {
 		)
 	})
 
-	t.Run("Input larger then the MaxInitCodeSize", func(t *testing.T) {
+	t.Run("Input larger then the TxPoolMaxInitCodeSize", func(t *testing.T) {
 		t.Parallel()
 		pool := setupPool()
 		pool.forks.EIP158 = true
 
-		input := make([]byte, state.SpuriousDragonMaxCodeSize+1)
+		input := make([]byte, state.TxPoolMaxInitCodeSize+1)
 		_, err := rand.Read(input)
 		require.NoError(t, err)
 


### PR DESCRIPTION
# Description

The limit should be double the size of contract code size.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
