### PR TITLE
Fix test timeout  related to min connected peers

### DIFF
--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -343,6 +343,8 @@ func (p *Polybft) startConsensusProtocol() {
 		return
 	}
 
+	p.logger.Debug("peers connected")
+
 	newBlockSub := p.blockchain.SubscribeEvents()
 	defer newBlockSub.Close()
 

--- a/e2e-polybft/e2e/acls_test.go
+++ b/e2e-polybft/e2e/acls_test.go
@@ -42,7 +42,7 @@ func TestE2E_AllowList_ContractDeployment(t *testing.T) {
 
 	otherAddr := types.Address{0x1}
 
-	cluster := framework.NewTestCluster(t, 3,
+	cluster := framework.NewTestCluster(t, 5,
 		framework.WithPremine(adminAddr, targetAddr),
 		framework.WithContractDeployerAllowListAdmin(adminAddr),
 		framework.WithContractDeployerAllowListEnabled(otherAddr),
@@ -140,7 +140,7 @@ func TestE2E_BlockList_ContractDeployment(t *testing.T) {
 
 	otherAddr := types.Address{0x1}
 
-	cluster := framework.NewTestCluster(t, 3,
+	cluster := framework.NewTestCluster(t, 5,
 		framework.WithPremine(adminAddr, targetAddr),
 		framework.WithContractDeployerBlockListAdmin(adminAddr),
 		framework.WithContractDeployerBlockListEnabled(otherAddr),
@@ -223,7 +223,7 @@ func TestE2E_AllowList_Transactions(t *testing.T) {
 	targetAddr := types.Address(target.Address())
 	otherAddr := types.Address(other.Address())
 
-	cluster := framework.NewTestCluster(t, 3,
+	cluster := framework.NewTestCluster(t, 5,
 		framework.WithPremine(adminAddr, targetAddr, otherAddr),
 		framework.WithTransactionsAllowListAdmin(adminAddr),
 		framework.WithTransactionsAllowListEnabled(otherAddr),
@@ -306,7 +306,7 @@ func TestE2E_BlockList_Transactions(t *testing.T) {
 	targetAddr := types.Address(target.Address())
 	otherAddr := types.Address(other.Address())
 
-	cluster := framework.NewTestCluster(t, 3,
+	cluster := framework.NewTestCluster(t, 5,
 		framework.WithPremine(adminAddr, targetAddr, otherAddr),
 		framework.WithTransactionsBlockListAdmin(adminAddr),
 		framework.WithTransactionsBlockListEnabled(otherAddr),
@@ -376,7 +376,7 @@ func TestE2E_AddressLists_Bridge(t *testing.T) {
 	targetAddr := types.Address(target.Address())
 	otherAddr := types.Address(other.Address())
 
-	cluster := framework.NewTestCluster(t, 3,
+	cluster := framework.NewTestCluster(t, 5,
 		framework.WithPremine(adminAddr, targetAddr, otherAddr),
 		framework.WithBridgeAllowListAdmin(adminAddr),
 		framework.WithBridgeAllowListEnabled(otherAddr),

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -684,7 +684,7 @@ func (c *TestCluster) WaitUntil(timeout, pollFrequency time.Duration, handler fu
 func (c *TestCluster) WaitForReady(t *testing.T) {
 	t.Helper()
 
-	require.NoError(t, c.WaitForBlock(1, 30*time.Second))
+	require.NoError(t, c.WaitForBlock(1, time.Minute))
 }
 
 func (c *TestCluster) WaitForBlock(n uint64, timeout time.Duration) error {

--- a/e2e-polybft/property/property_test.go
+++ b/e2e-polybft/property/property_test.go
@@ -23,7 +23,7 @@ func TestProperty_DifferentVotingPower(t *testing.T) {
 
 	rapid.Check(t, func(tt *rapid.T) {
 		var (
-			numNodes  = rapid.Uint64Range(4, 8).Draw(tt, "number of cluster nodes")
+			numNodes  = rapid.Uint64Range(5, 8).Draw(tt, "number of cluster nodes")
 			epochSize = rapid.OneOf(rapid.Just(4), rapid.Just(10)).Draw(tt, "epoch size")
 			numBlocks = rapid.Uint64Range(2, 5).Draw(tt, "number of blocks the cluster should mine")
 		)

--- a/network/server.go
+++ b/network/server.go
@@ -400,7 +400,7 @@ func (s *Server) runDial() {
 		//nolint:godox
 		// TODO: Right now the dial task are done sequentially because Connect
 		// is a blocking request. In the future we should try to make up to
-		// maxDials requests concurrently (to be fixed in EVM-541)
+		// maxDials requests concurrently (to be fixed in EVM-543)
 		for s.connectionCounts.HasFreeOutboundConn() {
 			tt := s.dialQueue.PopTask()
 			if tt == nil {


### PR DESCRIPTION
The problem with timeout in tests when waiting for cluster start-up is related to not enough min connected peers due to a dialing problem. Before starting the polybft consensus protocol, there is a check if at least 2 peers are connected before proceeding with the initialization. When dialing peers, the dial can fail for several reasons, e.g.
- the identity protocol is not yet registered on the peer we want to connect to (this is not unusual since in test the servers in the cluster are started at the same time)
"unable to create new identity client connection, protocols not supported: [/id/0.1]"
- for some reason, dial timeout occurs. Since we don't set the timeout explicitly when creating the p2p host, a default dial timeout is used which libp2p sets to 15s, and it should be quite enough (this should happen very rarely unless there is some issue with the machine)
"failed to negotiate security protocol: context deadline exceeded"

If this happens there is a redial mechanism which should handle this and after that peers will be eventually connected. However, during multiple tests executing when analyzing this problem, there is a doubt that a bug in the process of discovering peers and adding them to dialing queue exists. Analyzing the logs from this one case (3 nodes in total), it can be seen that the node connected to 1 peer but could not connect to another peer. Later, dialing that other peer is not called because the dial queue was empty, even though the peer should be added when running peer discovery. It seems that peer was present in the routing table, but it was disconnected, also when dialing fails in regular cases we see the logs for removing the peer info ("Attempted removing missing peer") which will probably enable adding it to the dialing queue and it this problematic scenario these logs are missing. Since the problem should be analyzed more detailed (if possible with higher reproducibility), and there is a [task](https://polygon.atlassian.net/browse/EVM-543?search_id=32e4bab5-9c41-4e53-8428-b19331fba4e5) in which the parallel peer dialing should be implemented which should enhance peers connection time, this problematic scenario will be explained in that task and logs attached.
Through this PR the following is done:
- timeout for cluster startup is increased to 1 min, this can help if dialing timeout occurs in a way that it will be more time available for redialing
- number of nodes in test that are failing because of this specific issue are increased (for allow list from 3 to 5 and for property tests min nodes is set to 5 as well), this can be helpful if it takes time for discover protocol to add peer to the queue or if the above described problematic case occurs the tolerance of bad nodes count will be greater with more nodes
Probably we should review the condition for number of min peers condition when waiting before starting consensus protocol (minSyncPeers = 2 in polybft.go) and (compare it to?) minimum peer connections used for keepAliveMinimumPeerConnections (MinimumPeerConnections = 1 in server.go)

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
