### PR TITLE
[RFC-201/205]: EVM-603-Register supernet and child chain

### DIFF
--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -107,8 +107,7 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 	chainConfig := &chain.Chain{
 		Name: p.name,
 		Params: &chain.Params{
-			ChainID: int64(p.chainID),
-			Forks:   chain.AllForksEnabled,
+			Forks: chain.AllForksEnabled,
 			Engine: map[string]interface{}{
 				string(server.PolyBFTConsensus): polyBftConfig,
 			},

--- a/command/rootchain/deploy/deploy.go
+++ b/command/rootchain/deploy/deploy.go
@@ -320,6 +320,10 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 			artifact: contractsapi.StateSender,
 		},
 		{
+			name:     checkpointManagerName,
+			artifact: contractsapi.CheckpointManager,
+		},
+		{
 			name:     blsName,
 			artifact: contractsapi.BLS,
 		},
@@ -379,13 +383,6 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 
 				return append(artifact.Bytecode, encoded...), nil
 			},
-		},
-		{
-			// since checkpoint manager needs chain Id,
-			// and since chain id is gotten when registering chain on stake manager
-			// we must deploy it the last
-			name:     checkpointManagerName,
-			artifact: contractsapi.CheckpointManager,
 		},
 	}
 

--- a/command/rootchain/deploy/deploy.go
+++ b/command/rootchain/deploy/deploy.go
@@ -627,7 +627,8 @@ func sendTransaction(txRelayer txrelayer.TxRelayer, txn *ethgo.Transaction, cont
 	deployerKey ethgo.Key) (*ethgo.Receipt, error) {
 	receipt, err := txRelayer.SendTransaction(txn, deployerKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to send transaction to %s contract (%s). error: %w", contractName, txn.To.Address(), err)
+		return nil, fmt.Errorf("failed to send transaction to %s contract (%s). error: %w",
+			contractName, txn.To.Address(), err)
 	}
 
 	if receipt == nil || receipt.Status != uint64(types.ReceiptSuccess) {

--- a/command/rootchain/deploy/deploy.go
+++ b/command/rootchain/deploy/deploy.go
@@ -515,12 +515,12 @@ func registerChainOnStakeManager(txRelayer txrelayer.TxRelayer,
 
 	for _, log := range receipt.Logs {
 		doesMatch, err := childChainRegisteredEvent.ParseLog(log)
-		if !doesMatch {
-			continue
-		}
-
 		if err != nil {
 			return 0, err
+		}
+
+		if !doesMatch {
+			continue
 		}
 
 		chainID = childChainRegisteredEvent.ID.Int64()

--- a/command/rootchain/deploy/deploy.go
+++ b/command/rootchain/deploy/deploy.go
@@ -1,6 +1,7 @@
 package deploy
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -204,8 +205,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		}
 	}
 
-	rootchainCfg, err := deployContracts(outputter, client,
-		chainConfig.Params.ChainID, consensusConfig.InitialValidatorSet)
+	rootchainCfg, chainID, err := deployContracts(outputter, client, consensusConfig.InitialValidatorSet)
 	if err != nil {
 		outputter.SetError(fmt.Errorf("failed to deploy rootchain contracts: %w", err))
 
@@ -228,7 +228,9 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	// write updated chain configuration
+	chainConfig.Params.ChainID = chainID
 	chainConfig.Params.Engine[polybft.ConsensusName] = consensusConfig
+
 	if err := cmdHelper.WriteGenesisConfigToDisk(chainConfig, params.genesisPath); err != nil {
 		outputter.SetError(fmt.Errorf("failed to save chain configuration bridge data: %w", err))
 
@@ -243,16 +245,16 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 // / deployContracts deploys and initializes rootchain smart contracts
 func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
-	chainID int64, initialValidators []*polybft.Validator) (*polybft.RootchainConfig, error) {
+	initialValidators []*polybft.Validator) (*polybft.RootchainConfig, int64, error) {
 	// if the bridge contract is not created, we have to deploy all the contracts
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithClient(client))
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize tx relayer: %w", err)
+		return nil, 0, fmt.Errorf("failed to initialize tx relayer: %w", err)
 	}
 
 	deployerKey, err := helper.GetRootchainPrivateKey(params.deployerKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize deployer key: %w", err)
+		return nil, 0, fmt.Errorf("failed to initialize deployer key: %w", err)
 	}
 
 	if params.isTestMode {
@@ -260,7 +262,7 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 		txn := &ethgo.Transaction{To: &deployerAddr, Value: ethgo.Ether(1)}
 
 		if _, err = txRelayer.SendTransactionLocal(txn); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 	}
 
@@ -280,7 +282,7 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 		// use existing root chain ERC20 token
 		if err := populateExistingTokenAddr(client.Eth(),
 			params.rootERC20TokenAddr, rootERC20Name, rootchainConfig); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 	} else {
 		// deploy MockERC20 as a default root chain ERC20 token
@@ -292,7 +294,7 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 		// use existing root chain ERC721 token
 		if err := populateExistingTokenAddr(client.Eth(),
 			params.rootERC721TokenAddr, rootERC721Name, rootchainConfig); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 	} else {
 		// deploy MockERC721 as a default root chain ERC721 token
@@ -304,7 +306,7 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 		// use existing root chain ERC1155 token
 		if err := populateExistingTokenAddr(client.Eth(),
 			params.rootERC1155TokenAddr, rootERC1155Name, rootchainConfig); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 	} else {
 		// deploy MockERC1155 as a default root chain ERC1155 token
@@ -316,10 +318,6 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 		{
 			name:     stateSenderName,
 			artifact: contractsapi.StateSender,
-		},
-		{
-			name:     checkpointManagerName,
-			artifact: contractsapi.CheckpointManager,
 		},
 		{
 			name:     blsName,
@@ -382,6 +380,13 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 				return append(artifact.Bytecode, encoded...), nil
 			},
 		},
+		{
+			// since checkpoint manager needs chain Id,
+			// and since chain id is gotten when registering chain on stake manager
+			// we must deploy it the last
+			name:     checkpointManagerName,
+			artifact: contractsapi.CheckpointManager,
+		},
 	}
 
 	allContracts = append(tokenContracts, allContracts...)
@@ -392,7 +397,7 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 		if contract.constructorCallback != nil {
 			b, err := contract.constructorCallback(contract.artifact, rootchainConfig)
 			if err != nil {
-				return nil, err
+				return nil, 0, err
 			}
 
 			input = b
@@ -405,18 +410,18 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 
 		receipt, err := txRelayer.SendTransaction(txn, deployerKey)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 
 		if receipt == nil || receipt.Status != uint64(types.ReceiptSuccess) {
-			return nil, fmt.Errorf("deployment of %s contract failed", contract.name)
+			return nil, 0, fmt.Errorf("deployment of %s contract failed", contract.name)
 		}
 
 		contractAddr := types.Address(receipt.ContractAddress)
 
 		populatorFn, ok := metadataPopulatorMap[contract.name]
 		if !ok {
-			return nil, fmt.Errorf("rootchain metadata populator not registered for contract '%s'", contract.name)
+			return nil, 0, fmt.Errorf("rootchain metadata populator not registered for contract '%s'", contract.name)
 		}
 
 		populatorFn(rootchainConfig, contractAddr)
@@ -424,10 +429,15 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 		outputter.WriteCommandResult(newDeployContractsResult(contract.name, contractAddr, receipt.TransactionHash))
 	}
 
+	chainID, err := registerChainOnStakeManager(txRelayer, rootchainConfig, deployerKey)
+	if err != nil {
+		return nil, 0, err
+	}
+
 	// init CheckpointManager
 	if err := initializeCheckpointManager(outputter, txRelayer, chainID,
 		initialValidators, rootchainConfig, deployerKey); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	outputter.WriteCommandResult(&messageResult{
@@ -436,7 +446,7 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 
 	// init ExitHelper
 	if err := initializeExitHelper(txRelayer, rootchainConfig, deployerKey); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	outputter.WriteCommandResult(&messageResult{
@@ -445,14 +455,14 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client,
 
 	// init RootERC20Predicate
 	if err := initializeRootERC20Predicate(txRelayer, rootchainConfig, deployerKey); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	outputter.WriteCommandResult(&messageResult{
 		Message: fmt.Sprintf("%s %s contract is initialized", contractsDeploymentTitle, rootERC20PredicateName),
 	})
 
-	return rootchainConfig, nil
+	return rootchainConfig, chainID, nil
 }
 
 // populateExistingTokenAddr checks whether given token is deployed on the provided address.
@@ -476,6 +486,57 @@ func populateExistingTokenAddr(eth *jsonrpc.Eth, tokenAddr, tokenName string,
 	populatorFn(rootchainCfg, addr)
 
 	return nil
+}
+
+// registerChainOnStakeManager registers child chain and its supernet manager on rootchain
+func registerChainOnStakeManager(txRelayer txrelayer.TxRelayer,
+	rootchainCfg *polybft.RootchainConfig, deployerKey ethgo.Key) (int64, error) {
+	registerChainFn := &contractsapi.RegisterChildChainStakeManagerFn{
+		Manager: rootchainCfg.CustomSupernetManagerAddress,
+	}
+
+	encoded, err := registerChainFn.EncodeAbi()
+	if err != nil {
+		return 0, fmt.Errorf("failed to encode parameters for registering child chain on supernets. error: %w", err)
+	}
+
+	txn := &ethgo.Transaction{
+		To:    (*ethgo.Address)(&rootchainCfg.StakeManagerAddress),
+		Input: encoded,
+	}
+
+	receipt, err := sendTransaction(txRelayer, txn, checkpointManagerName, deployerKey)
+	if err != nil {
+		return 0, err
+	}
+
+	var (
+		childChainRegisteredEvent contractsapi.ChildManagerRegisteredEvent
+		found                     bool
+		chainID                   int64
+	)
+
+	for _, log := range receipt.Logs {
+		doesMatch, err := childChainRegisteredEvent.ParseLog(log)
+		if !doesMatch {
+			continue
+		}
+
+		if err != nil {
+			return 0, err
+		}
+
+		chainID = childChainRegisteredEvent.ID.Int64()
+		found = true
+
+		break
+	}
+
+	if !found {
+		return 0, errors.New("could not find a log that child chain was registered on stake manager")
+	}
+
+	return chainID, nil
 }
 
 // initializeCheckpointManager invokes initialize function on "CheckpointManager" smart contract
@@ -509,7 +570,9 @@ func initializeCheckpointManager(
 		Input: initCheckpointInput,
 	}
 
-	return sendTransaction(txRelayer, txn, checkpointManagerName, deployerKey)
+	_, err = sendTransaction(txRelayer, txn, checkpointManagerName, deployerKey)
+
+	return err
 }
 
 // initializeExitHelper invokes initialize function on "ExitHelper" smart contract
@@ -527,7 +590,9 @@ func initializeExitHelper(txRelayer txrelayer.TxRelayer, rootchainConfig *polybf
 		Input: input,
 	}
 
-	return sendTransaction(txRelayer, txn, exitHelperName, deployerKey)
+	_, err = sendTransaction(txRelayer, txn, exitHelperName, deployerKey)
+
+	return err
 }
 
 // initializeRootERC20Predicate invokes initialize function on "RootERC20Predicate" smart contract
@@ -552,22 +617,24 @@ func initializeRootERC20Predicate(txRelayer txrelayer.TxRelayer, rootchainConfig
 		Input: input,
 	}
 
-	return sendTransaction(txRelayer, txn, rootERC20PredicateName, deployerKey)
+	_, err = sendTransaction(txRelayer, txn, rootERC20PredicateName, deployerKey)
+
+	return err
 }
 
 // sendTransaction sends provided transaction
 func sendTransaction(txRelayer txrelayer.TxRelayer, txn *ethgo.Transaction, contractName string,
-	deployerKey ethgo.Key) error {
+	deployerKey ethgo.Key) (*ethgo.Receipt, error) {
 	receipt, err := txRelayer.SendTransaction(txn, deployerKey)
 	if err != nil {
-		return fmt.Errorf("failed to send transaction to %s contract (%s). error: %w", contractName, txn.To.Address(), err)
+		return nil, fmt.Errorf("failed to send transaction to %s contract (%s). error: %w", contractName, txn.To.Address(), err)
 	}
 
 	if receipt == nil || receipt.Status != uint64(types.ReceiptSuccess) {
-		return fmt.Errorf("transaction execution failed on %s contract", contractName)
+		return nil, fmt.Errorf("transaction execution failed on %s contract", contractName)
 	}
 
-	return nil
+	return receipt, nil
 }
 
 // validatorSetToABISlice converts given validators to generic map

--- a/command/rootchain/deploy/deploy_test.go
+++ b/command/rootchain/deploy/deploy_test.go
@@ -37,7 +37,7 @@ func TestDeployContracts_NoPanics(t *testing.T) {
 	outputter := command.InitializeOutputter(GetCommand())
 
 	require.NotPanics(t, func() {
-		_, err = deployContracts(outputter, client, 10, []*polybft.Validator{})
+		_, _, err = deployContracts(outputter, client, []*polybft.Validator{})
 	})
 	require.NoError(t, err)
 }

--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -157,6 +157,16 @@ func main() {
 				"ValidatorRegistered",
 			},
 		},
+		{
+			"StakeManager",
+			gensc.StakeManager,
+			[]string{
+				"registerChildChain",
+			},
+			[]string{
+				"ChildManagerRegistered",
+			},
+		},
 	}
 
 	generatedData := &generatedData{}

--- a/consensus/polybft/contractsapi/contractsapi.go
+++ b/consensus/polybft/contractsapi/contractsapi.go
@@ -843,3 +843,40 @@ func (v *ValidatorRegisteredEvent) ParseLog(log *ethgo.Log) (bool, error) {
 
 	return true, decodeEvent(CustomSupernetManager.Abi.Events["ValidatorRegistered"], log, v)
 }
