### PR TITLE
Add receivers to sync state actions on sequence diagram

### DIFF
--- a/docs/bridge/sequences.md
+++ b/docs/bridge/sequences.md
@@ -1,6 +1,6 @@
 ## Deposit
 
-Bridge tokens from rootchain to childchain via deposit.
+Bridge ERC 20 tokens from rootchain to childchain via deposit.
 
 ```mermaid
 sequenceDiagram
@@ -8,10 +8,10 @@ sequenceDiagram
 	Edge->>RootERC20.sol: approve(RootERC20Predicate)
 	Edge->>RootERC20Predicate.sol: deposit()
 	RootERC20Predicate.sol->>RootERC20Predicate.sol: mapToken()
-	RootERC20Predicate.sol->>StateSender.sol: syncState(MAP_TOKEN_SIG)
+	RootERC20Predicate.sol->>StateSender.sol: syncState(MAP_TOKEN_SIG), recv=ChildERC20Predicate
 	RootERC20Predicate.sol-->>Edge: TokenMapped Event
 	StateSender.sol-->>Edge: StateSynced Event to map tokens on child predicate
-	RootERC20Predicate.sol->>StateSender.sol: syncState(DEPOSIT_SIG)
+	RootERC20Predicate.sol->>StateSender.sol: syncState(DEPOSIT_SIG), recv=ChildERC20Predicate
 	StateSender.sol-->>Edge: StateSynced Event to deposit on child chain
 	Edge->>User: ok
 	Edge->>StateReceiver.sol:commit()
@@ -24,14 +24,14 @@ sequenceDiagram
 
 ## Withdraw
 
-Move tokens from childchain to rootchain via withdrawal.
+Bridge ERC 20 tokens from childchain to rootchain via withdrawal.
 
 ```mermaid
 sequenceDiagram
 	User->>Edge: withdraw
 	Edge->>ChildERC20Predicate.sol: withdrawTo()
 	ChildERC20Predicate.sol->>ChildERC20: burn()
-	ChildERC20Predicate.sol->>L2StateSender.sol: syncState(rootToken, WITHDRAW_SIG), recv=RootERC20Predicate
+	ChildERC20Predicate.sol->>L2StateSender.sol: syncState(WITHDRAW_SIG), recv=RootERC20Predicate
 	Edge->>User: tx hash
 	User->>Edge: get tx receipt
 	Edge->>User: exit event id
@@ -42,7 +42,7 @@ sequenceDiagram
 ```
 ## Exit
 
-Finalize withdrawal of tokens from childchain to rootchain.
+Finalize withdrawal of ERC 20 tokens from childchain to rootchain.
 
 ```mermaid
 sequenceDiagram


### PR DESCRIPTION
# Description

This PR adds a bit of more information to the sequences diagram (e.g. receiver contract when `syncState` is being called).

Preview of diagrams is here:
https://github.com/0xPolygon/polygon-edge/blob/ed6966ff8da4b3bb3ad364008504fb8019d9a257/docs/bridge/sequences.md

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
