### PR TITLE
EVM-584 Panic -> send on closed channel inside syncer

### DIFF
--- a/network/gossip.go
+++ b/network/gossip.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
 	"sync/atomic"
 
 	"github.com/hashicorp/go-hclog"
@@ -22,10 +23,13 @@ const (
 type Topic struct {
 	logger hclog.Logger
 
-	topic   *pubsub.Topic
-	typ     reflect.Type
-	closeCh chan struct{}
-	closed  *uint64
+	topic  *pubsub.Topic
+	typ    reflect.Type
+	closed *uint64
+
+	ctx       context.Context
+	cancelFn  context.CancelFunc
+	waitGroup sync.WaitGroup
 }
 
 func (t *Topic) createObj() proto.Message {
@@ -43,12 +47,14 @@ func (t *Topic) Close() {
 		return
 	}
 
+	t.cancelFn()       // close all subscribers
+	t.waitGroup.Wait() // wait for all the subscribers to finish
+
+	// if all subscribers are finished, close the topic
 	if t.topic != nil {
 		t.topic.Close()
 		t.topic = nil
 	}
-
-	close(t.closeCh)
 }
 
 func (t *Topic) Publish(obj proto.Message) error {
@@ -75,18 +81,14 @@ func (t *Topic) Subscribe(handler func(obj interface{}, from peer.ID)) error {
 }
 
 func (t *Topic) readLoop(sub *pubsub.Subscription, handler func(obj interface{}, from peer.ID)) {
-	ctx, cancelFn := context.WithCancel(context.Background())
-
-	go func() {
-		<-t.closeCh
-		cancelFn()
-	}()
+	t.waitGroup.Add(1)
+	defer t.waitGroup.Done()
 
 	for {
-		msg, err := sub.Next(ctx)
+		msg, err := sub.Next(t.ctx)
 		if err != nil {
 			// Above cancelFn() called.
-			if errors.Is(err, ctx.Err()) {
+			if errors.Is(err, t.ctx.Err()) {
 				break
 			}
 
@@ -114,12 +116,15 @@ func (s *Server) NewTopic(protoID string, obj proto.Message) (*Topic, error) {
 		return nil, err
 	}
 
+	ctx, cancelFn := context.WithCancel(context.Background())
+
 	tt := &Topic{
-		logger:  s.logger.Named(protoID),
-		topic:   topic,
-		typ:     reflect.TypeOf(obj).Elem(),
-		closeCh: make(chan struct{}),
-		closed:  new(uint64),
+		logger:   s.logger.Named(protoID),
+		topic:    topic,
+		typ:      reflect.TypeOf(obj).Elem(),
+		closed:   new(uint64),
+		ctx:      ctx,
+		cancelFn: cancelFn,
 	}
 
 	return tt, nil

--- a/network/gossip_test.go
+++ b/network/gossip_test.go
@@ -9,7 +9,6 @@ import (
 
 	testproto "github.com/0xPolygon/polygon-edge/network/proto"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/stretchr/testify/assert"
 )
 
 func NumSubscribers(srv *Server, topic string) int {
@@ -110,18 +109,13 @@ func TestSimpleGossip(t *testing.T) {
 }
 
 func Test_RepeatedClose(t *testing.T) {
-	incr := 0
 	topic := &Topic{
-		cancelFn: func() {
-			incr++
-		},
-		closed: new(uint64),
+		closeCh: make(chan struct{}),
+		closed:  new(uint64),
 	}
 
 	// Call Close() twice to ensure that underlying logic (e.g. channel close) is
 	// only executed once.
 	topic.Close()
 	topic.Close()
-
-	assert.Equal(t, 1, incr)
 }

--- a/network/gossip_test.go
+++ b/network/gossip_test.go
@@ -9,6 +9,7 @@ import (
 
 	testproto "github.com/0xPolygon/polygon-edge/network/proto"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/assert"
 )
 
 func NumSubscribers(srv *Server, topic string) int {
@@ -109,13 +110,18 @@ func TestSimpleGossip(t *testing.T) {
 }
 
 func Test_RepeatedClose(t *testing.T) {
+	incr := 0
 	topic := &Topic{
-		closeCh: make(chan struct{}),
-		closed:  new(uint64),
+		cancelFn: func() {
+			incr++
+		},
+		closed: new(uint64),
 	}
 
 	// Call Close() twice to ensure that underlying logic (e.g. channel close) is
 	// only executed once.
 	topic.Close()
 	topic.Close()
+
+	assert.Equal(t, 1, incr)
 }


### PR DESCRIPTION
# Description

Bug fix for panic that occurs frequently on CI unit tests
```
panic: send on closed channel

goroutine 1185 [running]:

[github.com/0xPolygon/polygon-edge/syncer.(*syncPeerClient](http://github.com/0xPolygon/polygon-edge/syncer.(*syncPeerClient)).handleStatusUpdate(0xc0026cc500, {0x1086380?, 0xc002a38690}, {0xc0028e9ec0, 0x27})

 /home/runner/work/polygon-edge/polygon-edge/syncer/client.go:219 +0x216

[Network Graph · 0xPolygon/polygon-edge](http://github.com/0xPolygon/polygon-edge/network.(*Topic) ).readLoop.func2()

 /home/runner/work/polygon-edge/polygon-edge/network/gossip.go:106 +0xcb

created by [Network Graph · 0xPolygon/polygon-edge](http://github.com/0xPolygon/polygon-edge/network.(*Topic) ).readLoop

 /home/runner/work/polygon-edge/polygon-edge/network/gossip.go:98 +0x14a
```

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually

