### PR TITLE
[RFC-201/205]: EVM-608-Supernet command

### DIFF
--- a/command/polybft/polybft_command.go
+++ b/command/polybft/polybft_command.go
@@ -3,6 +3,7 @@ package polybft
 import (
 	"github.com/0xPolygon/polygon-edge/command/rootchain/registration"
 	"github.com/0xPolygon/polygon-edge/command/rootchain/staking"
+	"github.com/0xPolygon/polygon-edge/command/rootchain/supernet"
 	"github.com/0xPolygon/polygon-edge/command/rootchain/whitelist"
 	"github.com/0xPolygon/polygon-edge/command/sidechain/unstaking"
 	"github.com/0xPolygon/polygon-edge/command/sidechain/validators"
@@ -27,6 +28,9 @@ func GetCommand() *cobra.Command {
 		registration.GetCommand(),
 		// rootchain (stake manager) stake command
 		staking.GetCommand(),
+		// rootchain (supernet manager) command for finalizing genesis
+		// validator set and enabling staking
+		supernet.GetCommand(),
 	)
 
 	return polybftCmd

--- a/command/rootchain/helper/metadata.go
+++ b/command/rootchain/helper/metadata.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
+	polybftWallet "github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/umbracle/ethgo"
@@ -88,4 +90,27 @@ func ReadRootchainIP() (string, error) {
 	}
 
 	return fmt.Sprintf("http://%s:%s", ports[0].HostIP, ports[0].HostPort), nil
+}
+
+func GetECDSAKey(privateKey, accountDir, accountConfig string) (ethgo.Key, error) {
+	if privateKey != "" {
+		key, err := GetRootchainPrivateKey(privateKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize private key: %w", err)
+		}
+
+		return key, nil
+	}
+
+	secretsManager, err := polybftsecrets.GetSecretsManager(accountDir, accountConfig, true)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := polybftWallet.GetEcdsaFromSecret(secretsManager)
+	if err != nil {
+		return nil, err
+	}
+
+	return key, nil
 }

--- a/command/rootchain/helper/metadata.go
+++ b/command/rootchain/helper/metadata.go
@@ -107,10 +107,5 @@ func GetECDSAKey(privateKey, accountDir, accountConfig string) (ethgo.Key, error
 		return nil, err
 	}
 
-	key, err := polybftWallet.GetEcdsaFromSecret(secretsManager)
-	if err != nil {
-		return nil, err
-	}
-
-	return key, nil
+	return polybftWallet.GetEcdsaFromSecret(secretsManager)
 }

--- a/command/rootchain/supernet/params.go
+++ b/command/rootchain/supernet/params.go
@@ -27,7 +27,10 @@ func (sp *supernetParams) validateFlags() error {
 		return sidechainHelper.ValidateSecretFlags(sp.accountDir, sp.accountConfig)
 	}
 
-	return nil
+	// validate jsonrpc address
+	_, err := helper.ParseJSONRPCAddress(sp.jsonRPC)
+
+	return err
 }
 
 type supernetResult struct {

--- a/command/rootchain/supernet/params.go
+++ b/command/rootchain/supernet/params.go
@@ -1,0 +1,58 @@
+package supernet
+
+import (
+	"bytes"
+
+	"github.com/0xPolygon/polygon-edge/command/helper"
+	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
+)
+
+const (
+	finalizeGenesisSetFlag = "finalize-genesis-set"
+	enableStakingFlag      = "enable-staking"
+)
+
+type supernetParams struct {
+	accountDir             string
+	accountConfig          string
+	privateKey             string
+	jsonRPC                string
+	supernetManagerAddress string
+	finalizeGenesisSet     bool
+	enableStaking          bool
+}
+
+func (sp *supernetParams) validateFlags() error {
+	if sp.privateKey == "" {
+		return sidechainHelper.ValidateSecretFlags(sp.accountDir, sp.accountConfig)
+	}
+
+	return nil
+}
+
+type supernetResult struct {
+	isGenesisSetFinalized bool
+	isStakingEnabled      bool
+}
+
+func (sr supernetResult) GetOutput() string {
+	var (
+		buffer bytes.Buffer
+		vals   []string
+	)
+
+	buffer.WriteString("\n[SUPERNET COMMAND]\n")
+
+	if sr.isGenesisSetFinalized {
+		vals = append(vals, "Genesis validator set finalized on supernet manager")
+	}
+
+	if sr.isStakingEnabled {
+		vals = append(vals, "Staking enabled on supernet manager")
+	}
+
+	buffer.WriteString(helper.FormatKV(vals))
+	buffer.WriteString("\n")
+
+	return buffer.String()
+}

--- a/command/rootchain/supernet/supernet.go
+++ b/command/rootchain/supernet/supernet.go
@@ -99,7 +99,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("enlist validator failed: %w", err)
 	}
 
-	gasPrice, err := rootHelper.GetGasPriceOnRoot(params.jsonRPC)
+	gasPrice, err := txRelayer.GetGasPrice()
 	if err != nil {
 		return err
 	}

