### PR TITLE
Fix RLP marshal byte array and enhancements to stake manager

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -229,7 +229,6 @@ func (c *consensusRuntime) initStakeManager(logger hcf.Logger) error {
 	c.stakeManager = newStakeManager(
 		logger.Named("stake-manager"),
 		c.state,
-		c.config.blockchain,
 		rootRelayer,
 		wallet.NewEcdsaSigner(c.config.Key),
 		contracts.ValidatorSetContract,

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -210,12 +210,6 @@ type systemStateMock struct {
 	mock.Mock
 }
 
-func (m *systemStateMock) GetStakeOnValidatorSet(validatorAddr types.Address) (*big.Int, error) {
-	args := m.Called()
-
-	return args.Get(0).(*big.Int), args.Error(1) //nolint:forcetypeassert
-}
-
 func (m *systemStateMock) GetNextCommittedIndex() (uint64, error) {
 	args := m.Called()
 

--- a/consensus/polybft/stake_manager.go
+++ b/consensus/polybft/stake_manager.go
@@ -354,7 +354,7 @@ func (sc *validatorStakeMap) removeStake(address types.Address, amount *big.Int)
 	stakeData.IsActive = stakeData.VotingPower.Cmp(bigZero) > 0
 }
 
-// getSorted returns all validators (*ValidatorMetadata) in sorted order
+// getSorted returns validators (*ValidatorMetadata) in sorted order
 func (sc validatorStakeMap) getSorted(maxValidatorSetSize int) AccountSet {
 	activeValidators := make(AccountSet, 0, len(sc))
 

--- a/consensus/polybft/stake_manager.go
+++ b/consensus/polybft/stake_manager.go
@@ -128,7 +128,7 @@ func (s *stakeManager) PostBlock(req *PostBlockRequest) error {
 			stakeMap.removeStake(event.From, event.Value)
 		} else {
 			// this should not happen, but lets log it if it does
-			s.logger.Debug("Found a transfer event that represents neither stake nor unstake")
+			s.logger.Warn("Found a transfer event that represents neither stake nor unstake")
 		}
 	}
 
@@ -166,7 +166,7 @@ func (s *stakeManager) UpdateValidatorSet(epoch uint64, oldValidatorSet AccountS
 	stakeMap := fullValidatorSet.Validators
 
 	// slice of all validator set
-	newValidatorSet := stakeMap.getActiveValidators(s.maxValidatorSetSize)
+	newValidatorSet := stakeMap.getSorted(s.maxValidatorSetSize)
 	// set of all addresses that will be in next validator set
 	addressesSet := make(map[types.Address]struct{}, len(newValidatorSet))
 
@@ -354,8 +354,8 @@ func (sc *validatorStakeMap) removeStake(address types.Address, amount *big.Int)
 	stakeData.IsActive = stakeData.VotingPower.Cmp(bigZero) > 0
 }
 
-// getActiveValidators returns all validators (*ValidatorMetadata) in sorted order
-func (sc validatorStakeMap) getActiveValidators(maxValidatorSetSize int) AccountSet {
+// getSorted returns all validators (*ValidatorMetadata) in sorted order
+func (sc validatorStakeMap) getSorted(maxValidatorSetSize int) AccountSet {
 	activeValidators := make(AccountSet, 0, len(sc))
 
 	for _, v := range sc {
@@ -387,7 +387,7 @@ func (sc validatorStakeMap) getActiveValidators(maxValidatorSetSize int) Account
 func (sc validatorStakeMap) String() string {
 	var sb strings.Builder
 
-	for _, x := range sc {
+	for _, x := range sc.getSorted(len(sc)) {
 		bls := ""
 		if x.BlsKey != nil {
 			bls = hex.EncodeToString(x.BlsKey.Marshal())

--- a/consensus/polybft/system_state.go
+++ b/consensus/polybft/system_state.go
@@ -26,8 +26,6 @@ type SystemState interface {
 	GetEpoch() (uint64, error)
 	// GetNextCommittedIndex retrieves next committed bridge state sync index
 	GetNextCommittedIndex() (uint64, error)
-	// GetStakeOnValidatorSet retrieves stake of given validator on ValidatorSet contract
-	GetStakeOnValidatorSet(validatorAddr types.Address) (*big.Int, error)
 }
 
 var _ SystemState = &SystemStateImpl{}
@@ -52,21 +50,6 @@ func NewSystemState(valSetAddr types.Address, stateRcvAddr types.Address, provid
 	)
 
 	return s
-}
-
-// GetStakeOnValidatorSet retrieves stake of given validator on ValidatorSet contract
-func (s *SystemStateImpl) GetStakeOnValidatorSet(validatorAddr types.Address) (*big.Int, error) {
-	rawResult, err := s.validatorContract.Call("balanceOf", ethgo.Latest, validatorAddr)
-	if err != nil {
-		return nil, err
-	}
-
-	balance, isOk := rawResult["0"].(*big.Int)
-	if !isOk {
-		return nil, fmt.Errorf("failed to decode balance")
-	}
-
-	return balance, nil
 }
 
 // GetEpoch retrieves current epoch number from the smart contract

--- a/consensus/polybft/system_state.go
+++ b/consensus/polybft/system_state.go
@@ -1,7 +1,6 @@
 package polybft
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/big"
 
@@ -99,24 +98,4 @@ func (s *SystemStateImpl) GetNextCommittedIndex() (uint64, error) {
 	}
 
 	return nextCommittedIndex.Uint64() + 1, nil
-}
-
-func buildLogsFromReceipts(entry []*types.Receipt, header *types.Header) []*types.Log {
-	var logs []*types.Log
-
-	for _, taskReceipt := range entry {
-		for _, taskLog := range taskReceipt.Logs {
-			log := new(types.Log)
-			*log = *taskLog
-
-			data := map[string]interface{}{
-				"Hash":   header.Hash,
-				"Number": header.Number,
-			}
-			log.Data, _ = json.Marshal(&data)
-			logs = append(logs, log)
-		}
-	}
-
-	return logs
 }

--- a/consensus/polybft/system_state_test.go
+++ b/consensus/polybft/system_state_test.go
@@ -2,7 +2,6 @@ package polybft
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"math/big"
 	"testing"
 
@@ -156,72 +155,4 @@ func newTestTransition(t *testing.T, alloc map[types.Address]*chain.GenesisAccou
 	assert.NoError(t, err)
 
 	return transition
-}
-
-func Test_buildLogsFromReceipts(t *testing.T) {
-	t.Parallel()
-
-	defaultHeader := &types.Header{
-		Number: 100,
-	}
-
-	type args struct {
-		entry  []*types.Receipt
-		header *types.Header
-	}
-
-	data := map[string]interface{}{
-		"Hash":   defaultHeader.Hash,
-		"Number": defaultHeader.Number,
-	}
-
-	dataArray, err := json.Marshal(&data)
-	require.NoError(t, err)
-
-	tests := []struct {
-		name string
-		args args
-		want []*types.Log
-	}{
-		{
-			name: "no entries provided",
-		},
-		{
-			name: "successfully created logs",
-			args: args{
-				entry: []*types.Receipt{
-					{
-						Logs: []*types.Log{
-							{
-								Address: types.BytesToAddress([]byte{0, 1}),
-								Topics:  nil,
-								Data:    dataArray,
-							},
-						},
-					},
-				},
-				header: defaultHeader,
-			},
-			want: []*types.Log{
-				{
-					Address: types.BytesToAddress([]byte{0, 1}),
-					Topics:  nil,
-					Data:    dataArray,
-				},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			assert.EqualValuesf(t,
-				tt.want,
-				buildLogsFromReceipts(tt.args.entry, tt.args.header),
-				"buildLogsFromReceipts(%v, %v)", tt.args.entry, tt.args.header,
-			)
-		})
-	}
 }

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.2
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
-	github.com/umbracle/fastrlp v0.1.0
+	github.com/umbracle/fastrlp v0.1.1-0.20230504065717-58a1b8a9929d
 	github.com/umbracle/go-eth-bn256 v0.0.0-20230125114011-47cb310d9b0b
 	golang.org/x/crypto v0.8.0
 	google.golang.org/grpc v1.56.0-dev

--- a/go.sum
+++ b/go.sum
@@ -680,8 +680,8 @@ github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/umbracle/ethgo v0.1.4-0.20230326234627-15b1df435098 h1:OXYAHR6AKpV2A/BjQNECXod9rR8r5XOT2QCakD2r0YQ=
 github.com/umbracle/ethgo v0.1.4-0.20230326234627-15b1df435098/go.mod h1:bjxSp984qsxCStKoKjqz5fgugi4uWj6+/tFkSEpjk3A=
-github.com/umbracle/fastrlp v0.1.0 h1:V0W3f6ZKWqbu1KggdhnRWOi+t7+PfL3VyAffJqayI5s=
-github.com/umbracle/fastrlp v0.1.0/go.mod h1:5RHgqiFjd4vLJESMWagP/E7su+5Gzk0iqqmrotR8WdA=
+github.com/umbracle/fastrlp v0.1.1-0.20230504065717-58a1b8a9929d h1:HAg1Kpr9buwRxEiC2UXU9oT2AU8uCU7o3/WTH+Lt5wo=
+github.com/umbracle/fastrlp v0.1.1-0.20230504065717-58a1b8a9929d/go.mod h1:5RHgqiFjd4vLJESMWagP/E7su+5Gzk0iqqmrotR8WdA=
 github.com/umbracle/go-eth-bn256 v0.0.0-20230125114011-47cb310d9b0b h1:5/xofhZiOG0I9DQXqDSPxqYObk6QI7mBGMJI+ngyIgc=
 github.com/umbracle/go-eth-bn256 v0.0.0-20230125114011-47cb310d9b0b/go.mod h1:H8SeC2PWEciymT92Mt07Qcfjr2FMEuCz/V+KPtPTy+U=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -331,8 +331,6 @@ func PadLeftOrTrim(bb []byte, size int) []byte {
 
 // ExtendByteSlice extends given byte slice by needLength parameter and trims it
 func ExtendByteSlice(b []byte, needLength int) []byte {
-	b = b[:cap(b)]
-
 	if n := needLength - len(b); n > 0 {
 		b = append(b, make([]byte, n)...)
 	}

--- a/types/rlp_encoding_test.go
+++ b/types/rlp_encoding_test.go
@@ -388,5 +388,5 @@ func Test_MarshalBug(t *testing.T) {
 
 	marshal(marshalTwo) // without fixing this, marshaling will cause corruption of the corrupted slice
 
-	require.NotEqual(t, emptyArray[:], corruptedSlice[:len(emptyArray)])
+	require.Equal(t, emptyArray[:], corruptedSlice[:len(emptyArray)])
 }

--- a/types/rlp_encoding_test.go
+++ b/types/rlp_encoding_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/umbracle/fastrlp"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type codec interface {
@@ -356,4 +357,36 @@ func testRLPData(arena *fastrlp.Arena, omitValues map[string]bool) []byte {
 	testData = vv.MarshalTo(testData)
 
 	return testData
+}
+
+func Test_MarshalBug(t *testing.T) {
+	t.Parallel()
+
+	marshal := func(obj func(*fastrlp.Arena) *fastrlp.Value) []byte {
+		ar := fastrlp.DefaultArenaPool.Get()
+		defer fastrlp.DefaultArenaPool.Put(ar)
+
+		return obj(ar).MarshalTo(nil)
+	}
+
+	emptyArray := [8]byte{}
+	corruptedSlice := make([]byte, 32)
+	corruptedSlice[29], corruptedSlice[30], corruptedSlice[31] = 5, 126, 64
+	intOfCorruption := uint64(18_446_744_073_709_551_615) // 2^64-1
+
+	marshalOne := func(ar *fastrlp.Arena) *fastrlp.Value {
+		return ar.NewBytes(corruptedSlice)
+	}
+
+	marshalTwo := func(ar *fastrlp.Arena) *fastrlp.Value {
+		return ar.NewUint(intOfCorruption)
+	}
+
+	marshal(marshalOne)
+
+	require.Equal(t, emptyArray[:], corruptedSlice[:len(emptyArray)])
+
+	marshal(marshalTwo) // without fixing this, marshaling will cause corruption of the corrupted slice
+
+	require.NotEqual(t, emptyArray[:], corruptedSlice[:len(emptyArray)])
 }

--- a/types/rlp_encoding_test.go
+++ b/types/rlp_encoding_test.go
@@ -359,7 +359,7 @@ func testRLPData(arena *fastrlp.Arena, omitValues map[string]bool) []byte {
 	return testData
 }
 
-func Test_MarshalBug(t *testing.T) {
+func Test_MarshalCorruptedBytesArray(t *testing.T) {
 	t.Parallel()
 
 	marshal := func(obj func(*fastrlp.Arena) *fastrlp.Value) []byte {

--- a/types/rlp_marshal.go
+++ b/types/rlp_marshal.go
@@ -75,12 +75,12 @@ func (h *Header) MarshalRLPTo(dst []byte) []byte {
 func (h *Header) MarshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 	vv := arena.NewArray()
 
-	vv.Set(arena.NewBytes(h.ParentHash.Bytes()))
-	vv.Set(arena.NewBytes(h.Sha3Uncles.Bytes()))
+	vv.Set(arena.NewCopyBytes(h.ParentHash.Bytes()))
+	vv.Set(arena.NewCopyBytes(h.Sha3Uncles.Bytes()))
 	vv.Set(arena.NewCopyBytes(h.Miner[:]))
-	vv.Set(arena.NewBytes(h.StateRoot.Bytes()))
-	vv.Set(arena.NewBytes(h.TxRoot.Bytes()))
-	vv.Set(arena.NewBytes(h.ReceiptsRoot.Bytes()))
+	vv.Set(arena.NewCopyBytes(h.StateRoot.Bytes()))
+	vv.Set(arena.NewCopyBytes(h.TxRoot.Bytes()))
+	vv.Set(arena.NewCopyBytes(h.ReceiptsRoot.Bytes()))
 	vv.Set(arena.NewCopyBytes(h.LogsBloom[:]))
 
 	vv.Set(arena.NewUint(h.Difficulty))
@@ -90,7 +90,7 @@ func (h *Header) MarshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 	vv.Set(arena.NewUint(h.Timestamp))
 
 	vv.Set(arena.NewCopyBytes(h.ExtraData))
-	vv.Set(arena.NewBytes(h.MixHash.Bytes()))
+	vv.Set(arena.NewCopyBytes(h.MixHash.Bytes()))
 	vv.Set(arena.NewCopyBytes(h.Nonce[:]))
 
 	vv.Set(arena.NewUint(h.BaseFee))
@@ -135,7 +135,7 @@ func (r *Receipt) MarshalRLPWith(a *fastrlp.Arena) *fastrlp.Value {
 	if r.Status != nil {
 		vv.Set(a.NewUint(uint64(*r.Status)))
 	} else {
-		vv.Set(a.NewBytes(r.Root[:]))
+		vv.Set(a.NewCopyBytes(r.Root[:]))
 	}
 
 	vv.Set(a.NewUint(r.CumulativeGasUsed))
@@ -163,15 +163,15 @@ func (r *Receipt) MarshalLogsWith(a *fastrlp.Arena) *fastrlp.Value {
 
 func (l *Log) MarshalRLPWith(a *fastrlp.Arena) *fastrlp.Value {
 	v := a.NewArray()
-	v.Set(a.NewBytes(l.Address.Bytes()))
+	v.Set(a.NewCopyBytes(l.Address.Bytes()))
 
 	topics := a.NewArray()
 	for _, t := range l.Topics {
-		topics.Set(a.NewBytes(t.Bytes()))
+		topics.Set(a.NewCopyBytes(t.Bytes()))
 	}
 
 	v.Set(topics)
-	v.Set(a.NewBytes(l.Data))
+	v.Set(a.NewCopyBytes(l.Data))
 
 	return v
 }
@@ -215,7 +215,7 @@ func (t *Transaction) MarshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 
 	// Address may be empty
 	if t.To != nil {
-		vv.Set(arena.NewBytes((*t.To).Bytes()))
+		vv.Set(arena.NewCopyBytes(t.To.Bytes()))
 	} else {
 		vv.Set(arena.NewNull())
 	}
@@ -237,7 +237,7 @@ func (t *Transaction) MarshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 	vv.Set(arena.NewBigInt(t.S))
 
 	if t.Type == StateTx {
-		vv.Set(arena.NewBytes((t.From).Bytes()))
+		vv.Set(arena.NewCopyBytes(t.From.Bytes()))
 	}
 
 	return vv

--- a/types/rlp_marshal.go
+++ b/types/rlp_marshal.go
@@ -42,7 +42,7 @@ func (b *Block) MarshalRLPWith(ar *fastrlp.Arena) *fastrlp.Value {
 		v0 := ar.NewArray()
 		for _, tx := range b.Transactions {
 			if tx.Type != LegacyTx {
-				v0.Set(ar.NewBytes([]byte{byte(tx.Type)}))
+				v0.Set(ar.NewCopyBytes([]byte{byte(tx.Type)}))
 			}
 
 			v0.Set(tx.MarshalRLPWith(ar))
@@ -75,13 +75,13 @@ func (h *Header) MarshalRLPTo(dst []byte) []byte {
 func (h *Header) MarshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 	vv := arena.NewArray()
 
-	vv.Set(arena.NewBytes(h.ParentHash.Bytes()))
-	vv.Set(arena.NewBytes(h.Sha3Uncles.Bytes()))
-	vv.Set(arena.NewBytes(h.Miner[:]))
-	vv.Set(arena.NewBytes(h.StateRoot.Bytes()))
-	vv.Set(arena.NewBytes(h.TxRoot.Bytes()))
-	vv.Set(arena.NewBytes(h.ReceiptsRoot.Bytes()))
-	vv.Set(arena.NewBytes(h.LogsBloom[:]))
+	vv.Set(arena.NewCopyBytes(h.ParentHash.Bytes()))
+	vv.Set(arena.NewCopyBytes(h.Sha3Uncles.Bytes()))
+	vv.Set(arena.NewCopyBytes(h.Miner[:]))
+	vv.Set(arena.NewCopyBytes(h.StateRoot.Bytes()))
+	vv.Set(arena.NewCopyBytes(h.TxRoot.Bytes()))
+	vv.Set(arena.NewCopyBytes(h.ReceiptsRoot.Bytes()))
+	vv.Set(arena.NewCopyBytes(h.LogsBloom[:]))
 
 	vv.Set(arena.NewUint(h.Difficulty))
 	vv.Set(arena.NewUint(h.Number))
@@ -89,9 +89,9 @@ func (h *Header) MarshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 	vv.Set(arena.NewUint(h.GasUsed))
 	vv.Set(arena.NewUint(h.Timestamp))
 
-	vv.Set(arena.NewBytes(h.ExtraData))
-	vv.Set(arena.NewBytes(h.MixHash.Bytes()))
-	vv.Set(arena.NewBytes(h.Nonce[:]))
+	vv.Set(arena.NewCopyBytes(h.ExtraData))
+	vv.Set(arena.NewCopyBytes(h.MixHash.Bytes()))
+	vv.Set(arena.NewCopyBytes(h.Nonce[:]))
 
 	vv.Set(arena.NewUint(h.BaseFee))
 
@@ -107,7 +107,7 @@ func (r *Receipts) MarshalRLPWith(a *fastrlp.Arena) *fastrlp.Value {
 
 	for _, rr := range *r {
 		if !rr.IsLegacyTx() {
-			vv.Set(a.NewBytes([]byte{byte(rr.TransactionType)}))
+			vv.Set(a.NewCopyBytes([]byte{byte(rr.TransactionType)}))
 		}
 
 		vv.Set(rr.MarshalRLPWith(a))
@@ -135,11 +135,11 @@ func (r *Receipt) MarshalRLPWith(a *fastrlp.Arena) *fastrlp.Value {
 	if r.Status != nil {
 		vv.Set(a.NewUint(uint64(*r.Status)))
 	} else {
-		vv.Set(a.NewBytes(r.Root[:]))
+		vv.Set(a.NewCopyBytes(r.Root[:]))
 	}
 
 	vv.Set(a.NewUint(r.CumulativeGasUsed))
-	vv.Set(a.NewBytes(r.LogsBloom[:]))
+	vv.Set(a.NewCopyBytes(r.LogsBloom[:]))
 	vv.Set(r.MarshalLogsWith(a))
 
 	return vv
@@ -163,15 +163,15 @@ func (r *Receipt) MarshalLogsWith(a *fastrlp.Arena) *fastrlp.Value {
 
 func (l *Log) MarshalRLPWith(a *fastrlp.Arena) *fastrlp.Value {
 	v := a.NewArray()
-	v.Set(a.NewBytes(l.Address.Bytes()))
+	v.Set(a.NewCopyBytes(l.Address.Bytes()))
 
 	topics := a.NewArray()
 	for _, t := range l.Topics {
-		topics.Set(a.NewBytes(t.Bytes()))
+		topics.Set(a.NewCopyBytes(t.Bytes()))
 	}
 
 	v.Set(topics)
-	v.Set(a.NewBytes(l.Data))
+	v.Set(a.NewCopyBytes(l.Data))
 
 	return v
 }
@@ -215,13 +215,13 @@ func (t *Transaction) MarshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 
 	// Address may be empty
 	if t.To != nil {
-		vv.Set(arena.NewBytes(t.To.Bytes()))
+		vv.Set(arena.NewCopyBytes(t.To.Bytes()))
 	} else {
 		vv.Set(arena.NewNull())
 	}
 
 	vv.Set(arena.NewBigInt(t.Value))
-	vv.Set(arena.NewBytes(t.Input))
+	vv.Set(arena.NewCopyBytes(t.Input))
 
 	// Specify access list as per spec.
 	// This is needed to have the same format as other EVM chains do.
@@ -237,7 +237,7 @@ func (t *Transaction) MarshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 	vv.Set(arena.NewBigInt(t.S))
 
 	if t.Type == StateTx {
-		vv.Set(arena.NewBytes(t.From.Bytes()))
+		vv.Set(arena.NewCopyBytes(t.From.Bytes()))
 	}
 
 	return vv

--- a/types/rlp_marshal.go
+++ b/types/rlp_marshal.go
@@ -75,13 +75,13 @@ func (h *Header) MarshalRLPTo(dst []byte) []byte {
 func (h *Header) MarshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 	vv := arena.NewArray()
 
-	vv.Set(arena.NewCopyBytes(h.ParentHash.Bytes()))
-	vv.Set(arena.NewCopyBytes(h.Sha3Uncles.Bytes()))
-	vv.Set(arena.NewCopyBytes(h.Miner[:]))
-	vv.Set(arena.NewCopyBytes(h.StateRoot.Bytes()))
-	vv.Set(arena.NewCopyBytes(h.TxRoot.Bytes()))
-	vv.Set(arena.NewCopyBytes(h.ReceiptsRoot.Bytes()))
-	vv.Set(arena.NewCopyBytes(h.LogsBloom[:]))
+	vv.Set(arena.NewBytes(h.ParentHash.Bytes()))
+	vv.Set(arena.NewBytes(h.Sha3Uncles.Bytes()))
+	vv.Set(arena.NewBytes(h.Miner[:]))
+	vv.Set(arena.NewBytes(h.StateRoot.Bytes()))
+	vv.Set(arena.NewBytes(h.TxRoot.Bytes()))
+	vv.Set(arena.NewBytes(h.ReceiptsRoot.Bytes()))
+	vv.Set(arena.NewBytes(h.LogsBloom[:]))
 
 	vv.Set(arena.NewUint(h.Difficulty))
 	vv.Set(arena.NewUint(h.Number))
@@ -89,9 +89,9 @@ func (h *Header) MarshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 	vv.Set(arena.NewUint(h.GasUsed))
 	vv.Set(arena.NewUint(h.Timestamp))
 
-	vv.Set(arena.NewCopyBytes(h.ExtraData))
-	vv.Set(arena.NewCopyBytes(h.MixHash.Bytes()))
-	vv.Set(arena.NewCopyBytes(h.Nonce[:]))
+	vv.Set(arena.NewBytes(h.ExtraData))
+	vv.Set(arena.NewBytes(h.MixHash.Bytes()))
+	vv.Set(arena.NewBytes(h.Nonce[:]))
 
 	vv.Set(arena.NewUint(h.BaseFee))
 
@@ -135,11 +135,11 @@ func (r *Receipt) MarshalRLPWith(a *fastrlp.Arena) *fastrlp.Value {
 	if r.Status != nil {
 		vv.Set(a.NewUint(uint64(*r.Status)))
 	} else {
-		vv.Set(a.NewCopyBytes(r.Root[:]))
+		vv.Set(a.NewBytes(r.Root[:]))
 	}
 
 	vv.Set(a.NewUint(r.CumulativeGasUsed))
-	vv.Set(a.NewCopyBytes(r.LogsBloom[:]))
+	vv.Set(a.NewBytes(r.LogsBloom[:]))
 	vv.Set(r.MarshalLogsWith(a))
 
 	return vv
@@ -163,15 +163,15 @@ func (r *Receipt) MarshalLogsWith(a *fastrlp.Arena) *fastrlp.Value {
 
 func (l *Log) MarshalRLPWith(a *fastrlp.Arena) *fastrlp.Value {
 	v := a.NewArray()
-	v.Set(a.NewCopyBytes(l.Address.Bytes()))
+	v.Set(a.NewBytes(l.Address.Bytes()))
 
 	topics := a.NewArray()
 	for _, t := range l.Topics {
-		topics.Set(a.NewCopyBytes(t.Bytes()))
+		topics.Set(a.NewBytes(t.Bytes()))
 	}
 
 	v.Set(topics)
-	v.Set(a.NewCopyBytes(l.Data))
+	v.Set(a.NewBytes(l.Data))
 
 	return v
 }
@@ -215,13 +215,13 @@ func (t *Transaction) MarshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 
 	// Address may be empty
 	if t.To != nil {
-		vv.Set(arena.NewCopyBytes(t.To.Bytes()))
+		vv.Set(arena.NewBytes(t.To.Bytes()))
 	} else {
 		vv.Set(arena.NewNull())
 	}
 
 	vv.Set(arena.NewBigInt(t.Value))
-	vv.Set(arena.NewCopyBytes(t.Input))
+	vv.Set(arena.NewBytes(t.Input))
 
 	// Specify access list as per spec.
 	// This is needed to have the same format as other EVM chains do.
@@ -237,7 +237,7 @@ func (t *Transaction) MarshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
 	vv.Set(arena.NewBigInt(t.S))
 
 	if t.Type == StateTx {
-		vv.Set(arena.NewCopyBytes(t.From.Bytes()))
+		vv.Set(arena.NewBytes(t.From.Bytes()))
 	}
 
 	return vv


### PR DESCRIPTION
# Description

A bug is discovered in the `fastrlp` library in the `NewBytes` method. We should use `NewCopyBytes` wherever we have a non-transient slice/array, since `NewBytes` was not resetting memory properly. In a meanwhile, `fastrlp` library was fixed by wrapping `NewCopyBytes` function within the `NewBytes` (https://github.com/umbracle/fastrlp/pull/14), meaning that these two functions are interchangeable, so this PR updates the version of `fastrlp` library as well.
The stake manager is reverted to the behavior before the workaround for the bug in `fastrlp` is applied.

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backward-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [X] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually