### PR TITLE
Move IBFT E2E tests to nighly builds

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,11 +1,11 @@
 ---
 name: E2E tests
 on:  # yamllint disable-line rule:truthy
-  push:
-    branches:
-      - main
-      - develop
-  pull_request:
+  workflow_call:
+    outputs:
+      workflow_output:
+        description: "E2E IBFT output"
+        value: ${{ jobs.build.outputs.e2eibft_output_failure }}
 
 jobs:
   build:
@@ -14,16 +14,26 @@ jobs:
       E2E_TESTS: true
       E2E_LOGS: true
       CI_VERBOSE: true
+    outputs:
+      e2eibft_output_failure: ${{ steps.run_e2eibft_failure.outputs.test_output }}
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+
       - name: Install Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
+
       - name: Run tests
         run: make test-e2e
+
+      - name: Run tests failed
+        if: failure()
+        id: run_e2eibft_failure
+        run: echo "test_output=false" >> $GITHUB_OUTPUT
+
       - name: Archive test logs
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,8 +19,13 @@ jobs:
       SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
   e2e:
-    name: Polybft E2E Tests
+    name: PolyBFT E2E Tests
     uses: ./.github/workflows/e2e-polybft.yml
+    needs: build
+
+  e2eibft:
+    name: IBFT E2E Tests
+    uses: ./.github/workflows/e2e.yml
     needs: build
 
   property:
@@ -36,7 +41,7 @@ jobs:
   notification:
     name: Nightly Notifications
     runs-on: ubuntu-latest
-    needs: [build, test, e2e, property, fuzz]
+    needs: [build, test, e2e, e2eibft, property, fuzz]
     if: success() || failure()
     steps:
       - name: Notify Slack
@@ -88,6 +93,13 @@ jobs:
                   "text": {
                     "type": "mrkdwn",
                     "text": "E2E tests ${{ needs.e2e.outputs.workflow_output == '' && ':white_check_mark:' || ':x: `failed`' }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "E2E IBFT tests ${{ needs.e2eibft.outputs.workflow_output == '' && ':white_check_mark:' || ':x: `failed`' }}"
                   }
                 },
                 {


### PR DESCRIPTION
# Description

Only run IBFT e2e tests on nightly builds, also report the corresponding output.

This is a way to reduce the number of checks on normal PRs, and also optimize the cost.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
