### PR TITLE
Info about code access is added to the trace

### DIFF
--- a/state/immutable-trie/snapshot.go
+++ b/state/immutable-trie/snapshot.go
@@ -100,7 +100,7 @@ func (s *Snapshot) Commit(objs []*state.Object) (state.Snapshot, *types.Trace, [
 		t.Proof()
 	}
 
-	return &Snapshot{trie: trie, state: s.state}, s.trace, root
+	return &Snapshot{trie: trie, state: s.state, trace: &types.Trace{}}, s.trace, root
 }
 
 type tracer struct {

--- a/state/txn_test.go
+++ b/state/txn_test.go
@@ -43,7 +43,7 @@ func (m *mockSnapshot) GetAccount(addr types.Address) (*Account, error) {
 }
 
 func (m *mockSnapshot) GetCode(hash types.Hash) ([]byte, bool) {
-	return nil, false
+	return []byte{0x1}, true
 }
 
 func newStateWithPreState(preState map[types.Address]*PreState) readSnapshot {
@@ -85,8 +85,10 @@ func TestTxn_TracesCompaction(t *testing.T) {
 	txn.SetState(addr, types.ZeroHash, oneHash) // updates
 	txn.SetState(addr, oneHash, types.ZeroHash)
 
+	txn.GetCode(addr)
+
 	txn.TouchAccount(addr)
-	require.Len(t, txn.journal, 16)
+	require.Len(t, txn.journal, 18)
 
 	trace := txn.getCompactJournal()
 	require.Len(t, trace, 1)
@@ -100,8 +102,9 @@ func TestTxn_TracesCompaction(t *testing.T) {
 			types.ZeroHash: oneHash,
 			oneHash:        types.ZeroHash,
 		},
-		Touched: boolTruePtr(),
-		Read:    boolTruePtr(),
+		CodeRead: []byte{0x1},
+		Touched:  boolTruePtr(),
+		Read:     boolTruePtr(),
 	})
 }
 
@@ -118,10 +121,11 @@ func TestJournalEntry_Merge(t *testing.T) {
 			Storage: map[types.Hash]types.Hash{
 				types.ZeroHash: types.ZeroHash,
 			},
-			Code:    []byte{0x1},
-			Suicide: boolTruePtr(),
-			Touched: boolTruePtr(),
-			Read:    boolTruePtr(),
+			Code:     []byte{0x1},
+			CodeRead: []byte{0x1},
+			Suicide:  boolTruePtr(),
+			Touched:  boolTruePtr(),
+			Read:     boolTruePtr(),
 			StorageRead: map[types.Hash]struct{}{
 				types.ZeroHash: {},
 			},

--- a/types/types.go
+++ b/types/types.go
@@ -240,6 +240,9 @@ type JournalEntry struct {
 	// Code tracks the initialization of the contract Code
 	Code []byte `json:"code,omitempty"`
 
+	// CodeRead tracks whether the contract Code was read
+	CodeRead []byte `json:"code_read,omitempty"`
+
 	// Suicide tracks whether the contract has been self destructed
 	Suicide *bool `json:"suicide,omitempty"`
 
@@ -271,6 +274,10 @@ func (j *JournalEntry) Merge(jj *JournalEntry) {
 
 	if jj.Code != nil && !bytes.Equal(jj.Code, j.Code) {
 		j.Code = jj.Code
+	}
+
+	if jj.CodeRead != nil && !bytes.Equal(jj.CodeRead, j.CodeRead) {
+		j.CodeRead = jj.CodeRead
 	}
 
 	if jj.Suicide != nil && jj.Suicide != j.Suicide {


### PR DESCRIPTION
# Description

This PR adds information in trace about the bytecode of all smart contracts accessed by any txn (even indirectly through contracts calling each other) by extending journal entry with the CodeRead field. This is requested by zero team.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code
