### PR TITLE
EVM-666: Fix `eth_getLogs` index issue

### DIFF
--- a/jsonrpc/filter_manager.go
+++ b/jsonrpc/filter_manager.go
@@ -375,10 +375,13 @@ func (f *FilterManager) getLogsFromBlock(query *LogQuery, block *types.Block) ([
 		return nil, err
 	}
 
-	logs := make([]*Log, 0)
+	var (
+		logIdx int
+		logs   = make([]*Log, 0)
+	)
 
 	for idx, receipt := range receipts {
-		for logIdx, log := range receipt.Logs {
+		for _, log := range receipt.Logs {
 			if query.Match(log) {
 				logs = append(logs, &Log{
 					Address:     log.Address,
@@ -391,6 +394,8 @@ func (f *FilterManager) getLogsFromBlock(query *LogQuery, block *types.Block) ([
 					LogIndex:    argUint64(logIdx),
 				})
 			}
+
+			logIdx++
 		}
 	}
 

--- a/jsonrpc/filter_manager.go
+++ b/jsonrpc/filter_manager.go
@@ -375,10 +375,8 @@ func (f *FilterManager) getLogsFromBlock(query *LogQuery, block *types.Block) ([
 		return nil, err
 	}
 
-	var (
-		logIdx int
-		logs   = make([]*Log, 0)
-	)
+	logIdx := uint64(0)
+	logs := make([]*Log, 0)
 
 	for idx, receipt := range receipts {
 		for _, log := range receipt.Logs {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,13 +1,13 @@
 sonar.projectKey=polygon-edge
 
 sonar.sources=.
-sonar.exclusions=**/*_test.go,**/vendor/**,**/*.py,**/core-contracts/**
+sonar.exclusions=**/*_test.go,**/vendor/**,**/*.py,**/core-contracts/**,**/tests/**
  
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 sonar.test.exclusions=**/vendor/**
 
-sonar.coverage.exclusions=**/vendor/**,**/*.py
+sonar.coverage.exclusions=**/vendor/**,**/*.py,**/tests/**
 
 # =====================================================
 #   Properties specific to Go


### PR DESCRIPTION
# Description

This PR fixes issue where `eth_getLog` rpc call did not return correct values for `LogIndex` for block logs.

Before, the `LogIndex` field was set by transaction instead of block. For example, if block had two transactions with two logs each, the call would return log indexes: 0, 1, 0, 1, instead of: 0, 1, 2, 3.

This PR added a UT for this.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually