### PR TITLE
Remove check for ZeroHash to enable Nexon's Chainlink VRF use case.

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -147,10 +147,6 @@ func RecoverPubkey(signature, hash []byte) (*ecdsa.PublicKey, error) {
 		return nil, errHashOfInvalidLength
 	}
 
-	// if types.BytesToHash(hash) == types.ZeroHash {
-	// 	return nil, errZeroHash
-	// }
-
 	size := len(signature)
 	term := byte(27)
 

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -147,7 +147,6 @@ func RecoverPubkey(signature, hash []byte) (*ecdsa.PublicKey, error) {
 		return nil, errHashOfInvalidLength
 	}
 
-	// Commenting out below if-statement to remove ZeroHash checks with crashes Nexon's Chainlink VRF contracts.
 	// if types.BytesToHash(hash) == types.ZeroHash {
 	// 	return nil, errZeroHash
 	// }

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -147,9 +147,10 @@ func RecoverPubkey(signature, hash []byte) (*ecdsa.PublicKey, error) {
 		return nil, errHashOfInvalidLength
 	}
 
-	if types.BytesToHash(hash) == types.ZeroHash {
-		return nil, errZeroHash
-	}
+	// Commenting out below if-statement to remove ZeroHash checks with crashes Nexon's Chainlink VRF contracts.
+	// if types.BytesToHash(hash) == types.ZeroHash {
+	// 	return nil, errZeroHash
+	// }
 
 	size := len(signature)
 	term := byte(27)

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -456,13 +456,6 @@ func TestRecoverPublicKey(t *testing.T) {
 		require.ErrorIs(t, err, errHashOfInvalidLength)
 	})
 
-	// t.Run("Zero hash", func(t *testing.T) {
-	// 	t.Parallel()
-
-	// 	_, err := RecoverPubkey(testSignature, types.ZeroHash[:])
-	// 	require.ErrorIs(t, err, errZeroHash)
-	// })
-
 	t.Run("Ok signature and hash", func(t *testing.T) {
 		t.Parallel()
 

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -456,7 +456,6 @@ func TestRecoverPublicKey(t *testing.T) {
 		require.ErrorIs(t, err, errHashOfInvalidLength)
 	})
 
-	// Commenting out below test to remove ZeroHash checks with crashes Nexon's Chainlink VRF contracts.
 	// t.Run("Zero hash", func(t *testing.T) {
 	// 	t.Parallel()
 

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -456,12 +456,13 @@ func TestRecoverPublicKey(t *testing.T) {
 		require.ErrorIs(t, err, errHashOfInvalidLength)
 	})
 
-	t.Run("Zero hash", func(t *testing.T) {
-		t.Parallel()
+	// Commenting out below test to remove ZeroHash checks with crashes Nexon's Chainlink VRF contracts.
+	// t.Run("Zero hash", func(t *testing.T) {
+	// 	t.Parallel()
 
-		_, err := RecoverPubkey(testSignature, types.ZeroHash[:])
-		require.ErrorIs(t, err, errZeroHash)
-	})
+	// 	_, err := RecoverPubkey(testSignature, types.ZeroHash[:])
+	// 	require.ErrorIs(t, err, errZeroHash)
+	// })
 
 	t.Run("Ok signature and hash", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
# Description

Remove check for ZeroHash to enable Nexon's Chainlink VRF use case.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