+
+type RegisterChildChainStakeManagerFn struct {
+	Manager types.Address `abi:"manager"`
+}
+
+func (r *RegisterChildChainStakeManagerFn) Sig() []byte {
+	return StakeManager.Abi.Methods["registerChildChain"].ID()
+}
+
+func (r *RegisterChildChainStakeManagerFn) EncodeAbi() ([]byte, error) {
+	return StakeManager.Abi.Methods["registerChildChain"].Encode(r)
+}
+
+func (r *RegisterChildChainStakeManagerFn) DecodeAbi(buf []byte) error {
+	return decodeMethod(StakeManager.Abi.Methods["registerChildChain"], buf, r)
+}
+
+type ChildManagerRegisteredEvent struct {
+	ID      *big.Int      `abi:"id"`
+	Manager types.Address `abi:"manager"`
+}
+
+func (*ChildManagerRegisteredEvent) Sig() ethgo.Hash {
+	return StakeManager.Abi.Events["ChildManagerRegistered"].ID()
+}
+
+func (*ChildManagerRegisteredEvent) Encode(inputs interface{}) ([]byte, error) {
+	return StakeManager.Abi.Events["ChildManagerRegistered"].Inputs.Encode(inputs)
+}
+
+func (c *ChildManagerRegisteredEvent) ParseLog(log *ethgo.Log) (bool, error) {
+	if !StakeManager.Abi.Events["ChildManagerRegistered"].Match(log) {
+		return false, nil
+	}
+
+	return true, decodeEvent(StakeManager.Abi.Events["ChildManagerRegistered"], log, c)
+}


### PR DESCRIPTION
# Description

This PR registers child chain and supernet manager to root `StakeManager` contract. Now, `chainID` parameter (ID of child chain) is gotten when registering it to rootchain.

After `StakeManager` gets deployed, as well as `SupernetManager`, we register the child chain by sending the `registerChildChain` transaction to `StakeManager`, which emits a `ChildManagerRegistered` event with `ID` of the child chain. This is all done while deploying the root contracts in the `deploy` command.

After the transaction is executed successfully, we will save the `childID` to the `genesis` file.

**IMPORTANT NOTE**: This PR does not remove the `chainID` flag from the `genesis` command. It removes it's setting when running `genesis` for `polybft`. This will be revised later on. `E2E` are expected to fail.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Removes the setting of `chainID` from the `chai-id` flag in `genesis` command for `polybft`. For `polybft` this is updated in the `genesis` file, after the root contracts are deployed.

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually