### PR TITLE
Provide correct state sync event logs filter in `TestE2E_Bridge_Transfers`

### DIFF
--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -184,8 +184,7 @@ func (b *BlockBuilder) writeTxPoolTransaction(tx *types.Transaction) (bool, erro
 		return true, nil
 	}
 
-	err := b.WriteTx(tx)
-	if err != nil {
+	if err := b.WriteTx(tx); err != nil {
 		if _, ok := err.(*state.GasLimitReachedTransitionApplicationError); ok { //nolint:errorlint
 			// stop processing
 			return true, err

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -35,7 +35,7 @@ func TestE2E_Bridge_Transfers(t *testing.T) {
 		numBlockConfirmations = 2
 		// make epoch size long enough, so that all exit events are processed within the same epoch
 		epochSize  = 30
-		sprintSize = 5
+		sprintSize = uint64(5)
 	)
 
 	receivers := make([]string, transfersCount)
@@ -78,8 +78,9 @@ func TestE2E_Bridge_Transfers(t *testing.T) {
 			),
 		)
 
+		finalBlockNum := 8 * sprintSize
 		// wait for a couple of sprints
-		require.NoError(t, cluster.WaitForBlock(8*sprintSize, 2*time.Minute))
+		require.NoError(t, cluster.WaitForBlock(finalBlockNum, 2*time.Minute))
 
 		// the transactions are processed and there should be a success events
 		var stateSyncedResult contractsapi.StateSyncResultEvent
@@ -92,7 +93,7 @@ func TestE2E_Bridge_Transfers(t *testing.T) {
 		}
 
 		filter.SetFromUint64(0)
-		filter.SetToUint64(8 * sprintSize)
+		filter.SetToUint64(finalBlockNum)
 
 		logs, err := childEthEndpoint.GetLogs(filter)
 		require.NoError(t, err)

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -92,7 +92,7 @@ func TestE2E_Bridge_Transfers(t *testing.T) {
 		}
 
 		filter.SetFromUint64(0)
-		filter.SetToUint64(100)
+		filter.SetToUint64(8 * sprintSize)
 
 		logs, err := childEthEndpoint.GetLogs(filter)
 		require.NoError(t, err)
@@ -229,6 +229,7 @@ func TestE2E_Bridge_Transfers(t *testing.T) {
 			),
 		)
 
+		finalBlockNum := midBlockNumber + 5*sprintSize
 		// wait for a few more sprints
 		require.NoError(t, cluster.WaitForBlock(midBlockNumber+5*sprintSize, 3*time.Minute))
 
@@ -253,7 +254,7 @@ func TestE2E_Bridge_Transfers(t *testing.T) {
 		}
 
 		filter.SetFromUint64(initialBlockNum)
-		filter.SetToUint64(initialBlockNum + 2*epochSize)
+		filter.SetToUint64(finalBlockNum)
 
 		logs, err := childEthEndpoint.GetLogs(filter)
 		require.NoError(t, err)

--- a/syncer/client_test.go
+++ b/syncer/client_test.go
@@ -354,7 +354,7 @@ func TestPeerConnectionUpdateEventCh(t *testing.T) {
 	wgForGossip.Wait()
 
 	// close to terminate goroutine
-	close(client.peerStatusUpdateCh)
+	client.Close()
 
 	// wait until collecting routine is done
 	wgForConnectingStatus.Wait()


### PR DESCRIPTION
# Description

This PR provides correct start and ending block numbers when making assertions against the `StateSyncResult` events count. Prior to this change, those were set arbitrarily, and it could be possible that some of the state sync events being executed by the `multiple deposit batches per epoch` subtest are captured by the `bridge ERC 20 tokens` subtest.

An example of such faulty execution can be found [here](https://github.com/0xPolygon/polygon-edge/actions/runs/4676705154/jobs/8283333453).

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually