### PR TITLE
EVM-475 status sent, a little bit of service refactoring

### DIFF
--- a/command/aarelayer/aa_relayer.go
+++ b/command/aarelayer/aa_relayer.go
@@ -60,7 +60,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		jsonRPC = "http://" + jsonRPC
 	}
 
-	txSender, err := service.NewAATxSender(jsonRPC)
+	txSender, err := service.NewAARPCClient(jsonRPC)
 	if err != nil {
 		return err
 	}
@@ -103,6 +103,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		state,
 		account.Ecdsa,
 		invokerAddress,
+		params.chainID,
 		logger,
 		service.WithPullTime(config.PullTime),
 		service.WithReceiptDelay(config.ReceiptRetryDelay),

--- a/command/aarelayer/aa_relayer.go
+++ b/command/aarelayer/aa_relayer.go
@@ -16,7 +16,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/spf13/cobra"
-	"github.com/umbracle/ethgo"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -84,7 +83,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	pool := service.NewAAPool()
 	pool.Init(pending)
 
-	currentNonce, err := aaRPCClient.GetAANonce(ethgo.Address(invokerAddress), account.Ecdsa.Address())
+	currentNonce, err := state.GetNonce()
 	if err != nil {
 		return err
 	}

--- a/command/aarelayer/service/aa_relayer_service.go
+++ b/command/aarelayer/service/aa_relayer_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"net"
 	"sync/atomic"
 	"time"
@@ -11,17 +12,22 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
 	"github.com/umbracle/ethgo"
+	"github.com/umbracle/ethgo/wallet"
 )
 
