### PR TITLE
Additional header validations

### DIFF
--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -76,7 +76,7 @@ func (b *BlockBuilder) Reset() error {
 		ParentHash:   b.params.Parent.Hash,
 		Number:       b.params.Parent.Number + 1,
 		Miner:        b.params.Coinbase[:],
-		Difficulty:   1,
+		Difficulty:   0,
 		StateRoot:    types.EmptyRootHash, // this avoids needing state for now
 		TxRoot:       types.EmptyRootHash,
 		ReceiptsRoot: types.EmptyRootHash, // this avoids needing state for now

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -33,7 +33,7 @@ var (
 	errCommitEpochTxSingleExpected = errors.New("only one commit epoch transaction is allowed in an epoch ending block")
 	errProposalDontMatch           = errors.New("failed to insert proposal, because the validated proposal " +
 		"is either nil or it does not match the received one")
-	pbftNonce = types.EncodeNonce(0)
+	pbftNonce = types.Nonce{}
 )
 
 type fsm struct {
@@ -589,7 +589,7 @@ func (f *fsm) verifyCommitEpochTx(commitEpochTx *types.Transaction) error {
 
 func validateHeaderFields(parent *types.Header, header *types.Header) error {
 	if len(header.ExtraData) < ExtraVanity {
-		return fmt.Errorf("extra-data shorter than 32 bytes (%d)", len(header.ExtraData))
+		return fmt.Errorf("extra-data shorter than %d bytes (%d)", ExtraVanity, len(header.ExtraData))
 	}
 	// verify parent hash
 	if parent.Hash != header.ParentHash {

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -33,8 +33,7 @@ var (
 	errCommitEpochTxSingleExpected = errors.New("only one commit epoch transaction is allowed in an epoch ending block")
 	errProposalDontMatch           = errors.New("failed to insert proposal, because the validated proposal " +
 		"is either nil or it does not match the received one")
-	pbftDifficulty = uint64(0)
-	pbftNonce      = types.Nonce{}
+	pbftNonce = types.Nonce{}
 )
 
 type fsm struct {
@@ -616,7 +615,7 @@ func validateHeaderFields(parent *types.Header, header *types.Header) error {
 	if header.MixHash != PolyBFTMixDigest {
 		return fmt.Errorf("mix digest is not correct")
 	}
-	// difficulty must be > 0
+	// difficulty must be zero
 	if header.Difficulty != 0 {
 		return fmt.Errorf("difficulty should be zero")
 	}

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -599,11 +599,11 @@ func validateHeaderFields(parent *types.Header, header *types.Header) error {
 	if header.Number != parent.Number+1 {
 		return fmt.Errorf("invalid number")
 	}
-	//verifity header is zero
+	// verify header nonce is zero
 	if header.Nonce != zeroNonce {
 		return fmt.Errorf("invalid nonce")
 	}
-	//verify that the gasUsed is <= gasLimit
+	// verify that the gasUsed is <= gasLimit
 	if header.GasUsed > header.GasLimit {
 		return fmt.Errorf("invalid gasLimit: have %v, max %v", header.GasUsed, header.GasLimit)
 	}

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -33,6 +33,7 @@ var (
 	errCommitEpochTxSingleExpected = errors.New("only one commit epoch transaction is allowed in an epoch ending block")
 	errProposalDontMatch           = errors.New("failed to insert proposal, because the validated proposal " +
 		"is either nil or it does not match the received one")
+	pbftNonce = types.EncodeNonce(0)
 )
 
 type fsm struct {
@@ -594,6 +595,13 @@ func validateHeaderFields(parent *types.Header, header *types.Header) error {
 	// verify parent number
 	if header.Number != parent.Number+1 {
 		return fmt.Errorf("invalid number")
+	}
+	if header.Nonce != pbftNonce {
+		return fmt.Errorf("invalid nonce")
+	}
+	//verify that the gasUsed is <= gasLimit
+	if header.GasUsed > header.GasLimit {
+		return fmt.Errorf("invalid gasLimit: have %v, max %v", header.GasUsed, header.GasLimit)
 	}
 	// verify time has passed
 	if header.Timestamp <= parent.Timestamp {

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -588,6 +588,9 @@ func (f *fsm) verifyCommitEpochTx(commitEpochTx *types.Transaction) error {
 }
 
 func validateHeaderFields(parent *types.Header, header *types.Header) error {
+	if len(header.ExtraData) < 32 {
+		return fmt.Errorf("extra-data shorter than 32 bytes (%d)", len(header.ExtraData))
+	}
 	// verify parent hash
 	if parent.Hash != header.ParentHash {
 		return fmt.Errorf("incorrect header parent hash (parent=%s, header parent=%s)", parent.Hash, header.ParentHash)

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -33,7 +33,8 @@ var (
 	errCommitEpochTxSingleExpected = errors.New("only one commit epoch transaction is allowed in an epoch ending block")
 	errProposalDontMatch           = errors.New("failed to insert proposal, because the validated proposal " +
 		"is either nil or it does not match the received one")
-	pbftNonce = types.Nonce{}
+	pbftDifficulty = uint64(0)
+	pbftNonce      = types.Nonce{}
 )
 
 type fsm struct {
@@ -599,6 +600,7 @@ func validateHeaderFields(parent *types.Header, header *types.Header) error {
 	if header.Number != parent.Number+1 {
 		return fmt.Errorf("invalid number")
 	}
+	//verifity header is zero
 	if header.Nonce != pbftNonce {
 		return fmt.Errorf("invalid nonce")
 	}
@@ -615,8 +617,8 @@ func validateHeaderFields(parent *types.Header, header *types.Header) error {
 		return fmt.Errorf("mix digest is not correct")
 	}
 	// difficulty must be > 0
-	if header.Difficulty <= 0 {
-		return fmt.Errorf("difficulty should be greater than zero")
+	if header.Difficulty != 0 {
+		return fmt.Errorf("difficulty should be zero")
 	}
 	// calculated header hash must be correct
 	if header.Hash != types.HeaderHash(header) {

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -588,7 +588,7 @@ func (f *fsm) verifyCommitEpochTx(commitEpochTx *types.Transaction) error {
 }
 
 func validateHeaderFields(parent *types.Header, header *types.Header) error {
-	if len(header.ExtraData) < 32 {
+	if len(header.ExtraData) < ExtraVanity {
 		return fmt.Errorf("extra-data shorter than 32 bytes (%d)", len(header.ExtraData))
 	}
 	// verify parent hash

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -33,7 +33,7 @@ var (
 	errCommitEpochTxSingleExpected = errors.New("only one commit epoch transaction is allowed in an epoch ending block")
 	errProposalDontMatch           = errors.New("failed to insert proposal, because the validated proposal " +
 		"is either nil or it does not match the received one")
-	pbftNonce = types.Nonce{}
+	zeroNonce = types.Nonce{}
 )
 
 type fsm struct {
@@ -600,7 +600,7 @@ func validateHeaderFields(parent *types.Header, header *types.Header) error {
 		return fmt.Errorf("invalid number")
 	}
 	//verifity header is zero
-	if header.Nonce != pbftNonce {
+	if header.Nonce != zeroNonce {
 		return fmt.Errorf("invalid nonce")
 	}
 	//verify that the gasUsed is <= gasLimit

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -27,8 +27,9 @@ import (
 func TestFSM_ValidateHeader(t *testing.T) {
 	t.Parallel()
 
+	extra := createTestExtra(AccountSet{}, AccountSet{}, 0, 0, 0)
 	parent := &types.Header{Number: 0, Hash: types.BytesToHash([]byte{1, 2, 3})}
-	header := &types.Header{Number: 0}
+	header := &types.Header{Number: 0, ExtraData: extra}
 
 	// parent hash
 	require.ErrorContains(t, validateHeaderFields(parent, header), "incorrect header parent hash")

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -48,10 +48,10 @@ func TestFSM_ValidateHeader(t *testing.T) {
 	header.MixHash = PolyBFTMixDigest
 
 	// difficulty
-	header.Difficulty = 0
-	require.ErrorContains(t, validateHeaderFields(parent, header), "difficulty should be greater than zero")
-
 	header.Difficulty = 1
+	require.ErrorContains(t, validateHeaderFields(parent, header), "difficulty should be zero")
+
+	header.Difficulty = 0
 	header.Hash = types.BytesToHash([]byte{11, 22, 33})
 	require.ErrorContains(t, validateHeaderFields(parent, header), "invalid header hash")
 
@@ -1242,7 +1242,7 @@ func TestFSM_Validate_FailToVerifySignatures(t *testing.T) {
 			ParentHash: parent.Hash,
 			Timestamp:  parent.Timestamp + 1,
 			MixHash:    PolyBFTMixDigest,
-			Difficulty: 1,
+			Difficulty: 0,
 			ExtraData:  parent.ExtraData,
 		},
 	})

--- a/consensus/polybft/polybft_test.go
+++ b/consensus/polybft/polybft_test.go
@@ -142,7 +142,7 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 		ParentHash: parentHeader.Hash,
 		Timestamp:  parentHeader.Timestamp + 1,
 		MixHash:    PolyBFTMixDigest,
-		Difficulty: 1,
+		Difficulty: 0,
 	}
 	updateHeaderExtra(currentHeader, currentDelta, nil,
 		&CheckpointData{

--- a/types/header.go
+++ b/types/header.go
@@ -58,6 +58,11 @@ func (n Nonce) String() string {
 func (n Nonce) MarshalText() ([]byte, error) {
 	return []byte(n.String()), nil
 }
+func EncodeNonce(i uint64) Nonce {
+	var n Nonce
+	binary.BigEndian.PutUint64(n[:], i)
+	return n
+}
 
 func (h *Header) Copy() *Header {
 	newHeader := &Header{

--- a/types/header.go
+++ b/types/header.go
@@ -41,7 +41,7 @@ func (h *Header) HasReceipts() bool {
 }
 
 func (h *Header) SetNonce(i uint64) {
-	binary.BigEndian.PutUint64(h.Nonce[:], i)
+	h.Nonce.EncodeNonce(i)
 }
 
 func (h *Header) IsGenesis() bool {
@@ -58,10 +58,9 @@ func (n Nonce) String() string {
 func (n Nonce) MarshalText() ([]byte, error) {
 	return []byte(n.String()), nil
 }
-func EncodeNonce(i uint64) Nonce {
-	var n Nonce
+
+func (n Nonce) EncodeNonce(i uint64) {
 	binary.BigEndian.PutUint64(n[:], i)
-	return n
 }
 
 func (h *Header) Copy() *Header {


### PR DESCRIPTION
# Description

The PR add more validations for header in `validationHeaderFields`.

- Check header `ExtraData` length. If length is less than 32 bytes return error. 
- Check header `Nonce` equals to zero, if not return error.
- Check header `GasUsed` less than headers `GasiLimit`, if exceed  return error
- Check header `Difficulty` equals to zero, if not return error.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it

