### PR TITLE
add validation for future blocks

### DIFF
--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/0xPolygon/go-ibft/messages"
 	"github.com/0xPolygon/go-ibft/messages/proto"
@@ -33,6 +34,7 @@ var (
 	errCommitEpochTxSingleExpected = errors.New("only one commit epoch transaction is allowed in an epoch ending block")
 	errProposalDontMatch           = errors.New("failed to insert proposal, because the validated proposal " +
 		"is either nil or it does not match the received one")
+	allowedFutureBlockTimeSeconds = int64(60)
 )
 
 type fsm struct {
@@ -587,6 +589,10 @@ func (f *fsm) verifyCommitEpochTx(commitEpochTx *types.Transaction) error {
 }
 
 func validateHeaderFields(parent *types.Header, header *types.Header) error {
+	// verify time is from the future
+	if header.Timestamp > uint64(time.Now().UTC().Unix()+allowedFutureBlockTimeSeconds) {
+		return fmt.Errorf("block from the future")
+	}
 	// verify parent hash
 	if parent.Hash != header.ParentHash {
 		return fmt.Errorf("incorrect header parent hash (parent=%s, header parent=%s)", parent.Hash, header.ParentHash)

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -34,7 +34,7 @@ var (
 	errCommitEpochTxSingleExpected = errors.New("only one commit epoch transaction is allowed in an epoch ending block")
 	errProposalDontMatch           = errors.New("failed to insert proposal, because the validated proposal " +
 		"is either nil or it does not match the received one")
-	allowedFutureBlockTimeSeconds = int64(60)
+	allowedFutureBlockTimeSeconds = int64(15)
 )
 
 type fsm struct {

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -54,6 +54,11 @@ func TestFSM_ValidateHeader(t *testing.T) {
 	header.Hash = types.BytesToHash([]byte{11, 22, 33})
 	require.ErrorContains(t, validateHeaderFields(parent, header), "invalid header hash")
 
+	header.Timestamp = uint64(time.Now().UTC().Unix() + 150)
+	require.ErrorContains(t, validateHeaderFields(parent, header), "block from the future")
+
+	header.Timestamp = uint64(time.Now().UTC().Unix())
+
 	header.ComputeHash()
 	require.NoError(t, validateHeaderFields(parent, header))
 }

--- a/consensus/polybft/polybft_test.go
+++ b/consensus/polybft/polybft_test.go
@@ -126,7 +126,7 @@ func TestPolybft_VerifyHeader(t *testing.T) {
 
 	parentHeader := &types.Header{
 		Number:    polyBftConfig.EpochSize,
-		Timestamp: uint64(time.Now().UTC().UnixMilli()),
+		Timestamp: uint64(time.Now().UTC().Unix()),
 	}
 	parentCommitment := updateHeaderExtra(parentHeader, parentDelta, nil, &CheckpointData{EpochNumber: 1}, accountSetParent)
 


### PR DESCRIPTION
# Description
The PR add validations for header in `validationHeaderFields`. Changes includes check for future block, whitch includes checking if the timestamp is within 15 seconds of `time.Now().UTC().Unix()`, if not, we assume that it is a future block and return error.

Please provide a detailed description of what was done in this PR

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
