### PR TITLE
Fix Lint GH workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          args: --timeout 10m
+          args: --timeout 10m --verbose

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,10 +2,13 @@
 name: Lint
 on:  # yamllint disable-line rule:truthy
   push:
+    branches:
+      - '*'
     tags-ignore:
       - 'v*'
     paths:
       - '**.go'
+    pull_request:
   workflow_call: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,6 @@
 name: Lint
 on:  # yamllint disable-line rule:truthy
   push:
-    branches-ignore:
-      - 'develop'
-      - 'release/**'
     tags-ignore:
       - 'v*'
     paths:
@@ -26,3 +23,5 @@ jobs:
 
       - name: Lint
         uses: golangci/golangci-lint-action@v3
+        with:
+          args: --timeout 10m


### PR DESCRIPTION
# Description

Linting GH workflow does not get triggered on some occasions (most notable is external collaborators' pull requests. E.g.: https://github.com/0xPolygon/polygon-edge/pull/1503). This PR tries to fix that, by removing ignored branches.

Also, it is noticed that linting can fail due to timeout elapses, which is mitigated by increasing the timeout.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually