### PR TITLE
Set parent state root to the trace

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -849,6 +849,7 @@ func (b *Blockchain) executeBlockTransactions(block *types.Block) (*BlockResult,
 	}
 
 	_, trace, root := txn.Commit()
+	trace.ParentStateRoot = parent.StateRoot
 
 	// Append the receipts to the receipts cache
 	b.receiptsCache.Add(header.Hash, txn.Receipts())

--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -109,6 +109,7 @@ func (b *BlockBuilder) Build(handler func(h *types.Header)) (*types.FullBlock, e
 	}
 
 	_, trace, root := b.state.Commit()
+	trace.ParentStateRoot = b.params.Parent.StateRoot
 	b.header.StateRoot = root
 	b.header.GasUsed = b.state.TotalGas()
 

--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -107,6 +107,7 @@ func (p *blockchainWrapper) ProcessBlock(parent *types.Header, block *types.Bloc
 	}
 
 	_, trace, root := transition.Commit()
+	trace.ParentStateRoot = parent.StateRoot
 
 	if root != block.Header.StateRoot {
 		return nil, fmt.Errorf("incorrect state root: (%s, %s)", root, block.Header.StateRoot)

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -170,6 +170,7 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 		h.ExtraData = append(make([]byte, ExtraVanity), extra.MarshalRLPTo(nil)...)
 		h.MixHash = PolyBFTMixDigest
 	})
+	stateBlock.Trace.ParentStateRoot = parent.StateRoot
 
 	if err != nil {
 		return nil, err

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -170,7 +170,6 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 		h.ExtraData = append(make([]byte, ExtraVanity), extra.MarshalRLPTo(nil)...)
 		h.MixHash = PolyBFTMixDigest
 	})
-	stateBlock.Trace.ParentStateRoot = parent.StateRoot
 
 	if err != nil {
 		return nil, err

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -758,6 +758,9 @@ func TestE2E_Consensus_Trace(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEqual(t, blockResponse.Miner, ethgo.ZeroAddress)
 
+		parentBlock, err := ethEndpoint.GetBlockByHash(blockResponse.ParentHash, false)
+		require.NoError(t, err)
+
 		sysClient := cluster.Servers[i].Conn()
 		traceResp, err := sysClient.GetTrace(context.Background(), &proto.GetTraceRequest{Number: receipt.BlockNumber})
 		require.NoError(t, err)
@@ -765,6 +768,7 @@ func TestE2E_Consensus_Trace(t *testing.T) {
 		var trace *types.Trace
 		err = json.Unmarshal(traceResp.Trace, &trace)
 		require.NoError(t, err)
+		require.Equal(t, parentBlock.StateRoot.Bytes(), trace.ParentStateRoot.Bytes())
 
 		containsCoinbaseAddr, containsSenderAddr, containsReceiverAddr := false, false, false
 


### PR DESCRIPTION
# Description

The trace did not have a parent state root set. This PR sets it, after the trace is created when the transition is commited. The test is changed to include this check. 

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
