### PR TITLE
EVM-437 Batch calls over websockets not working properly

### DIFF
--- a/jsonrpc/codec.go
+++ b/jsonrpc/codec.go
@@ -15,6 +15,8 @@ type Request struct {
 	Params json.RawMessage `json:"params,omitempty"`
 }
 
+type BatchRequest []Request
+
 // Response is a jsonrpc response interface
 type Response interface {
 	GetID() interface{}

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -251,7 +251,8 @@ func (d *Dispatcher) HandleWs(reqBody []byte, conn wsConn) ([]byte, error) {
 
 		err := json.Unmarshal(reqBody, &batchReq)
 		if err != nil {
-			return NewRPCResponse(nil, "2.0", nil, NewInvalidRequestError("Invalid json request")).Bytes()
+			return NewRPCResponse(nil, "2.0", nil,
+				NewInvalidRequestError("Invalid json batch request")).Bytes()
 		}
 
 		// if not disabled, avoid handling long batch requests
@@ -267,7 +268,7 @@ func (d *Dispatcher) HandleWs(reqBody []byte, conn wsConn) ([]byte, error) {
 		responses := make([][]byte, len(batchReq))
 
 		for i, req := range batchReq {
-			responses[i], err = d.handleWs(req, conn).Bytes()
+			responses[i], err = d.handleSingleWs(req, conn).Bytes()
 			if err != nil {
 				return nil, err
 			}
@@ -289,10 +290,10 @@ func (d *Dispatcher) HandleWs(reqBody []byte, conn wsConn) ([]byte, error) {
 		return NewRPCResponse(req.ID, "2.0", nil, NewInvalidRequestError("Invalid json request")).Bytes()
 	}
 
-	return d.handleWs(req, conn).Bytes()
+	return d.handleSingleWs(req, conn).Bytes()
 }
 
-func (d *Dispatcher) handleWs(req Request, conn wsConn) Response {
+func (d *Dispatcher) handleSingleWs(req Request, conn wsConn) Response {
 	id, err := formatID(req.ID)
 	if err != nil {
 		return NewRPCResponse(nil, "2.0", nil, err)

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -245,7 +245,7 @@ func (d *Dispatcher) HandleWs(reqBody []byte, conn wsConn) ([]byte, error) {
 
 	reqBody = bytes.TrimLeft(reqBody, " \t\r\n")
 
-	// if body begins with [ than consider this request as batch request
+	// if body begins with [ consider it as a batch request
 	if len(reqBody) > 0 && reqBody[0] == openSquareBracket {
 		var batchReq BatchRequest
 

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -56,6 +57,10 @@ type dispatcherParams struct {
 	priceLimit              uint64
 	jsonRPCBatchLengthLimit uint64
 	blockRangeLimit         uint64
+}
+
+func (dp dispatcherParams) isExceedingBatchLengthLimit(value uint64) bool {
+	return dp.jsonRPCBatchLengthLimit != 0 && value > dp.jsonRPCBatchLengthLimit
 }
 
 func newDispatcher(
@@ -161,22 +166,23 @@ type wsConn interface {
 
 // as per https://www.jsonrpc.org/specification, the `id` in JSON-RPC 2.0
 // can only be a string or a non-decimal integer
-func formatFilterResponse(id interface{}, resp string) (string, Error) {
+func formatID(id interface{}) (interface{}, Error) {
 	switch t := id.(type) {
 	case string:
-		return fmt.Sprintf(`{"jsonrpc":"2.0","id":"%s","result":"%s"}`, t, resp), nil
+		return t, nil
 	case float64:
 		if t == math.Trunc(t) {
-			return fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"result":"%s"}`, int(t), resp), nil
+			return int(t), nil
 		} else {
 			return "", NewInvalidRequestError("Invalid json request")
 		}
 	case nil:
-		return fmt.Sprintf(`{"jsonrpc":"2.0","id":null,"result":"%s"}`, resp), nil
+		return nil, nil
 	default:
 		return "", NewInvalidRequestError("Invalid json request")
 	}
 }
+
 func (d *Dispatcher) handleSubscribe(req Request, conn wsConn) (string, Error) {
 	var params []interface{}
 	if err := json.Unmarshal(req.Params, &params); err != nil {
@@ -231,20 +237,37 @@ func (d *Dispatcher) RemoveFilterByWs(conn wsConn) {
 }
 
 func (d *Dispatcher) HandleWs(reqBody []byte, conn wsConn) ([]byte, error) {
-	// first try to unmarshal to batch request
-	// if there is an error try to unmarshal to single request
-	var batchReq BatchRequest
-	if err := json.Unmarshal(reqBody, &batchReq); err == nil {
-		const (
-			openSquareBracket  = 91 // [
-			closeSquareBracket = 93 // ]
-			comma              = 44 // ,
-		)
+	const (
+		openSquareBracket  byte = '['
+		closeSquareBracket byte = ']'
+		comma              byte = ','
+	)
+
+	reqBody = bytes.TrimLeft(reqBody, " \t\r\n")
+
+	// if body begins with [ than consider this request as batch request
+	if len(reqBody) > 0 && reqBody[0] == openSquareBracket {
+		var batchReq BatchRequest
+
+		err := json.Unmarshal(reqBody, &batchReq)
+		if err != nil {
+			return NewRPCResponse(nil, "2.0", nil, NewInvalidRequestError("Invalid json request")).Bytes()
+		}
+
+		// if not disabled, avoid handling long batch requests
+		if d.params.isExceedingBatchLengthLimit(uint64(len(batchReq))) {
+			return NewRPCResponse(
+				nil,
+				"2.0",
+				nil,
+				NewInvalidRequestError("Batch request length too long"),
+			).Bytes()
+		}
 
 		responses := make([][]byte, len(batchReq))
 
 		for i, req := range batchReq {
-			responses[i], err = d.handleWs(req, conn)
+			responses[i], err = d.handleWs(req, conn).Bytes()
 			if err != nil {
 				return nil, err
 			}
@@ -266,53 +289,37 @@ func (d *Dispatcher) HandleWs(reqBody []byte, conn wsConn) ([]byte, error) {
 		return NewRPCResponse(req.ID, "2.0", nil, NewInvalidRequestError("Invalid json request")).Bytes()
 	}
 
-	return d.handleWs(req, conn)
+	return d.handleWs(req, conn).Bytes()
 }
 
-func (d *Dispatcher) handleWs(req Request, conn wsConn) ([]byte, error) {
-	// if the request method is eth_subscribe we need to create a
-	// new filter with ws connection
-	if req.Method == "eth_subscribe" {
-		filterID, err := d.handleSubscribe(req, conn)
-		if err != nil {
-			return NewRPCResponse(req.ID, "2.0", nil, err).Bytes()
-		}
-
-		resp, err := formatFilterResponse(req.ID, filterID)
-
-		if err != nil {
-			return NewRPCResponse(req.ID, "2.0", nil, err).Bytes()
-		}
-
-		return []byte(resp), nil
-	}
-
-	if req.Method == "eth_unsubscribe" {
-		ok, err := d.handleUnsubscribe(req)
-		if err != nil {
-			return nil, err
-		}
-
-		res := "false"
-		if ok {
-			res = "true"
-		}
-
-		resp, err := formatFilterResponse(req.ID, res)
-		if err != nil {
-			return NewRPCResponse(req.ID, "2.0", nil, err).Bytes()
-		}
-
-		return []byte(resp), nil
-	}
-
-	// its a normal query that we handle with the dispatcher
-	resp, err := d.handleReq(req)
+func (d *Dispatcher) handleWs(req Request, conn wsConn) Response {
+	id, err := formatID(req.ID)
 	if err != nil {
-		return nil, err
+		return NewRPCResponse(nil, "2.0", nil, err)
 	}
 
-	return NewRPCResponse(req.ID, "2.0", resp, err).Bytes()
+	var response []byte
+
+	switch req.Method {
+	case "eth_subscribe":
+		var filterID string
+
+		// if the request method is eth_subscribe we need to create a new filter with ws connection
+		if filterID, err = d.handleSubscribe(req, conn); err == nil {
+			response = []byte(fmt.Sprintf("\"%s\"", filterID))
+		}
+	case "eth_unsubscribe":
+		var ok bool
+
+		if ok, err = d.handleUnsubscribe(req); err == nil {
+			response = []byte(strconv.FormatBool(ok))
+		}
+	default:
+		// its a normal query that we handle with the dispatcher
+		response, err = d.handleReq(req)
+	}
+
+	return NewRPCResponse(id, "2.0", response, err)
 }
 
 func (d *Dispatcher) Handle(reqBody []byte) ([]byte, error) {
@@ -337,7 +344,7 @@ func (d *Dispatcher) Handle(reqBody []byte) ([]byte, error) {
 	}
 
 	// handle batch requests
-	var requests []Request
+	var requests BatchRequest
 	if err := json.Unmarshal(reqBody, &requests); err != nil {
 		return NewRPCResponse(
 			nil,
@@ -348,7 +355,7 @@ func (d *Dispatcher) Handle(reqBody []byte) ([]byte, error) {
 	}
 
 	// if not disabled, avoid handling long batch requests
-	if d.params.jsonRPCBatchLengthLimit != 0 && len(requests) > int(d.params.jsonRPCBatchLengthLimit) {
+	if d.params.isExceedingBatchLengthLimit(uint64(len(requests))) {
 		return NewRPCResponse(
 			nil,
 			"2.0",

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -2,6 +2,7 @@ package jsonrpc
 
 import (
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"reflect"
 	"testing"
@@ -102,6 +103,8 @@ func TestDispatcher_HandleWebsocketConnection_EthSubscribe(t *testing.T) {
 }
 
 func TestDispatcher_WebsocketConnection_RequestFormats(t *testing.T) {
+	t.Parallel()
+
 	store := newMockStore()
 	dispatcher := newTestDispatcher(t,
 		hclog.NewNullLogger(),
@@ -212,6 +215,8 @@ func (m *mockService) Filter(f LogQuery) (interface{}, error) {
 }
 
 func TestDispatcherFuncDecode(t *testing.T) {
+	t.Parallel()
+
 	srv := &mockService{msgCh: make(chan interface{}, 10)}
 
 	dispatcher := newTestDispatcher(t,
@@ -290,20 +295,29 @@ func TestDispatcherFuncDecode(t *testing.T) {
 }
 
 func TestDispatcherBatchRequest(t *testing.T) {
-	handle := func(dispatcher *Dispatcher, reqBody []byte) []byte {
-		res, _ := dispatcher.Handle(reqBody)
+	t.Parallel()
 
-		return res
-	}
-
-	cases := []struct {
+	type caseData struct {
 		name          string
 		desc          string
 		dispatcher    *Dispatcher
 		reqBody       []byte
 		err           *ObjectError
 		batchResponse []*SuccessResponse
-	}{
+	}
+
+	mock := &mockWsConn{
+		SetFilterIDFn: func(s string) {
+		},
+		GetFilterIDFn: func() string {
+			return ""
+		},
+		WriteMessageFn: func(i int, b []byte) error {
+			return nil
+		},
+	}
+
+	cases := []caseData{
 		{
 			"leading-whitespace",
 			"test with leading whitespace (\"  \\t\\n\\n\\r\\)",
@@ -425,14 +439,12 @@ func TestDispatcherBatchRequest(t *testing.T) {
 		},
 	}
 
-	for _, c := range cases {
-		res := handle(c.dispatcher, c.reqBody)
-
+	check := func(c caseData, res []byte) {
 		if c.err != nil {
 			var resp ErrorResponse
 
 			assert.NoError(t, expectBatchJSONResult(res, &resp))
-			assert.Equal(t, resp.Error, c.err)
+			assert.Equal(t, c.err, resp.Error)
 		} else {
 			var batchResp []SuccessResponse
 			assert.NoError(t, expectBatchJSONResult(res, &batchResp))
@@ -440,21 +452,87 @@ func TestDispatcherBatchRequest(t *testing.T) {
 			if c.name == "leading-whitespace" {
 				assert.Len(t, batchResp, 4)
 				for index, resp := range batchResp {
-					assert.Equal(t, resp.Error, c.batchResponse[index].Error)
+					assert.Equal(t, c.batchResponse[index].Error, resp.Error)
 				}
 			} else if c.name == "valid-batch-req" {
 				assert.Len(t, batchResp, 6)
 				for index, resp := range batchResp {
-					assert.Equal(t, resp.Error, c.batchResponse[index].Error)
+					assert.Equal(t, c.batchResponse[index].Error, resp.Error)
 				}
 			} else if c.name == "no-limits" {
 				assert.Len(t, batchResp, 12)
 				for index, resp := range batchResp {
-					assert.Equal(t, resp.Error, c.batchResponse[index].Error)
+					assert.Equal(t, c.batchResponse[index].Error, resp.Error)
 				}
 			}
 		}
 	}
+
+	for _, c := range cases {
+		c := c
+
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			res, _ := c.dispatcher.HandleWs(c.reqBody, mock)
+
+			check(c, res)
+
+			res, _ = c.dispatcher.Handle(c.reqBody)
+
+			check(c, res)
+		})
+	}
+}
+
+func TestDispatcher_WebsocketConnection_Unsubscribe(t *testing.T) {
+	t.Parallel()
+
+	store := newMockStore()
+	dispatcher := newTestDispatcher(t,
+		hclog.NewNullLogger(),
+		store,
+		&dispatcherParams{
+			chainID:                 0,
+			priceLimit:              0,
+			jsonRPCBatchLengthLimit: 20,
+			blockRangeLimit:         1000,
+		},
+	)
+	mockConn := &mockWsConn{
+		SetFilterIDFn: func(s string) {
+		},
+		GetFilterIDFn: func() string {
+			return ""
+		},
+		WriteMessageFn: func(i int, b []byte) error {
+			return nil
+		},
+	}
+
+	resp := SuccessResponse{}
+	reqUnsub := func(n string) []byte {
+		return []byte(fmt.Sprintf(`{"method": "eth_unsubscribe", "params": [%s]}`, n))
+	}
+
+	// non existing subscription
+	r, err := dispatcher.HandleWs(reqUnsub("\"787832\""), mockConn)
+	require.NoError(t, err)
+
+	require.NoError(t, json.Unmarshal(r, &resp))
+	assert.Equal(t, "false", string(resp.Result))
+
+	r, err = dispatcher.HandleWs([]byte(`{"method": "eth_subscribe", "params": ["newHeads"]}`), mockConn)
+	require.NoError(t, err)
+
+	require.NoError(t, json.Unmarshal(r, &resp))
+
+	// existing subscription
+	r, err = dispatcher.HandleWs(reqUnsub(string(resp.Result)), mockConn)
+	require.NoError(t, err)
+
+	require.NoError(t, json.Unmarshal(r, &resp))
+	assert.Equal(t, "true", string(resp.Result))
 }
 
 func newTestDispatcher(t *testing.T, logger hclog.Logger, store JSONRPCStore, params *dispatcherParams) *Dispatcher {


### PR DESCRIPTION
# Description

There was no support for batch requests over web socket in edge

```
HI Team - [@Jesse Lee](https://0xpolygon.slack.com/team/U044LBPUHUG) and I observed that polycli monitor didn't work properly when connected to Edge via websocket.  It works fine on a standard HTTP transport. The root cause seems to be that websocket RPC doesn't seem to support standard JSON RPC requests that are [batched.In](http://batched.in/) the example screenshot, I'm doing 4 things:


OK .Making a batch call over websocket to Alchemy. This works fine


NOT OK. Making a batch call over websocket to v0.7.1-alpha3 Nexon. This does not work.


NOT OK. Making a batch call over websocket to v0.6.2 Necon. This does not work.


OK. Making a batch call over HTTP to v0.7.1-alpha3 Nexon. This works fineJust wanted to check and see if we're doing something wrong or if this is expected behavior?
```

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually
