### PR TITLE
Fixed error handling for op code CREATE2

### DIFF
--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -1101,7 +1101,9 @@ func opCreate(op OpCode) instruction {
 		v := c.push1()
 		if op == CREATE && c.config.Homestead && errors.Is(result.Err, runtime.ErrCodeStoreOutOfGas) {
 			v.Set(zero)
-		} else if result.Failed() && !errors.Is(result.Err, runtime.ErrCodeStoreOutOfGas) {
+		} else if op == CREATE && result.Failed() && !errors.Is(result.Err, runtime.ErrCodeStoreOutOfGas) {
+			v.Set(zero)
+		} else if op == CREATE2 && result.Failed() {
 			v.Set(zero)
 		} else {
 			v.SetBytes(contract.Address.Bytes())


### PR DESCRIPTION
# Description

This PR introduces fix for [this](https://github.com/0xPolygon/polygon-edge/issues/1372) and [this](https://polygon.atlassian.net/browse/EVM-663?atlOrigin=eyJpIjoiYTIwMmJlYzQwMWIxNDE3MGJhNTYxMTczM2NmNTgwMGYiLCJwIjoiaiJ9) issue.
The error handling wasn't done the right way so the state was reverted but the op code CREATE2 was reporting the success. This is now fixed to match the way errors for CREATE2 are handled in go-ethereum. See the go-ethereum error handling [here](https://github.com/ethereum/go-ethereum/blob/78f7a6b7f29acd31e16a8ef41e37ae15d515f840/core/vm/instructions.go#L646).

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually
