### PR TITLE
EVM-677: Fix log index issue on `eth_getTransactionReceipt`

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -327,8 +327,7 @@ func (e *Eth) GetTransactionReceipt(hash types.Hash) (interface{}, error) {
 
 		// accumulate receipt logs indexes from block transactions
 		// that are before the desired transaction
-		receipt := receipts[i]
-		logIndex += len(receipt.Logs)
+		logIndex += len(receipts[i].Logs)
 	}
 
 	if txIndex == -1 {

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -315,35 +315,41 @@ func (e *Eth) GetTransactionReceipt(hash types.Hash) (interface{}, error) {
 		return nil, nil
 	}
 	// find the transaction in the body
-	indx := -1
+	txIndex := -1
+	logIndex := 0
 
 	for i, txn := range block.Transactions {
 		if txn.Hash == hash {
-			indx = i
+			txIndex = i
 
 			break
 		}
+
+		// accumulate receipt logs indexes from block transactions
+		// that are before the desired transaction
+		receipt := receipts[i]
+		logIndex += len(receipt.Logs)
 	}
 
-	if indx == -1 {
+	if txIndex == -1 {
 		// txn not found
 		return nil, nil
 	}
 
-	txn := block.Transactions[indx]
-	raw := receipts[indx]
+	txn := block.Transactions[txIndex]
+	raw := receipts[txIndex]
 
 	logs := make([]*Log, len(raw.Logs))
-	for indx, elem := range raw.Logs {
-		logs[indx] = &Log{
+	for i, elem := range raw.Logs {
+		logs[i] = &Log{
 			Address:     elem.Address,
 			Topics:      elem.Topics,
 			Data:        argBytes(elem.Data),
 			BlockHash:   block.Hash(),
 			BlockNumber: argUint64(block.Number()),
 			TxHash:      txn.Hash,
-			TxIndex:     argUint64(indx),
-			LogIndex:    argUint64(indx),
+			TxIndex:     argUint64(txIndex),
+			LogIndex:    argUint64(logIndex + i),
 			Removed:     false,
 		}
 	}
@@ -354,7 +360,7 @@ func (e *Eth) GetTransactionReceipt(hash types.Hash) (interface{}, error) {
 		LogsBloom:         raw.LogsBloom,
 		Status:            argUint64(*raw.Status),
 		TxHash:            txn.Hash,
-		TxIndex:           argUint64(indx),
+		TxIndex:           argUint64(txIndex),
 		BlockHash:         block.Hash(),
 		BlockNumber:       argUint64(block.Number()),
 		GasUsed:           argUint64(raw.GasUsed),


### PR DESCRIPTION
# Description

`eth_getTransactionReceipt` did not return correct indexes of logs. For example, if we had a block with 2 transactions with 2 logs each, and if we want a receipt from the second transaction, the function would return log indexes 0, 1, instead of 2, 3, since there is a transaction in the block that had logs before the desired transaction.

This PR fixes the issue and adds new UT.

This is continuation of work from [PR 1533](https://github.com/0xPolygon/polygon-edge/pull/1533).

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually