### PR TITLE
EVM-523 Fix race condition in gas estimation

### DIFF
--- a/jsonrpc/eth_state_test.go
+++ b/jsonrpc/eth_state_test.go
@@ -612,10 +612,7 @@ func getExampleStore() *mockSpecialStore {
 // the latest block gas limit for the upper bound, or the specified
 // gas limit in the transaction
 func TestEth_EstimateGas_GasLimit(t *testing.T) {
-	//nolint:godox
-	// TODO Make this test run in parallel when the race condition is fixed in gas estimation (to be fixed in EVM-523)
-	store := getExampleStore()
-	ethEndpoint := newTestEthEndpoint(store)
+	t.Parallel()
 
 	testTable := []struct {
 		name             string
@@ -650,7 +647,14 @@ func TestEth_EstimateGas_GasLimit(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
+		testCase := testCase
+
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := getExampleStore()
+			ethEndpoint := newTestEthEndpoint(store)
+
 			// Set up the apply hook
 			if errors.Is(testCase.expectedError, state.ErrNotEnoughIntrinsicGas) {
 				// We want to trigger a situation where no value in the gas range is correct


### PR DESCRIPTION
# Description

Resolve TODO in  TestEth_EstimateGas_GasLimit (jsonrpc/eth_state_test.go) by fixing  the race condition caused by gas estimation (EstimateGas function).

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
