### PR TITLE
Polybft adaptation for writing traces on all validators

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1,9 +1,12 @@
 package blockchain
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"math/big"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 
@@ -46,8 +49,8 @@ type Blockchain struct {
 	executor  Executor
 	txSigner  TxSigner
 
-	config  *chain.Chain // Config containing chain information
-	genesis types.Hash   // The hash of the genesis block
+	config  *Config    // Config containing chain information
+	genesis types.Hash // The hash of the genesis block
 
 	headersCache    *lru.Cache // LRU cache for the headers
 	difficultyCache *lru.Cache // LRU cache for the difficulty
@@ -101,6 +104,7 @@ type BlockResult struct {
 	Root     types.Hash
 	Receipts []*types.Receipt
 	TotalGas uint64
+	Trace    *types.Trace
 }
 
 // updateGasPriceAvg updates the rolling average value of the gas price
@@ -185,7 +189,7 @@ func (b *Blockchain) GetAvgGasPrice() *big.Int {
 func NewBlockchain(
 	logger hclog.Logger,
 	db storage.Storage,
-	config *chain.Chain,
+	config *Config,
 	consensus Verifier,
 	executor Executor,
 	txSigner TxSigner,
@@ -249,7 +253,7 @@ func (b *Blockchain) ComputeGenesis() error {
 		}
 
 		// validate that the genesis file in storage matches the chain.Genesis
-		if b.genesis != b.config.Genesis.Hash() {
+		if b.genesis != b.config.Chain.Genesis.Hash() {
 			return fmt.Errorf("genesis file does not match current genesis")
 		}
 
@@ -274,12 +278,12 @@ func (b *Blockchain) ComputeGenesis() error {
 		b.setCurrentHeader(header, diff)
 	} else {
 		// empty storage, write the genesis
-		if err := b.writeGenesis(b.config.Genesis); err != nil {
+		if err := b.writeGenesis(b.config.Chain.Genesis); err != nil {
 			return err
 		}
 	}
 
-	b.logger.Info("genesis", "hash", b.config.Genesis.Hash())
+	b.logger.Info("genesis", "hash", b.config.Chain.Genesis.Hash())
 
 	return nil
 }
@@ -326,7 +330,7 @@ func (b *Blockchain) CurrentTD() *big.Int {
 
 // Config returns the blockchain configuration
 func (b *Blockchain) Config() *chain.Params {
-	return b.config.Params
+	return b.config.Chain.Params
 }
 
 // GetHeader returns the block header using the hash
@@ -671,17 +675,17 @@ func (b *Blockchain) VerifyFinalizedBlock(block *types.Block) (*types.FullBlock,
 	}
 
 	// Do the initial block verification
-	receipts, err := b.verifyBlock(block)
+	blockResult, err := b.verifyBlock(block)
 	if err != nil {
 		return nil, err
 	}
 
-	return &types.FullBlock{Block: block, Receipts: receipts}, nil
+	return &types.FullBlock{Block: block, Receipts: blockResult.Receipts, Trace: blockResult.Trace}, nil
 }
 
 // verifyBlock does the base (common) block verification steps by
 // verifying the block body as well as the parent information
-func (b *Blockchain) verifyBlock(block *types.Block) ([]*types.Receipt, error) {
+func (b *Blockchain) verifyBlock(block *types.Block) (*BlockResult, error) {
 	// Make sure the block is present
 	if block == nil {
 		return nil, ErrNoBlock
@@ -693,12 +697,12 @@ func (b *Blockchain) verifyBlock(block *types.Block) ([]*types.Receipt, error) {
 	}
 
 	// Make sure the block body data is valid
-	receipts, err := b.verifyBlockBody(block)
+	blockResult, err := b.verifyBlockBody(block)
 	if err != nil {
 		return nil, err
 	}
 
-	return receipts, nil
+	return blockResult, nil
 }
 
 // verifyBlockParent makes sure that the child block is in line
@@ -756,7 +760,7 @@ func (b *Blockchain) verifyBlockParent(childBlock *types.Block) error {
 // - The trie roots match up (state, transactions, receipts, uncles)
 // - The receipts match up
 // - The execution result matches up
-func (b *Blockchain) verifyBlockBody(block *types.Block) ([]*types.Receipt, error) {
+func (b *Blockchain) verifyBlockBody(block *types.Block) (*BlockResult, error) {
 	// Make sure the Uncles root matches up
 	if hash := buildroot.CalculateUncleRoot(block.Uncles); hash != block.Header.Sha3Uncles {
 		b.logger.Error(fmt.Sprintf(
@@ -790,7 +794,7 @@ func (b *Blockchain) verifyBlockBody(block *types.Block) ([]*types.Receipt, erro
 		return nil, fmt.Errorf("unable to verify block execution result, %w", err)
 	}
 
-	return blockResult.Receipts, nil
+	return blockResult, nil
 }
 
 // verifyBlockResult verifies that the block transaction execution result
@@ -844,9 +848,7 @@ func (b *Blockchain) executeBlockTransactions(block *types.Block) (*BlockResult,
 		return nil, err
 	}
 
-	//nolint:godox
-	// TODO write trace ?
-	_, _, root := txn.Commit()
+	_, trace, root := txn.Commit()
 
 	// Append the receipts to the receipts cache
 	b.receiptsCache.Add(header.Hash, txn.Receipts())
@@ -855,6 +857,7 @@ func (b *Blockchain) executeBlockTransactions(block *types.Block) (*BlockResult,
 		Root:     root,
 		Receipts: txn.Receipts(),
 		TotalGas: txn.TotalGas(),
+		Trace:    trace,
 	}, nil
 }
 
@@ -890,6 +893,11 @@ func (b *Blockchain) WriteFullBlock(fblock *types.FullBlock, source string) erro
 	// Otherwise, a client might ask for a header once the receipt is valid,
 	// but before it is written into the storage
 	if err := b.db.WriteReceipts(block.Hash(), fblock.Receipts); err != nil {
+		return err
+	}
+
+	// write the trace
+	if err := b.writeTrace(fblock.Trace, header.Number); err != nil {
 		return err
 	}
 
@@ -1276,6 +1284,22 @@ func (b *Blockchain) writeFork(header *types.Header) error {
 
 	newForks = append(newForks, header.Hash)
 	if err := b.db.WriteForks(newForks); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// writeTrace writes the block trace to the file
+func (b *Blockchain) writeTrace(trace *types.Trace, blockNumber uint64) error {
+	raw, err := json.Marshal(trace)
+	if err != nil {
+		return err
+	}
+
+	consensusDir := filepath.Join(b.config.DataDir, "consensus")
+	if err := ioutil.WriteFile(
+		filepath.Join(consensusDir, fmt.Sprintf("trace_%d", blockNumber))+".json", raw, 0600); err != nil {
 		return err
 	}
 

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1299,7 +1299,7 @@ func (b *Blockchain) writeTrace(trace *types.Trace, blockNumber uint64) error {
 
 	consensusDir := filepath.Join(b.config.DataDir, "consensus")
 	if err := ioutil.WriteFile(
-		filepath.Join(consensusDir, fmt.Sprintf("trace_%d", blockNumber))+".json", raw, 0600); err != nil {
+		filepath.Join(consensusDir, fmt.Sprintf("trace_%d.json", blockNumber)), raw, 0600); err != nil {
 		return err
 	}
 

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -955,7 +955,7 @@ func TestCalculateGasLimit(t *testing.T) {
 				t.Fatalf("unable to construct the blockchain, %v", blockchainErr)
 			}
 
-			b.config.Params = &chain.Params{
+			b.config.Chain.Params = &chain.Params{
 				BlockGasTarget: tt.blockGasTarget,
 			}
 

--- a/blockchain/config.go
+++ b/blockchain/config.go
@@ -1,0 +1,9 @@
+package blockchain
+
+import "github.com/0xPolygon/polygon-edge/chain"
+
+// Config is the configuration for the blockchain
+type Config struct {
+	Chain   *chain.Chain // the reference to the chain configuration
+	DataDir string       // the base data directory for the client
+}

--- a/blockchain/testing.go
+++ b/blockchain/testing.go
@@ -144,7 +144,7 @@ func NewMockBlockchain(
 	var (
 		mockVerifier = &MockVerifier{}
 		executor     = &mockExecutor{}
-		config       = &chain.Chain{
+		chainConfig  = &chain.Chain{
 			Genesis: &chain.Genesis{
 				Number:   0,
 				GasLimit: 0,
@@ -185,7 +185,7 @@ func NewMockBlockchain(
 				return nil, errInvalidTypeAssertion
 			}
 
-			callback(config)
+			callback(chainConfig)
 		}
 
 		// Execute the storage callback
@@ -204,7 +204,7 @@ func NewMockBlockchain(
 		db:        mockStorage,
 		consensus: mockVerifier,
 		executor:  executor,
-		config:    config,
+		config:    &Config{Chain: chainConfig},
 		stream:    &eventStream{},
 		gpAverage: &gasPriceAverage{
 			price: big.NewInt(0),
@@ -347,7 +347,7 @@ func newBlockChain(config *chain.Chain, executor Executor) (*Blockchain, error) 
 		return nil, err
 	}
 
-	b, err := NewBlockchain(hclog.NewNullLogger(), db, config, &MockVerifier{}, executor, &mockSigner{})
+	b, err := NewBlockchain(hclog.NewNullLogger(), db, &Config{Chain: config}, &MockVerifier{}, executor, &mockSigner{})
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -108,9 +108,8 @@ func (b *BlockBuilder) Build(handler func(h *types.Header)) (*types.FullBlock, e
 		handler(b.header)
 	}
 
-	//nolint:godox
-	// TODO write trace
-	_, _, b.header.StateRoot = b.state.Commit()
+	_, trace, root := b.state.Commit()
+	b.header.StateRoot = root
 	b.header.GasUsed = b.state.TotalGas()
 
 	// build the block
@@ -125,6 +124,7 @@ func (b *BlockBuilder) Build(handler func(h *types.Header)) (*types.FullBlock, e
 	return &types.FullBlock{
 		Block:    b.block,
 		Receipts: b.state.Receipts(),
+		Trace:    trace,
 	}, nil
 }
 

--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -106,9 +106,7 @@ func (p *blockchainWrapper) ProcessBlock(parent *types.Header, block *types.Bloc
 		}
 	}
 
-	//nolint:godox
-	// TODO write trace
-	_, _, root := transition.Commit()
+	_, trace, root := transition.Commit()
 
 	if root != block.Header.StateRoot {
 		return nil, fmt.Errorf("incorrect state root: (%s, %s)", root, block.Header.StateRoot)
@@ -124,6 +122,7 @@ func (p *blockchainWrapper) ProcessBlock(parent *types.Header, block *types.Bloc
 	return &types.FullBlock{
 		Block:    builtBlock,
 		Receipts: transition.Receipts(),
+		Trace:    trace,
 	}, nil
 }
 

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"path"
@@ -13,6 +15,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/e2e-polybft/framework"
+	"github.com/0xPolygon/polygon-edge/server/proto"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/require"
@@ -698,4 +701,85 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 		}, nonMinterAcc.Ecdsa)
 	require.NoError(t, err)
 	require.Equal(t, uint64(types.ReceiptFailed), receipt.Status)
+}
+
+func TestE2E_Consensus_Trace(t *testing.T) {
+	const (
+		validatorSecrets = "test-chain-1"
+		newAccSecrets    = "test-chain-newAcc"
+		epochSize        = 5
+		validatorCount   = 5
+	)
+
+	cluster := framework.NewTestCluster(t, validatorCount,
+		framework.WithEpochReward(100000),
+		framework.WithEpochSize(epochSize))
+	defer cluster.Stop()
+
+	// init new account
+	_, err := cluster.InitSecrets(newAccSecrets, 1)
+	require.NoError(t, err)
+
+	cluster.WaitForReady(t)
+
+	// extract new acc secrets
+	newAccSecretsPath := path.Join(cluster.Config.TmpDir, newAccSecrets)
+	newAcc, err := sidechain.GetAccountFromDir(newAccSecretsPath)
+	require.NoError(t, err)
+
+	newAccAddr := newAcc.Ecdsa.Address()
+
+	// extract validator's secrets
+	validatorSecretsPath := path.Join(cluster.Config.TmpDir, validatorSecrets)
+
+	validatorAcc, err := sidechain.GetAccountFromDir(validatorSecretsPath)
+	require.NoError(t, err)
+
+	validatorAddr := validatorAcc.Ecdsa.Address()
+
+	// transfer funds to the new account
+	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(cluster.Servers[0].JSONRPCAddr()))
+	require.NoError(t, err)
+
+	receipt, err := txRelayer.SendTransaction(&ethgo.Transaction{
+		From:  validatorAddr,
+		To:    &newAccAddr,
+		Value: ethgo.Ether(2),
+	}, validatorAcc.Ecdsa)
+	require.NoError(t, err)
+	require.Equal(t, uint64(types.ReceiptSuccess), receipt.Status)
+	require.NotNil(t, receipt.TransactionHash)
+
+	// verify trace existence on all validators
+	for i := 0; i < validatorCount; i++ {
+		ethEndpoint := cluster.Servers[i].JSONRPC().Eth()
+
+		blockResponse, err := ethEndpoint.GetBlockByNumber(ethgo.BlockNumber(receipt.BlockNumber), false)
+		require.NoError(t, err)
+		require.NotEqual(t, blockResponse.Miner, ethgo.ZeroAddress)
+
+		sysClient := cluster.Servers[i].Conn()
+		traceResp, err := sysClient.GetTrace(context.Background(), &proto.GetTraceRequest{Number: receipt.BlockNumber})
+		require.NoError(t, err)
+
+		var trace *types.Trace
+		err = json.Unmarshal(traceResp.Trace, &trace)
+		require.NoError(t, err)
+
+		containsCoinbaseAddr, containsSenderAddr, containsReceiverAddr := false, false, false
+
+		var journalEntry *types.JournalEntry
+
+		for _, tr := range trace.TxnTraces {
+			_, containsCoinbaseAddr = tr.Delta[types.Address(blockResponse.Miner)]
+			_, containsSenderAddr = tr.Delta[types.Address(validatorAddr)]
+
+			journalEntry, containsReceiverAddr = tr.Delta[types.Address(newAccAddr)]
+			require.True(t, journalEntry.Balance.Cmp(ethgo.Ether(2)) == 0)
+		}
+
+		require.True(t, containsCoinbaseAddr)
+		require.True(t, containsSenderAddr)
+		require.True(t, containsReceiverAddr)
+	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -267,7 +267,9 @@ func NewServer(config *Config) (*Server, error) {
 	}
 
 	// blockchain object
-	m.blockchain, err = blockchain.NewBlockchain(logger, db, config.Chain, nil, m.executor, signer)
+	blockchainConfig := &blockchain.Config{Chain: config.Chain, DataDir: config.DataDir}
+	m.blockchain, err = blockchain.NewBlockchain(logger, db, blockchainConfig, nil, m.executor, signer)
+
 	if err != nil {
 		return nil, err
 	}

--- a/types/header.go
+++ b/types/header.go
@@ -94,6 +94,7 @@ type Body struct {
 type FullBlock struct {
 	Block    *Block
 	Receipts []*Receipt
+	Trace    *Trace
 }
 
 type Block struct {


### PR DESCRIPTION
Before this PR, trace was written only for ibft protocol (on proposer node). Polybft protocol is added to feat-zero branch in previous commit when the 0.8.1 version of edge is merged into it but the trace functionality is not integrated for polybft at that moment.
This PR adds:
- support for writing traces for polybft protocol in all cases (does not meter if the block is added by consensus or by syncer, or the note is proposer or regular validator). This means that queering any validator node to get the trace for block n will return result.
This PR does not fix the issue on ibft related to the fact that the trace for the block n is written only on validator for block n (it is plan to use polybft for zero integration)

The changes include:
- extending FullBlock type with the Trace
- adding new config type for the blockchain, it wraps existing chain config and adds data dir which is needed when writing trace on block insertion
- trace data is added to the full block when: 
  - the proposer builds the block (and saves it in the fsm target for the later insertion in the blockchain),  
  - the validator process received block from the consensus (and saves it in the fsm target for the later insertion in the blockchain),
  - the syncer receives the block which will be inserted to the blockchain  


# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
