### PR TITLE
Return Revert result as Data

### DIFF
--- a/jsonrpc/codec.go
+++ b/jsonrpc/codec.go
@@ -93,6 +93,25 @@ func (e *ObjectError) Error() string {
 	return string(data)
 }
 
+func (e *ObjectError) MarshalJSON() ([]byte, error) {
+	var ds string
+
+	data := e.Data.([]byte)
+	if len(data) > 0 {
+		ds = "0x" + string(data)
+	}
+
+	return json.Marshal(&struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Data    string `json:"data,omitempty"`
+	}{
+		Code:    e.Code,
+		Message: e.Message,
+		Data:    ds,
+	})
+}
+
 const (
 	pending  = "pending"
 	latest   = "latest"
@@ -190,8 +209,8 @@ func (b *BlockNumber) UnmarshalJSON(buffer []byte) error {
 }
 
 // NewRPCErrorResponse is used to create a custom error response
-func NewRPCErrorResponse(id interface{}, errCode int, err string, jsonrpcver string) Response {
-	errObject := &ObjectError{errCode, err, nil}
+func NewRPCErrorResponse(id interface{}, errCode int, err string, data []byte, jsonrpcver string) Response {
+	errObject := &ObjectError{errCode, err, data}
 
 	response := &ErrorResponse{
 		JSONRPC: jsonrpcver,
@@ -209,7 +228,7 @@ func NewRPCResponse(id interface{}, jsonrpcver string, reply []byte, err Error) 
 	case nil:
 		response = &SuccessResponse{JSONRPC: jsonrpcver, ID: id, Result: reply}
 	default:
-		response = NewRPCErrorResponse(id, err.ErrorCode(), err.Error(), jsonrpcver)
+		response = NewRPCErrorResponse(id, err.ErrorCode(), err.Error(), reply, jsonrpcver)
 	}
 
 	return response

--- a/jsonrpc/codec.go
+++ b/jsonrpc/codec.go
@@ -96,10 +96,9 @@ func (e *ObjectError) Error() string {
 func (e *ObjectError) MarshalJSON() ([]byte, error) {
 	var ds string
 
-	if data, ok := e.Data.([]byte); ok {
-		if len(data) > 0 {
-			ds = "0x" + string(data)
-		}
+	data, ok := e.Data.([]byte)
+	if ok && len(data) > 0 {
+		ds = "0x" + string(data)
 	}
 
 	return json.Marshal(&struct {

--- a/jsonrpc/codec.go
+++ b/jsonrpc/codec.go
@@ -96,9 +96,10 @@ func (e *ObjectError) Error() string {
 func (e *ObjectError) MarshalJSON() ([]byte, error) {
 	var ds string
 
-	data := e.Data.([]byte)
-	if len(data) > 0 {
-		ds = "0x" + string(data)
+	if data, ok := e.Data.([]byte); ok {
+		if len(data) > 0 {
+			ds = "0x" + string(data)
+		}
 	}
 
 	return json.Marshal(&struct {

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -371,12 +371,15 @@ func (d *Dispatcher) handleReq(req Request) ([]byte, Error) {
 		}
 	}
 
+	var (
+		data []byte
+		err  error
+		ok   bool
+	)
+
 	output := fd.fv.Call(inArgs)
 	if err := getError(output[1]); err != nil {
 		d.logInternalError(req.Method, err)
-
-		var data []byte
-		var ok bool
 
 		if res := output[0].Interface(); res != nil {
 			data, ok = res.([]byte)
@@ -388,11 +391,6 @@ func (d *Dispatcher) handleReq(req Request) ([]byte, Error) {
 
 		return data, NewInvalidRequestError(err.Error())
 	}
-
-	var (
-		data []byte
-		err  error
-	)
 
 	if res := output[0].Interface(); res != nil {
 		data, err = json.Marshal(res)

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -376,9 +376,11 @@ func (d *Dispatcher) handleReq(req Request) ([]byte, Error) {
 		d.logInternalError(req.Method, err)
 
 		var data []byte
+		var ok bool
+
 		if res := output[0].Interface(); res != nil {
-			var ok bool
 			data, ok = res.([]byte)
+
 			if !ok {
 				return nil, NewInternalError(err.Error())
 			}

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -377,7 +377,11 @@ func (d *Dispatcher) handleReq(req Request) ([]byte, Error) {
 
 		var data []byte
 		if res := output[0].Interface(); res != nil {
-			data = res.([]byte)
+			var ok bool
+			data, ok = res.([]byte)
+			if !ok {
+				return nil, NewInternalError(err.Error())
+			}
 		}
 
 		return data, NewInvalidRequestError(err.Error())

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -328,7 +328,7 @@ func (d *Dispatcher) Handle(reqBody []byte) ([]byte, error) {
 	for _, req := range requests {
 		var response, err = d.handleReq(req)
 		if err != nil {
-			errorResponse := NewRPCResponse(req.ID, "2.0", nil, err)
+			errorResponse := NewRPCResponse(req.ID, "2.0", response, err)
 			responses = append(responses, errorResponse)
 
 			continue
@@ -375,7 +375,12 @@ func (d *Dispatcher) handleReq(req Request) ([]byte, Error) {
 	if err := getError(output[1]); err != nil {
 		d.logInternalError(req.Method, err)
 
-		return nil, NewInvalidRequestError(err.Error())
+		var data []byte
+		if res := output[0].Interface(); res != nil {
+			data = res.([]byte)
+		}
+
+		return data, NewInvalidRequestError(err.Error())
 	}
 
 	var (

--- a/jsonrpc/eth_blockchain_test.go
+++ b/jsonrpc/eth_blockchain_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/0xPolygon/polygon-edge/blockchain"
+	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/helper/progress"
 	"github.com/0xPolygon/polygon-edge/state/runtime"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -333,6 +334,33 @@ func TestEth_Call(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, res)
 	})
+
+	t.Run("returns error and result as data of a reverted transaction execution", func(t *testing.T) {
+		t.Parallel()
+
+		returnValue := []byte("Reverted()")
+
+		store := newMockBlockStore()
+		store.add(newTestBlock(100, hash1))
+		store.ethCallError = runtime.ErrExecutionReverted
+		store.returnValue = returnValue
+		eth := newTestEthEndpoint(store)
+		contractCall := &txnArgs{
+			From:     &addr0,
+			To:       &addr1,
+			Gas:      argUintPtr(100000),
+			GasPrice: argBytesPtr([]byte{0x64}),
+			Value:    argBytesPtr([]byte{0x64}),
+			Data:     nil,
+			Nonce:    argUintPtr(0),
+		}
+
+		res, err := eth.Call(contractCall, BlockNumberOrHash{}, nil)
+		assert.Error(t, err)
+		assert.NotNil(t, res)
+		bres := res.([]byte)
+		assert.Equal(t, []byte(hex.EncodeToString(returnValue)), bres)
+	})
 }
 
 type testStore interface {
@@ -348,6 +376,7 @@ type mockBlockStore struct {
 	isSyncing       bool
 	averageGasPrice int64
 	ethCallError    error
+	returnValue     []byte
 }
 
 func newMockBlockStore() *mockBlockStore {
@@ -518,7 +547,10 @@ func (m *mockBlockStore) GetAvgGasPrice() *big.Int {
 }
 
 func (m *mockBlockStore) ApplyTxn(header *types.Header, txn *types.Transaction, overrides types.StateOverride) (*runtime.ExecutionResult, error) {
-	return &runtime.ExecutionResult{Err: m.ethCallError}, nil
+	return &runtime.ExecutionResult{
+		Err:         m.ethCallError,
+		ReturnValue: m.returnValue,
+	}, nil
 }
 
 func (m *mockBlockStore) SubscribeEvents() blockchain.Subscription {

--- a/jsonrpc/eth_blockchain_test.go
+++ b/jsonrpc/eth_blockchain_test.go
@@ -358,7 +358,7 @@ func TestEth_Call(t *testing.T) {
 		res, err := eth.Call(contractCall, BlockNumberOrHash{}, nil)
 		assert.Error(t, err)
 		assert.NotNil(t, res)
-		bres := res.([]byte)
+		bres := res.([]byte) // nolint:forcetypeassert
 		assert.Equal(t, []byte(hex.EncodeToString(returnValue)), bres)
 	})
 }

--- a/jsonrpc/eth_blockchain_test.go
+++ b/jsonrpc/eth_blockchain_test.go
@@ -358,7 +358,7 @@ func TestEth_Call(t *testing.T) {
 		res, err := eth.Call(contractCall, BlockNumberOrHash{}, nil)
 		assert.Error(t, err)
 		assert.NotNil(t, res)
-		bres := res.([]byte) // nolint:forcetypeassert
+		bres := res.([]byte) //nolint:forcetypeassert
 		assert.Equal(t, []byte(hex.EncodeToString(returnValue)), bres)
 	})
 }

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -1,6 +1,7 @@
 package jsonrpc
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -488,7 +489,7 @@ func (e *Eth) Call(arg *txnArgs, filter BlockNumberOrHash, apiOverride *stateOve
 
 	// Check if an EVM revert happened
 	if result.Reverted() {
-		return nil, constructErrorFromRevert(result)
+		return []byte(hex.EncodeToString(result.ReturnValue)), constructErrorFromRevert(result)
 	}
 
 	if result.Failed() {


### PR DESCRIPTION
# Description

This allows returning custom revert errors from solidity, they are ABI encoded functions that can represent rich and gas efficient revert messages.

Details of custom errors: https://blog.soliditylang.org/2021/04/21/custom-errors/

This is the implementation expected by ethers.js and web3.js and the format go-ethereum chose https://github.com/ethereum/go-ethereum/issues/19027#issuecomment-640500608

<img width="920" alt="image" src="https://github.com/0xPolygon/polygon-edge/assets/47026/0dfc3c9c-f0a3-41bd-832a-842fa96b4ace">

This PR implements it following this format.

Fixes https://github.com/0xPolygon/polygon-edge/issues/1350

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
