### PR TITLE
Obsolete block time flag from server command

### DIFF
--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -299,6 +299,7 @@ func (p *genesisParams) initIBFTEngineMap(ibftType fork.IBFTType) {
 		string(server.IBFTConsensus): map[string]interface{}{
 			fork.KeyType:          ibftType,
 			fork.KeyValidatorType: p.ibftValidatorType,
+			fork.KeyBlockTime:     p.blockTime,
 			ibft.KeyEpochSize:     p.epochSize,
 		},
 	}

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi/artifact"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/command"
@@ -88,7 +89,7 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 
 	polyBftConfig := &polybft.PolyBFTConfig{
 		InitialValidatorSet: manifest.GenesisValidators,
-		BlockTime:           p.blockTime,
+		BlockTime:           common.Duration{Duration: p.blockTime},
 		EpochSize:           p.epochSize,
 		SprintSize:          p.sprintSize,
 		EpochReward:         p.epochReward,

--- a/command/ibft/switch/params.go
+++ b/command/ibft/switch/params.go
@@ -403,6 +403,7 @@ func appendIBFTForks(
 		Type:          ibftType,
 		ValidatorType: validatorType,
 		From:          common.JSONNumber{Value: from},
+		BlockTime:     lastFork.BlockTime,
 	}
 
 	switch ibftType {

--- a/command/server/config/config.go
+++ b/command/server/config/config.go
@@ -25,7 +25,6 @@ type Config struct {
 	TxPool                   *TxPool    `json:"tx_pool" yaml:"tx_pool"`
 	LogLevel                 string     `json:"log_level" yaml:"log_level"`
 	RestoreFile              string     `json:"restore_file" yaml:"restore_file"`
-	BlockTime                uint64     `json:"block_time_s" yaml:"block_time_s"`
 	Headers                  *Headers   `json:"headers" yaml:"headers"`
 	LogFilePath              string     `json:"log_to" yaml:"log_to"`
 	JSONRPCBatchRequestLimit uint64     `json:"json_rpc_batch_request_limit" yaml:"json_rpc_batch_request_limit"`
@@ -111,7 +110,6 @@ func DefaultConfig() *Config {
 		},
 		LogLevel:    "INFO",
 		RestoreFile: "",
-		BlockTime:   DefaultBlockTime,
 		Headers: &Headers{
 			AccessControlAllowOrigins: []string{"*"},
 		},

--- a/command/server/config/config.go
+++ b/command/server/config/config.go
@@ -64,9 +64,6 @@ type Headers struct {
 }
 
 const (
-	// DefaultBlockTime minimum block generation time in seconds
-	DefaultBlockTime uint64 = 2
-
 	// BlockTimeMultiplierForTimeout Multiplier to get IBFT timeout from block time
 	// timeout is calculated when IBFT timeout is not specified
 	BlockTimeMultiplierForTimeout uint64 = 5

--- a/command/server/init.go
+++ b/command/server/init.go
@@ -19,7 +19,6 @@ import (
 )
 
 var (
-	errInvalidBlockTime       = errors.New("invalid block time specified")
 	errDataDirectoryUndefined = errors.New("data directory not defined")
 )
 
@@ -50,10 +49,6 @@ func (p *serverParams) initRawParams() error {
 		return err
 	}
 
-	if err := p.initBlockTime(); err != nil {
-		return err
-	}
-
 	if p.isDevMode {
 		p.initDevMode()
 	}
@@ -64,14 +59,6 @@ func (p *serverParams) initRawParams() error {
 	p.relayer = p.rawConfig.Relayer
 
 	return p.initAddresses()
-}
-
-func (p *serverParams) initBlockTime() error {
-	if p.rawConfig.BlockTime < 1 {
-		return errInvalidBlockTime
-	}
-
-	return nil
 }
 
 func (p *serverParams) initDataDirLocation() error {

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -33,7 +33,6 @@ const (
 	blockGasTargetFlag           = "block-gas-target"
 	secretsConfigFlag            = "secrets-config"
 	restoreFlag                  = "restore"
-	blockTimeFlag                = "block-time"
 	devIntervalFlag              = "dev-interval"
 	devFlag                      = "dev"
 	corsOriginFlag               = "access-control-allow-origins"
@@ -179,7 +178,6 @@ func (p *serverParams) generateConfig() *server.Config {
 		MaxAccountEnqueued: p.rawConfig.TxPool.MaxAccountEnqueued,
 		SecretsManager:     p.secretsConfig,
 		RestoreFile:        p.getRestoreFilePath(),
-		BlockTime:          p.rawConfig.BlockTime,
 		LogLevel:           hclog.LevelFromString(p.rawConfig.LogLevel),
 		JSONLogFormat:      p.rawConfig.JSONLogFormat,
 		LogFilePath:        p.logFileLocation,

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -185,13 +185,6 @@ func setFlags(cmd *cobra.Command) {
 		"maximum number of enqueued transactions per account",
 	)
 
-	cmd.Flags().Uint64Var(
-		&params.rawConfig.BlockTime,
-		blockTimeFlag,
-		defaultConfig.BlockTime,
-		"minimum block time in seconds (at least 1s)",
-	)
-
 	cmd.Flags().StringArrayVar(
 		&params.corsAllowedOrigins,
 		corsOriginFlag,

--- a/consensus/ibft/fork/fork.go
+++ b/consensus/ibft/fork/fork.go
@@ -13,10 +13,12 @@ const (
 	KeyType          = "type"
 	KeyTypes         = "types"
 	KeyValidatorType = "validator_type"
+	KeyBlockTime     = "blockTime"
 )
 
 var (
 	ErrUndefinedIBFTConfig = errors.New("IBFT config is not defined")
+	errInvalidBlockTime    = errors.New("invalid block time provided")
 )
 
 // IBFT Fork represents setting in params.engine.ibft of genesis.json
@@ -26,6 +28,7 @@ type IBFTFork struct {
 	Deployment    *common.JSONNumber       `json:"deployment,omitempty"`
 	From          common.JSONNumber        `json:"from"`
 	To            *common.JSONNumber       `json:"to,omitempty"`
+	BlockTime     *common.Duration         `json:"blockTime,omitempty"`
 
 	// PoA
 	Validators validators.Validators `json:"validators,omitempty"`
@@ -42,6 +45,7 @@ func (f *IBFTFork) UnmarshalJSON(data []byte) error {
 		Deployment        *common.JSONNumber        `json:"deployment,omitempty"`
 		From              common.JSONNumber         `json:"from"`
 		To                *common.JSONNumber        `json:"to,omitempty"`
+		BlockTime         *common.Duration          `json:"blockTime,omitempty"`
 		Validators        interface{}               `json:"validators,omitempty"`
 		MaxValidatorCount *common.JSONNumber        `json:"maxValidatorCount,omitempty"`
 		MinValidatorCount *common.JSONNumber        `json:"minValidatorCount,omitempty"`
@@ -55,6 +59,7 @@ func (f *IBFTFork) UnmarshalJSON(data []byte) error {
 	f.Deployment = raw.Deployment
 	f.From = raw.From
 	f.To = raw.To
+	f.BlockTime = raw.BlockTime
 	f.MaxValidatorCount = raw.MaxValidatorCount
 	f.MinValidatorCount = raw.MinValidatorCount
 
@@ -74,11 +79,7 @@ func (f *IBFTFork) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if err := json.Unmarshal(validatorsBytes, f.Validators); err != nil {
-		return err
-	}
-
-	return nil
+	return json.Unmarshal(validatorsBytes, f.Validators)
 }
 
 // GetIBFTForks returns IBFT fork configurations from chain config
@@ -98,6 +99,20 @@ func GetIBFTForks(ibftConfig map[string]interface{}) (IBFTForks, error) {
 			}
 		}
 
+		var blockTime *common.Duration = nil
+
+		blockTimeGeneric, ok := ibftConfig[KeyBlockTime]
+		if ok {
+			blockTimeRaw, err := json.Marshal(blockTimeGeneric)
+			if err != nil {
+				return nil, errInvalidBlockTime
+			}
+
+			if err := json.Unmarshal(blockTimeRaw, &blockTime); err != nil {
+				return nil, errInvalidBlockTime
+			}
+		}
+
 		return IBFTForks{
 			{
 				Type:          typ,
@@ -105,6 +120,7 @@ func GetIBFTForks(ibftConfig map[string]interface{}) (IBFTForks, error) {
 				ValidatorType: validatorType,
 				From:          common.JSONNumber{Value: 0},
 				To:            nil,
+				BlockTime:     blockTime,
 			},
 		}, nil
 	}

--- a/consensus/ibft/fork/fork_test.go
+++ b/consensus/ibft/fork/fork_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	testHelper "github.com/0xPolygon/polygon-edge/helper/tests"
@@ -62,6 +63,7 @@ func TestIBFTForkUnmarshalJSON(t *testing.T) {
 			data: fmt.Sprintf(`{
 				"type": "%s",
 				"validator_type": "%s",
+				"blockTime": %d,
 				"validators": [
 					{
 						"Address": "%s"
@@ -72,8 +74,9 @@ func TestIBFTForkUnmarshalJSON(t *testing.T) {
 				],
 				"from": %d,
 				"to": %d
-			}`,
+				}`,
 				PoA, validators.ECDSAValidatorType,
+				3000000000,
 				types.StringToAddress("1"), types.StringToAddress("2"),
 				16, 20,
 			),
@@ -86,6 +89,7 @@ func TestIBFTForkUnmarshalJSON(t *testing.T) {
 					validators.NewECDSAValidator(types.StringToAddress("1")),
 					validators.NewECDSAValidator(types.StringToAddress("2")),
 				),
+				BlockTime:         &common.Duration{Duration: 3 * time.Second},
 				MaxValidatorCount: nil,
 				MinValidatorCount: nil,
 			},

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -310,7 +310,7 @@ func (c *consensusRuntime) FSM() error {
 		parent,
 		types.Address(c.config.Key.Address()),
 		c.config.txPool,
-		c.config.PolyBFTConfig.BlockTime,
+		c.config.PolyBFTConfig.BlockTime.Duration,
 		c.logger,
 	)
 

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -15,6 +15,7 @@ import (
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
@@ -447,7 +448,7 @@ func Test_NewConsensusRuntime(t *testing.T) {
 		},
 		EpochSize:  10,
 		SprintSize: 10,
-		BlockTime:  2 * time.Second,
+		BlockTime:  common.Duration{Duration: 2 * time.Second},
 	}
 
 	validators := newTestValidators(t, 3).getPublicIdentities()

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
@@ -34,7 +33,7 @@ type PolyBFTConfig struct {
 	SprintSize uint64 `json:"sprintSize"`
 
 	// BlockTime is target frequency of blocks production
-	BlockTime time.Duration `json:"blockTime"`
+	BlockTime common.Duration `json:"blockTime"`
 
 	// Governance is the initial governance address
 	Governance types.Address `json:"governance"`

--- a/consensus/polybft/sc_integration_test.go
+++ b/consensus/polybft/sc_integration_test.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
@@ -278,7 +277,6 @@ func TestIntegration_CommitEpoch(t *testing.T) {
 
 		polyBFTConfig := PolyBFTConfig{
 			InitialValidatorSet: initValidators,
-			BlockTime:           2 * time.Second,
 			EpochSize:           24 * 60 * 60 / 2,
 			SprintSize:          5,
 			EpochReward:         reward,

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -277,6 +277,13 @@ func (t *TestServer) GenerateGenesis() error {
 		args = append(args, "--premine", acct.Addr.String()+":0x"+acct.Balance.Text(16))
 	}
 
+	// provide block time flag
+	// (e2e framework expects BlockTime parameter to be provided in seconds)
+	if t.Config.BlockTime != 0 {
+		args = append(args, "--block-time",
+			(time.Duration(t.Config.BlockTime) * time.Second).String())
+	}
+
 	// add consensus flags
 	switch t.Config.Consensus {
 	case ConsensusIBFT:
@@ -427,10 +434,6 @@ func (t *TestServer) Start(ctx context.Context) error {
 	// add block gas target
 	if t.Config.BlockGasTarget != 0 {
 		args = append(args, "--block-gas-target", *types.EncodeUint64(t.Config.BlockGasTarget))
-	}
-
-	if t.Config.BlockTime != 0 {
-		args = append(args, "--block-time", strconv.FormatUint(t.Config.BlockTime, 10))
 	}
 
 	if t.Config.IBFTBaseTimeout != 0 {

--- a/e2e/ibft_test.go
+++ b/e2e/ibft_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/0xPolygon/polygon-edge/command/server/config"
 	ibftSigner "github.com/0xPolygon/polygon-edge/consensus/ibft/signer"
 	"github.com/0xPolygon/polygon-edge/e2e/framework"
 	"github.com/0xPolygon/polygon-edge/helper/tests"
@@ -19,6 +18,8 @@ import (
 // TestIbft_Transfer sends a transfer transaction (EOA -> EOA)
 // and verifies it was mined
 func TestIbft_Transfer(t *testing.T) {
+	const defaultBlockTime uint64 = 2
+
 	testCases := []struct {
 		name            string
 		blockTime       uint64
@@ -27,7 +28,7 @@ func TestIbft_Transfer(t *testing.T) {
 	}{
 		{
 			name:            "default block time",
-			blockTime:       config.DefaultBlockTime,
+			blockTime:       defaultBlockTime,
 			ibftBaseTimeout: 0, // use default value
 			validatorType:   validators.ECDSAValidatorType,
 		},
@@ -39,7 +40,7 @@ func TestIbft_Transfer(t *testing.T) {
 		},
 		{
 			name:            "with BLS",
-			blockTime:       config.DefaultBlockTime,
+			blockTime:       defaultBlockTime,
 			ibftBaseTimeout: 0, // use default value
 			validatorType:   validators.BLSValidatorType,
 		},

--- a/server/config.go
+++ b/server/config.go
@@ -24,7 +24,6 @@ type Config struct {
 	PriceLimit         uint64
 	MaxAccountEnqueued uint64
 	MaxSlots           uint64
-	BlockTime          uint64
 
 	Telemetry *Telemetry
 	Network   *network.Config

--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -44,6 +45,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/umbracle/ethgo"
 	"google.golang.org/grpc"
+)
+
+var (
+	errBlockTimeMissing = errors.New("block time configuration is missing")
+	errBlockTimeInvalid = errors.New("block time configuration is invalid")
 )
 
 // Server is the central manager of the blockchain client
@@ -500,6 +506,11 @@ func (s *Server) setupConsensus() error {
 		engineConfig = map[string]interface{}{}
 	}
 
+	blockTime, err := extractBlockTime(engineConfig)
+	if err != nil {
+		return err
+	}
+
 	config := &consensus.Config{
 		Params: s.config.Chain.Params,
 		Config: engineConfig,
@@ -517,7 +528,7 @@ func (s *Server) setupConsensus() error {
 			Grpc:                  s.grpcServer,
 			Logger:                s.logger,
 			SecretsManager:        s.secretsManager,
-			BlockTime:             s.config.BlockTime,
+			BlockTime:             uint64(blockTime.Seconds()),
 			NumBlockConfirmations: s.config.NumBlockConfirmations,
 		},
 	)
@@ -529,6 +540,28 @@ func (s *Server) setupConsensus() error {
 	s.consensus = consensus
 
 	return nil
+}
+
+// extractBlockTime extracts blockTime parameter from consensus engine configuration.
+// If it is missing or invalid, an appropriate error is returned.
+func extractBlockTime(engineConfig map[string]interface{}) (common.Duration, error) {
+	blockTimeGeneric, ok := engineConfig["blockTime"]
+	if !ok {
+		return common.Duration{}, errBlockTimeMissing
+	}
+
+	blockTimeRaw, err := json.Marshal(blockTimeGeneric)
+	if err != nil {
+		return common.Duration{}, errBlockTimeInvalid
+	}
+
+	var blockTime common.Duration
+
+	if err := json.Unmarshal(blockTimeRaw, &blockTime); err != nil {
+		return common.Duration{}, errBlockTimeInvalid
+	}
+
+	return blockTime, nil
 }
 
 // setupRelayer sets up the relayer

--- a/server/server.go
+++ b/server/server.go
@@ -568,6 +568,10 @@ func extractBlockTime(engineConfig map[string]interface{}) (common.Duration, err
 		return common.Duration{}, errBlockTimeInvalid
 	}
 
+	if blockTime.Seconds() < 1 {
+		return common.Duration{}, errBlockTimeInvalid
+	}
+
 	return blockTime, nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -506,9 +506,16 @@ func (s *Server) setupConsensus() error {
 		engineConfig = map[string]interface{}{}
 	}
 
-	blockTime, err := extractBlockTime(engineConfig)
-	if err != nil {
-		return err
+	var (
+		blockTime = common.Duration{Duration: 0}
+		err       error
+	)
+
+	if engineName != string(DummyConsensus) && engineName != string(DevConsensus) {
+		blockTime, err = extractBlockTime(engineConfig)
+		if err != nil {
+			return err
+		}
 	}
 
 	config := &consensus.Config{


### PR DESCRIPTION
# Description

This PR removes `block-time` flag from the server command and server config. Instead, it resolves it from a consensus engine parameters map. `PolyBFT` and `IBFT` consensus protocols have defined block time. `Dev` and `Dummy` consensuses are initialized with 0 block time, as those are used solely for testing.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually