### PR TITLE
EVM-525 Write load test for adding peers

### DIFF
--- a/network/server_discovery.go
+++ b/network/server_discovery.go
@@ -206,8 +206,11 @@ func (s *Server) setupDiscovery() error {
 
 	// Set the PeerAdded event handler
 	routingTable.PeerAdded = func(p peer.ID) {
-		info := s.host.Peerstore().PeerInfo(p)
-		s.addToDialQueue(&info, common.PriorityRandomDial)
+		// this is called from the lock. because of that execute addToDialQueue on separated routine
+		go func() {
+			info := s.host.Peerstore().PeerInfo(p)
+			s.addToDialQueue(&info, common.PriorityRandomDial)
+		}()
 	}
 
 	// Set the PeerRemoved event handler

--- a/network/server_identity.go
+++ b/network/server_identity.go
@@ -42,8 +42,6 @@ func (s *Server) AddPeer(id peer.ID, direction network.Direction) {
 
 	// Emit the event alerting listeners
 	// WARNING: THIS CALL IS POTENTIALLY BLOCKING
-	// UNDER HEAVY LOAD. IT SHOULD BE SUBSTITUTED
-	// WITH AN EVENT SYSTEM THAT ACTUALLY WORKS
 	s.emitEvent(id, peerEvent.PeerConnected)
 }
 

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -1025,13 +1025,7 @@ func TestPeerAdditionDeletion(t *testing.T) {
 	}
 
 	t.Run("peers are added correctly", func(t *testing.T) {
-		server := createServer()
-
-		//nolint:godox
-		// TODO increase this number to something astronomical
-		// when the networking package has an event system that actually works,
-		// as emitEvent can completely bug out when under load inside Server.AddPeer (to be fixed in EVM-525)
-		generateAndAddPeers(server, 10)
+		generateAndAddPeers(createServer(), 2500)
 	})
 
 	t.Run("no duplicate peers added", func(t *testing.T) {


### PR DESCRIPTION
# Description

Extend `TestPeerAdditionDeletion` with testing `AddPeers` when the peer number is significantly big. This test should address TODO comment in the test. 

There was a deadlock because discovery was subscribed to network server events using `s.SubscribeFn(context.Background(), discoveryService.HandleNetworkEvent)`.
In `server_discovery.go`, there was a definition of a custom callback function:
```
routingTable.PeerAdded = func(p peer.ID) {
    info := s.host.Peerstore().PeerInfo(p)
    s.addToDialQueue(&info, common.PriorityRandomDial)
}
```	
and that callback function was called by the routing table library on the line `_, err := d.routingTable.TryAddPeer(peerID, false, false)` inside `HandleNetworkEvent` handler.

The method addToDialQueue is defined as:
```
 func (s *Server) addToDialQueue(addr *peer.AddrInfo, priority common.DialPriority) {
	s.dialQueue.AddTask(addr, priority)
	s.emitEvent(addr.ID, peerEvent.PeerAddedToDialQueue)
}
```

Emitting an event is a blocking function, new event is being emitted from the routine which handles event and each subscription channel used in the network server is not buffered. All these factors can lead to a deadlock.

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually

