### PR TITLE
Fix txpool unit tests

### DIFF
--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -1836,7 +1836,7 @@ func TestPermissionSmartContractDeployment(t *testing.T) {
 		)
 	})
 
-	t.Run("dynamic fee tx placed without EIP-1559 fork enabled", func(t *testing.T) {
+	t.Run("dynamic fee tx placed without eip-1559 fork enabled", func(t *testing.T) {
 		t.Parallel()
 		pool := setupPool()
 		pool.forks.London = false

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -34,6 +34,7 @@ var (
 	forks = &chain.Forks{
 		Homestead: chain.NewFork(0),
 		Istanbul:  chain.NewFork(0),
+		London:    chain.NewFork(0),
 	}
 )
 
@@ -86,7 +87,7 @@ func newTestPoolWithSlots(maxSlots uint64, mockStore ...store) (*TxPool, error) 
 
 	return NewTxPool(
 		hclog.NewNullLogger(),
-		chain.AllForksEnabled.At(0),
+		forks.At(0),
 		storeToUse,
 		nil,
 		nil,


### PR DESCRIPTION
# Description

This PR fixes tx pool unit tests, because of recently introduced validation in #1120 which prevents adding dynamic fee transactions if London hard fork is not enabled.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
