### PR TITLE
WriteFailedReceipt removed

### DIFF
--- a/consensus/ibft/consensus_backend.go
+++ b/consensus/ibft/consensus_backend.go
@@ -300,7 +300,6 @@ type txExeResult struct {
 
 type transitionInterface interface {
 	Write(txn *types.Transaction) error
-	WriteFailedReceipt(txn *types.Transaction) error
 }
 
 func (i *backendIBFT) writeTransactions(
@@ -381,15 +380,6 @@ func (i *backendIBFT) writeTransaction(
 
 	if tx.ExceedsBlockGasLimit(gasLimit) {
 		i.txpool.Drop(tx)
-
-		if err := transition.WriteFailedReceipt(tx); err != nil {
-			i.logger.Error(
-				fmt.Sprintf(
-					"unable to write failed receipt for transaction %s",
-					tx.Hash,
-				),
-			)
-		}
 
 		// continue processing
 		return &txExeResult{tx, fail}, true

--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -130,7 +130,7 @@ func (b *BlockBuilder) Build(handler func(h *types.Header)) (*types.FullBlock, e
 func (b *BlockBuilder) WriteTx(tx *types.Transaction) error {
 	if tx.ExceedsBlockGasLimit(b.params.GasLimit) {
 		b.params.Logger.Info("Transaction gas limit exceedes block gas limit", "hash", tx.Hash,
-			"tx gas limit", tx.Gas, "bloc gas limt", b.params.GasLimit)
+			"tx gas limit", tx.Gas, "block gas limt", b.params.GasLimit)
 
 		return txpool.ErrBlockLimitExceeded
 	}

--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -131,6 +131,7 @@ func (b *BlockBuilder) WriteTx(tx *types.Transaction) error {
 	if tx.ExceedsBlockGasLimit(b.params.GasLimit) {
 		b.params.Logger.Info("Transaction gas limit exceedes block gas limit", "hash", tx.Hash,
 			"tx gas limit", tx.Gas, "bloc gas limt", b.params.GasLimit)
+
 		return txpool.ErrBlockLimitExceeded
 	}
 

--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -129,10 +129,6 @@ func (b *BlockBuilder) Build(handler func(h *types.Header)) (*types.FullBlock, e
 // WriteTx applies given transaction to the state. If transaction apply fails, it reverts the saved snapshot.
 func (b *BlockBuilder) WriteTx(tx *types.Transaction) error {
 	if tx.ExceedsBlockGasLimit(b.params.GasLimit) {
-		if err := b.state.WriteFailedReceipt(tx); err != nil {
-			return err
-		}
-
 		return txpool.ErrBlockLimitExceeded
 	}
 

--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -129,6 +129,8 @@ func (b *BlockBuilder) Build(handler func(h *types.Header)) (*types.FullBlock, e
 // WriteTx applies given transaction to the state. If transaction apply fails, it reverts the saved snapshot.
 func (b *BlockBuilder) WriteTx(tx *types.Transaction) error {
 	if tx.ExceedsBlockGasLimit(b.params.GasLimit) {
+		b.params.Logger.Info("Transaction gas limit exceedes block gas limit", "hash", tx.Hash,
+			"tx gas limit", tx.Gas, "bloc gas limt", b.params.GasLimit)
 		return txpool.ErrBlockLimitExceeded
 	}
 

--- a/state/executor.go
+++ b/state/executor.go
@@ -137,10 +137,6 @@ func (e *Executor) ProcessBlock(
 
 	for _, t := range block.Transactions {
 		if t.ExceedsBlockGasLimit(block.Header.GasLimit) {
-			if err := txn.WriteFailedReceipt(t); err != nil {
-				return nil, err
-			}
-
 			continue
 		}
 
@@ -308,37 +304,6 @@ func (t *Transition) Receipts() []*types.Receipt {
 }
 
 var emptyFrom = types.Address{}
-
-func (t *Transition) WriteFailedReceipt(txn *types.Transaction) error {
-	signer := crypto.NewSigner(t.config, uint64(t.ctx.ChainID))
-
-	if txn.From == emptyFrom && txn.Type == types.LegacyTx {
-		// Decrypt the from address
-		from, err := signer.Sender(txn)
-		if err != nil {
-			return NewTransitionApplicationError(err, false)
-		}
-
-		txn.From = from
-	}
-
-	receipt := &types.Receipt{
-		CumulativeGasUsed: t.totalGas,
-		TransactionType:   txn.Type,
-		TxHash:            txn.Hash,
-		Logs:              t.state.Logs(),
-	}
-
-	receipt.LogsBloom = types.CreateBloom([]*types.Receipt{receipt})
-	receipt.SetStatus(types.ReceiptFailed)
-	t.receipts = append(t.receipts, receipt)
-
-	if txn.To == nil {
-		receipt.ContractAddress = crypto.CreateAddress(txn.From, txn.Nonce).Ptr()
-	}
-
-	return nil
-}
 
 // Write writes another transaction to the executor
 func (t *Transition) Write(txn *types.Transaction) error {


### PR DESCRIPTION
# Description

`WriteFailedReceipt` is a function of the `State Transition Function (STF) `that writes a “failed” transaction into the block, a “failed” transaction (given this logic) is a transaction that exceeds the block gas limit of the block (not the gas left on the block though). For example, if transaction A has a gas limit of 100 and the gas limit of the block is 99, the transaction gets included with _WriteFailedReceipt_ on the block. That means that the transaction is not executed but it is included in the block with a receipt. If the transaction is not executed, it means that there is no gas cost for the user to include the transaction, this is, there is no cost to fill the time of the block.
https://polygon.atlassian.net/browse/EVM-583

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes
No more failed transactions included into a block. 

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