--- a/command/rootchain/supernet/supernet.go
+++ b/command/rootchain/supernet/supernet.go
@@ -1,0 +1,163 @@
+package supernet
+
+import (
+	"fmt"
+
+	"github.com/0xPolygon/polygon-edge/command"
+	"github.com/0xPolygon/polygon-edge/command/helper"
+	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
+	rootHelper "github.com/0xPolygon/polygon-edge/command/rootchain/helper"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/txrelayer"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/spf13/cobra"
+	"github.com/umbracle/ethgo"
+)
+
+var params supernetParams
+
+func GetCommand() *cobra.Command {
+	registerCmd := &cobra.Command{
+		Use:     "supernet",
+		Short:   "Supernet command",
+		PreRunE: runPreRun,
+		RunE:    runCommand,
+	}
+
+	setFlags(registerCmd)
+
+	return registerCmd
+}
+
+func runPreRun(cmd *cobra.Command, _ []string) error {
+	params.jsonRPC = helper.GetJSONRPCAddress(cmd)
+
+	return params.validateFlags()
+}
+
+func setFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&params.accountDir,
+		polybftsecrets.AccountDirFlag,
+		"",
+		polybftsecrets.AccountDirFlagDesc,
+	)
+
+	cmd.Flags().StringVar(
+		&params.accountConfig,
+		polybftsecrets.AccountConfigFlag,
+		"",
+		polybftsecrets.AccountConfigFlagDesc,
+	)
+
+	cmd.Flags().StringVar(
+		&params.privateKey,
+		polybftsecrets.PrivateKeyFlag,
+		"",
+		polybftsecrets.PrivateKeyFlagDesc,
+	)
+
+	cmd.Flags().StringVar(
+		&params.supernetManagerAddress,
+		rootHelper.SupernetManagerFlag,
+		"",
+		rootHelper.SupernetManagerFlagDesc,
+	)
+
+	cmd.Flags().BoolVar(
+		&params.finalizeGenesisSet,
+		finalizeGenesisSetFlag,
+		false,
+		"indicates if genesis validator set should be finalized on rootchain",
+	)
+
+	cmd.Flags().BoolVar(
+		&params.enableStaking,
+		enableStakingFlag,
+		false,
+		"indicates if genesis validator set should be finalized on rootchain",
+	)
+
+	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
+	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.PrivateKeyFlag, polybftsecrets.AccountConfigFlag)
+	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.PrivateKeyFlag, polybftsecrets.AccountDirFlag)
+
+	helper.RegisterJSONRPCFlag(cmd)
+}
+
+func runCommand(cmd *cobra.Command, _ []string) error {
+	outputter := command.InitializeOutputter(cmd)
+	defer outputter.WriteOutput()
+
+	ownerKey, err := rootHelper.GetECDSAKey(params.privateKey, params.accountDir, params.accountConfig)
+	if err != nil {
+		return err
+	}
+
+	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC))
+	if err != nil {
+		return fmt.Errorf("enlist validator failed: %w", err)
+	}
+
+	gasPrice, err := rootHelper.GetGasPriceOnRoot(params.jsonRPC)
+	if err != nil {
+		return err
+	}
+
+	supernetAddr := ethgo.Address(types.StringToAddress(params.supernetManagerAddress))
+
+	if params.finalizeGenesisSet {
+		encoded, err := contractsapi.CustomSupernetManager.Abi.Methods["finalizeGenesis"].Encode([]interface{}{})
+		if err != nil {
+			return err
+		}
+
+		txn := &ethgo.Transaction{
+			From:     ownerKey.Address(),
+			Input:    encoded,
+			To:       &supernetAddr,
+			GasPrice: gasPrice,
+		}
+
+		receipt, err := txRelayer.SendTransaction(txn, ownerKey)
+		if err != nil {
+			return fmt.Errorf("finalizing genesis validator set failed. Error: %w", err)
+		}
+
+		if receipt.Status == uint64(types.ReceiptFailed) {
+			return fmt.Errorf("finalizing genesis validator set transaction failed on block %d", receipt.BlockNumber)
+		}
+	}
+
+	if params.enableStaking {
+		encoded, err := contractsapi.CustomSupernetManager.Abi.Methods["enableStaking"].Encode([]interface{}{})
+		if err != nil {
+			return err
+		}
+
+		txn := &ethgo.Transaction{
+			From:     ownerKey.Address(),
+			Input:    encoded,
+			To:       &supernetAddr,
+			GasPrice: gasPrice,
+		}
+
+		receipt, err := txRelayer.SendTransaction(txn, ownerKey)
+		if err != nil {
+			return fmt.Errorf("enabling staking on supernet manager failed. Error: %w", err)
+		}
+
+		if receipt.Status == uint64(types.ReceiptFailed) {
+			return fmt.Errorf("enable staking transaction failed on block %d", receipt.BlockNumber)
+		}
+	}
+
+	result := &supernetResult{
+		isGenesisSetFinalized: params.finalizeGenesisSet,
+		isStakingEnabled:      params.enableStaking,
+	}
+
+	outputter.WriteCommandResult(result)
+
+	return nil
+}

--- a/command/rootchain/supernet/supernet.go
+++ b/command/rootchain/supernet/supernet.go
@@ -19,7 +19,7 @@ var params supernetParams
 func GetCommand() *cobra.Command {
 	registerCmd := &cobra.Command{
 		Use:     "supernet",
-		Short:   "Supernet command",
+		Short:   "Supernet initialization & finalization command",
 		PreRunE: runPreRun,
 		RunE:    runCommand,
 	}

--- a/command/rootchain/whitelist/whitelist_validators.go
+++ b/command/rootchain/whitelist/whitelist_validators.go
@@ -9,7 +9,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	rootHelper "github.com/0xPolygon/polygon-edge/command/rootchain/helper"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/spf13/cobra"
@@ -84,27 +83,9 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	var ecdsaKey ethgo.Key
-
-	if params.privateKey != "" {
-		key, err := rootHelper.GetRootchainPrivateKey(params.privateKey)
-		if err != nil {
-			return fmt.Errorf("failed to initialize private key: %w", err)
-		}
-
-		ecdsaKey = key
-	} else {
-		secretsManager, err := polybftsecrets.GetSecretsManager(params.accountDir, params.accountConfig, true)
-		if err != nil {
-			return err
-		}
-
-		key, err := wallet.GetEcdsaFromSecret(secretsManager)
-		if err != nil {
-			return err
-		}
-
-		ecdsaKey = key
+	ecdsaKey, err := rootHelper.GetECDSAKey(params.privateKey, params.accountDir, params.accountDir)
+	if err != nil {
+		return err
 	}
 
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),

--- a/command/rootchain/whitelist/whitelist_validators.go
+++ b/command/rootchain/whitelist/whitelist_validators.go
@@ -91,7 +91,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(params.jsonRPC),
 		txrelayer.WithReceiptTimeout(150*time.Millisecond))
 	if err != nil {
-		return fmt.Errorf("enlist validator failed: %w", err)
+		return fmt.Errorf("whitelist validator failed. Could not create tx relayer: %w", err)
 	}
 
 	gasPrice, err := txRelayer.GetGasPrice()
@@ -105,7 +105,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 
 	encoded, err := whitelistFn.EncodeAbi()
 	if err != nil {
-		return fmt.Errorf("enlist validator failed: %w", err)
+		return fmt.Errorf("whitelist validator failed. Could not abi encode whitelist function: %w", err)
 	}
 
 	supernetAddr := ethgo.Address(types.StringToAddress(params.supernetManagerAddress))
@@ -118,11 +118,11 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 
 	receipt, err := txRelayer.SendTransaction(txn, ecdsaKey)
 	if err != nil {
-		return fmt.Errorf("enlist validator failed %w", err)
+		return fmt.Errorf("whitelist validator failed %w", err)
 	}
 
 	if receipt.Status == uint64(types.ReceiptFailed) {
-		return fmt.Errorf("enlist validator transaction failed on block %d", receipt.BlockNumber)
+		return fmt.Errorf("whitelist validator transaction failed on block %d", receipt.BlockNumber)
 	}
 
 	var (
@@ -146,7 +146,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	if len(result.newValidatorAddresses) != len(params.newValidatorAddresses) {
-		return fmt.Errorf("enlistment of validators did not pass successfully")
+		return fmt.Errorf("whitelist of validators did not pass successfully")
 	}
 
 	outputter.WriteCommandResult(result)

--- a/command/rootchain/whitelist/whitelist_validators.go
+++ b/command/rootchain/whitelist/whitelist_validators.go
@@ -83,7 +83,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	ecdsaKey, err := rootHelper.GetECDSAKey(params.privateKey, params.accountDir, params.accountDir)
+	ecdsaKey, err := rootHelper.GetECDSAKey(params.privateKey, params.accountDir, params.accountConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

Through this PR we added a new command called `supernet`. The command will be in e2e tests to finalize initial validator set on rootchain, and to enable staking, before starting the child chain.

Command flags:
- `data-dir` - the directory for the Polygon Edge data if the local FS is used. (mutually exclusive with the `config` and `private-key` flags).
- `config` - the path to the SecretsManager config file, if omitted, the local FS secrets manager is used (mutually exclusive with the `data-dir` and `private-key` flags).
- `private-key` - hex encoded private key of the `SupernetManager` contract deployer. This flag is only a temporary solution, since Secret Manager (for now) does not support the absence of a bls key ((mutually exclusive with the `data-dir` and `config` flags).
- `finalize-genesis-set` - finalizes genesis validator set on root contract (`SupernetManager`).
- `enable-staking` - enables staking on root chain (`SupernetManager` and `StakeManager`).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually