### PR TITLE
Add burn contract address in the cluster script

### DIFF
--- a/scripts/cluster
+++ b/scripts/cluster
@@ -1,28 +1,30 @@
 #!/usr/bin/env bash
 
 function initIbftConsensus() {
-    echo "Running with ibft consensus"
-    ./polygon-edge secrets init --insecure --data-dir test-chain- --num 4
+  echo "Running with ibft consensus"
+  ./polygon-edge secrets init --insecure --data-dir test-chain- --num 4
 
-    node1_id=$(./polygon-edge secrets output --data-dir test-chain-1 | grep Node | head -n 1 | awk -F ' ' '{print $4}')
-    node2_id=$(./polygon-edge secrets output --data-dir test-chain-2 | grep Node | head -n 1 | awk -F ' ' '{print $4}')
+  node1_id=$(./polygon-edge secrets output --data-dir test-chain-1 | grep Node | head -n 1 | awk -F ' ' '{print $4}')
+  node2_id=$(./polygon-edge secrets output --data-dir test-chain-2 | grep Node | head -n 1 | awk -F ' ' '{print $4}')
 
-    genesis_params="--consensus ibft --ibft-validators-prefix-path test-chain- \
+  genesis_params="--consensus ibft --ibft-validators-prefix-path test-chain- \
     --bootnode /ip4/127.0.0.1/tcp/30301/p2p/$node1_id \
     --bootnode /ip4/127.0.0.1/tcp/30302/p2p/$node2_id"
 }
 
 function initPolybftConsensus() {
-    echo "Running with polybft consensus"
-    genesis_params="--consensus polybft"
-    ./polygon-edge polybft-secrets --insecure --data-dir test-chain- --num 4
+  echo "Running with polybft consensus"
+  genesis_params="--consensus polybft"
+  ./polygon-edge polybft-secrets --insecure --data-dir test-chain- --num 4
 }
 
 function createGenesis() {
-    ./polygon-edge genesis $genesis_params \
-      --block-gas-limit 10000000 \
-      --premine 0x85da99c8a7c2c95964c8efd687e95e632fc533d6:1000000000000000000000 \
-      --epoch-size 10
+  ./polygon-edge genesis $genesis_params \
+    --block-gas-limit 10000000 \
+    --premine 0x85da99c8a7c2c95964c8efd687e95e632fc533d6:1000000000000000000000 \
+    --premine 0x0000000000000000000000000000000000000000 \
+    --epoch-size 10 \
+    --burn-contract 0:0x0000000000000000000000000000000000000000
 }
 
 function startServerFromBinary() {
@@ -40,7 +42,7 @@ function startServerFromBinary() {
     ./polygon-edge server --data-dir ./test-chain-4 --chain genesis.json \
       --grpc-address :40000 --libp2p :30304 --jsonrpc :40002 \
       --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-4.log &
-      wait
+    wait
   else
     ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json \
       --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 \
@@ -54,29 +56,29 @@ function startServerFromBinary() {
     ./polygon-edge server --data-dir ./test-chain-4 --chain genesis.json \
       --grpc-address :40000 --libp2p :30304 --jsonrpc :40002 \
       --num-block-confirmations 2 --seal --log-level DEBUG &
-      wait
+    wait
   fi
 }
 
 function startServerFromDockerCompose() {
-    case "$1" in
-      "ibft")
-        docker-compose -f ./docker/local/docker-compose.yml up -d --build
-        ;;
-      "polybft")
-        cd core-contracts && npm install && npm run compile && cd -
-        go run ./consensus/polybft/contractsapi/artifacts-gen/main.go
-        EDGE_CONSENSUS=polybft docker-compose -f ./docker/local/docker-compose.yml up -d --build
-        ;;
-    esac
+  case "$1" in
+  "ibft")
+    docker-compose -f ./docker/local/docker-compose.yml up -d --build
+    ;;
+  "polybft")
+    cd core-contracts && npm install && npm run compile && cd -
+    go run ./consensus/polybft/contractsapi/artifacts-gen/main.go
+    EDGE_CONSENSUS=polybft docker-compose -f ./docker/local/docker-compose.yml up -d --build
+    ;;
+  esac
 }
 
 function destroyDockerEnvironment() {
-    docker-compose -f ./docker/local/docker-compose.yml down -v
+  docker-compose -f ./docker/local/docker-compose.yml down -v
 }
 
 function stopDockerEnvironment() {
-    docker-compose -f ./docker/local/docker-compose.yml stop
+  docker-compose -f ./docker/local/docker-compose.yml stop
 }
 
 set -e
@@ -90,46 +92,46 @@ go build -o polygon-edge .
 
 # If --docker flag is set run docker environment otherwise run from binary
 case "$2" in
-  "--docker")
-    # cluster {consensus} --docker destroy
-    if [ "$3" == "destroy" ]; then
-      destroyDockerEnvironment
-      echo "Docker $1 environment destroyed!"
-      exit 0
-    # cluster {consensus} --docker stop
-    elif [ "$3" == "stop" ]; then
-      stopDockerEnvironment
-      echo "Docker $1 environment stoped!"
-      exit 0;
-    fi
-
-    # cluster {consensus} --docker
-    echo "Running $1 docker environment..."
-    startServerFromDockerCompose $1
-    echo "Docker $1 environment deployed."
+"--docker")
+  # cluster {consensus} --docker destroy
+  if [ "$3" == "destroy" ]; then
+    destroyDockerEnvironment
+    echo "Docker $1 environment destroyed!"
     exit 0
-    ;;
-  # cluster {consensus}
-  *)
-    echo "Running $1 environment from local binary..."
-    # Initialize ibft or polybft consensus
-    if [ "$1" == "ibft" ]; then
-      # Initialize ibft consensus
-      initIbftConsensus
-      # Create genesis file and start the server from binary
-      createGenesis
-      startServerFromBinary $2
-      exit 0;
-    elif [ "$1" == "polybft" ]; then
-      # Initialize polybft consensus
-      initPolybftConsensus
-      # Create genesis file and start the server from binary
-      createGenesis
-      startServerFromBinary $2
-      exit 0;
-    else
-      echo "Unsupported consensus mode. Supported modes are: ibft and polybft "
-      exit 1;
-    fi
+  # cluster {consensus} --docker stop
+  elif [ "$3" == "stop" ]; then
+    stopDockerEnvironment
+    echo "Docker $1 environment stoped!"
+    exit 0
+  fi
+
+  # cluster {consensus} --docker
+  echo "Running $1 docker environment..."
+  startServerFromDockerCompose $1
+  echo "Docker $1 environment deployed."
+  exit 0
+  ;;
+# cluster {consensus}
+*)
+  echo "Running $1 environment from local binary..."
+  # Initialize ibft or polybft consensus
+  if [ "$1" == "ibft" ]; then
+    # Initialize ibft consensus
+    initIbftConsensus
+    # Create genesis file and start the server from binary
+    createGenesis
+    startServerFromBinary $2
+    exit 0
+  elif [ "$1" == "polybft" ]; then
+    # Initialize polybft consensus
+    initPolybftConsensus
+    # Create genesis file and start the server from binary
+    createGenesis
+    startServerFromBinary $2
+    exit 0
+  else
+    echo "Unsupported consensus mode. Supported modes are: ibft and polybft "
+    exit 1
+  fi
   ;;
 esac


### PR DESCRIPTION
# Description

This PR fixes cluster script (non-Docker mode) by adding `burn-contract` flag value, which was introduced in #1120 and is mandatory one.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually