### PR TITLE
"native-token-config" flag added to genesis command

### DIFF
--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -209,7 +209,7 @@ func setFlags(cmd *cobra.Command) {
 
 		cmd.Flags().StringVar(
 			&params.nativeTokenConfigRaw,
-			nativeTokenFlag,
+			nativeTokenConfigFlag,
 			"",
 			"configuration of native token in format <name:symbol:decimalsCount>",
 		)

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -211,7 +211,7 @@ func setFlags(cmd *cobra.Command) {
 			&params.nativeTokenConfigRaw,
 			nativeTokenFlag,
 			"",
-			"configuration of native token in format <name:symbol:decimals>",
+			"configuration of native token in format <name:symbol:decimalsCount>",
 		)
 	}
 

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -211,7 +211,7 @@ func setFlags(cmd *cobra.Command) {
 			&params.nativeTokenConfigRaw,
 			nativeTokenConfigFlag,
 			"",
-			"configuration of native token in format <name:symbol:decimalsCount>",
+			"configuration of native token in format <name:symbol:decimals count>",
 		)
 	}
 

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -204,7 +204,14 @@ func setFlags(cmd *cobra.Command) {
 			&params.mintableNativeToken,
 			mintableTokenFlag,
 			false,
-			"flag indicate whether mintable or non-mintable native ERC20 token is deployed",
+			"flag indicate whether mintable or non-mintable native token is deployed",
+		)
+
+		cmd.Flags().StringVar(
+			&params.nativeTokenConfigRaw,
+			nativeTokenFlag,
+			"",
+			"configuration of native token in format <name:symbol:decimals>",
 		)
 	}
 

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -122,7 +122,7 @@ func (p *genesisParams) validateFlags() error {
 	}
 
 	if p.isPolyBFTConsensus() {
-		if err := p.decodeTokenParams(); err != nil {
+		if err := p.extractTokenParams(); err != nil {
 			return errInvalidTokenParams
 		}
 	}
@@ -401,7 +401,7 @@ func (p *genesisParams) predeployStakingSC() (*chain.GenesisAccount, error) {
 	return stakingAccount, nil
 }
 
-func (p *genesisParams) decodeTokenParams() error {
+func (p *genesisParams) extractTokenParams() error {
 	if p.nativeTokenConfigRaw == "" {
 		p.nativeTokenConfig = &polybft.TokenConfig{
 			TokenName:     defaultTokenName,
@@ -430,7 +430,7 @@ func (p *genesisParams) decodeTokenParams() error {
 			return errInvalidTokenParams
 		}
 
-		decimals, err := strconv.ParseUint(strings.TrimSpace(params[1]), 10, 8)
+		decimals, err := strconv.ParseUint(strings.TrimSpace(params[2]), 10, 8)
 		if err != nil {
 			return errInvalidTokenParams
 		}

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -124,7 +124,7 @@ func (p *genesisParams) validateFlags() error {
 
 	if p.isPolyBFTConsensus() {
 		if err := p.extractTokenParams(); err != nil {
-			return errInvalidTokenParams
+			return err
 		}
 	}
 

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -55,7 +55,8 @@ var (
 	errValidatorsNotSpecified = errors.New("validator information not specified")
 	errUnsupportedConsensus   = errors.New("specified consensusRaw not supported")
 	errInvalidEpochSize       = errors.New("epoch size must be greater than 1")
-	errInvalidTokenParams     = errors.New("native token params were not submitted in proper format <name:symbol:decimalsCount>")
+	errInvalidTokenParams     = errors.New("native token params were not submitted in proper" +
+		" format <name:symbol:decimals count>")
 )
 
 type genesisParams struct {

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -3,6 +3,7 @@ package genesis
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -54,7 +55,7 @@ var (
 	errValidatorsNotSpecified = errors.New("validator information not specified")
 	errUnsupportedConsensus   = errors.New("specified consensusRaw not supported")
 	errInvalidEpochSize       = errors.New("epoch size must be greater than 1")
-	errInvalidTokenParams     = errors.New("native token params were not submitted in format <name:symbol:decimals>")
+	errInvalidTokenParams     = errors.New("native token params were not submitted in proper format <name:symbol:decimalsCount>")
 )
 
 type genesisParams struct {
@@ -431,7 +432,7 @@ func (p *genesisParams) extractTokenParams() error {
 		}
 
 		decimals, err := strconv.ParseUint(strings.TrimSpace(params[2]), 10, 8)
-		if err != nil {
+		if err != nil || decimals <= 0 || decimals > math.MaxUint8 {
 			return errInvalidTokenParams
 		}
 

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -406,15 +406,15 @@ func (p *genesisParams) predeployStakingSC() (*chain.GenesisAccount, error) {
 func (p *genesisParams) extractTokenParams() error {
 	if p.nativeTokenConfigRaw == "" {
 		p.nativeTokenConfig = &polybft.TokenConfig{
-			TokenName:     defaultTokenName,
-			TokenSymbol:   defaultTokenSymbol,
-			TokenDecimals: defaultTokenDecimals,
+			Name:     defaultTokenName,
+			Symbol:   defaultTokenSymbol,
+			Decimals: defaultTokenDecimals,
 		}
 	} else {
 		p.nativeTokenConfig = &polybft.TokenConfig{
-			TokenName:     defaultTokenName,
-			TokenSymbol:   defaultTokenSymbol,
-			TokenDecimals: defaultTokenDecimals,
+			Name:     defaultTokenName,
+			Symbol:   defaultTokenSymbol,
+			Decimals: defaultTokenDecimals,
 		}
 
 		params := strings.Split(p.nativeTokenConfigRaw, ":")
@@ -422,13 +422,13 @@ func (p *genesisParams) extractTokenParams() error {
 			return errInvalidTokenParams
 		}
 
-		p.nativeTokenConfig.TokenName = strings.TrimSpace(params[0])
-		if p.nativeTokenConfig.TokenName == "" {
+		p.nativeTokenConfig.Name = strings.TrimSpace(params[0])
+		if p.nativeTokenConfig.Name == "" {
 			return errInvalidTokenParams
 		}
 
-		p.nativeTokenConfig.TokenSymbol = strings.TrimSpace(params[1])
-		if p.nativeTokenConfig.TokenSymbol == "" {
+		p.nativeTokenConfig.Symbol = strings.TrimSpace(params[1])
+		if p.nativeTokenConfig.Symbol == "" {
 			return errInvalidTokenParams
 		}
 
@@ -437,7 +437,7 @@ func (p *genesisParams) extractTokenParams() error {
 			return errInvalidTokenParams
 		}
 
-		p.nativeTokenConfig.TokenDecimals = uint8(decimals)
+		p.nativeTokenConfig.Decimals = uint8(decimals)
 	}
 
 	return nil

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -97,7 +97,7 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 		Bridge:              bridge,
 		InitialTrieRoot:     types.StringToHash(p.initialStateRoot),
 		MintableNativeToken: p.mintableNativeToken,
-		NativTokenConfig:    p.nativeTokenConfig,
+		NativeTokenConfig:   p.nativeTokenConfig,
 	}
 
 	chainConfig := &chain.Chain{

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -93,10 +93,11 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 		SprintSize:          p.sprintSize,
 		EpochReward:         p.epochReward,
 		// use 1st account as governance address
-		Governance:         manifest.GenesisValidators[0].Address,
-		Bridge:             bridge,
-		InitialTrieRoot:    types.StringToHash(p.initialStateRoot),
-		MintableERC20Token: p.mintableNativeToken,
+		Governance:          manifest.GenesisValidators[0].Address,
+		Bridge:              bridge,
+		InitialTrieRoot:     types.StringToHash(p.initialStateRoot),
+		MintableNativeToken: p.mintableNativeToken,
+		NativTokenConfig:    p.nativeTokenConfig,
 	}
 
 	chainConfig := &chain.Chain{

--- a/consensus/polybft/contracts_initializer.go
+++ b/consensus/polybft/contracts_initializer.go
@@ -17,12 +17,6 @@ const (
 	minDelegation = 1
 )
 
-var (
-	nativeTokenName     = "Polygon"
-	nativeTokenSymbol   = "MATIC"
-	nativeTokenDecimals = uint8(18)
-)
-
 // getInitChildValidatorSetInput builds input parameters for ChildValidatorSet SC initialization
 func getInitChildValidatorSetInput(polyBFTConfig PolyBFTConfig) ([]byte, error) {
 	apiValidators := make([]*contractsapi.ValidatorInit, len(polyBFTConfig.InitialValidatorSet))

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -143,15 +143,15 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 			rootNativeERC20Token = polyBFTConfig.Bridge.RootNativeERC20Addr
 		}
 
-		if polyBFTConfig.MintableERC20Token {
+		if polyBFTConfig.MintableNativeToken {
 			// initialize NativeERC20Mintable SC
 			params := &contractsapi.InitializeNativeERC20MintableFn{
 				Predicate_: contracts.ChildERC20PredicateContract,
 				Owner_:     polyBFTConfig.Governance,
 				RootToken_: rootNativeERC20Token,
-				Name_:      nativeTokenName,
-				Symbol_:    nativeTokenSymbol,
-				Decimals_:  nativeTokenDecimals,
+				Name_:      polyBFTConfig.NativTokenConfig.TokenName,
+				Symbol_:    polyBFTConfig.NativTokenConfig.TokenSymbol,
+				Decimals_:  polyBFTConfig.NativTokenConfig.TokenDecimals,
 			}
 
 			input, err := params.EncodeAbi()
@@ -165,9 +165,9 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 		} else {
 			// initialize NativeERC20 SC
 			params := &contractsapi.InitializeNativeERC20Fn{
-				Name_:      nativeTokenName,
-				Symbol_:    nativeTokenSymbol,
-				Decimals_:  nativeTokenDecimals,
+				Name_:      polyBFTConfig.NativTokenConfig.TokenName,
+				Symbol_:    polyBFTConfig.NativTokenConfig.TokenSymbol,
+				Decimals_:  polyBFTConfig.NativTokenConfig.TokenDecimals,
 				RootToken_: rootNativeERC20Token,
 				Predicate_: contracts.ChildERC20PredicateContract,
 			}

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -149,9 +149,9 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 				Predicate_: contracts.ChildERC20PredicateContract,
 				Owner_:     polyBFTConfig.Governance,
 				RootToken_: rootNativeERC20Token,
-				Name_:      polyBFTConfig.NativTokenConfig.TokenName,
-				Symbol_:    polyBFTConfig.NativTokenConfig.TokenSymbol,
-				Decimals_:  polyBFTConfig.NativTokenConfig.TokenDecimals,
+				Name_:      polyBFTConfig.NativeTokenConfig.TokenName,
+				Symbol_:    polyBFTConfig.NativeTokenConfig.TokenSymbol,
+				Decimals_:  polyBFTConfig.NativeTokenConfig.TokenDecimals,
 			}
 
 			input, err := params.EncodeAbi()
@@ -165,9 +165,9 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 		} else {
 			// initialize NativeERC20 SC
 			params := &contractsapi.InitializeNativeERC20Fn{
-				Name_:      polyBFTConfig.NativTokenConfig.TokenName,
-				Symbol_:    polyBFTConfig.NativTokenConfig.TokenSymbol,
-				Decimals_:  polyBFTConfig.NativTokenConfig.TokenDecimals,
+				Name_:      polyBFTConfig.NativeTokenConfig.TokenName,
+				Symbol_:    polyBFTConfig.NativeTokenConfig.TokenSymbol,
+				Decimals_:  polyBFTConfig.NativeTokenConfig.TokenDecimals,
 				RootToken_: rootNativeERC20Token,
 				Predicate_: contracts.ChildERC20PredicateContract,
 			}

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -149,9 +149,9 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 				Predicate_: contracts.ChildERC20PredicateContract,
 				Owner_:     polyBFTConfig.Governance,
 				RootToken_: rootNativeERC20Token,
-				Name_:      polyBFTConfig.NativeTokenConfig.TokenName,
-				Symbol_:    polyBFTConfig.NativeTokenConfig.TokenSymbol,
-				Decimals_:  polyBFTConfig.NativeTokenConfig.TokenDecimals,
+				Name_:      polyBFTConfig.NativeTokenConfig.Name,
+				Symbol_:    polyBFTConfig.NativeTokenConfig.Symbol,
+				Decimals_:  polyBFTConfig.NativeTokenConfig.Decimals,
 			}
 
 			input, err := params.EncodeAbi()
@@ -165,9 +165,9 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 		} else {
 			// initialize NativeERC20 SC
 			params := &contractsapi.InitializeNativeERC20Fn{
-				Name_:      polyBFTConfig.NativeTokenConfig.TokenName,
-				Symbol_:    polyBFTConfig.NativeTokenConfig.TokenSymbol,
-				Decimals_:  polyBFTConfig.NativeTokenConfig.TokenDecimals,
+				Name_:      polyBFTConfig.NativeTokenConfig.Name,
+				Symbol_:    polyBFTConfig.NativeTokenConfig.Symbol,
+				Decimals_:  polyBFTConfig.NativeTokenConfig.Decimals,
 				RootToken_: rootNativeERC20Token,
 				Predicate_: contracts.ChildERC20PredicateContract,
 			}

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -38,8 +38,10 @@ type PolyBFTConfig struct {
 	// Governance is the initial governance address
 	Governance types.Address `json:"governance"`
 
-	// MintableERC20Token denotes whether mintable ERC20 token is used
-	MintableERC20Token bool `json:"mintableERC20"`
+	// MintableNativeToken denotes whether mintable native token is used
+	MintableNativeToken bool `json:"mintableNative"`
+
+	NativTokenConfig *TokenConfig `json:"nativeTokenConfig"`
 
 	InitialTrieRoot types.Hash `json:"initialTrieRoot"`
 }
@@ -261,4 +263,11 @@ func (m *Manifest) Save(manifestPath string) error {
 	}
 
 	return nil
+}
+
+// TokenConfig is the configuration of nativ token used by edge network
+type TokenConfig struct {
+	TokenName     string `json:"tokenName"`
+	TokenSymbol   string `json:"tokenSymbol"`
+	TokenDecimals uint8  `json:"tokenDecimals"`
 }

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -41,7 +41,8 @@ type PolyBFTConfig struct {
 	// MintableNativeToken denotes whether mintable native token is used
 	MintableNativeToken bool `json:"mintableNative"`
 
-	NativTokenConfig *TokenConfig `json:"nativeTokenConfig"`
+	// NativeTokenConfig defines name, symbol and decimal count of the native token
+	NativeTokenConfig *TokenConfig `json:"nativeTokenConfig"`
 
 	InitialTrieRoot types.Hash `json:"initialTrieRoot"`
 }
@@ -265,9 +266,9 @@ func (m *Manifest) Save(manifestPath string) error {
 	return nil
 }
 
-// TokenConfig is the configuration of nativ token used by edge network
+// TokenConfig is the configuration of native token used by edge network
 type TokenConfig struct {
-	TokenName     string `json:"tokenName"`
-	TokenSymbol   string `json:"tokenSymbol"`
-	TokenDecimals uint8  `json:"tokenDecimals"`
+	Name     string `json:"name"`
+	Symbol   string `json:"symbol"`
+	Decimals uint8  `json:"decimals"`
 }

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -622,7 +622,7 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 
 	nativeTokenAddr := ethgo.Address(contracts.NativeERC20TokenContract)
 
-	queryNativeERC20Metadata := func(funcName string, abiType *abi.Type, relayer txrelayer.TxRelayer) map[string]interface{} {
+	queryNativeERC20Metadata := func(funcName string, abiType *abi.Type, relayer txrelayer.TxRelayer) interface{} {
 		valueHex, err := ABICall(relayer, contractsapi.NativeERC20Mintable, nativeTokenAddr, ethgo.ZeroAddress, funcName)
 		require.NoError(t, err)
 
@@ -634,7 +634,7 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 		err = abiType.DecodeStruct(valueRaw, &decodedResult)
 		require.NoError(t, err)
 
-		return decodedResult
+		return decodedResult["0"]
 	}
 
 	validatorsAddrs := make([]types.Address, validatorCount)
@@ -677,16 +677,13 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 	stringABIType := abi.MustNewType("tuple(string)")
 	uint8ABIType := abi.MustNewType("tuple(uint8)")
 
-	decodedResult := queryNativeERC20Metadata("name", stringABIType, relayer)
-	name := decodedResult["0"].(string) //nolint:forcetypeassert
+	name := queryNativeERC20Metadata("name", stringABIType, relayer)
 	require.Equal(t, tokenName, name)
 
-	decodedResult = queryNativeERC20Metadata("symbol", stringABIType, relayer)
-	symbol := decodedResult["0"].(string) //nolint:forcetypeassert
+	symbol := queryNativeERC20Metadata("symbol", stringABIType, relayer)
 	require.Equal(t, tokenSymbol, symbol)
 
-	decodedResult = queryNativeERC20Metadata("decimals", uint8ABIType, relayer)
-	decimalsCount := decodedResult["0"].(uint8) //nolint:forcetypeassert
+	decimalsCount := queryNativeERC20Metadata("decimals", uint8ABIType, relayer)
 	require.Equal(t, decimals, decimalsCount)
 
 	// send mint transactions

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -620,6 +620,7 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 	cluster := framework.NewTestCluster(t,
 		validatorCount,
 		framework.WithMintableNativeToken(true),
+		framework.WithNativeTokenConfig("MyPolygon:MyMatic:18"),
 		framework.WithEpochSize(epochSize),
 		framework.WithSecretsCallback(func(addrs []types.Address, config *framework.TestClusterConfig) {
 			for i, addr := range addrs {

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -68,25 +68,26 @@ func resolveBinary() string {
 type TestClusterConfig struct {
 	t *testing.T
 
-	Name                string
-	Premine             []string // address[:amount]
-	PremineValidators   []string // address[:amount]
-	StakeAmounts        []string // address[:amount]
-	MintableNativeToken bool
-	HasBridge           bool
-	BootnodeCount       int
-	NonValidatorCount   int
-	WithLogs            bool
-	WithStdout          bool
-	LogsDir             string
-	TmpDir              string
-	BlockGasLimit       uint64
-	ValidatorPrefix     string
-	Binary              string
-	ValidatorSetSize    uint64
-	EpochSize           int
-	EpochReward         int
-	SecretsCallback     func([]types.Address, *TestClusterConfig)
+	Name                 string
+	Premine              []string // address[:amount]
+	PremineValidators    []string // address[:amount]
+	StakeAmounts         []string // address[:amount]
+	MintableNativeToken  bool
+	HasBridge            bool
+	BootnodeCount        int
+	NonValidatorCount    int
+	WithLogs             bool
+	WithStdout           bool
+	LogsDir              string
+	TmpDir               string
+	BlockGasLimit        uint64
+	ValidatorPrefix      string
+	Binary               string
+	ValidatorSetSize     uint64
+	EpochSize            int
+	EpochReward          int
+	NativeTokenConfigRaw string
+	SecretsCallback      func([]types.Address, *TestClusterConfig)
 
 	ContractDeployerAllowListAdmin   []types.Address
 	ContractDeployerAllowListEnabled []types.Address
@@ -282,6 +283,12 @@ func WithPropertyTestLogging() ClusterOption {
 	}
 }
 
+func WithNativeTokenConfig(tokenConfigRaw string) ClusterOption {
+	return func(h *TestClusterConfig) {
+		h.NativeTokenConfigRaw = tokenConfigRaw
+	}
+}
+
 func isTrueEnv(e string) bool {
 	return strings.ToLower(os.Getenv(e)) == "true"
 }
@@ -411,6 +418,11 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 			"--epoch-reward", strconv.Itoa(cluster.Config.EpochReward),
 			"--premine", "0x0000000000000000000000000000000000000000",
 			"--trieroot", cluster.Config.InitialStateRoot.String(),
+		}
+
+		// add optional genesis flags
+		if cluster.Config.NativeTokenConfigRaw != "" {
+			args = append(args, "--native-token-config", cluster.Config.NativeTokenConfigRaw)
 		}
 
 		if len(cluster.Config.Premine) != 0 {


### PR DESCRIPTION
# Description
The native token name, symbol, and decimals count are currently hardcoded on the Edge. However, it should be possible to customize it using a genesis command flag.
It could be a string flag in the following format: `<name>:<symbol>:<decimals>`. Given values should be parsed and provided to the `NativeERC20` or `NativeERC20Mintable` during initialization phase.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Executing command locally for valid and invalid situations.

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it


