### PR TITLE
Change folders hierarchy for property tests logs

### DIFF
--- a/.github/workflows/e2e-polybft.yml
+++ b/.github/workflows/e2e-polybft.yml
@@ -18,7 +18,6 @@ jobs:
     env:
       E2E_TESTS: true
       E2E_LOGS: true
-      E2E_TESTS_TYPE: 'integration'
       CI_VERBOSE: true
     outputs:
       e2e_output_failure: ${{ steps.run_e2e_failure.outputs.test_output }}

--- a/.github/workflows/property-polybft.yml
+++ b/.github/workflows/property-polybft.yml
@@ -17,7 +17,6 @@ jobs:
     env:
       E2E_TESTS: true
       E2E_LOGS: true
-      E2E_TESTS_TYPE: 'property'
       CI_VERBOSE: true
     outputs:
       property_output_failure: ${{ steps.run_property_failure.outputs.test_output }}

--- a/Makefile
+++ b/Makefile
@@ -58,14 +58,14 @@ test-e2e:
 test-e2e-polybft:
     # We can not build with race because of a bug in boltdb dependency
 	go build -o artifacts/polygon-edge .
-	env EDGE_BINARY=${PWD}/artifacts/polygon-edge E2E_TESTS=true E2E_LOGS=true E2E_TESTS_TYPE=integration \
+	env EDGE_BINARY=${PWD}/artifacts/polygon-edge E2E_TESTS=true E2E_LOGS=true \
 	go test -v -timeout=45m ./e2e-polybft/e2e/...
 
 .PHONY: test-property-polybft
 test-property-polybft:
     # We can not build with race because of a bug in boltdb dependency
 	go build -o artifacts/polygon-edge .
-	env EDGE_BINARY=${PWD}/artifacts/polygon-edge E2E_TESTS=true E2E_LOGS=true E2E_TESTS_TYPE=property go test -v -timeout=30m ./e2e-polybft/property/...
+	env EDGE_BINARY=${PWD}/artifacts/polygon-edge E2E_TESTS=true E2E_LOGS=true go test -v -timeout=30m ./e2e-polybft/property/...
 
 .PHONY: compile-core-contracts
 compile-core-contracts:

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -284,6 +284,7 @@ func isTrueEnv(e string) bool {
 }
 
 func NewPropertyTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *TestCluster {
+	t.Helper()
 	opts = append(opts, WithPropertyTestLogging())
 
 	return NewTestCluster(t, validatorsCount, opts...)

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -285,6 +285,7 @@ func isTrueEnv(e string) bool {
 
 func NewPropertyTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *TestCluster {
 	t.Helper()
+
 	opts = append(opts, WithPropertyTestLogging())
 
 	return NewTestCluster(t, validatorsCount, opts...)

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -283,6 +283,12 @@ func isTrueEnv(e string) bool {
 	return strings.ToLower(os.Getenv(e)) == "true"
 }
 
+func NewPropertyTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *TestCluster {
+	opts = append(opts, WithPropertyTestLogging())
+
+	return NewTestCluster(t, validatorsCount, opts...)
+}
+
 func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *TestCluster {
 	t.Helper()
 

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -43,9 +43,6 @@ const (
 	// envStdoutEnabled signal whether the output of the nodes get piped to stdout
 	envStdoutEnabled = "E2E_STDOUT"
 
-	// envE2ETestsType used just to display type of test if skipped
-	envE2ETestsType = "E2E_TESTS_TYPE"
-
 	// prefix for validator directory
 	defaultValidatorPrefix = "test-chain-"
 )
@@ -312,8 +309,10 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 	}
 
 	if !isTrueEnv(envE2ETestsEnabled) {
-		testType := os.Getenv(envE2ETestsType)
-		if testType == "" {
+		var testType string
+		if config.IsPropertyTest {
+			testType = "property"
+		} else {
 			testType = "integration"
 		}
 

--- a/e2e-polybft/property/property_test.go
+++ b/e2e-polybft/property/property_test.go
@@ -3,6 +3,7 @@ package property
 import (
 	"fmt"
 	"math"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -27,8 +28,6 @@ func TestProperty_DifferentVotingPower(t *testing.T) {
 			numBlocks = rapid.Uint64Range(2, 5).Draw(tt, "number of blocks the cluster should mine")
 		)
 
-		t.Logf("Test run with %d nodes, epoch size: %d. Number of blocks to mine: %d", numNodes, epochSize, numBlocks)
-
 		premine := make([]uint64, numNodes)
 
 		// premined amount will determine validator's stake and therefore voting power
@@ -44,6 +43,9 @@ func TestProperty_DifferentVotingPower(t *testing.T) {
 				}
 			}))
 		defer cluster.Stop()
+
+		t.Logf("Test %v, run with %d nodes, epoch size: %d. Number of blocks to mine: %d",
+			filepath.Base(cluster.Config.LogsDir), numNodes, epochSize, numBlocks)
 
 		// wait for single epoch to process withdrawal
 		require.NoError(t, cluster.WaitForBlock(numBlocks, blockTime*time.Duration(numBlocks)))

--- a/e2e-polybft/property/property_test.go
+++ b/e2e-polybft/property/property_test.go
@@ -27,6 +27,8 @@ func TestProperty_DifferentVotingPower(t *testing.T) {
 			numBlocks = rapid.Uint64Range(2, 5).Draw(tt, "number of blocks the cluster should mine")
 		)
 
+		t.Logf("Test run with %d nodes, epoch size: %d. Number of blocks to mine: %d", numNodes, epochSize, numBlocks)
+
 		premine := make([]uint64, numNodes)
 
 		// premined amount will determine validator's stake and therefore voting power

--- a/e2e-polybft/property/property_test.go
+++ b/e2e-polybft/property/property_test.go
@@ -35,6 +35,7 @@ func TestProperty_DifferentVotingPower(t *testing.T) {
 		}
 
 		cluster := framework.NewTestCluster(t, int(numNodes),
+			framework.WithPropertyTestLogging(),
 			framework.WithEpochSize(epochSize),
 			framework.WithSecretsCallback(func(adresses []types.Address, config *framework.TestClusterConfig) {
 				for i, a := range adresses {

--- a/e2e-polybft/property/property_test.go
+++ b/e2e-polybft/property/property_test.go
@@ -34,8 +34,7 @@ func TestProperty_DifferentVotingPower(t *testing.T) {
 			premine[i] = rapid.Uint64Range(1, maxPremine).Draw(tt, fmt.Sprintf("stake for node %d", i+1))
 		}
 
-		cluster := framework.NewTestCluster(t, int(numNodes),
-			framework.WithPropertyTestLogging(),
+		cluster := framework.NewPropertyTestCluster(t, int(numNodes),
 			framework.WithEpochSize(epochSize),
 			framework.WithSecretsCallback(func(adresses []types.Address, config *framework.TestClusterConfig) {
 				for i, a := range adresses {


### PR DESCRIPTION
# Description

Since property tests run `cluster` multiple times (and logs of all runs are in one folder), for better separation of logs, this PR (in the case of a property test), creates this folder hierarchy for logs:

![image](https://user-images.githubusercontent.com/100121253/230905069-d57c8cbf-7138-489e-aed6-cc3c4a3dd39b.png)

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually