### PR TITLE
[RFC-201/205] Event log data issue workaround fix

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -221,7 +221,7 @@ func (c *consensusRuntime) initCheckpointManager(logger hcf.Logger) error {
 
 // initStakeManager initializes stake manager
 func (c *consensusRuntime) initStakeManager(logger hcf.Logger) error {
-	txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(c.config.PolyBFTConfig.Bridge.JSONRPCEndpoint))
+	rootRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(c.config.PolyBFTConfig.Bridge.JSONRPCEndpoint))
 	if err != nil {
 		return err
 	}
@@ -229,7 +229,8 @@ func (c *consensusRuntime) initStakeManager(logger hcf.Logger) error {
 	c.stakeManager = newStakeManager(
 		logger.Named("stake-manager"),
 		c.state,
-		txRelayer,
+		c.config.blockchain,
+		rootRelayer,
 		wallet.NewEcdsaSigner(c.config.Key),
 		contracts.ValidatorSetContract,
 		c.config.PolyBFTConfig.Bridge.CustomSupernetManagerAddr,

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -210,19 +210,10 @@ type systemStateMock struct {
 	mock.Mock
 }
 
-func (m *systemStateMock) GetValidatorSet() (AccountSet, error) {
+func (m *systemStateMock) GetStakeOnValidatorSet(validatorAddr types.Address) (*big.Int, error) {
 	args := m.Called()
-	if len(args) == 1 {
-		accountSet, _ := args.Get(0).(AccountSet)
 
-		return accountSet, nil
-	} else if len(args) == 2 {
-		accountSet, _ := args.Get(0).(AccountSet)
-
-		return accountSet, args.Error(1)
-	}
-
-	panic("systemStateMock.GetValidatorSet doesn't support such combination of arguments") //nolint:gocritic
+	return args.Get(0).(*big.Int), args.Error(1) //nolint:forcetypeassert
 }
 
 func (m *systemStateMock) GetNextCommittedIndex() (uint64, error) {

--- a/consensus/polybft/stake_manager.go
+++ b/consensus/polybft/stake_manager.go
@@ -144,13 +144,7 @@ func (s *stakeManager) PostBlock(req *PostBlockRequest) error {
 				return fmt.Errorf("could not retrieve balance of validator %v on ValidatorSet", a)
 			}
 
-			validator, exists := stakeMap[a]
-			if !exists {
-				stakeMap.setStake(a, stake)
-			} else {
-				validator.VotingPower = stake
-				validator.IsActive = validator.VotingPower.Cmp(bigZero) > 0
-			}
+			stakeMap.setStake(a, stake)
 		}
 	}
 

--- a/consensus/polybft/stake_manager.go
+++ b/consensus/polybft/stake_manager.go
@@ -117,6 +117,7 @@ func (s *stakeManager) PostBlock(req *PostBlockRequest) error {
 	stakeMap := fullValidatorSet.Validators
 
 	updatedValidatorsBalance := make(map[types.Address]struct{}, 0)
+
 	for _, event := range events {
 		if event.IsStake() {
 			updatedValidatorsBalance[event.To] = struct{}{}
@@ -359,6 +360,7 @@ func newValidatorStakeMap(validatorSet AccountSet) validatorStakeMap {
 // setStake sets given amount of stake to a validator defined by address
 func (sc *validatorStakeMap) setStake(address types.Address, amount *big.Int) {
 	isActive := amount.Cmp(bigZero) > 0
+
 	if metadata, exists := (*sc)[address]; exists {
 		metadata.VotingPower = amount
 		metadata.IsActive = isActive

--- a/consensus/polybft/stake_manager.go
+++ b/consensus/polybft/stake_manager.go
@@ -128,6 +128,8 @@ func (s *stakeManager) PostBlock(req *PostBlockRequest) error {
 		}
 	}
 
+	// this is a temporary solution (a workaround) for a bug where amount
+	// in transfer event is not correctly generated (unknown 4 bytes are added to begging of Data array)
 	if len(updatedValidatorsBalance) > 0 {
 		provider, err := s.blockchain.GetStateProviderForBlock(req.FullBlock.Block.Header)
 		if err != nil {

--- a/consensus/polybft/stake_manager.go
+++ b/consensus/polybft/stake_manager.go
@@ -51,6 +51,7 @@ type stakeManager struct {
 	logger                  hclog.Logger
 	state                   *State
 	rootChainRelayer        txrelayer.TxRelayer
+	blockchain              blockchainBackend
 	key                     ethgo.Key
 	validatorSetContract    types.Address
 	supernetManagerContract types.Address
@@ -61,7 +62,8 @@ type stakeManager struct {
 func newStakeManager(
 	logger hclog.Logger,
 	state *State,
-	relayer txrelayer.TxRelayer,
+	blockchain blockchainBackend,
+	rootchainRelayer txrelayer.TxRelayer,
 	key ethgo.Key,
 	validatorSetAddr, supernetManagerAddr types.Address,
 	maxValidatorSetSize int,
@@ -69,7 +71,8 @@ func newStakeManager(
 	return &stakeManager{
 		logger:                  logger,
 		state:                   state,
-		rootChainRelayer:        relayer,
+		blockchain:              blockchain,
+		rootChainRelayer:        rootchainRelayer,
 		key:                     key,
 		validatorSetContract:    validatorSetAddr,
 		supernetManagerContract: supernetManagerAddr,
@@ -113,16 +116,38 @@ func (s *stakeManager) PostBlock(req *PostBlockRequest) error {
 
 	stakeMap := fullValidatorSet.Validators
 
+	updatedValidatorsBalance := make(map[types.Address]struct{}, 0)
 	for _, event := range events {
 		if event.IsStake() {
-			// then this amount was minted To validator address
-			stakeMap.addStake(event.To, event.Value)
+			updatedValidatorsBalance[event.To] = struct{}{}
 		} else if event.IsUnstake() {
-			// then this amount was burned From validator address
-			stakeMap.removeStake(event.From, event.Value)
+			updatedValidatorsBalance[event.From] = struct{}{}
 		} else {
-			// this should not happen, but lets log it if it does
 			s.logger.Debug("Found a transfer event that represents neither stake nor unstake")
+		}
+	}
+
+	if len(updatedValidatorsBalance) > 0 {
+		provider, err := s.blockchain.GetStateProviderForBlock(req.FullBlock.Block.Header)
+		if err != nil {
+			return err
+		}
+
+		systemState := s.blockchain.GetSystemState(provider)
+
+		for a := range updatedValidatorsBalance {
+			balance, err := systemState.GetStakeOnValidatorSet(a)
+			if err != nil {
+				return fmt.Errorf("could not retrieve balance of validator %v on ValidatorSet", a)
+			}
+
+			validator, exists := stakeMap[a]
+			if !exists {
+				stakeMap.setStake(a, balance)
+			} else {
+				validator.VotingPower = balance
+				validator.IsActive = validator.VotingPower.Cmp(bigZero) > 0
+			}
 		}
 	}
 
@@ -234,7 +259,9 @@ func (s *stakeManager) getTransferEventsFromReceipts(receipts []*types.Receipt) 
 
 			var transferEvent contractsapi.TransferEvent
 
-			doesMatch, err := transferEvent.ParseLog(convertLog(log))
+			convertedLog := convertLog(log)
+
+			doesMatch, err := transferEvent.ParseLog(convertedLog)
 			if err != nil {
 				return nil, err
 			}
@@ -329,25 +356,19 @@ func newValidatorStakeMap(validatorSet AccountSet) validatorStakeMap {
 	return stakeMap
 }
 
-// addStake adds given amount to a validator defined by address
-func (sc *validatorStakeMap) addStake(address types.Address, amount *big.Int) {
+// setStake sets given amount of stake to a validator defined by address
+func (sc *validatorStakeMap) setStake(address types.Address, amount *big.Int) {
+	isActive := amount.Cmp(bigZero) > 0
 	if metadata, exists := (*sc)[address]; exists {
-		metadata.VotingPower.Add(metadata.VotingPower, amount)
-		metadata.IsActive = metadata.VotingPower.Cmp(bigZero) > 0
+		metadata.VotingPower = amount
+		metadata.IsActive = isActive
 	} else {
 		(*sc)[address] = &ValidatorMetadata{
 			VotingPower: new(big.Int).Set(amount),
 			Address:     address,
-			IsActive:    true,
+			IsActive:    isActive,
 		}
 	}
-}
-
-// removeStake removes given amount from validator defined by address
-func (sc *validatorStakeMap) removeStake(address types.Address, amount *big.Int) {
-	stakeData := (*sc)[address]
-	stakeData.VotingPower.Sub(stakeData.VotingPower, amount)
-	stakeData.IsActive = stakeData.VotingPower.Cmp(bigZero) > 0
 }
 
 // getActiveValidators returns all validators (*ValidatorMetadata) in sorted order

--- a/consensus/polybft/stake_manager_test.go
+++ b/consensus/polybft/stake_manager_test.go
@@ -120,6 +120,7 @@ func TestStakeManager_PostBlock(t *testing.T) {
 	fullValidatorSet, err := state.StakeStore.getFullValidatorSet()
 	require.NoError(t, err)
 	require.Len(t, fullValidatorSet.Validators, len(allAliases))
+
 	for _, v := range fullValidatorSet.Validators {
 		require.Equal(t, newStake, v.VotingPower.Uint64())
 	}

--- a/consensus/polybft/system_state.go
+++ b/consensus/polybft/system_state.go
@@ -27,6 +27,8 @@ type SystemState interface {
 	GetEpoch() (uint64, error)
 	// GetNextCommittedIndex retrieves next committed bridge state sync index
 	GetNextCommittedIndex() (uint64, error)
+	// GetStakeOnValidatorSet retrieves stake of given validator on ValidatorSet contract
+	GetStakeOnValidatorSet(validatorAddr types.Address) (*big.Int, error)
 }
 
 var _ SystemState = &SystemStateImpl{}
@@ -51,6 +53,22 @@ func NewSystemState(valSetAddr types.Address, stateRcvAddr types.Address, provid
 	)
 
 	return s
+}
+
+// GetStakeOnValidatorSet retrieves stake of given validator on ValidatorSet contract
+func (s *SystemStateImpl) GetStakeOnValidatorSet(validatorAddr types.Address) (*big.Int, error) {
+	rawResult, err := s.validatorContract.Call("balanceOf", ethgo.Latest, validatorAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	balance, isOk := rawResult["0"].(*big.Int)
+
+	if !isOk {
+		return nil, fmt.Errorf("failed to decode balance")
+	}
+
+	return balance, nil
 }
 
 // GetEpoch retrieves current epoch number from the smart contract

--- a/consensus/polybft/system_state.go
+++ b/consensus/polybft/system_state.go
@@ -63,7 +63,6 @@ func (s *SystemStateImpl) GetStakeOnValidatorSet(validatorAddr types.Address) (*
 	}
 
 	balance, isOk := rawResult["0"].(*big.Int)
-
 	if !isOk {
 		return nil, fmt.Errorf("failed to decode balance")
 	}


### PR DESCRIPTION
# Description

While testing RFC-201/205 changes with validator stake and storage rework, a strange issue occurred while getting `ERC20 Transfer` event logs from transaction receipts, where `Data` field in the log is not correctly generated in some validator nodes. 

`Transfer` event is emitted in the `ValidatorSet` contract when validator stake is transferred from root to child chain. In some of the nodes, once the `opLog` is executed for the given event log, the `Data` field of the log (which carries the amount of tokens the validator staked), gets incorrectly generated (4 bytes are added to the beginning of the array which should not be there). This is a random behavior and happens in random nodes. A number of nodes generate correct data field on the log, but random number of nodes, does not.

It looks like this only happens when `Data` field in logs is a `big.Int`.

This PR offers  a workaround for updating validator stake (voting power) on client, by reading the balance of the validator on the `ValidatorSet` contract directly, without using the amount in the parsed event.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually