### PR TITLE
Return hex encoded number in eth_getBlockTransactionCountByNumber endpoint

### DIFF
--- a/jsonrpc/eth_blockchain_test.go
+++ b/jsonrpc/eth_blockchain_test.go
@@ -95,7 +95,7 @@ func TestEth_Block_GetBlockTransactionCountByNumber(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, res, "expected to return block, but got nil")
-	assert.Equal(t, res, types.EncodeUint64(10))
+	assert.Equal(t, "0xa", res)
 }
 
 func TestEth_GetTransactionByHash(t *testing.T) {

--- a/jsonrpc/eth_blockchain_test.go
+++ b/jsonrpc/eth_blockchain_test.go
@@ -95,7 +95,7 @@ func TestEth_Block_GetBlockTransactionCountByNumber(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, res, "expected to return block, but got nil")
-	assert.Equal(t, res, 10)
+	assert.Equal(t, res, types.EncodeUint64(10))
 }
 
 func TestEth_GetTransactionByHash(t *testing.T) {

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -178,7 +178,7 @@ func (e *Eth) GetBlockTransactionCountByNumber(number BlockNumber) (interface{},
 		return nil, nil
 	}
 
-	return types.EncodeUint64(uint64(len(block.Transactions))), nil
+	return *types.EncodeUint64(uint64(len(block.Transactions))), nil
 }
 
 // BlockNumber returns current block number

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -178,7 +178,7 @@ func (e *Eth) GetBlockTransactionCountByNumber(number BlockNumber) (interface{},
 		return nil, nil
 	}
 
-	return len(block.Transactions), nil
+	return types.EncodeUint64(uint64(len(block.Transactions))), nil
 }
 
 // BlockNumber returns current block number

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -50,12 +50,6 @@ func ParseUint256orHex(val *string) (*big.Int, error) {
 	return b, nil
 }
 
-func ParseInt64orHex(val *string) (int64, error) {
-	i, err := ParseUint64orHex(val)
-
-	return int64(i), err
-}
-
 func ParseBytes(val *string) ([]byte, error) {
 	if val == nil {
 		return []byte{}, nil


### PR DESCRIPTION
# Description

Return the hex-encoded number instead of the actual number in eth_getBlockTransactionCountByNumber endpoint

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

