### PR TITLE
Modify rootchain command to use the provided private key to fund validators

### DIFF
--- a/command/rootchain/fund/fund.go
+++ b/command/rootchain/fund/fund.go
@@ -91,19 +91,16 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	var (
-		deployerKey    ethgo.Key
-		stakeTokenAddr types.Address
-	)
+	deployerKey, err := helper.GetRootchainPrivateKey(params.deployerPrivateKey)
+	if err != nil {
+		outputter.SetError(fmt.Errorf("failed to initialize deployer private key: %w", err))
 
-	if params.mintStakeToken || params.deployerPrivateKey != "" {
-		deployerKey, err = helper.GetRootchainPrivateKey(params.deployerPrivateKey)
-		if err != nil {
-			outputter.SetError(fmt.Errorf("failed to initialize deployer private key: %w", err))
+		return
+	}
 
-			return
-		}
+	var stakeTokenAddr types.Address
 
+	if params.mintStakeToken {
 		stakeTokenAddr = types.StringToAddress(params.stakeTokenAddr)
 	}
 

--- a/command/rootchain/fund/fund.go
+++ b/command/rootchain/fund/fund.go
@@ -96,7 +96,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		stakeTokenAddr types.Address
 	)
 
-	if params.mintStakeToken {
+	if params.mintStakeToken || params.deployerPrivateKey != "" {
 		deployerKey, err = helper.GetRootchainPrivateKey(params.deployerPrivateKey)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("failed to initialize deployer private key: %w", err))
@@ -126,7 +126,14 @@ func runCommand(cmd *cobra.Command, _ []string) {
 					Value: params.amountValues[i],
 				}
 
-				receipt, err := txRelayer.SendTransactionLocal(txn)
+				var receipt *ethgo.Receipt
+
+				if params.deployerPrivateKey != "" {
+					receipt, err = txRelayer.SendTransaction(txn, deployerKey)
+				} else {
+					receipt, err = txRelayer.SendTransactionLocal(txn)
+				}
+
 				if err != nil {
 					return fmt.Errorf("failed to send fund validator '%s' transaction: %w", validatorAddr, err)
 				}


### PR DESCRIPTION
# Description

This PR fixes the [issue](https://github.com/0xPolygon/polygon-edge/issues/1528) with rootchain fund command when the rootchain is not locally deployed geth instance. If the "private-key" flag is set, then it will be used to sign the transactions to send tokens to validators. Otherwise, validators will be funded by the coinbase account by sending an unsigned transaction, which is only possible with geth instance started in development mode.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
