### PR TITLE
`eth_getBlockByHash` and `eth_getBlockByNumber` JSON RPC endpoints should omit `Committed` field

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -37,7 +37,7 @@ type Consensus interface {
 	// GetBridgeProvider returns an instance of BridgeDataProvider
 	GetBridgeProvider() BridgeDataProvider
 
-	// Filters extra data in header that is not a part of block hash
+	// FilterExtra filters extra data in header that is not a part of block hash
 	FilterExtra(extra []byte) ([]byte, error)
 
 	// Initialize initializes the consensus (e.g. setup data)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -37,6 +37,9 @@ type Consensus interface {
 	// GetBridgeProvider returns an instance of BridgeDataProvider
 	GetBridgeProvider() BridgeDataProvider
 
+	// Filters extra data in header that is not a part of block hash
+	FilterExtra(extra []byte) ([]byte, error)
+
 	// Initialize initializes the consensus (e.g. setup data)
 	Initialize() error
 

--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -246,3 +246,7 @@ func (d *Dev) Close() error {
 func (d *Dev) GetBridgeProvider() consensus.BridgeDataProvider {
 	return nil
 }
+
+func (d *Dev) FilterExtra(extra []byte) ([]byte, error) {
+	return extra, nil
+}

--- a/consensus/dummy/dummy.go
+++ b/consensus/dummy/dummy.go
@@ -79,6 +79,10 @@ func (d *Dummy) GetBridgeProvider() consensus.BridgeDataProvider {
 	return nil
 }
 
+func (d *Dummy) FilterExtra(extra []byte) ([]byte, error) {
+	return extra, nil
+}
+
 func (d *Dummy) run() {
 	d.logger.Info("started")
 	// do nothing

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -552,6 +552,11 @@ func (i *backendIBFT) GetBridgeProvider() consensus.BridgeDataProvider {
 	return nil
 }
 
+// FilterExtra is the implementation of Consensus interface
+func (i *backendIBFT) FilterExtra(extra []byte) ([]byte, error) {
+	return extra, nil
+}
+
 // updateCurrentModules updates Signer, Hooks, and Validators
 // that are used at specified height
 // by fetching from ForkManager

--- a/consensus/polybft/extra.go
+++ b/consensus/polybft/extra.go
@@ -693,7 +693,7 @@ func GetIbftExtraClean(extraRaw []byte) ([]byte, error) {
 		Committed:  &Signature{},
 	}
 
-	return ibftExtra.MarshalRLPTo(nil), nil
+	return append(make([]byte, ExtraVanity), ibftExtra.MarshalRLPTo(nil)...), nil
 }
 
 // GetIbftExtra returns the istanbul extra data field from the passed in header

--- a/consensus/polybft/extra_test.go
+++ b/consensus/polybft/extra_test.go
@@ -886,7 +886,6 @@ func Test_GetIbftExtraClean(t *testing.T) {
 	require.Equal(t, extra.Parent.AggregatedSignature, extraTwo.Parent.AggregatedSignature)
 	require.Equal(t, extra.Parent.Bitmap, extraTwo.Parent.Bitmap)
 
-	require.Empty(t, extraTwo.Seal)
 	require.Nil(t, extraTwo.Committed.AggregatedSignature)
 	require.Nil(t, extraTwo.Committed.Bitmap)
 }

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -487,7 +487,14 @@ func (p *Polybft) PreCommitState(_ *types.Header, _ *state.Transition) error {
 	return nil
 }
 
-// GetBridgeProvider returns an instance of BridgeDataProvider
+// GetBridgeProvider is an implementation of Consensus interface
+// Returns an instance of BridgeDataProvider
 func (p *Polybft) GetBridgeProvider() consensus.BridgeDataProvider {
 	return p.runtime
+}
+
+// GetBridgeProvider is an implementation of Consensus interface
+// Filters extra data to not contain Committed field
+func (p *Polybft) FilterExtra(extra []byte) ([]byte, error) {
+	return GetIbftExtraClean(extra)
 }

--- a/jsonrpc/eth_blockchain_test.go
+++ b/jsonrpc/eth_blockchain_test.go
@@ -525,6 +525,10 @@ func (m *mockBlockStore) SubscribeEvents() blockchain.Subscription {
 	return nil
 }
 
+func (m *mockBlockStore) FilterExtra(extra []byte) ([]byte, error) {
+	return extra, nil
+}
+
 func newTestBlock(number uint64, hash types.Hash) *types.Block {
 	return &types.Block{
 		Header: &types.Header{

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -69,7 +69,7 @@ type ethBlockchainStore interface {
 }
 
 type ethFilter interface {
-	// FilterExtra filters data from block extra that is not included in block hash
+	// FilterExtra filters extra data from header extra that is not included in block hash
 	FilterExtra(extra []byte) ([]byte, error)
 }
 

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -137,7 +137,8 @@ func (e *Eth) GetBlockByNumber(number BlockNumber, fullTx bool) (interface{}, er
 		return nil, err
 	}
 
-	headerCopy.ExtraData = filteredExtra // no need to recompute hash (filtered out data is not in the hash in the first place)
+	headerCopy.ExtraData = filteredExtra
+	// no need to recompute hash (filtered out data is not in the hash in the first place)
 	block.Header = headerCopy
 
 	return toBlock(block, fullTx), nil
@@ -159,7 +160,8 @@ func (e *Eth) GetBlockByHash(hash types.Hash, fullTx bool) (interface{}, error) 
 		return nil, err
 	}
 
-	headerCopy.ExtraData = filteredExtra // no need to recompute hash (filtered out data is not in the hash in the first place)
+	headerCopy.ExtraData = filteredExtra
+	// no need to recompute hash (filtered out data is not in the hash in the first place)
 	block.Header = headerCopy
 
 	return toBlock(block, fullTx), nil

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -128,18 +128,9 @@ func (e *Eth) GetBlockByNumber(number BlockNumber, fullTx bool) (interface{}, er
 		return nil, nil
 	}
 
-	// we need to copy it because the store returns header from storage directly
-	// and not a copy, so changing it, actually changes it in storage as well
-	headerCopy := block.Header.Copy()
-
-	filteredExtra, err := e.store.FilterExtra(headerCopy.ExtraData)
-	if err != nil {
+	if err := e.filterExtra(block); err != nil {
 		return nil, err
 	}
-
-	headerCopy.ExtraData = filteredExtra
-	// no need to recompute hash (filtered out data is not in the hash in the first place)
-	block.Header = headerCopy
 
 	return toBlock(block, fullTx), nil
 }
@@ -151,20 +142,28 @@ func (e *Eth) GetBlockByHash(hash types.Hash, fullTx bool) (interface{}, error) 
 		return nil, nil
 	}
 
+	if err := e.filterExtra(block); err != nil {
+		return nil, err
+	}
+
+	return toBlock(block, fullTx), nil
+}
+
+func (e *Eth) filterExtra(block *types.Block) error {
 	// we need to copy it because the store returns header from storage directly
 	// and not a copy, so changing it, actually changes it in storage as well
 	headerCopy := block.Header.Copy()
 
 	filteredExtra, err := e.store.FilterExtra(headerCopy.ExtraData)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	headerCopy.ExtraData = filteredExtra
 	// no need to recompute hash (filtered out data is not in the hash in the first place)
 	block.Header = headerCopy
 
-	return toBlock(block, fullTx), nil
+	return nil
 }
 
 func (e *Eth) GetBlockTransactionCountByNumber(number BlockNumber) (interface{}, error) {

--- a/jsonrpc/mocks_test.go
+++ b/jsonrpc/mocks_test.go
@@ -196,3 +196,7 @@ func (m *mockStore) GetStateSyncProof(stateSyncID uint64) (types.Proof, error) {
 
 	return ssp, nil
 }
+
+func (m *mockStore) FilterExtra(extra []byte) ([]byte, error) {
+	return extra, nil
+}


### PR DESCRIPTION
# Description

Since some fields in `polybft` in block header `ExtraData` are not included in the block hash calculation (`Committed` and `Seal` fields), they should not be returned by the `JsonRPC` endpoints (`GetBlockByNumber`, and `GetBlockByHash`).

This PR, apart from this, added a new UT.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually