### PR TITLE
Provide mintable parameter as a part of native token config

### DIFF
--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -219,18 +219,12 @@ func setFlags(cmd *cobra.Command) {
 			"trie root from the corresponding triedb",
 		)
 
-		cmd.Flags().BoolVar(
-			&params.mintableNativeToken,
-			mintableTokenFlag,
-			false,
-			"flag indicate whether mintable or non-mintable native token is deployed",
-		)
-
 		cmd.Flags().StringVar(
 			&params.nativeTokenConfigRaw,
 			nativeTokenConfigFlag,
 			"",
-			"configuration of native token in format <name:symbol:decimals count>",
+			"configuration of native token in format <name:symbol:decimals:mintable count>"+
+				"or <name:symbol:decimals:mintable count> if using mintable token",
 		)
 
 		cmd.Flags().StringVar(

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -223,8 +223,7 @@ func setFlags(cmd *cobra.Command) {
 			&params.nativeTokenConfigRaw,
 			nativeTokenConfigFlag,
 			"",
-			"configuration of native token in format <name:symbol:decimals:mintable count>"+
-				"or <name:symbol:decimals:mintable count> if using mintable token",
+			"configuration of native token in format <name:symbol:decimals count:mintable flag>",
 		)
 
 		cmd.Flags().StringVar(

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -490,20 +490,13 @@ func (p *genesisParams) extractNativeTokenMetadata() error {
 		return errInvalidTokenParams
 	}
 
-	p.nativeTokenConfig = &polybft.TokenConfig{
-		Name:       defaultNativeTokenName,
-		Symbol:     defaultNativeTokenSymbol,
-		Decimals:   defaultNativeTokenDecimals,
-		IsMintable: false,
-	}
-
-	p.nativeTokenConfig.Name = strings.TrimSpace(params[0])
-	if p.nativeTokenConfig.Name == "" {
+	name := strings.TrimSpace(params[0])
+	if name == "" {
 		return errInvalidTokenParams
 	}
 
-	p.nativeTokenConfig.Symbol = strings.TrimSpace(params[1])
-	if p.nativeTokenConfig.Symbol == "" {
+	symbol := strings.TrimSpace(params[1])
+	if symbol == "" {
 		return errInvalidTokenParams
 	}
 
@@ -512,14 +505,17 @@ func (p *genesisParams) extractNativeTokenMetadata() error {
 		return errInvalidTokenParams
 	}
 
-	p.nativeTokenConfig.Decimals = uint8(decimals)
-
 	isMintable, err := strconv.ParseBool(strings.TrimSpace(params[3]))
 	if err != nil {
 		return errInvalidTokenParams
 	}
 
-	p.nativeTokenConfig.IsMintable = isMintable
+	p.nativeTokenConfig = &polybft.TokenConfig{
+		Name:       name,
+		Symbol:     symbol,
+		Decimals:   uint8(decimals),
+		IsMintable: isMintable,
+	}
 
 	return nil
 }

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -366,7 +366,7 @@ func (p *genesisParams) deployContracts(totalStake *big.Int,
 		},
 	}
 
-	if !params.nativeTokenConfig.Mintable {
+	if !params.nativeTokenConfig.IsMintable {
 		genesisContracts = append(genesisContracts,
 			&contractInfo{artifact: contractsapi.NativeERC20, address: contracts.NativeERC20TokenContract})
 	} else {

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -143,7 +143,6 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 		// use 1st account as governance address
 		Governance:           initialValidators[0].Address,
 		InitialTrieRoot:      types.StringToHash(p.initialStateRoot),
-		MintableNativeToken:  p.mintableNativeToken,
 		NativeTokenConfig:    p.nativeTokenConfig,
 		BridgeAllowListAdmin: bridgeAllowListAdmin,
 		BridgeBlockListAdmin: bridgeBlockListAdmin,
@@ -367,7 +366,7 @@ func (p *genesisParams) deployContracts(totalStake *big.Int,
 		},
 	}
 
-	if !params.mintableNativeToken {
+	if !params.nativeTokenConfig.Mintable {
 		genesisContracts = append(genesisContracts,
 			&contractInfo{artifact: contractsapi.NativeERC20, address: contracts.NativeERC20TokenContract})
 	} else {

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -215,7 +215,7 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 			rootNativeERC20Token = polyBFTConfig.Bridge.RootNativeERC20Addr
 		}
 
-		if polyBFTConfig.MintableNativeToken {
+		if polyBFTConfig.NativeTokenConfig.Mintable {
 			// initialize NativeERC20Mintable SC
 			params := &contractsapi.InitializeNativeERC20MintableFn{
 				Predicate_: contracts.ChildERC20PredicateContract,

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -215,7 +215,7 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 			rootNativeERC20Token = polyBFTConfig.Bridge.RootNativeERC20Addr
 		}
 
-		if polyBFTConfig.NativeTokenConfig.Mintable {
+		if polyBFTConfig.NativeTokenConfig.IsMintable {
 			// initialize NativeERC20Mintable SC
 			params := &contractsapi.InitializeNativeERC20MintableFn{
 				Predicate_: contracts.ChildERC20PredicateContract,

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -236,10 +236,10 @@ func (r *RootchainConfig) ToBridgeConfig() *BridgeConfig {
 
 // TokenConfig is the configuration of native token used by edge network
 type TokenConfig struct {
-	Name     string `json:"name"`
-	Symbol   string `json:"symbol"`
-	Decimals uint8  `json:"decimals"`
-	Mintable bool   `json:"mintable"`
+	Name       string `json:"name"`
+	Symbol     string `json:"symbol"`
+	Decimals   uint8  `json:"decimals"`
+	IsMintable bool   `json:"isMintable"`
 }
 
 type RewardsConfig struct {

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -37,9 +37,6 @@ type PolyBFTConfig struct {
 	// Governance is the initial governance address
 	Governance types.Address `json:"governance"`
 
-	// MintableNativeToken denotes whether mintable native token is used
-	MintableNativeToken bool `json:"mintableNative"`
-
 	// NativeTokenConfig defines name, symbol and decimal count of the native token
 	NativeTokenConfig *TokenConfig `json:"nativeTokenConfig"`
 
@@ -242,6 +239,7 @@ type TokenConfig struct {
 	Name     string `json:"name"`
 	Symbol   string `json:"symbol"`
 	Decimals uint8  `json:"decimals"`
+	Mintable bool   `json:"mintable"`
 }
 
 type RewardsConfig struct {

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -458,7 +458,7 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 
 	cluster := framework.NewTestCluster(t,
 		validatorCount,
-		framework.WithNativeTokenConfig(fmt.Sprintf("%s:%s:%d:mintable", tokenName, tokenSymbol, decimals)),
+		framework.WithNativeTokenConfig(fmt.Sprintf("%s:%s:%d:true", tokenName, tokenSymbol, decimals)),
 		framework.WithEpochSize(epochSize),
 		framework.WithSecretsCallback(func(addrs []types.Address, config *framework.TestClusterConfig) {
 			for i, addr := range addrs {

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -458,8 +458,7 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 
 	cluster := framework.NewTestCluster(t,
 		validatorCount,
-		framework.WithMintableNativeToken(true),
-		framework.WithNativeTokenConfig(fmt.Sprintf("%s:%s:%d", tokenName, tokenSymbol, decimals)),
+		framework.WithNativeTokenConfig(fmt.Sprintf("%s:%s:%d:mintable", tokenName, tokenSymbol, decimals)),
 		framework.WithEpochSize(epochSize),
 		framework.WithSecretsCallback(func(addrs []types.Address, config *framework.TestClusterConfig) {
 			for i, addr := range addrs {

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -76,7 +76,6 @@ type TestClusterConfig struct {
 	Premine              []string // address[:amount]
 	PremineValidators    []string // address[:amount]
 	StakeAmounts         []string // address[:amount]
-	MintableNativeToken  bool
 	WithoutBridge        bool
 	BootnodeCount        int
 	NonValidatorCount    int
@@ -197,12 +196,6 @@ func WithPremine(addresses ...types.Address) ClusterOption {
 		for _, a := range addresses {
 			h.Premine = append(h.Premine, a.String())
 		}
-	}
-}
-
-func WithMintableNativeToken(mintableToken bool) ClusterOption {
-	return func(h *TestClusterConfig) {
-		h.MintableNativeToken = mintableToken
 	}
 }
 
@@ -476,10 +469,6 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 			for _, premine := range cluster.Config.Premine {
 				args = append(args, "--premine", premine)
 			}
-		}
-
-		if cluster.Config.MintableNativeToken {
-			args = append(args, "--mintable-native-token")
 		}
 
 		if len(cluster.Config.BurnContracts) != 0 {


### PR DESCRIPTION
# Description

This PR makes mintable native token configuration as part of native token config. It is provided using the `native-token-config` flag in the `genesis` command. Format of this value is `<name:symbol:decimals count:mintable flag>` (e.g. "Test:TEST:10:true").

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
