### PR TITLE
Eth_call override unit test lint fix

### DIFF
--- a/state/executor_test.go
+++ b/state/executor_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestOverride(t *testing.T) {
 	t.Parallel()
+
 	state := newStateWithPreState(map[types.Address]*PreState{
 		{0x0}: {
 			Nonce:   1,


### PR DESCRIPTION
# Description

This PR fixes small linting error found in `TestOverride` unit test.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
