### PR TITLE
[RFC-201/205]: EVM-622-Save full validator set in db

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -481,6 +481,10 @@ func (c *consensusRuntime) restartEpoch(header *types.Header) (*epochMetadata, e
 		return nil, err
 	}
 
+	if err := c.stakeManager.PostEpoch(reqObj); err != nil {
+		return nil, err
+	}
+
 	return &epochMetadata{
 		Number:            epochNumber,
 		Validators:        validatorSet,

--- a/consensus/polybft/helpers_test.go
+++ b/consensus/polybft/helpers_test.go
@@ -175,3 +175,52 @@ func generateTestAccount(t *testing.T) *wallet.Account {
 
 	return acc
 }
+
+// createValidatorSetDelta calculates ValidatorSetDelta based on the provided old and new validator sets
+func createValidatorSetDelta(oldValidatorSet, newValidatorSet AccountSet) (*ValidatorSetDelta, error) {
+	var addedValidators, updatedValidators AccountSet
+
+	oldValidatorSetMap := make(map[types.Address]*ValidatorMetadata)
+	removedValidators := map[types.Address]int{}
+
+	for i, validator := range oldValidatorSet {
+		if (validator.Address != types.Address{}) {
+			removedValidators[validator.Address] = i
+			oldValidatorSetMap[validator.Address] = validator
+		}
+	}
+
+	for _, newValidator := range newValidatorSet {
+		// Check if the validator is among both old and new validator set
+		oldValidator, validatorExists := oldValidatorSetMap[newValidator.Address]
+		if validatorExists {
+			if !oldValidator.EqualAddressAndBlsKey(newValidator) {
+				return nil, fmt.Errorf("validator '%s' found in both old and new validator set, but its BLS keys differ",
+					newValidator.Address.String())
+			}
+
+			// If it is, then discard it from removed validators...
+			delete(removedValidators, newValidator.Address)
+
+			if !oldValidator.Equals(newValidator) {
+				updatedValidators = append(updatedValidators, newValidator)
+			}
+		} else {
+			// ...otherwise it is added
+			addedValidators = append(addedValidators, newValidator)
+		}
+	}
+
+	removedValsBitmap := bitmap.Bitmap{}
+	for _, i := range removedValidators {
+		removedValsBitmap.Set(uint64(i))
+	}
+
+	delta := &ValidatorSetDelta{
+		Added:   addedValidators,
+		Updated: updatedValidators,
+		Removed: removedValsBitmap,
+	}
+
+	return delta, nil
+}

--- a/consensus/polybft/stake_manager.go
+++ b/consensus/polybft/stake_manager.go
@@ -341,6 +341,7 @@ func (sc *validatorStakeMap) removeStake(address types.Address, amount *big.Int)
 // getActiveValidators returns all validators (*ValidatorMetadata) in sorted order
 func (sc validatorStakeMap) getActiveValidators(maxValidatorSetSize int) []*ValidatorMetadata {
 	activeValidators := make([]*ValidatorMetadata, 0, len(sc))
+
 	for _, v := range sc {
 		if v.VotingPower.Cmp(bigZero) > 0 {
 			activeValidators = append(activeValidators, v)

--- a/consensus/polybft/stake_manager.go
+++ b/consensus/polybft/stake_manager.go
@@ -337,7 +337,6 @@ type stakeCounter struct {
 // newStakeCounter returns a new instance of stake counter
 func newStakeCounter(oldCurrentValidatorSet, oldFullValidatorSet AccountSet,
 	maxValidatorSetSize int) *stakeCounter {
-
 	stakeCounter := &stakeCounter{
 		stakeMap:               make(map[types.Address]*big.Int),
 		oldCurrentValidatorSet: make(map[types.Address]*expandedValidatorMetadata, len(oldCurrentValidatorSet)),

--- a/consensus/polybft/stake_manager_test.go
+++ b/consensus/polybft/stake_manager_test.go
@@ -26,6 +26,16 @@ func TestStakeManager_PostEpoch(t *testing.T) {
 		maxValidatorSetSize: 10,
 	}
 
+	t.Run("Not first epoch", func(t *testing.T) {
+		require.NoError(t, stakeManager.PostEpoch(&PostEpochRequest{
+			NewEpochID:   2,
+			ValidatorSet: NewValidatorSet(validators, stakeManager.logger),
+		}))
+
+		_, err := state.StakeStore.getFullValidatorSet()
+		require.ErrorIs(t, errNoFullValidatorSet, err)
+	})
+
 	t.Run("First epoch", func(t *testing.T) {
 		require.NoError(t, stakeManager.PostEpoch(&PostEpochRequest{
 			NewEpochID:   1,
@@ -35,16 +45,6 @@ func TestStakeManager_PostEpoch(t *testing.T) {
 		fullValidatorSet, err := state.StakeStore.getFullValidatorSet()
 		require.NoError(t, err)
 		require.Len(t, fullValidatorSet, len(validators))
-	})
-
-	t.Run("Not first epoch", func(t *testing.T) {
-		require.NoError(t, stakeManager.PostEpoch(&PostEpochRequest{
-			NewEpochID:   2,
-			ValidatorSet: NewValidatorSet(validators, stakeManager.logger),
-		}))
-
-		_, err := state.StakeStore.getFullValidatorSet()
-		require.ErrorIs(t, errNoFullValidatorSet, err)
 	})
 }
 

--- a/consensus/polybft/stake_manager_test.go
+++ b/consensus/polybft/stake_manager_test.go
@@ -214,6 +214,7 @@ func TestStakeCounter_ShouldBeDeterministic(t *testing.T) {
 
 		test := func() []*ValidatorMetadata {
 			stakeCounter := newValidatorStakeMap(validators.getPublicIdentities("A", "B", "C", "D", "E"))
+
 			return stakeCounter.getActiveValidators(maxValidatorSetSize)
 		}
 

--- a/consensus/polybft/state_store_stake.go
+++ b/consensus/polybft/state_store_stake.go
@@ -13,7 +13,7 @@ var (
 	// key of the full validator set in bucket
 	fullValidatorSetKey = []byte("fullValidatorSet")
 	// error returned if full validator set does not exists in db
-	errorsNoFullValidatorSet = errors.New("full validator set not in db")
+	errNoFullValidatorSet = errors.New("full validator set not in db")
 )
 
 type StakeStore struct {
@@ -44,10 +44,11 @@ func (s *StakeStore) insertFullValidatorSet(fullValidatorSet AccountSet) error {
 // getFullValidatorSet returns full validator set from its bucket if exists
 func (s *StakeStore) getFullValidatorSet() (AccountSet, error) {
 	var fullValidatorSet AccountSet
+
 	err := s.db.View(func(tx *bolt.Tx) error {
 		raw := tx.Bucket(validatorSetBucket).Get(fullValidatorSetKey)
 		if raw == nil {
-			return errorsNoFullValidatorSet
+			return errNoFullValidatorSet
 		}
 
 		return fullValidatorSet.Unmarshal(raw)

--- a/consensus/polybft/state_store_stake.go
+++ b/consensus/polybft/state_store_stake.go
@@ -1,17 +1,19 @@
 package polybft
 
 import (
-	"encoding/json"
+	"errors"
 	"fmt"
 
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
-	"github.com/0xPolygon/polygon-edge/helper/common"
 	bolt "go.etcd.io/bbolt"
 )
 
 var (
-	// bucket to store stake changed events
-	stakeChangeBucket = []byte("stakeChange")
+	// bucket to store full validator set
+	validatorSetBucket = []byte("fullValidatorSetBucket")
+	// key of the full validator set in bucket
+	fullValidatorSetKey = []byte("fullValidatorSet")
+	// error returned if full validator set does not exists in db
+	errorsNoFullValidatorSet = errors.New("full validator set not in db")
 )
 
 type StakeStore struct {
@@ -20,62 +22,36 @@ type StakeStore struct {
 
 // initialize creates necessary buckets in DB if they don't already exist
 func (s *StakeStore) initialize(tx *bolt.Tx) error {
-	if _, err := tx.CreateBucketIfNotExists(stakeChangeBucket); err != nil {
+	if _, err := tx.CreateBucketIfNotExists(validatorSetBucket); err != nil {
 		return fmt.Errorf("failed to create bucket=%s: %w", string(epochsBucket), err)
 	}
 
 	return nil
 }
 
-// insertTransferEvents inserts provided transfer events to stake change bucket for given epoch
-func (s *StakeStore) insertTransferEvents(epoch uint64, transferEvents []*contractsapi.TransferEvent) error {
+// insertFullValidatorSet inserts full validator set to its bucket (or updates it if exists)
+func (s *StakeStore) insertFullValidatorSet(fullValidatorSet AccountSet) error {
 	return s.db.Update(func(tx *bolt.Tx) error {
-		eventsInDB, err := s.getTransferEventsLocked(tx, epoch)
+		raw, err := fullValidatorSet.Marshal()
 		if err != nil {
 			return err
 		}
 
-		eventsInDB = append(eventsInDB, transferEvents...)
-
-		raw, err := json.Marshal(eventsInDB)
-		if err != nil {
-			return err
-		}
-
-		return tx.Bucket(stakeChangeBucket).Put(common.EncodeUint64ToBytes(epoch), raw)
+		return tx.Bucket(validatorSetBucket).Put(fullValidatorSetKey, raw)
 	})
 }
 
-// getTransferEvents returns a slice of transfer events (stake changed events) that happened in given epoch
-func (s *StakeStore) getTransferEvents(epoch uint64) ([]*contractsapi.TransferEvent, error) {
-	var transferEvents []*contractsapi.TransferEvent
-
+// getFullValidatorSet returns full validator set from its bucket if exists
+func (s *StakeStore) getFullValidatorSet() (AccountSet, error) {
+	var fullValidatorSet AccountSet
 	err := s.db.View(func(tx *bolt.Tx) error {
-		res, err := s.getTransferEventsLocked(tx, epoch)
-		if err != nil {
-			return err
+		raw := tx.Bucket(validatorSetBucket).Get(fullValidatorSetKey)
+		if raw == nil {
+			return errorsNoFullValidatorSet
 		}
-		transferEvents = res
 
-		return nil
+		return fullValidatorSet.Unmarshal(raw)
 	})
 
-	return transferEvents, err
-}
-
-// getTransferEventsLocked gets all transfer events from db associated with given epoch
-func (s *StakeStore) getTransferEventsLocked(tx *bolt.Tx, epoch uint64) ([]*contractsapi.TransferEvent, error) {
-	bucket := tx.Bucket(stakeChangeBucket)
-
-	v := bucket.Get(common.EncodeUint64ToBytes(epoch))
-	if v == nil {
-		return nil, nil
-	}
-
-	var transferEvents []*contractsapi.TransferEvent
-	if err := json.Unmarshal(v, &transferEvents); err != nil {
-		return nil, err
-	}
-
-	return transferEvents, nil
+	return fullValidatorSet, err
 }

--- a/consensus/polybft/state_store_stake_test.go
+++ b/consensus/polybft/state_store_stake_test.go
@@ -11,11 +11,9 @@ func TestState_Insert_And_Get_FullValidatorSet(t *testing.T) {
 	state := newTestState(t)
 
 	t.Run("No full validator set", func(t *testing.T) {
-		t.Parallel()
-
 		_, err := state.StakeStore.getFullValidatorSet()
 
-		require.ErrorIs(t, err, errorsNoFullValidatorSet)
+		require.ErrorIs(t, err, errNoFullValidatorSet)
 	})
 
 	t.Run("Insert validator set", func(t *testing.T) {

--- a/consensus/polybft/state_store_stake_test.go
+++ b/consensus/polybft/state_store_stake_test.go
@@ -1,71 +1,42 @@
 package polybft
 
 import (
-	"math/big"
 	"testing"
 
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
-	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestState_Insert_And_Get_TransferEvents_PerEpoch(t *testing.T) {
-	t.Parallel()
-
-	const (
-		numOfEpochs         = 11
-		numOfBlocksPerEpoch = 10
-	)
-
+func TestState_Insert_And_Get_FullValidatorSet(t *testing.T) {
 	state := newTestState(t)
-	insertTestTransferEvents(t, state, numOfEpochs, numOfBlocksPerEpoch)
 
-	t.Run("Get events for existing epoch", func(t *testing.T) {
+	t.Run("No full validator set", func(t *testing.T) {
 		t.Parallel()
 
-		events, err := state.StakeStore.getTransferEvents(1)
+		_, err := state.StakeStore.getFullValidatorSet()
 
-		require.NoError(t, err)
-		require.Len(t, events, numOfBlocksPerEpoch)
+		require.ErrorIs(t, err, errorsNoFullValidatorSet)
 	})
 
-	t.Run("Get events for non-existing epoch", func(t *testing.T) {
-		t.Parallel()
-
-		events, err := state.StakeStore.getTransferEvents(12)
+	t.Run("Insert validator set", func(t *testing.T) {
+		validators := newTestValidators(t, 5).getPublicIdentities()
+		err := state.StakeStore.insertFullValidatorSet(validators)
 
 		assert.NoError(t, err)
-		assert.Len(t, events, 0)
+
+		fullValidatorSet, err := state.StakeStore.getFullValidatorSet()
+		require.NoError(t, err)
+		assert.Len(t, fullValidatorSet, len(validators))
 	})
-}
 
-func insertTestTransferEvents(t *testing.T, state *State,
-	numOfEpochs, numOfEventsPerEpoch int) []*contractsapi.TransferEvent {
-	t.Helper()
+	t.Run("Update validator set", func(t *testing.T) {
+		validators := newTestValidators(t, 10).getPublicIdentities()
+		err := state.StakeStore.insertFullValidatorSet(validators)
 
-	var (
-		index = uint64(0)
-	)
+		assert.NoError(t, err)
 
-	allEvents := make([]*contractsapi.TransferEvent, 0)
-
-	for i := uint64(1); i <= uint64(numOfEpochs); i++ {
-		transferEvents := make([]*contractsapi.TransferEvent, numOfEventsPerEpoch)
-		for j := 1; j <= numOfEventsPerEpoch; j++ {
-			transferEvents[j-1] =
-				&contractsapi.TransferEvent{
-					From:  types.ZeroAddress,
-					To:    types.BytesToAddress([]byte{0, 1}),
-					Value: big.NewInt(1),
-				}
-			index++
-		}
-
-		require.NoError(t, state.StakeStore.insertTransferEvents(i, transferEvents))
-
-		allEvents = append(allEvents, transferEvents...)
-	}
-
-	return allEvents
+		fullValidatorSet, err := state.StakeStore.getFullValidatorSet()
+		require.NoError(t, err)
+		assert.Len(t, fullValidatorSet, len(validators))
+	})
 }


### PR DESCRIPTION
# Description

In order to have correct validator set update, we need to store entire validator set to `boltdb` (not just active ones).
This is done on every block finalization, where we update the full validator set in our `boltdb` using the transfer events fired by `ValidatorSet`contract on child chain, when validator stake changes on child chain.

**IMPORTANT NOTE**: `e2e` tests will fail, until the last PR in the RFC-201/205 saga, which fixes them.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually