### PR TITLE
modified txRelayer to fetch gasprice from current eth client instead of hardcoded one

### DIFF
--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -102,6 +102,11 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 
 	txn.Nonce = nonce
 
+	gasPrice, err := t.Client().Eth().GasPrice()
+	if err != nil {
+		return ethgo.ZeroHash, err
+	}
+
 	if txn.GasPrice == 0 {
 		txn.GasPrice = DefaultGasPrice
 	}

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -107,6 +107,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 		if err != nil {
 			return ethgo.ZeroHash, err
 		}
+		
 		txn.GasPrice = gasPrice
 	}
 

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -108,7 +108,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 	}
 
 	if txn.GasPrice == 0 {
-		txn.GasPrice = DefaultGasPrice
+		txn.GasPrice = gasPrice
 	}
 
 	if txn.Gas == 0 {

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -102,12 +102,11 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 
 	txn.Nonce = nonce
 
-	gasPrice, err := t.Client().Eth().GasPrice()
-	if err != nil {
-		return ethgo.ZeroHash, err
-	}
-
 	if txn.GasPrice == 0 {
+		gasPrice, err := t.Client().Eth().GasPrice()
+		if err != nil {
+			return ethgo.ZeroHash, err
+		}
 		txn.GasPrice = gasPrice
 	}
 

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -107,7 +107,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 		if err != nil {
 			return ethgo.ZeroHash, err
 		}
-		
+
 		txn.GasPrice = gasPrice
 	}
 


### PR DESCRIPTION
# Description

This PR fixes the https://github.com/0xPolygon/polygon-edge/issues/1551 with rootchain deploy command when the rootchain is not locally deployed geth instance. If the "private-key" flag is set, then fetch the gasPrice limit using eth client. Otherwise, all transaction will go with default hardcoded value of gasLimit, which will only work with geth instance.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