-const receiptSuccess = 1
+const (
+	receiptSuccess  = 1
+	defaultGasLimit = 5242880 // 0x500000
+)
 
 // AARelayerService pulls transaction from pool one at the time and sends it to relayer
 type AARelayerService struct {
 	pool         AAPool
 	state        AATxState
-	txSender     AATxSender
+	rpcClient    AARPCClient
 	key          ethgo.Key
 	invokerAddr  types.Address
+	chainID      int64
 	currentNonce uint64
 	pullTime     time.Duration // pull from txpool every `pullTime` second/millisecond
 	receiptDelay time.Duration
@@ -30,23 +36,26 @@ type AARelayerService struct {
 }
 
 func NewAARelayerService(
-	txSender AATxSender,
+	rpcClient AARPCClient,
 	pool AAPool,
 	state AATxState,
 	key ethgo.Key,
-	invokerAddr types.Address, logger hclog.Logger,
+	invokerAddr types.Address,
+	chainID int64,
+	logger hclog.Logger,
 	opts ...TxRelayerOption) (*AARelayerService, error) {
-	nonce, err := txSender.GetNonce(key.Address())
+	nonce, err := rpcClient.GetNonce(key.Address()) // get initial nonce for the aarelayer
 	if err != nil {
 		return nil, err
 	}
 
 	service := &AARelayerService{
-		txSender:     txSender,
+		rpcClient:    rpcClient,
 		pool:         pool,
 		state:        state,
 		key:          key,
 		invokerAddr:  invokerAddr,
+		chainID:      chainID,
 		currentNonce: nonce,
 		pullTime:     time.Millisecond * 5000,
 		receiptDelay: time.Millisecond * 500,
@@ -71,103 +80,79 @@ func (rs *AARelayerService) Start(ctx context.Context) {
 			return
 		case <-ticker.C:
 			stateTx := rs.getFirstValidTx()
-
-			if stateTx != nil { // there is something to process
-				go func() {
-					if err := rs.executeJob(ctx, stateTx); err != nil {
-						rs.logger.Error(
-							"transaction execution has been failed",
-							"id", stateTx.ID,
-							"from", stateTx.Tx.Transaction.From,
-							"nonce", stateTx.Tx.Transaction.Nonce,
-							"err", err)
-					}
-				}()
+			if stateTx == nil { // nothing to process
+				continue
 			}
+
+			if err := rs.addToQueue(stateTx); err != nil {
+				rs.logger.Error(
+					"error while adding transaction to the queue",
+					"id", stateTx.ID,
+					"from", stateTx.Tx.Transaction.From,
+					"err", err)
+
+				continue
+			}
+
+			go func() {
+				if err := rs.executeJob(ctx, stateTx); err != nil {
+					rs.logger.Error(
+						"transaction execution has been failed",
+						"id", stateTx.ID,
+						"from", stateTx.Tx.Transaction.From,
+						"nonce", stateTx.Nonce,
+						"err", err)
+				}
+			}()
 		}
 	}
 }
 
 func (rs *AARelayerService) executeJob(ctx context.Context, stateTx *AAStateTransaction) error {
-	var netErr net.Error
-
-	rs.logger.Info("transaction execution has been started",
-		"id", stateTx.ID,
-		"from", stateTx.Tx.Transaction.From,
-		"nonce", stateTx.Tx.Transaction.Nonce)
-
-	tx, err := rs.makeEthgoTransaction(stateTx)
-	if err != nil {
-		// this should not happened
-		rs.pool.Push(stateTx)
-
+	if err := rs.sendTransaction(stateTx); err != nil {
 		return err
 	}
 
-	hash, err := rs.txSender.SendTransaction(tx, rs.key)
-	// if its network error return tx back to the pool
-	if errors.As(err, &netErr) {
-		rs.pool.Push(stateTx)
-
-		return err
-	} else if err != nil {
-		errstr := err.Error()
-		stateTx.Error = &errstr
-
-		if errUpdate := rs.state.Update(stateTx); errUpdate != nil {
-			errstr = errUpdate.Error()
-
-			return fmt.Errorf("err = %w, update error = %s", err, errstr)
-		}
-
-		return err
-	}
-
-	atomic.AddUint64(&rs.currentNonce, 1) // increment global nonce for this relayer
-
-	stateTx.Status = StatusQueued
-	stateTx.Hash = hash
-
-	if err := rs.state.Update(stateTx); err != nil {
-		rs.logger.Error("error while updating tx state to queued", "id", stateTx.ID, "err", err)
-	}
-
-	rs.logger.Info("transaction has been sent to the invoker", "id", stateTx.ID)
-
-	receipt, err := rs.txSender.WaitForReceipt(ctx, hash, rs.receiptDelay, rs.numRetries)
-	if err != nil {
-		errstr := err.Error()
-		stateTx.Error = &errstr
-		stateTx.Status = StatusFailed
-
-		rs.logger.Warn("transaction receipt error",
-			"id", stateTx.ID,
-			"from", stateTx.Tx.Transaction.From,
-			"nonce", stateTx.Tx.Transaction.Nonce,
-			"err", errstr)
-	} else {
-		rs.populateStateTx(stateTx, receipt)
-	}
-
-	if err := rs.state.Update(stateTx); err != nil {
-		return fmt.Errorf("error while updating tx state to %s, err = %w", stateTx.Status, err)
-	}
-
-	return nil
+	return rs.waitForReceipt(ctx, stateTx)
 }
 
-func (rs *AARelayerService) makeEthgoTransaction(stateTx *AAStateTransaction) (*ethgo.Transaction, error) {
-	input, err := stateTx.Tx.ToAbi()
+func (rs *AARelayerService) makeEthgoTransaction(stateTx *AAStateTransaction) ([]byte, ethgo.Hash, error) {
+	gasPrice, err := rs.rpcClient.GetGasPrice()
 	if err != nil {
-		return nil, err
+		return nil, ethgo.ZeroHash, err
 	}
 
-	return &ethgo.Transaction{
-		From:  rs.key.Address(),
-		To:    (*ethgo.Address)(&rs.invokerAddr),
-		Input: input,
-		Nonce: atomic.LoadUint64(&rs.currentNonce),
-	}, nil
+	input, err := stateTx.Tx.ToAbi()
+	if err != nil {
+		return nil, ethgo.ZeroHash, err
+	}
+
+	tx := &ethgo.Transaction{
+		From:     rs.key.Address(),
+		To:       (*ethgo.Address)(&rs.invokerAddr),
+		Input:    input,
+		Nonce:    stateTx.Nonce,
+		Gas:      defaultGasLimit,
+		ChainID:  big.NewInt(rs.chainID),
+		GasPrice: gasPrice,
+	}
+
+	signer := wallet.NewEIP155Signer(tx.ChainID.Uint64())
+	if _, err := signer.SignTx(tx, rs.key); err != nil {
+		return nil, ethgo.ZeroHash, err
+	}
+
+	hash, err := tx.GetHash()
+	if err != nil {
+		return nil, ethgo.ZeroHash, err
+	}
+
+	raw, err := tx.MarshalRLPTo(nil)
+	if err != nil {
+		return nil, ethgo.ZeroHash, err
+	}
+
+	return raw, hash, nil
 }
 
 // getFirstValidTx takes from the pool first arrived transaction which nonce is good
@@ -185,7 +170,7 @@ func (rs *AARelayerService) getFirstValidTx() *AAStateTransaction {
 
 		address := poppedTx.Tx.Transaction.From
 
-		nonce, err := rs.txSender.GetAANonce(ethgo.Address(rs.invokerAddr), ethgo.Address(address))
+		nonce, err := rs.rpcClient.GetAANonce(ethgo.Address(rs.invokerAddr), ethgo.Address(address))
 		if err != nil {
 			rs.logger.Warn("transaction retrieving nonce failed",
 				"tx", poppedTx.ID, "from", address, "err", err)
@@ -230,6 +215,82 @@ func (rs *AARelayerService) getFirstValidTx() *AAStateTransaction {
 	}
 
 	return stateTx
+}
+
+func (rs *AARelayerService) addToQueue(stateTx *AAStateTransaction) error {
+	stateTx.Nonce = atomic.LoadUint64(&rs.currentNonce) // setup nonce for this transaction
+
+	txRaw, hash, err := rs.makeEthgoTransaction(stateTx)
+	if err != nil {
+		rs.pool.Push(stateTx) // if something went wrong in this step,  tx should return to the pending pool
+
+		return fmt.Errorf("failed to create transaction: %w", err)
+	}
+
+	// transaction is now in the queued state
+	stateTx.Status = StatusQueued
+	stateTx.Hash = hash
+	stateTx.Raw = txRaw
+
+	if err := rs.state.Update(stateTx); err != nil {
+		rs.pool.Push(stateTx) // if update status fails, tx should return to the pending pool
+
+		return fmt.Errorf("failed to update transaction state to queued: %w", err)
+	}
+
+	atomic.AddUint64(&rs.currentNonce, 1) // increment current aa relayer nonce
+
+	return nil
+}
+
+func (rs *AARelayerService) sendTransaction(stateTx *AAStateTransaction) error {
+	var netErr net.Error
+
+	_, err := rs.rpcClient.SendTransaction(stateTx.Raw)
+	if errors.As(err, &netErr) {
+		return fmt.Errorf("failed to send transaction: %w", err)
+	} else if err != nil {
+		errstr := err.Error()
+		stateTx.Error = &errstr
+		stateTx.Status = StatusFailed // change status on all non network related errors?
+
+		if errUpdate := rs.state.Update(stateTx); errUpdate != nil {
+			return fmt.Errorf("failed to send transaction: %w, update error: %s", err, errUpdate.Error())
+		}
+
+		return err
+	}
+
+	rs.logger.Info("transaction has been sent to the invoker", "id", stateTx.ID)
+
+	// transaction is now in the sent state
+	stateTx.Status = StatusSent
+	if err := rs.state.Update(stateTx); err != nil {
+		// if fails, just log error. We should figure out how to update to status sent if state update fails
+		rs.logger.Warn("failed to update transaction state to sent", "id", stateTx.ID, "err", err)
+	}
+
+	return nil
+}
+
+func (rs *AARelayerService) waitForReceipt(ctx context.Context, stateTx *AAStateTransaction) error {
+	receipt, err := rs.rpcClient.WaitForReceipt(ctx, stateTx.Hash, rs.receiptDelay, rs.numRetries)
+	if err != nil {
+		errstr := err.Error()
+		stateTx.Error = &errstr
+		stateTx.Status = StatusFailed
+
+		rs.logger.Warn("transaction receipt error",
+			"id", stateTx.ID, "hash", stateTx.Hash, "err", err)
+	} else {
+		rs.populateStateTx(stateTx, receipt)
+	}
+
+	if err := rs.state.Update(stateTx); err != nil {
+		return fmt.Errorf("failed to update transaction state to %s, err = %w", stateTx.Status, err)
+	}
+
+	return nil
 }
 
 func (rs *AARelayerService) populateStateTx(stateTx *AAStateTransaction, receipt *ethgo.Receipt) {

--- a/command/aarelayer/service/aa_relayer_service_test.go
+++ b/command/aarelayer/service/aa_relayer_service_test.go
@@ -68,6 +68,7 @@ func Test_AARelayerService_Start(t *testing.T) {
 
 	state := new(dummyAATxState)
 	state.On("Update", mock.Anything).Return(nil)
+	state.On("UpdateNonce", mock.Anything).Return(nil)
 
 	aaTxSender := new(dummyAATxSender)
 	aaTxSender.On("GetAANonce", ethgo.Address(aaInvokerAddress), ethgo.Address(address)).
@@ -307,7 +308,7 @@ type dummyAATxState struct {
 }
 
 func (t *dummyAATxState) Add(transaction *AATransaction) (*AAStateTransaction, error) {
-	args := t.Called()
+	args := t.Called(transaction)
 
 	return args.Get(0).(*AAStateTransaction), args.Error(1) //nolint:forcetypeassert
 }
@@ -339,6 +340,16 @@ func (t *dummyAATxState) Update(stateTx *AAStateTransaction) error {
 	if stateTx.Status == StatusFailed {
 		return errors.New("Update failed")
 	}
+
+	return args.Error(0)
+}
+func (t *dummyAATxState) GetNonce() (uint64, error) {
+	args := t.Called()
+
+	return args.Get(0).(uint64), args.Error(1) //nolint:forcetypeassert
+}
+func (t *dummyAATxState) UpdateNonce(nonce uint64) error {
+	args := t.Called(nonce)
 
 	return args.Error(0)
 }

--- a/command/aarelayer/service/aa_state.go
+++ b/command/aarelayer/service/aa_state.go
@@ -19,6 +19,8 @@ type AATxState interface {
 	GetAllPending() ([]*AAStateTransaction, error)
 	// Get all queued transactions
 	GetAllQueued() ([]*AAStateTransaction, error)
+	// Get all sent transactions
+	GetAllSent() ([]*AAStateTransaction, error)
 	// Update modifies the metadata for the AA transaction
 	Update(stateTx *AAStateTransaction) error
 }
@@ -26,12 +28,14 @@ type AATxState interface {
 var (
 	pendingBucket  = []byte("pending")
 	queuedBucket   = []byte("queued")
+	sentBucket     = []byte("sent")
 	finishedBucket = []byte("finished")
 
-	allBuckets        = [][]byte{pendingBucket, queuedBucket, finishedBucket}
+	allBuckets        = [][]byte{pendingBucket, queuedBucket, sentBucket, finishedBucket}
 	statusToBucketMap = map[string][]byte{
 		StatusPending:   pendingBucket,
 		StatusQueued:    queuedBucket,
+		StatusSent:      sentBucket,
 		StatusCompleted: finishedBucket,
 		StatusFailed:    finishedBucket,
 	}
@@ -100,6 +104,10 @@ func (s *aaTxState) GetAllPending() ([]*AAStateTransaction, error) {
 
 func (s *aaTxState) GetAllQueued() ([]*AAStateTransaction, error) {
 	return s.getAllFromBucket(queuedBucket)
+}
+
+func (s *aaTxState) GetAllSent() ([]*AAStateTransaction, error) {
+	return s.getAllFromBucket(sentBucket)
 }
 
 func (s *aaTxState) Update(stateTx *AAStateTransaction) error {

--- a/command/aarelayer/service/aa_state_test.go
+++ b/command/aarelayer/service/aa_state_test.go
@@ -148,4 +148,22 @@ func Test_AAState_UpdateGetQueuedGetPending(t *testing.T) {
 	assert.Len(t, txsPending, 0)
 	assert.NoError(t, err2)
 	assert.Len(t, txsQueued, 4)
+
+	for i := range txsQueued[:2] {
+		txsQueued[i].Status = StatusSent
+
+		require.NoError(t, state.Update(txsQueued[i]))
+	}
+
+	// retrieve again
+	txsQueued, err1 = state.GetAllQueued()
+	txsPending, err2 = state.GetAllPending()
+	txSent, err3 := state.GetAllSent()
+
+	assert.NoError(t, err1)
+	assert.Len(t, txsPending, 0)
+	assert.NoError(t, err2)
+	assert.Len(t, txsQueued, 2)
+	assert.NoError(t, err3)
+	assert.Len(t, txSent, 2)
 }

--- a/command/aarelayer/service/aa_types.go
+++ b/command/aarelayer/service/aa_types.go
@@ -19,10 +19,11 @@ const (
 	domainSeparatorVersion = "1.0.0"
 
 	// Statuses
-	StatusPending   = "pending"   // The AA transaction is on the Pool
-	StatusQueued    = "queued"    // The AA transaction is waiting to be mined.
-	StatusCompleted = "completed" // The `AA transaction` was mined in a block.
-	StatusFailed    = "failed"    // AA transaction` failed during the process.
+	StatusPending   = "pending"   // tx is currently on the pending pool
+	StatusQueued    = "queued"    // tx is in a queue and waiting to be sent
+	StatusSent      = "sent"      // tx has been sent and is waiting for a receipt
+	StatusCompleted = "completed" // tx has been successfully mined into a block and is now complete
+	StatusFailed    = "failed"    // tx failed during the process and may or may not have been included in a block
 )
 
 // Types and keccak256 values of types from AccountAbstractionInvoker.sol
@@ -290,7 +291,6 @@ type Log struct {
 type AAStateTransaction struct {
 	ID           string         `json:"id"`
 	Tx           *AATransaction `json:"tx,omitempty"`
-	Hash         ethgo.Hash     `json:"hash,omitempty"`
 	Time         int64          `json:"time"`
 	TimeQueued   int64          `json:"time_queued"`
 	TimeFinished int64          `json:"time_completed"`
@@ -298,6 +298,9 @@ type AAStateTransaction struct {
 	Gas          uint64         `json:"gas"`
 	Mined        *Mined         `json:"mined,omitempty"`
 	Error        *string        `json:"error,omitempty"`
+	Hash         ethgo.Hash     `json:"hash,omitempty"`
+	Raw          []byte         `json:"raw,omitempty"`
+	Nonce        uint64         `json:"nonce,omitempty"`
 }
 
 func getDomainSeparatorHash(address types.Address, chainID int64) (types.Hash, error) {


### PR DESCRIPTION
# Description

New status `Sent` has been added.
`AATxSender` has been renamed to `AARPCClient ` and all logic from sending transaction is moved to service
New bucket has been added to state
With these changes it would be easier to create another two pools:
- queued pool (simple queue) -> service should pop from front of the queue and sent transactions in order. It can happen in rare cases that tx from this queue are already sent. This can happen if bolt db fails after transaction has been successfully  sent to node. So, some logic for this should be also implemented
- sent pool (simple queue) -> service should pop from front of the queue and wait for receipt for that transaction (hash is stored inside state tx)

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
