### PR TITLE
Disable london hardfork if burn contract address is not provided

### DIFF
--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -382,7 +382,7 @@ func (p *genesisParams) initGenesisConfig() error {
 	if len(p.burnContracts) > 0 {
 		chainConfig.Genesis.BaseFee = command.DefaultGenesisBaseFee
 		chainConfig.Genesis.BaseFeeEM = command.DefaultGenesisBaseFeeEM
-		chainConfig.Params.BurnContract = map[uint64]string{}
+		chainConfig.Params.BurnContract = make(map[uint64]string, len(p.burnContracts))
 
 		for _, burnContract := range p.burnContracts {
 			block, address, err := parseBurnContractInfo(burnContract)

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -356,6 +356,12 @@ func (p *genesisParams) generateGenesis() error {
 }
 
 func (p *genesisParams) initGenesisConfig() error {
+	// Disable london hardfork if burn contract address is not provided
+	enabledForks := chain.AllForksEnabled
+	if len(p.burnContracts) == 0 {
+		enabledForks.London = nil
+	}
+
 	chainConfig := &chain.Chain{
 		Name: p.name,
 		Genesis: &chain.Genesis{
@@ -364,25 +370,28 @@ func (p *genesisParams) initGenesisConfig() error {
 			Alloc:      map[types.Address]*chain.GenesisAccount{},
 			ExtraData:  p.extraData,
 			GasUsed:    command.DefaultGenesisGasUsed,
-			BaseFee:    command.DefaultGenesisBaseFee,
-			BaseFeeEM:  command.DefaultGenesisBaseFeeEM,
 		},
 		Params: &chain.Params{
-			ChainID:      int64(p.chainID),
-			Forks:        chain.AllForksEnabled,
-			Engine:       p.consensusEngineConfig,
-			BurnContract: map[uint64]string{},
+			ChainID: int64(p.chainID),
+			Forks:   enabledForks,
+			Engine:  p.consensusEngineConfig,
 		},
 		Bootnodes: p.bootnodes,
 	}
 
-	for _, burnContract := range p.burnContracts {
-		block, address, err := parseBurnContractInfo(burnContract)
-		if err != nil {
-			return err
-		}
+	if len(p.burnContracts) > 0 {
+		chainConfig.Genesis.BaseFee = command.DefaultGenesisBaseFee
+		chainConfig.Genesis.BaseFeeEM = command.DefaultGenesisBaseFeeEM
+		chainConfig.Params.BurnContract = map[uint64]string{}
 
-		chainConfig.Params.BurnContract[block] = address.String()
+		for _, burnContract := range p.burnContracts {
+			block, address, err := parseBurnContractInfo(burnContract)
+			if err != nil {
+				return err
+			}
+
+			chainConfig.Params.BurnContract[block] = address.String()
+		}
 	}
 
 	// Predeploy staking smart contract if needed

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -111,15 +111,20 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 		NativeTokenConfig:   p.nativeTokenConfig,
 	}
 
+	// Disable london hardfork if burn contract address is not provided
+	enabledForks := chain.AllForksEnabled
+	if len(p.burnContracts) == 0 {
+		enabledForks.London = nil
+	}
+
 	chainConfig := &chain.Chain{
 		Name: p.name,
 		Params: &chain.Params{
 			ChainID: int64(p.chainID),
-			Forks:   chain.AllForksEnabled,
+			Forks:   enabledForks,
 			Engine: map[string]interface{}{
 				string(server.PolyBFTConsensus): polyBftConfig,
 			},
-			BurnContract: map[uint64]string{},
 		},
 		Bootnodes: p.bootnodes,
 	}
@@ -156,13 +161,17 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 		}
 	}
 
-	for _, burnContract := range p.burnContracts {
-		block, addr, err := parseBurnContractInfo(burnContract)
-		if err != nil {
-			return err
-		}
+	if len(p.burnContracts) > 0 {
+		chainConfig.Params.BurnContract = map[uint64]string{}
 
-		chainConfig.Params.BurnContract[block] = addr.String()
+		for _, burnContract := range p.burnContracts {
+			block, addr, err := parseBurnContractInfo(burnContract)
+			if err != nil {
+				return err
+			}
+
+			chainConfig.Params.BurnContract[block] = addr.String()
+		}
 	}
 
 	validatorMetadata := make([]*polybft.ValidatorMetadata, len(initialValidators))

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -162,7 +162,7 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 	}
 
 	if len(p.burnContracts) > 0 {
-		chainConfig.Params.BurnContract = map[uint64]string{}
+		chainConfig.Params.BurnContract = make(map[uint64]string, len(p.burnContracts))
 
 		for _, burnContract := range p.burnContracts {
 			block, addr, err := parseBurnContractInfo(burnContract)
@@ -204,8 +204,6 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 		ExtraData:  genesisExtraData,
 		GasUsed:    command.DefaultGenesisGasUsed,
 		Mixhash:    polybft.PolyBFTMixDigest,
-		BaseFee:    chain.GenesisBaseFee,
-		BaseFeeEM:  chain.GenesisBaseFeeEM,
 	}
 
 	if len(p.contractDeployerAllowListAdmin) != 0 {
@@ -260,6 +258,13 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 			AdminAddresses:   stringSliceToAddressSlice(p.bridgeBlockListAdmin),
 			EnabledAddresses: stringSliceToAddressSlice(p.bridgeBlockListEnabled),
 		}
+	}
+
+	if len(p.burnContracts) > 0 {
+		// only populate base fee and base fee multiplier values if burn contract(s)
+		// is provided
+		chainConfig.Genesis.BaseFee = command.DefaultGenesisBaseFee
+		chainConfig.Genesis.BaseFeeEM = command.DefaultGenesisBaseFeeEM
 	}
 
 	return helper.WriteGenesisConfigToDisk(chainConfig, params.genesisPath)


### PR DESCRIPTION
# Description

Disable london hardfork if burn contract address is not provided when generating genesis file using CLI. 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually
