### PR TITLE
EVM-554: Some events might not be received by subscriber

### DIFF
--- a/blockchain/subscription_test.go
+++ b/blockchain/subscription_test.go
@@ -51,3 +51,61 @@ func TestSubscription(t *testing.T) {
 
 	assert.Equal(t, event.NewChain[0].Number, caughtEventNum)
 }
+
+func TestSubscription_BufferedChannel_MultipleSubscriptions(t *testing.T) {
+	t.Parallel()
+
+	var (
+		e                  = &eventStream{}
+		wg                 sync.WaitGroup
+		numOfEvents        = 100000
+		numOfSubscriptions = 10
+	)
+
+	subscriptions := make([]*subscription, numOfSubscriptions)
+	wg.Add(numOfSubscriptions)
+
+	worker := func(id int, sub *subscription) {
+		updateCh := sub.GetEventCh()
+		caughtEvents := 0
+
+		defer wg.Done()
+
+		for {
+			select {
+			case <-updateCh:
+				caughtEvents++
+				if caughtEvents == numOfEvents {
+					return
+				}
+			case <-time.After(10 * time.Second):
+				t.Errorf("subscription %d did not caught all events", id)
+			}
+		}
+	}
+
+	for i := 0; i < numOfSubscriptions; i++ {
+		sub := e.subscribe()
+		subscriptions[i] = sub
+
+		go worker(i, sub)
+	}
+
+	// Send the events to the channels
+	for i := 0; i < numOfEvents; i++ {
+		e.push(&Event{
+			NewChain: []*types.Header{
+				{
+					Number: uint64(i),
+				},
+			},
+		})
+	}
+
+	// Wait for the events to be processed
+	wg.Wait()
+
+	for _, s := range subscriptions {
+		s.Close()
+	}
+}


### PR DESCRIPTION
# Description

In the `subscription.go`, `eventStream` when pushing new event to all subscriptions, had a `select case` with `default` branch, where in case an event could not be added to the update channel, just ignored it. This is not a correct way, since most of the time, we need all the events that we subscribed to. 

Through this PR, we are now using buffered update channels to mitigate the case where some events might not be passed to the subscriber. 
PR also cleans the code from unnecessary go routines, and adds a new UT test.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually