### PR TITLE
Fix dependabot PRs reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,4 @@ updates:
     pull-request-branch-name:
       separator: "-"
     reviewers:
-      - "lazartravica"
-      - "Kourin1996"
-      - "zivkovicmilos"
+      - "0xPolygon/core-edge"


### PR DESCRIPTION
# Description

Add `0xPolygon/core-edge` alias as reviewers of dependabot PRs.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
