### PR TITLE
Remove validator-set-size flag from cluster script

### DIFF
--- a/scripts/cluster
+++ b/scripts/cluster
@@ -14,7 +14,7 @@ function initIbftConsensus() {
 
 function initPolybftConsensus() {
     echo "Running with polybft consensus"
-    genesis_params="--consensus polybft --validator-set-size=4 --bridge-json-rpc http://127.0.0.1:8545"
+    genesis_params="--consensus polybft --bridge-json-rpc http://127.0.0.1:8545"
     ./polygon-edge polybft-secrets --insecure --data-dir test-chain- --num 4
     ./polygon-edge manifest
 }


### PR DESCRIPTION
# Description

Removes `validator-set-size` flag from `cluster` script, because that flag was removed from PR https://github.com/0xPolygon/polygon-edge/pull/1378: since it was not used in `genesis`.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually