### PR TITLE
EVM-675 Implement additional metrics

### DIFF
--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -110,7 +110,8 @@ func (p *blockchainWrapper) ProcessBlock(parent *types.Header, block *types.Bloc
 
 	_, root := transition.Commit()
 
-	metrics.SetGauge([]string{consensusMetricsPrefix, "block_execution_time"}, float32(time.Now().UTC().Sub(start).Seconds()))
+	metrics.SetGauge([]string{consensusMetricsPrefix, "block_execution_time"},
+		float32(time.Now().UTC().Sub(start).Seconds()))
 
 	if root != block.Header.StateRoot {
 		return nil, fmt.Errorf("incorrect state root: (%s, %s)", root, block.Header.StateRoot)

--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -122,8 +122,6 @@ func (p *blockchainWrapper) ProcessBlock(parent *types.Header, block *types.Bloc
 		Receipts: transition.Receipts(),
 	})
 
-	updateBlockSpaceUsedMetric(builtBlock.Header.GasUsed)
-
 	return &types.FullBlock{
 		Block:    builtBlock,
 		Receipts: transition.Receipts(),

--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 	"time"
 
-	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/go-hclog"
 
 	"github.com/0xPolygon/polygon-edge/blockchain"
@@ -110,8 +109,7 @@ func (p *blockchainWrapper) ProcessBlock(parent *types.Header, block *types.Bloc
 
 	_, root := transition.Commit()
 
-	metrics.SetGauge([]string{consensusMetricsPrefix, "block_execution_time"},
-		float32(time.Now().UTC().Sub(start).Seconds()))
+	updateBlockExecutionMetric(start)
 
 	if root != block.Header.StateRoot {
 		return nil, fmt.Errorf("incorrect state root: (%s, %s)", root, block.Header.StateRoot)
@@ -124,7 +122,7 @@ func (p *blockchainWrapper) ProcessBlock(parent *types.Header, block *types.Bloc
 		Receipts: transition.Receipts(),
 	})
 
-	metrics.SetGauge([]string{consensusMetricsPrefix, "block_space_used"}, float32(builtBlock.Header.GasUsed))
+	updateBlockSpaceUsedMetric(builtBlock.Header.GasUsed)
 
 	return &types.FullBlock{
 		Block:    builtBlock,

--- a/consensus/polybft/consensus_metrics.go
+++ b/consensus/polybft/consensus_metrics.go
@@ -46,3 +46,14 @@ func updateEpochMetrics(epoch epochMetadata) {
 	// update number of validators metrics
 	metrics.SetGauge([]string{consensusMetricsPrefix, "validators"}, float32(epoch.Validators.Len()))
 }
+
+// updateBlockExecutionMetric updates the block execution metric
+func updateBlockExecutionMetric(start time.Time) {
+	metrics.SetGauge([]string{consensusMetricsPrefix, "block_execution_time"},
+		float32(time.Now().UTC().Sub(start).Seconds()))
+}
+
+// updateBlockSpaceUsedMetric updates the block space used metric
+func updateBlockSpaceUsedMetric(gasUsed uint64) {
+	metrics.SetGauge([]string{consensusMetricsPrefix, "block_space_used"}, float32(gasUsed))
+}

--- a/consensus/polybft/consensus_metrics.go
+++ b/consensus/polybft/consensus_metrics.go
@@ -34,6 +34,7 @@ func updateBlockMetrics(currentBlock *types.Block, parentHeader *types.Header) e
 	metrics.SetGauge([]string{consensusMetricsPrefix, "rounds"}, float32(extra.Checkpoint.BlockRound))
 	metrics.SetGauge([]string{consensusMetricsPrefix, "chain_head"}, float32(currentBlock.Number()))
 	metrics.IncrCounter([]string{consensusMetricsPrefix, "block_counter"}, float32(1))
+	metrics.SetGauge([]string{consensusMetricsPrefix, "block_space_used"}, float32(currentBlock.Header.GasUsed))
 
 	return nil
 }
@@ -51,9 +52,4 @@ func updateEpochMetrics(epoch epochMetadata) {
 func updateBlockExecutionMetric(start time.Time) {
 	metrics.SetGauge([]string{consensusMetricsPrefix, "block_execution_time"},
 		float32(time.Now().UTC().Sub(start).Seconds()))
-}
-
-// updateBlockSpaceUsedMetric updates the block space used metric
-func updateBlockSpaceUsedMetric(gasUsed uint64) {
-	metrics.SetGauge([]string{consensusMetricsPrefix, "block_space_used"}, float32(gasUsed))
 }

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -106,6 +106,8 @@ type fsm struct {
 // BuildProposal builds a proposal for the current round (used if proposer)
 func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 	start := time.Now().UTC()
+	defer metrics.SetGauge([]string{consensusMetricsPrefix, "block_building_time"},
+		float32(time.Now().UTC().Sub(start).Seconds()))
 
 	parent := f.parent
 
@@ -202,11 +204,8 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 	}
 
 	f.target = stateBlock
-	blockRlp := stateBlock.Block.MarshalRLP()
 
-	metrics.SetGauge([]string{consensusMetricsPrefix, "block_building_time"}, float32(time.Now().UTC().Sub(start).Seconds()))
-
-	return blockRlp, nil
+	return stateBlock.Block.MarshalRLP(), nil
 }
 
 // applyBridgeCommitmentTx builds state transaction which contains data for bridge commitment registration

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -8,8 +8,10 @@ import (
 	"math"
 	"reflect"
 	"strings"
+	"time"
 	"unicode"
 
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-hclog"
 )
 
@@ -377,8 +379,14 @@ func (d *Dispatcher) handleReq(req Request) ([]byte, Error) {
 		ok   bool
 	)
 
-	output := fd.fv.Call(inArgs)
+	start := time.Now().UTC()
+	output := fd.fv.Call(inArgs) // call rpc endpoint function
+	// measure execution time of rpc endpoint function
+	metrics.SetGauge([]string{jsonRpcMetric, req.Method + "_time"}, float32(time.Now().UTC().Sub(start).Seconds()))
+
 	if err := getError(output[1]); err != nil {
+		// measure error on the rpc endpoint function
+		metrics.IncrCounter([]string{jsonRpcMetric, req.Method + "_errors"}, 1)
 		d.logInternalError(req.Method, err)
 
 		if res := output[0].Interface(); res != nil {

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -382,11 +382,11 @@ func (d *Dispatcher) handleReq(req Request) ([]byte, Error) {
 	start := time.Now().UTC()
 	output := fd.fv.Call(inArgs) // call rpc endpoint function
 	// measure execution time of rpc endpoint function
-	metrics.SetGauge([]string{jsonRpcMetric, req.Method + "_time"}, float32(time.Now().UTC().Sub(start).Seconds()))
+	metrics.SetGauge([]string{jsonRPCMetric, req.Method + "_time"}, float32(time.Now().UTC().Sub(start).Seconds()))
 
 	if err := getError(output[1]); err != nil {
 		// measure error on the rpc endpoint function
-		metrics.IncrCounter([]string{jsonRpcMetric, req.Method + "_errors"}, 1)
+		metrics.IncrCounter([]string{jsonRPCMetric, req.Method + "_errors"}, 1)
 		d.logInternalError(req.Method, err)
 
 		if res := output[0].Interface(); res != nil {

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -9,7 +9,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
-const jsonRpcMetric = "json_rpc"
+const jsonRPCMetric = "json_rpc"
 
 // For union type of transaction and types.Hash
 type transactionOrHash interface {

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -9,6 +9,8 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
+const jsonRpcMetric = "json_rpc"
+
 // For union type of transaction and types.Hash
 type transactionOrHash interface {
 	getHash() types.Hash

--- a/syncer/service.go
+++ b/syncer/service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/network/grpc"
 	"github.com/0xPolygon/polygon-edge/syncer/proto"
 	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/armon/go-metrics"
 	"github.com/golang/protobuf/ptypes/empty"
 )
 
@@ -64,6 +65,7 @@ func (s *syncPeerService) GetBlocks(
 		}
 
 		resp := toProtoBlock(block)
+		metrics.SetGauge([]string{syncerMetrics, "egress_bytes"}, float32(len(resp.Block)))
 
 		// if client closes stream, context.Canceled is given
 		if err := stream.Send(resp); err != nil {

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/helper/progress"
 	"github.com/0xPolygon/polygon-edge/network/event"
 	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-hclog"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
@@ -207,6 +208,10 @@ func (s *syncer) Sync(callback func(*types.FullBlock) bool) error {
 	return nil
 }
 
+func (s *syncer) syncerMetricsRun() {
+
+}
+
 // bulkSyncWithPeer syncs block with a given peer
 func (s *syncer) bulkSyncWithPeer(peerID peer.ID, newBlockCallback func(*types.FullBlock) bool) (uint64, bool, error) {
 	localLatest := s.blockchain.Header().Number
@@ -240,13 +245,18 @@ func (s *syncer) bulkSyncWithPeer(peerID peer.ID, newBlockCallback func(*types.F
 
 			fullBlock, err := s.blockchain.VerifyFinalizedBlock(block)
 			if err != nil {
+				metrics.IncrCounter([]string{syncerMetrics, "bad_block"}, 1)
+
 				return lastReceivedNumber, false, fmt.Errorf("unable to verify block, %w", err)
 			}
 
 			if err := s.blockchain.WriteFullBlock(fullBlock, syncerName); err != nil {
+				metrics.IncrCounter([]string{syncerMetrics, "bad_block"}, 1)
+
 				return lastReceivedNumber, false, fmt.Errorf("failed to write block while bulk syncing: %w", err)
 			}
 
+			updateMetrics(fullBlock)
 			shouldTerminate = newBlockCallback(fullBlock)
 
 			lastReceivedNumber = block.Number()
@@ -254,4 +264,10 @@ func (s *syncer) bulkSyncWithPeer(peerID peer.ID, newBlockCallback func(*types.F
 			return lastReceivedNumber, shouldTerminate, errTimeout
 		}
 	}
+}
+
+func updateMetrics(fullBlock *types.FullBlock) {
+	metrics.SetGauge([]string{syncerMetrics, "tx_num"}, float32(len(fullBlock.Block.Transactions)))
+	metrics.SetGauge([]string{syncerMetrics, "receipts_num"}, float32(len(fullBlock.Receipts)))
+	metrics.SetGauge([]string{syncerMetrics, "blocks_num"}, 1)
 }

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -208,10 +208,6 @@ func (s *syncer) Sync(callback func(*types.FullBlock) bool) error {
 	return nil
 }
 
-func (s *syncer) syncerMetricsRun() {
-
-}
-
 // bulkSyncWithPeer syncs block with a given peer
 func (s *syncer) bulkSyncWithPeer(peerID peer.ID, newBlockCallback func(*types.FullBlock) bool) (uint64, bool, error) {
 	localLatest := s.blockchain.Header().Number

--- a/syncer/types.go
+++ b/syncer/types.go
@@ -16,6 +16,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+const syncerMetrics = "syncer"
+
 type Blockchain interface {
 	// SubscribeEvents subscribes new blockchain event
 	SubscribeEvents() blockchain.Subscription

--- a/txpool/slot_gauge.go
+++ b/txpool/slot_gauge.go
@@ -4,6 +4,7 @@ import (
 	"sync/atomic"
 
 	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/armon/go-metrics"
 )
 
 const (
@@ -23,12 +24,14 @@ func (g *slotGauge) read() uint64 {
 
 // increase increases the height of the gauge by the specified slots amount.
 func (g *slotGauge) increase(slots uint64) {
-	atomic.AddUint64(&g.height, slots)
+	newHeight := atomic.AddUint64(&g.height, slots)
+	metrics.SetGauge([]string{txPoolMetrics, "slots_used"}, float32(newHeight))
 }
 
 // decrease decreases the height of the gauge by the specified slots amount.
 func (g *slotGauge) decrease(slots uint64) {
-	atomic.AddUint64(&g.height, ^(slots - 1))
+	newHeight := atomic.AddUint64(&g.height, ^(slots - 1))
+	metrics.SetGauge([]string{txPoolMetrics, "slots_used"}, float32(newHeight))
 }
 
 // highPressure checks if the gauge level

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -596,13 +596,13 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 		}
 
 		if tx.GasFeeCap.BitLen() > 256 {
-			metrics.IncrCounter([]string{txPoolMetrics, "fee_cap_to_high_dynamic_tx"}, 1)
+			metrics.IncrCounter([]string{txPoolMetrics, "fee_cap_too_high_dynamic_tx"}, 1)
 
 			return ErrFeeCapVeryHigh
 		}
 
 		if tx.GasTipCap.BitLen() > 256 {
-			metrics.IncrCounter([]string{txPoolMetrics, "tip_to_high_dynamic_tx"}, 1)
+			metrics.IncrCounter([]string{txPoolMetrics, "tip_too_high_dynamic_tx"}, 1)
 
 			return ErrTipVeryHigh
 		}

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -530,16 +530,22 @@ func (p *TxPool) processEvent(event *blockchain.Event) {
 func (p *TxPool) validateTx(tx *types.Transaction) error {
 	// Check the transaction type. State transactions are not expected to be added to the pool
 	if tx.Type == types.StateTx {
+		metrics.IncrCounter([]string{txPoolMetrics, "invalid_tx_type"}, 1)
+
 		return ErrInvalidTxType
 	}
 
 	// Check the transaction size to overcome DOS Attacks
 	if uint64(len(tx.MarshalRLP())) > txMaxSize {
+		metrics.IncrCounter([]string{txPoolMetrics, "oversized_data_txs"}, 1)
+
 		return ErrOversizedData
 	}
 
 	// Check if the transaction has a strictly positive value
 	if tx.Value.Sign() < 0 {
+		metrics.IncrCounter([]string{txPoolMetrics, "negative_value_tx"}, 1)
+
 		return ErrNegativeValue
 	}
 
@@ -548,6 +554,8 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 	// Extract the sender
 	from, signerErr := p.signer.Sender(tx)
 	if signerErr != nil {
+		metrics.IncrCounter([]string{txPoolMetrics, "invalid_signature_txs"}, 1)
+
 		return ErrExtractSignature
 	}
 
@@ -555,6 +563,8 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 	// it matches the signer
 	if tx.From != types.ZeroAddress &&
 		tx.From != from {
+		metrics.IncrCounter([]string{txPoolMetrics, "invalid_sender_txs"}, 1)
+
 		return ErrInvalidSender
 	}
 
@@ -565,39 +575,55 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 
 	// Check if transaction can deploy smart contract
 	if tx.IsContractCreation() && p.forks.EIP158 && len(tx.Input) > state.TxPoolMaxInitCodeSize {
+		metrics.IncrCounter([]string{txPoolMetrics, "contract_deploy_too_large_txs"}, 1)
+
 		return runtime.ErrMaxCodeSizeExceeded
 	}
 
 	if tx.Type == types.DynamicFeeTx {
 		// Reject dynamic fee tx if london hardfork is not enabled
 		if !p.forks.London {
+			metrics.IncrCounter([]string{txPoolMetrics, "invalid_tx_type"}, 1)
+
 			return ErrInvalidTxType
 		}
 
 		// Check EIP-1559-related fields and make sure they are correct
 		if tx.GasFeeCap == nil || tx.GasTipCap == nil {
+			metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
+
 			return ErrUnderpriced
 		}
 
 		if tx.GasFeeCap.BitLen() > 256 {
+			metrics.IncrCounter([]string{txPoolMetrics, "fee_cap_to_high_dynamic_tx"}, 1)
+
 			return ErrFeeCapVeryHigh
 		}
 
 		if tx.GasTipCap.BitLen() > 256 {
+			metrics.IncrCounter([]string{txPoolMetrics, "tip_to_high_dynamic_tx"}, 1)
+
 			return ErrTipVeryHigh
 		}
 
 		if tx.GasFeeCap.Cmp(tx.GasTipCap) < 0 {
+			metrics.IncrCounter([]string{txPoolMetrics, "tip_above_fee_cap_dynamic_tx"}, 1)
+
 			return ErrTipAboveFeeCap
 		}
 
 		// Reject underpriced transactions
 		if tx.GasFeeCap.Cmp(new(big.Int).SetUint64(p.GetBaseFee())) < 0 {
+			metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
+
 			return ErrUnderpriced
 		}
 	} else {
 		// Legacy approach to check if the given tx is not underpriced
 		if tx.GetGasPrice(p.GetBaseFee()).Cmp(big.NewInt(0).SetUint64(p.priceLimit)) < 0 {
+			metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
+
 			return ErrUnderpriced
 		}
 	}
@@ -607,26 +633,36 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 
 	// Check nonce ordering
 	if p.store.GetNonce(stateRoot, tx.From) > tx.Nonce {
+		metrics.IncrCounter([]string{txPoolMetrics, "nonce_too_low_tx"}, 1)
+
 		return ErrNonceTooLow
 	}
 
 	accountBalance, balanceErr := p.store.GetBalance(stateRoot, tx.From)
 	if balanceErr != nil {
+		metrics.IncrCounter([]string{txPoolMetrics, "invalid_account_state_tx"}, 1)
+
 		return ErrInvalidAccountState
 	}
 
 	// Check if the sender has enough funds to execute the transaction
 	if accountBalance.Cmp(tx.Cost()) < 0 {
+		metrics.IncrCounter([]string{txPoolMetrics, "insufficient_funds_tx"}, 1)
+
 		return ErrInsufficientFunds
 	}
 
 	// Make sure the transaction has more gas than the basic transaction fee
 	intrinsicGas, err := state.TransactionGasCost(tx, p.forks.Homestead, p.forks.Istanbul)
 	if err != nil {
+		metrics.IncrCounter([]string{txPoolMetrics, "invalid_intrinsic_gas_tx"}, 1)
+
 		return err
 	}
 
 	if tx.Gas < intrinsicGas {
+		metrics.IncrCounter([]string{txPoolMetrics, "intrinsic_gas_low_tx"}, 1)
+
 		return ErrIntrinsicGas
 	}
 
@@ -634,6 +670,8 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 	latestBlockGasLimit := p.store.Header().GasLimit
 
 	if tx.Gas > latestBlockGasLimit {
+		metrics.IncrCounter([]string{txPoolMetrics, "block_gas_limit_exceeded_tx"}, 1)
+
 		return ErrBlockLimitExceeded
 	}
 
@@ -696,6 +734,8 @@ func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 		//	only accept transactions with expected nonce
 		if account := p.accounts.get(tx.From); account != nil &&
 			tx.Nonce > account.getNonce() {
+			metrics.IncrCounter([]string{txPoolMetrics, "rejected_future_tx"}, 1)
+
 			return ErrRejectFutureTx
 		}
 	}
@@ -709,6 +749,8 @@ func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 
 	// add to index
 	if ok := p.index.add(tx); !ok {
+		metrics.IncrCounter([]string{txPoolMetrics, "already_known_tx"}, 1)
+
 		return ErrAlreadyKnown
 	}
 
@@ -718,6 +760,8 @@ func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 	// send request [BLOCKING]
 	p.enqueueReqCh <- enqueueRequest{tx: tx}
 	p.eventManager.signalEvent(proto.EventType_ADDED, tx.Hash)
+
+	metrics.SetGauge([]string{txPoolMetrics, "added_tx"}, 1)
 
 	return nil
 }


### PR DESCRIPTION
# Description

Added additional metrics to `Edge` codebase:

### Consensus metrics:
- `consensus block_execution_time` - measures the time of block execution.
- `consensus block_building_time` - measures the block building time.
- `consensus block_space_used` - measures the gas used by block.

### Network metrics:
- `network egress_bytes` - measures the number of bytes sent over the P2P network in the gossip protocol.
- `network ingress_bytes` - measures the number of bytes received over the P2P network in the gossip protocol.
- `network bad_messages` - counter of bad messages received over the P2P network in the gossip protocol.

### TX Pool Metrics:
- `txpool slots_used` - amount of slots currently occupying the pool measured through time.
- `txpool invalid_tx_type` - counter of transactions that had invalid tx type.
- `txpool oversized_data_txs` - counter of transactions that had size more then allowed transaction max size.
- `txpool negative_value_tx` - counter of transactions that had negative `Value` field.
- `txpool invalid_signature_txs` - counter of transactions with invalid signature.
- `txpool invalid_sender_txs` - counter of transactions with invalid sender.
- `txpool contract_deploy_too_large_txs` - counter of contract deployment transactions where contract size is too large.
- `txpool underpriced_tx` - counter of underpriced transactions.
- `txpool fee_cap_too_high_dynamic_tx` - counter of dynamic (EIP-1559) transactions whose fee cap is too high.
- `txpool tip_too_high_dynamic_tx` - counter of dynamic (EIP-1559) transactions whose gas tip cap is too high.
- `txpool tip_above_fee_cap_dynamic_tx` - counter of dynamic (EIP-1559) transactions whose gas tip cap is above gas fee cap.
- `txpool nonce_too_low_tx` - counter of transactions whose nonce was too low.
- `txpool invalid_account_state_tx` - counter of transactions whose account state was invalid.
- `txpool insufficient_funds_tx` - counter of transactions whose sender did not have sufficient funds to execute them.
- `txpool invalid_intrinsic_gas_tx` - counter of transactions whose transaction gas cost could not be calculated.
- `txpool intrinsic_gas_low_tx` - counter of transactions whose gas is lower then calculated transaction gas cost.
- `txpool block_gas_limit_exceeded_tx` - counter of transactions whose gas cost exceeds the block gas limit.
- `txpool rejected_future_tx` - counter of rejected transaction s that have a future nonce.
- `txpool already_known_tx` - counter of transactions who were not added to the pool because they are already known transactions.
- `txpool added_tx` - measures the added transactions through time.

### JSON RPC metrics:
Each `JSON RPC` endpoint function has a metric that measures its execution time.
Each `JSON RPC` endpoint function has a metric that measures the number of errors that occurred in their execution (counter of all errors).

For example:
`json_rpc eth_getBlockByNumber_time` - measures the execution time of `eth_getBlockByNumber` endpoint.
`json_rpc eth_getBlockByNumber_errors` - measures the number of errors that happened in calls to given endpoint.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually