### PR TITLE
EVM-568 Increase MaxBlockBacklog for block tracker

### DIFF
--- a/tracker/event_tracker.go
+++ b/tracker/event_tracker.go
@@ -81,6 +81,12 @@ func (e *EventTracker) Start(ctx context.Context) error {
 	}
 
 	go func() {
+		if err := blockTracker.Init(); err != nil {
+			e.logger.Error("failed to init blocktracker", "error", err)
+
+			return
+		}
+
 		if err := blockTracker.Start(); err != nil {
 			e.logger.Error("failed to start blocktracker", "error", err)
 		}
@@ -93,7 +99,6 @@ func (e *EventTracker) Start(ctx context.Context) error {
 	}()
 
 	go func() {
-		// Sync method will also call blocktracker.Init(), so no need to call that method here
 		if err := tt.Sync(ctx); err != nil {
 			e.logger.Error("failed to sync", "error", err)
 		}


### PR DESCRIPTION
# Description

Part of the event tracker is the block tracker, which fetches blocks from provided JSON RPC endpoint. In order to determine if there are reorgs happening, there is a MaxBlockBacklog parameter. It turned out that default value of 10 blocks is not big enough.

The solution proposal is to initialize the `MaxBlockBacklog` parameter as `2*NumBlockConfirmations` (or consider putting even more).

`BlockTracker` creation/initialization is moved to `tracker/event_tracker.go`. That  way we have much more options when configuring blocktracker

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually
