### PR TITLE
refactor(server): remove block time configuration from config and server params

### DIFF
--- a/command/server/config/config.go
+++ b/command/server/config/config.go
@@ -25,7 +25,6 @@ type Config struct {
 	TxPool                   *TxPool    `json:"tx_pool" yaml:"tx_pool"`
 	LogLevel                 string     `json:"log_level" yaml:"log_level"`
 	RestoreFile              string     `json:"restore_file" yaml:"restore_file"`
-	BlockTime                uint64     `json:"block_time_s" yaml:"block_time_s"`
 	Headers                  *Headers   `json:"headers" yaml:"headers"`
 	LogFilePath              string     `json:"log_to" yaml:"log_to"`
 	JSONRPCBatchRequestLimit uint64     `json:"json_rpc_batch_request_limit" yaml:"json_rpc_batch_request_limit"`
@@ -111,7 +110,6 @@ func DefaultConfig() *Config {
 		},
 		LogLevel:    "INFO",
 		RestoreFile: "",
-		BlockTime:   DefaultBlockTime,
 		Headers: &Headers{
 			AccessControlAllowOrigins: []string{"*"},
 		},

--- a/command/server/init.go
+++ b/command/server/init.go
@@ -19,7 +19,6 @@ import (
 )
 
 var (
-	errInvalidBlockTime       = errors.New("invalid block time specified")
 	errDataDirectoryUndefined = errors.New("data directory not defined")
 )
 
@@ -50,10 +49,6 @@ func (p *serverParams) initRawParams() error {
 		return err
 	}
 
-	if err := p.initBlockTime(); err != nil {
-		return err
-	}
-
 	if p.isDevMode {
 		p.initDevMode()
 	}
@@ -64,14 +59,6 @@ func (p *serverParams) initRawParams() error {
 	p.relayer = p.rawConfig.Relayer
 
 	return p.initAddresses()
-}
-
-func (p *serverParams) initBlockTime() error {
-	if p.rawConfig.BlockTime < 1 {
-		return errInvalidBlockTime
-	}
-
-	return nil
 }
 
 func (p *serverParams) initDataDirLocation() error {

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -33,7 +33,6 @@ const (
 	blockGasTargetFlag           = "block-gas-target"
 	secretsConfigFlag            = "secrets-config"
 	restoreFlag                  = "restore"
-	blockTimeFlag                = "block-time"
 	devIntervalFlag              = "dev-interval"
 	devFlag                      = "dev"
 	corsOriginFlag               = "access-control-allow-origins"
@@ -179,7 +178,6 @@ func (p *serverParams) generateConfig() *server.Config {
 		MaxAccountEnqueued: p.rawConfig.TxPool.MaxAccountEnqueued,
 		SecretsManager:     p.secretsConfig,
 		RestoreFile:        p.getRestoreFilePath(),
-		BlockTime:          p.rawConfig.BlockTime,
 		LogLevel:           hclog.LevelFromString(p.rawConfig.LogLevel),
 		JSONLogFormat:      p.rawConfig.JSONLogFormat,
 		LogFilePath:        p.logFileLocation,

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -185,13 +185,6 @@ func setFlags(cmd *cobra.Command) {
 		"maximum number of enqueued transactions per account",
 	)
 
-	cmd.Flags().Uint64Var(
-		&params.rawConfig.BlockTime,
-		blockTimeFlag,
-		defaultConfig.BlockTime,
-		"minimum block time in seconds (at least 1s)",
-	)
-
 	cmd.Flags().StringArrayVar(
 		&params.corsAllowedOrigins,
 		corsOriginFlag,


### PR DESCRIPTION

# Description

The block time configuration was removed from the raw config and server params. 
The initBlockTime function was also removed from the server params.
`polygon-edge server` command was not doing anything with those values. 

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually
