### PR TITLE
Prevent ACL admins to remove themselves

### DIFF
--- a/e2e-polybft/e2e/acls_test.go
+++ b/e2e-polybft/e2e/acls_test.go
@@ -92,7 +92,7 @@ func TestE2E_AllowList_ContractDeployment(t *testing.T) {
 
 	{
 		// Step 4. 'adminAddr' sends a transaction to enable 'targetAddr'.
-		input, _ := addresslist.SetEnabledSignatureFunc.Encode([]interface{}{targetAddr})
+		input, _ := addresslist.SetEnabledFunc.Encode([]interface{}{targetAddr})
 
 		adminSetTxn := cluster.MethodTxn(t, admin, contracts.AllowListContractsAddr, input)
 		require.NoError(t, adminSetTxn.Wait())
@@ -110,7 +110,7 @@ func TestE2E_AllowList_ContractDeployment(t *testing.T) {
 	{
 		// Step 6. 'targetAddr' cannot enable other accounts since it is not an admin
 		// (The transaction fails)
-		input, _ := addresslist.SetEnabledSignatureFunc.Encode([]interface{}{types.ZeroAddress})
+		input, _ := addresslist.SetEnabledFunc.Encode([]interface{}{types.ZeroAddress})
 
 		adminSetFailTxn := cluster.MethodTxn(t, target, contracts.AllowListContractsAddr, input)
 		require.NoError(t, adminSetFailTxn.Wait())
@@ -184,7 +184,7 @@ func TestE2E_BlockList_ContractDeployment(t *testing.T) {
 
 	{
 		// Step 4. 'adminAddr' sends a transaction to enable 'targetAddr'.
-		input, _ := addresslist.SetEnabledSignatureFunc.Encode([]interface{}{targetAddr})
+		input, _ := addresslist.SetEnabledFunc.Encode([]interface{}{targetAddr})
 
 		adminSetTxn := cluster.MethodTxn(t, admin, contracts.BlockListContractsAddr, input)
 		require.NoError(t, adminSetTxn.Wait())
@@ -202,7 +202,7 @@ func TestE2E_BlockList_ContractDeployment(t *testing.T) {
 	{
 		// Step 6. 'targetAddr' cannot enable other accounts since it is not an admin
 		// (The transaction fails)
-		input, _ := addresslist.SetEnabledSignatureFunc.Encode([]interface{}{types.ZeroAddress})
+		input, _ := addresslist.SetEnabledFunc.Encode([]interface{}{types.ZeroAddress})
 
 		adminSetFailTxn := cluster.MethodTxn(t, target, contracts.BlockListContractsAddr, input)
 		require.NoError(t, adminSetFailTxn.Wait())
@@ -268,7 +268,7 @@ func TestE2E_AllowList_Transactions(t *testing.T) {
 
 	{
 		// Step 3. 'adminAddr' sends a transaction to enable 'targetAddr'.
-		input, _ := addresslist.SetEnabledSignatureFunc.Encode([]interface{}{targetAddr})
+		input, _ := addresslist.SetEnabledFunc.Encode([]interface{}{targetAddr})
 
 		adminSetTxn := cluster.MethodTxn(t, admin, contracts.AllowListTransactionsAddr, input)
 		require.NoError(t, adminSetTxn.Wait())
@@ -285,12 +285,21 @@ func TestE2E_AllowList_Transactions(t *testing.T) {
 	{
 		// Step 5. 'targetAddr' cannot enable other accounts since it is not an admin
 		// (The transaction fails)
-		input, _ := addresslist.SetEnabledSignatureFunc.Encode([]interface{}{types.ZeroAddress})
+		input, _ := addresslist.SetEnabledFunc.Encode([]interface{}{types.ZeroAddress})
 
 		adminSetFailTxn := cluster.MethodTxn(t, target, contracts.AllowListTransactionsAddr, input)
 		require.NoError(t, adminSetFailTxn.Wait())
 		require.True(t, adminSetFailTxn.Failed())
 		expectRole(t, cluster, contracts.AllowListTransactionsAddr, types.ZeroAddress, addresslist.NoRole)
+	}
+
+	{
+		// Step 6. 'adminAddr' sends a transaction to disable himself.
+		input, _ := addresslist.SetNoneFunc.Encode([]interface{}{adminAddr})
+
+		adminSetTxn := cluster.MethodTxn(t, admin, contracts.AllowListTransactionsAddr, input)
+		require.NoError(t, adminSetTxn.Wait())
+		expectRole(t, cluster, contracts.AllowListTransactionsAddr, targetAddr, addresslist.EnabledRole)
 	}
 }
 
@@ -339,7 +348,7 @@ func TestE2E_BlockList_Transactions(t *testing.T) {
 	{
 		// Step 3. 'targetAddr' cannot enable other accounts since it is not an admin
 		// (The transaction fails)
-		input, _ := addresslist.SetEnabledSignatureFunc.Encode([]interface{}{types.ZeroAddress})
+		input, _ := addresslist.SetEnabledFunc.Encode([]interface{}{types.ZeroAddress})
 
 		adminSetFailTxn := cluster.MethodTxn(t, target, contracts.BlockListTransactionsAddr, input)
 		require.NoError(t, adminSetFailTxn.Wait())
@@ -349,7 +358,7 @@ func TestE2E_BlockList_Transactions(t *testing.T) {
 
 	{
 		// Step 4. 'adminAddr' sends a transaction to enable 'targetAddr'.
-		input, _ := addresslist.SetEnabledSignatureFunc.Encode([]interface{}{targetAddr})
+		input, _ := addresslist.SetEnabledFunc.Encode([]interface{}{targetAddr})
 
 		adminSetTxn := cluster.MethodTxn(t, admin, contracts.BlockListTransactionsAddr, input)
 		require.NoError(t, adminSetTxn.Wait())

--- a/e2e-polybft/e2e/acls_test.go
+++ b/e2e-polybft/e2e/acls_test.go
@@ -299,6 +299,7 @@ func TestE2E_AllowList_Transactions(t *testing.T) {
 
 		noneSetTxn := cluster.MethodTxn(t, admin, contracts.AllowListTransactionsAddr, input)
 		require.NoError(t, noneSetTxn.Wait())
+		require.True(t, noneSetTxn.Failed())
 		expectRole(t, cluster, contracts.AllowListTransactionsAddr, adminAddr, addresslist.AdminRole)
 	}
 }

--- a/e2e-polybft/e2e/acls_test.go
+++ b/e2e-polybft/e2e/acls_test.go
@@ -297,9 +297,9 @@ func TestE2E_AllowList_Transactions(t *testing.T) {
 		// Step 6. 'adminAddr' sends a transaction to disable himself.
 		input, _ := addresslist.SetNoneFunc.Encode([]interface{}{adminAddr})
 
-		adminSetTxn := cluster.MethodTxn(t, admin, contracts.AllowListTransactionsAddr, input)
-		require.NoError(t, adminSetTxn.Wait())
-		expectRole(t, cluster, contracts.AllowListTransactionsAddr, targetAddr, addresslist.EnabledRole)
+		noneSetTxn := cluster.MethodTxn(t, admin, contracts.AllowListTransactionsAddr, input)
+		require.NoError(t, noneSetTxn.Wait())
+		expectRole(t, cluster, contracts.AllowListTransactionsAddr, adminAddr, addresslist.AdminRole)
 	}
 }
 

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -922,7 +922,7 @@ func TestE2E_Bridge_Transfers_AccessLists(t *testing.T) {
 		require.Error(t, err)
 
 		{
-			input, _ := addresslist.SetEnabledSignatureFunc.Encode([]interface{}{senderAccount.Ecdsa.Address()})
+			input, _ := addresslist.SetEnabledFunc.Encode([]interface{}{senderAccount.Ecdsa.Address()})
 			enableSetTxn := cluster.MethodTxn(t, admin, contracts.AllowListBridgeAddr, input)
 			require.NoError(t, enableSetTxn.Wait())
 			expectRole(t, cluster, contracts.AllowListBridgeAddr, types.Address(senderAccount.Ecdsa.Address()), addresslist.EnabledRole)
@@ -940,7 +940,7 @@ func TestE2E_Bridge_Transfers_AccessLists(t *testing.T) {
 		require.NoError(t, err)
 
 		{
-			input, _ := addresslist.SetEnabledSignatureFunc.Encode([]interface{}{senderAccount.Ecdsa.Address()})
+			input, _ := addresslist.SetEnabledFunc.Encode([]interface{}{senderAccount.Ecdsa.Address()})
 			disableSetTxn := cluster.MethodTxn(t, admin, contracts.BlockListBridgeAddr, input)
 			require.NoError(t, disableSetTxn.Wait())
 			expectRole(t, cluster, contracts.BlockListBridgeAddr, types.Address(senderAccount.Ecdsa.Address()), addresslist.EnabledRole)

--- a/state/runtime/addresslist/addresslist.go
+++ b/state/runtime/addresslist/addresslist.go
@@ -12,10 +12,10 @@ import (
 
 // list of function methods for the address list functionality
 var (
-	SetAdminFunc            = abi.MustNewMethod("function setAdmin(address)")
-	SetEnabledSignatureFunc = abi.MustNewMethod("function setEnabled(address)")
-	SetNoneFunc             = abi.MustNewMethod("function setNone(address)")
-	ReadAddressListFunc     = abi.MustNewMethod("function readAddressList(address) returns (uint256)")
+	SetAdminFunc        = abi.MustNewMethod("function setAdmin(address)")
+	SetEnabledFunc      = abi.MustNewMethod("function setEnabled(address)")
+	SetNoneFunc         = abi.MustNewMethod("function setNone(address)")
+	ReadAddressListFunc = abi.MustNewMethod("function readAddressList(address) returns (uint256)")
 )
 
 // list of gas costs for the operations
@@ -102,7 +102,7 @@ func (a *AddressList) runInputCall(caller types.Address, input []byte,
 	var updateRole Role
 	if bytes.Equal(sig, SetAdminFunc.ID()) {
 		updateRole = AdminRole
-	} else if bytes.Equal(sig, SetEnabledSignatureFunc.ID()) {
+	} else if bytes.Equal(sig, SetEnabledFunc.ID()) {
 		updateRole = EnabledRole
 	} else if bytes.Equal(sig, SetNoneFunc.ID()) {
 		updateRole = NoRole

--- a/state/runtime/addresslist/addresslist.go
+++ b/state/runtime/addresslist/addresslist.go
@@ -55,6 +55,7 @@ var (
 	errInputTooShort       = fmt.Errorf("wrong input size, expected 32")
 	errFunctionNotFound    = fmt.Errorf("function not found")
 	errWriteProtection     = fmt.Errorf("write protection")
+	errAdminSelfRemove     = fmt.Errorf("cannot remove admin role from caller")
 )
 
 func (a *AddressList) runInputCall(caller types.Address, input []byte,
@@ -123,6 +124,11 @@ func (a *AddressList) runInputCall(caller types.Address, input []byte,
 	addrRole := a.GetRole(caller)
 	if addrRole != AdminRole {
 		return nil, gasUsed, runtime.ErrNotAuth
+	}
+
+	// An admin can not remove himself from the list
+	if addrRole == AdminRole && caller == inputAddr {
+		return nil, gasUsed, errAdminSelfRemove
 	}
 
 	a.SetRole(inputAddr, updateRole)

--- a/state/runtime/addresslist/addresslist_test.go
+++ b/state/runtime/addresslist/addresslist_test.go
@@ -138,7 +138,7 @@ func TestAddressList_WriteOp_Full(t *testing.T) {
 		role   Role
 	}{
 		{SetAdminFunc, AdminRole},
-		{SetEnabledSignatureFunc, EnabledRole},
+		{SetEnabledFunc, EnabledRole},
 		{SetNoneFunc, NoRole},
 	}
 


### PR DESCRIPTION
# Description

This PR implements a protection to ACLs so going forward an admin can not remove himself from the admins list, it should be removed by another admin.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
