### PR TITLE
Move dispatcher failed dispatch method from ERROR to WARN log severity

### DIFF
--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -396,7 +396,7 @@ func (d *Dispatcher) handleReq(req Request) ([]byte, Error) {
 }
 
 func (d *Dispatcher) logInternalError(method string, err error) {
-	d.logger.Error("failed to dispatch", "method", method, "err", err)
+	d.logger.Warn("failed to dispatch", "method", method, "err", err)
 }
 
 func (d *Dispatcher) registerService(serviceName string, service interface{}) error {


### PR DESCRIPTION
# Description

We are running a cluster of validators and when users are hitting the RPC endpoints we get a huge amount of ERROR logs for user-initiated RPC requests. Would like to treat these as WARN instead.

~~If we could move to DEBUG, would also prefer it over WARN.~~

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually