### PR TITLE
Handle block tracker init/start failures and treat as fatal

### DIFF
--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -43,16 +43,16 @@ func HandleSignals(
 	closeFn func(),
 	outputter command.OutputFormatter,
 ) {
-	closeMessage := "Gracefully shutting down client...\n"
+	msg := "Gracefully shutting down client..."
 	select {
 	case sig := <-common.GetTerminationSignalCh():
-		closeMessage = fmt.Sprintf("\n[SIGNAL] Caught signal: %v\n", sig)
+		msg = fmt.Sprintf("\n[SIGNAL] Caught signal: %v\n%s", sig, msg)
 	case <-ctx.Done():
-		closeMessage = fmt.Sprintf("\n[CONTEXT] Done: %v\n", ctx.Err())
+		msg = fmt.Sprintf("\n[CONTEXT] Done: %v\n%s", ctx.Err(), msg)
 	}
 	outputter.SetCommandResult(
 		&ClientCloseResult{
-			Message: closeMessage,
+			Message: msg,
 		},
 	)
 	outputter.WriteOutput()

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -46,20 +46,12 @@ func HandleSignals(
 	closeFn func(),
 	outputter command.OutputFormatter,
 ) error {
-	signalCh := common.GetTerminationSignalCh()
-	var sig os.Signal
-	var err error
-	select {
-	case sig = <-signalCh:
-	case <-ctx.Done():
-		err = ctx.Err()
-	}
-
 	var closeMessage string
-	if err != nil {
-		closeMessage = fmt.Sprintf("\n[ERROR] Context done: %v\n", err)
-	} else {
+	select {
+	case sig := <-common.GetTerminationSignalCh():
 		closeMessage = fmt.Sprintf("\n[SIGNAL] Caught signal: %v\n", sig)
+	case <-ctx.Done():
+		closeMessage = fmt.Sprintf("\n[CONTEXT] Done: %v\n", ctx.Err())
 	}
 	closeMessage += "Gracefully shutting down client...\n"
 

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -319,7 +319,8 @@ func runServerLoop(
 	// Block on signals or errors
 	g, ctx := errgroup.WithContext(context.Background())
 	g.Go(func() error {
-		return helper.HandleSignals(ctx, serverInstance.Close, outputter)
+		helper.HandleSignals(ctx, serverInstance.Close, outputter)
+		return nil
 	})
 	g.Go(func() error {
 		select {

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -48,6 +48,8 @@ type Consensus interface {
 
 	// Close closes the connection
 	Close() error
+
+	SyncError() chan error
 }
 
 // Config is the configuration for the consensus

--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -253,3 +253,7 @@ func (d *Dev) GetBridgeProvider() consensus.BridgeDataProvider {
 func (d *Dev) FilterExtra(extra []byte) ([]byte, error) {
 	return extra, nil
 }
+
+func (d *Dev) SyncError() chan error {
+	return nil
+}

--- a/consensus/dummy/dummy.go
+++ b/consensus/dummy/dummy.go
@@ -88,3 +88,7 @@ func (d *Dummy) run() {
 	// do nothing
 	<-d.closeCh
 }
+
+func (d *Dummy) SyncError() chan error {
+	return nil
+}

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -687,3 +687,7 @@ func (i *backendIBFT) ValidateExtraDataFormat(header *types.Header) error {
 
 	return err
 }
+
+func (i *backendIBFT) SyncError() chan error {
+	return nil
+}

--- a/consensus/ibft/signer/helper_test.go
+++ b/consensus/ibft/signer/helper_test.go
@@ -73,7 +73,7 @@ func Test_wrapCommitHash(t *testing.T) {
 	assert.Equal(t, expectedOutput, output)
 }
 
-//nolint
+// nolint
 func Test_getOrCreateECDSAKey(t *testing.T) {
 	t.Parallel()
 
@@ -184,7 +184,7 @@ func Test_getOrCreateECDSAKey(t *testing.T) {
 	}
 }
 
-//nolint
+// nolint
 func Test_getOrCreateBLSKey(t *testing.T) {
 	t.Parallel()
 

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -164,33 +164,33 @@ func (c *consensusRuntime) close() {
 // initStateSyncManager initializes state sync manager
 // if bridge is not enabled, then a dummy state sync manager will be used
 func (c *consensusRuntime) initStateSyncManager(logger hcf.Logger) error {
-	if c.IsBridgeEnabled() {
-		stateSenderAddr := c.config.PolyBFTConfig.Bridge.StateSenderAddr
-		stateSyncManager, err := newStateSyncManager(
-			logger.Named("state-sync-manager"),
-			c.config.State,
-			&stateSyncConfig{
-				key:                   c.config.Key,
-				stateSenderAddr:       stateSenderAddr,
-				stateSenderStartBlock: c.config.PolyBFTConfig.Bridge.EventTrackerStartBlocks[stateSenderAddr],
-				jsonrpcAddr:           c.config.PolyBFTConfig.Bridge.JSONRPCEndpoint,
-				dataDir:               c.config.DataDir,
-				topic:                 c.config.bridgeTopic,
-				maxCommitmentSize:     maxCommitmentSize,
-				numBlockConfirmations: c.config.numBlockConfirmations,
-			},
-		)
-
-		if err != nil {
-			return err
-		}
-
-		c.stateSyncManager = stateSyncManager
-	} else {
+	if !c.IsBridgeEnabled() {
 		c.stateSyncManager = &dummyStateSyncManager{}
+		return nil
 	}
 
-	return c.stateSyncManager.Init()
+	// Bridge enabled ss manager
+	stateSenderAddr := c.config.PolyBFTConfig.Bridge.StateSenderAddr
+	stateSyncManager, err := newStateSyncManager(
+		logger.Named("state-sync-manager"),
+		c.config.State,
+		&stateSyncConfig{
+			key:                   c.config.Key,
+			stateSenderAddr:       stateSenderAddr,
+			stateSenderStartBlock: c.config.PolyBFTConfig.Bridge.EventTrackerStartBlocks[stateSenderAddr],
+			jsonrpcAddr:           c.config.PolyBFTConfig.Bridge.JSONRPCEndpoint,
+			dataDir:               c.config.DataDir,
+			topic:                 c.config.bridgeTopic,
+			maxCommitmentSize:     maxCommitmentSize,
+			numBlockConfirmations: c.config.numBlockConfirmations,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	c.stateSyncManager = stateSyncManager
+	return nil
 }
 
 // initCheckpointManager initializes checkpoint manager

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -443,6 +443,11 @@ func Test_NewConsensusRuntime(t *testing.T) {
 	require.NoError(t, err)
 
 	polyBftConfig := &PolyBFTConfig{
+		Bridge: &BridgeConfig{
+			StateSenderAddr:       types.Address{0x13},
+			CheckpointManagerAddr: types.Address{0x10},
+			JSONRPCEndpoint:       "testEndpoint",
+		},
 		EpochSize:  10,
 		SprintSize: 10,
 		BlockTime:  common.Duration{Duration: 2 * time.Second},
@@ -452,6 +457,7 @@ func Test_NewConsensusRuntime(t *testing.T) {
 
 	systemStateMock := new(systemStateMock)
 	systemStateMock.On("GetEpoch").Return(uint64(1)).Once()
+	systemStateMock.On("GetNextCommittedIndex").Return(uint64(1)).Once()
 
 	blockchainMock := &blockchainMock{}
 	blockchainMock.On("CurrentHeader").Return(&types.Header{Number: 1, ExtraData: createTestExtraForAccounts(t, 1, validators, nil)})
@@ -480,7 +486,9 @@ func Test_NewConsensusRuntime(t *testing.T) {
 	assert.Equal(t, uint64(10), runtime.config.PolyBFTConfig.SprintSize)
 	assert.Equal(t, uint64(10), runtime.config.PolyBFTConfig.EpochSize)
 	assert.Equal(t, "0x0000000000000000000000000000000000000101", contracts.ValidatorSetContract.String())
-	assert.False(t, runtime.IsBridgeEnabled())
+	assert.Equal(t, "0x1300000000000000000000000000000000000000", runtime.config.PolyBFTConfig.Bridge.StateSenderAddr.String())
+	assert.Equal(t, "0x1000000000000000000000000000000000000000", runtime.config.PolyBFTConfig.Bridge.CheckpointManagerAddr.String())
+	assert.True(t, runtime.IsBridgeEnabled())
 	systemStateMock.AssertExpectations(t)
 	blockchainMock.AssertExpectations(t)
 	polybftBackendMock.AssertExpectations(t)

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -437,6 +437,7 @@ func TestConsensusRuntime_FSM_EndOfEpoch_BuildCommitEpoch(t *testing.T) {
 }
 
 func Test_NewConsensusRuntime(t *testing.T) {
+	t.Skip("fails on no such host for JSON RPC endpoint in event tracker init/start")
 	t.Parallel()
 
 	_, err := os.Create("/tmp/consensusState.db")

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -437,18 +437,12 @@ func TestConsensusRuntime_FSM_EndOfEpoch_BuildCommitEpoch(t *testing.T) {
 }
 
 func Test_NewConsensusRuntime(t *testing.T) {
-	t.Skip("fails on no such host for JSON RPC endpoint in event tracker init/start")
 	t.Parallel()
 
 	_, err := os.Create("/tmp/consensusState.db")
 	require.NoError(t, err)
 
 	polyBftConfig := &PolyBFTConfig{
-		Bridge: &BridgeConfig{
-			StateSenderAddr:       types.Address{0x13},
-			CheckpointManagerAddr: types.Address{0x10},
-			JSONRPCEndpoint:       "testEndpoint",
-		},
 		EpochSize:  10,
 		SprintSize: 10,
 		BlockTime:  common.Duration{Duration: 2 * time.Second},
@@ -458,7 +452,6 @@ func Test_NewConsensusRuntime(t *testing.T) {
 
 	systemStateMock := new(systemStateMock)
 	systemStateMock.On("GetEpoch").Return(uint64(1)).Once()
-	systemStateMock.On("GetNextCommittedIndex").Return(uint64(1)).Once()
 
 	blockchainMock := &blockchainMock{}
 	blockchainMock.On("CurrentHeader").Return(&types.Header{Number: 1, ExtraData: createTestExtraForAccounts(t, 1, validators, nil)})
@@ -487,9 +480,7 @@ func Test_NewConsensusRuntime(t *testing.T) {
 	assert.Equal(t, uint64(10), runtime.config.PolyBFTConfig.SprintSize)
 	assert.Equal(t, uint64(10), runtime.config.PolyBFTConfig.EpochSize)
 	assert.Equal(t, "0x0000000000000000000000000000000000000101", contracts.ValidatorSetContract.String())
-	assert.Equal(t, "0x1300000000000000000000000000000000000000", runtime.config.PolyBFTConfig.Bridge.StateSenderAddr.String())
-	assert.Equal(t, "0x1000000000000000000000000000000000000000", runtime.config.PolyBFTConfig.Bridge.CheckpointManagerAddr.String())
-	assert.True(t, runtime.IsBridgeEnabled())
+	assert.False(t, runtime.IsBridgeEnabled())
 	systemStateMock.AssertExpectations(t)
 	blockchainMock.AssertExpectations(t)
 	polybftBackendMock.AssertExpectations(t)

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -151,6 +151,11 @@ func (s *stateSyncManager) initTracker() error {
 		// Sync errors are fatal for the sync manager
 		if err := <-syncErrCh; err != nil {
 			s.logger.Error("failed to sync state manager", "error", err)
+			// NOTE: runtime.Goexit() is preferred but we do not have
+			// a ctx that can be used to cancel any sibling goroutines that may
+			// have been started from the stack that calls this func. As such,
+			// we cannot ensure that runtime.Goexit() will cause the program to exit,
+			// even if we are in the main goroutine here.
 			os.Exit(1)
 		}
 	}()

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -35,7 +35,6 @@ type StateSyncProof struct {
 
 // StateSyncManager is an interface that defines functions for state sync workflow
 type StateSyncManager interface {
-	Init() error
 	Close()
 	Commitment() (*CommitmentMessageSigned, error)
 	GetStateSyncProof(stateSyncID uint64) (types.Proof, error)
@@ -49,7 +48,6 @@ var _ StateSyncManager = (*dummyStateSyncManager)(nil)
 // dummyStateSyncManager is used when bridge is not enabled
 type dummyStateSyncManager struct{}
 
-func (n *dummyStateSyncManager) Init() error                                   { return nil }
 func (n *dummyStateSyncManager) Close()                                        {}
 func (n *dummyStateSyncManager) SyncError() chan error                         { return nil }
 func (n *dummyStateSyncManager) Commitment() (*CommitmentMessageSigned, error) { return nil, nil }
@@ -107,20 +105,15 @@ func newStateSyncManager(logger hclog.Logger, state *State, config *stateSyncCon
 		syncErrCh: make(chan error),
 	}
 
-	return s, nil
-}
-
-// Init subscribes to bridge topics (getting votes) and start the event tracker routine
-func (s *stateSyncManager) Init() error {
 	if err := s.initTracker(); err != nil {
-		return fmt.Errorf("failed to init event tracker. Error: %w", err)
+		return nil, fmt.Errorf("failed to init event tracker. Error: %w", err)
 	}
 
 	if err := s.initTransport(); err != nil {
-		return fmt.Errorf("failed to initialize state sync transport layer. Error: %w", err)
+		return nil, fmt.Errorf("failed to initialize state sync transport layer. Error: %w", err)
 	}
 
-	return nil
+	return s, nil
 }
 
 func (s *stateSyncManager) Close() {

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -151,11 +151,9 @@ func (s *stateSyncManager) initTracker() error {
 		// Sync errors are fatal for the sync manager
 		if err := <-syncErrCh; err != nil {
 			s.logger.Error("failed to sync state manager", "error", err)
-			// NOTE: runtime.Goexit() is preferred but we do not have
-			// a ctx that can be used to cancel any sibling goroutines that may
-			// have been started from the stack that calls this func. As such,
-			// we cannot ensure that runtime.Goexit() will cause the program to exit,
-			// even if we are in the main goroutine here.
+			// NOTE: it would be better to either cancel a root context or
+			// propagate an error to main which results in root context cancellation
+			// and exit via main.
 			os.Exit(1)
 		}
 	}()

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -126,7 +126,6 @@ func (s *stateSyncManager) Close() {
 
 // initTracker starts a new event tracker (to receive new state sync events)
 func (s *stateSyncManager) initTracker() error {
-
 	evtTracker := tracker.NewEventTracker(
 		path.Join(s.config.dataDir, "/deposit.db"),
 		s.config.jsonrpcAddr,
@@ -150,9 +149,8 @@ func (s *stateSyncManager) initTracker() error {
 	}
 	go func() {
 		// Sync errors are fatal for the sync manager
-		err := <-syncErrCh
-		if err != nil {
-			s.logger.Error("failed sync state manager", "error", err)
+		if err := <-syncErrCh; err != nil {
+			s.logger.Error("failed to sync state manager", "error", err)
 			os.Exit(1)
 		}
 	}()

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer.go
@@ -106,9 +106,8 @@ func (r *StateSyncRelayer) Start() error {
 	}
 	go func() {
 		// Sync errors are not fatal for the relayer
-		err := <-syncErrCh
-		if err != nil {
-			r.logger.Error("failed sync relayer", "error", err)
+		if err := <-syncErrCh; err != nil {
+			r.logger.Error("failed to sync relayer", "error", err)
 		}
 	}()
 

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -30,6 +30,20 @@ var (
 	errInvalidDuration = errors.New("invalid duration")
 )
 
+func Merge(l, r chan error) chan error {
+	merge := make(chan error)
+	go func() {
+		select {
+		case err := <-l:
+			merge <- err
+		case err := <-r:
+			merge <- err
+		}
+		close(merge)
+	}()
+	return merge
+}
+
 // Min returns the strictly lower number
 func Min(a, b uint64) uint64 {
 	if a < b {

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -320,6 +320,8 @@ func GetTerminationSignalCh() <-chan os.Signal {
 		os.Interrupt,
 		syscall.SIGTERM,
 		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGKILL,
 	)
 
 	return signalCh

--- a/server/server.go
+++ b/server/server.go
@@ -938,6 +938,10 @@ func (s *Server) JoinPeer(rawPeerMultiaddr string) error {
 	return s.network.JoinPeer(rawPeerMultiaddr)
 }
 
+func (s *Server) Error() chan error {
+	return common.Merge(s.consensus.SyncError(), s.stateSyncRelayer.SyncError())
+}
+
 // Close closes the Minimal server (blockchain, networking, consensus)
 func (s *Server) Close() {
 	// Close the blockchain layer

--- a/server/server.go
+++ b/server/server.go
@@ -630,7 +630,7 @@ func (s *Server) setupRelayer() error {
 		trackerStartBlockConfig = polyBFTConfig.Bridge.EventTrackerStartBlocks
 	}
 
-	relayer := statesyncrelayer.NewRelayer(
+	s.stateSyncRelayer, err = statesyncrelayer.NewRelayer(
 		s.config.DataDir,
 		s.config.JSONRPC.JSONRPCAddr.String(),
 		ethgo.Address(contracts.StateReceiverContract),
@@ -638,9 +638,7 @@ func (s *Server) setupRelayer() error {
 		s.logger.Named("relayer"),
 		wallet.NewEcdsaSigner(wallet.NewKey(account)),
 	)
-
-	// start relayer
-	if err := relayer.Start(); err != nil {
+	if err != nil {
 		return fmt.Errorf("failed to start relayer: %w", err)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -170,8 +170,8 @@ func NewServer(config *Config) (*Server, error) {
 	}
 
 	// Set up datadog profiler
-	if ddErr := m.enableDataDogProfiler(); err != nil {
-		m.logger.Error("DataDog profiler setup failed", "err", ddErr.Error())
+	if err := m.enableDataDogProfiler(); err != nil {
+		m.logger.Error("DataDog profiler setup failed", "err", err.Error())
 	}
 
 	// Set up the secrets manager
@@ -937,6 +937,10 @@ func (s *Server) JoinPeer(rawPeerMultiaddr string) error {
 }
 
 func (s *Server) Error() chan error {
+	// Not all servers are relayers
+	if s.stateSyncRelayer == nil {
+		return s.consensus.SyncError()
+	}
 	return common.Merge(s.consensus.SyncError(), s.stateSyncRelayer.SyncError())
 }
 

--- a/tracker/event_tracker.go
+++ b/tracker/event_tracker.go
@@ -88,12 +88,13 @@ func (e *EventTracker) Start(ctx context.Context) error {
 			return fmt.Errorf("failed to init blocktracker: %w", err)
 		}
 
-
-		go func() {
 		if err := blockTracker.Start(); err != nil {
-			e.logger.Error("failed to start blocktracker", "error", err)
+			return fmt.Errorf("failed to start blocktracker: %w", err)
 		}
-	}()
+
+		if err := tt.Sync(ctx); err != nil {
+			return fmt.Errorf("failed to sync: %w", err)
+		}
 
 		return nil
 	})
@@ -102,12 +103,6 @@ func (e *EventTracker) Start(ctx context.Context) error {
 		<-ctx.Done()
 		blockTracker.Close()
 		store.Close()
-	}()
-
-	go func() {
-		if err := tt.Sync(ctx); err != nil {
-			e.logger.Error("failed to sync", "error", err)
-		}
 	}()
 
 	return g.Wait()

--- a/tracker/event_tracker.go
+++ b/tracker/event_tracker.go
@@ -101,6 +101,7 @@ func (e *EventTracker) Start(ctx context.Context) error {
 	go func() {
 		if err := tt.Sync(ctx); err != nil {
 			e.logger.Error("failed to sync", "error", err)
+			panic(err)
 		}
 	}()
 

--- a/tracker/event_tracker.go
+++ b/tracker/event_tracker.go
@@ -47,8 +47,8 @@ func NewEventTracker(
 
 // Start will initialize Block Tracker and Tracker instances and begin tracking events.
 // The Tracker will perform a concurrent sync operation which may take some time.
-// The sync error channel should be used to handle errors that occur from the concurrent sync operation.
-func (e *EventTracker) Start(ctx context.Context) (err error, syncErrCh chan error) {
+// The error channel should be used to handle errors that occur from the concurrent sync operation.
+func (e *EventTracker) Start(ctx context.Context) (error, chan error) {
 	e.logger.Info("Start tracking events",
 		"contract", e.contractAddr,
 		"JSON RPC address", e.rpcEndpoint,
@@ -99,6 +99,7 @@ func (e *EventTracker) Start(ctx context.Context) (err error, syncErrCh chan err
 	}()
 
 	// Run sync concurrently and return error channel
+	syncErrCh := make(chan error)
 	go func() {
 		syncErrCh <- tt.Sync(ctx)
 		close(syncErrCh)

--- a/tracker/event_tracker_test.go
+++ b/tracker/event_tracker_test.go
@@ -84,7 +84,7 @@ func TestEventTracker_TrackSyncEvents(t *testing.T) {
 		numBlockConfirmations: numBlockConfirmations,
 	}
 
-	err = tracker.Start(context.Background())
+	err, _ = tracker.Start(context.Background())
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)


### PR DESCRIPTION
# Description

Change Event Tracker creation logic to treat BlockTracker and Tracker errors as fatal.

Removes the possibility of running a validator without any block tracking against the rootchain due to init/start error of event tracker.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Found that the EventTracker Start() func took <20ms on my laptop. So these changes should not affect startup perf at all
