### PR TITLE
Transaction relayer fetching gas price from current eth client instead of using hardcoded value

### DIFF
--- a/command/rootchain/staking/stake.go
+++ b/command/rootchain/staking/stake.go
@@ -102,11 +102,6 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	gasPrice, err := txRelayer.Client().Eth().GasPrice()
-	if err != nil {
-		return err
-	}
-
 	approveTxn, err := rootHelper.CreateApproveERC20Txn(params.amountValue,
 		types.StringToAddress(params.stakeManagerAddr), types.StringToAddress(params.stakeTokenAddr))
 	if err != nil {
@@ -134,10 +129,9 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 
 	stakeManagerAddr := ethgo.Address(types.StringToAddress(params.stakeManagerAddr))
 	txn := &ethgo.Transaction{
-		From:     validatorAccount.Ecdsa.Address(),
-		Input:    encoded,
-		To:       &stakeManagerAddr,
-		GasPrice: gasPrice,
+		From:  validatorAccount.Ecdsa.Address(),
+		Input: encoded,
+		To:    &stakeManagerAddr,
 	}
 
 	receipt, err = txRelayer.SendTransaction(txn, validatorAccount.Ecdsa)

--- a/command/rootchain/supernet/supernet.go
+++ b/command/rootchain/supernet/supernet.go
@@ -117,11 +117,6 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("enlist validator failed: %w", err)
 	}
 
-	gasPrice, err := txRelayer.Client().Eth().GasPrice()
-	if err != nil {
-		return err
-	}
-
 	supernetAddr := ethgo.Address(types.StringToAddress(params.supernetManagerAddress))
 
 	if params.finalizeGenesisSet {
@@ -131,10 +126,9 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		}
 
 		txn := &ethgo.Transaction{
-			From:     ownerKey.Address(),
-			Input:    encoded,
-			To:       &supernetAddr,
-			GasPrice: gasPrice,
+			From:  ownerKey.Address(),
+			Input: encoded,
+			To:    &supernetAddr,
 		}
 
 		if _, err = txRelayer.Call(ownerKey.Address(), supernetAddr, encoded); err == nil {
@@ -185,10 +179,9 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		}
 
 		txn := &ethgo.Transaction{
-			From:     ownerKey.Address(),
-			Input:    encoded,
-			To:       &supernetAddr,
-			GasPrice: gasPrice,
+			From:  ownerKey.Address(),
+			Input: encoded,
+			To:    &supernetAddr,
 		}
 
 		receipt, err := txRelayer.SendTransaction(txn, ownerKey)

--- a/command/rootchain/whitelist/whitelist_validators.go
+++ b/command/rootchain/whitelist/whitelist_validators.go
@@ -94,11 +94,6 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("whitelist validator failed. Could not create tx relayer: %w", err)
 	}
 
-	gasPrice, err := txRelayer.Client().Eth().GasPrice()
-	if err != nil {
-		return err
-	}
-
 	whitelistFn := &contractsapi.WhitelistValidatorsCustomSupernetManagerFn{
 		Validators_: stringSliceToAddressSlice(params.newValidatorAddresses),
 	}
@@ -110,10 +105,9 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 
 	supernetAddr := ethgo.Address(types.StringToAddress(params.supernetManagerAddress))
 	txn := &ethgo.Transaction{
-		From:     ecdsaKey.Address(),
-		Input:    encoded,
-		To:       &supernetAddr,
-		GasPrice: gasPrice,
+		From:  ecdsaKey.Address(),
+		Input: encoded,
+		To:    &supernetAddr,
 	}
 
 	receipt, err := txRelayer.SendTransaction(txn, ecdsaKey)

--- a/command/rootchain/withdraw/withdraw.go
+++ b/command/rootchain/withdraw/withdraw.go
@@ -102,17 +102,11 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	gasPrice, err := txRelayer.Client().Eth().GasPrice()
-	if err != nil {
-		return err
-	}
-
 	stakeManagerAddr := ethgo.Address(types.StringToAddress(params.stakeManagerAddr))
 	txn := &ethgo.Transaction{
-		From:     validatorAccount.Ecdsa.Address(),
-		Input:    encoded,
-		To:       &stakeManagerAddr,
-		GasPrice: gasPrice,
+		From:  validatorAccount.Ecdsa.Address(),
+		Input: encoded,
+		To:    &stakeManagerAddr,
 	}
 
 	receipt, err := txRelayer.SendTransaction(txn, validatorAccount.Ecdsa)

--- a/command/sidechain/helper.go
+++ b/command/sidechain/helper.go
@@ -18,8 +18,6 @@ import (
 
 const (
 	AmountFlag = "amount"
-
-	DefaultGasPrice = 1879048192 // 0x70000000
 )
 
 func CheckIfDirectoryExist(dir string) error {

--- a/command/sidechain/rewards/rewards.go
+++ b/command/sidechain/rewards/rewards.go
@@ -95,10 +95,9 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txn := &ethgo.Transaction{
-		From:     validatorAddr,
-		Input:    encoded,
-		To:       &rewardPoolAddr,
-		GasPrice: sidechainHelper.DefaultGasPrice,
+		From:  validatorAddr,
+		Input: encoded,
+		To:    &rewardPoolAddr,
 	}
 
 	receipt, err := txRelayer.SendTransaction(txn, validatorAccount.Ecdsa)

--- a/command/sidechain/unstaking/unstake.go
+++ b/command/sidechain/unstaking/unstake.go
@@ -88,10 +88,9 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txn := &ethgo.Transaction{
-		From:     validatorAccount.Ecdsa.Address(),
-		Input:    encoded,
-		To:       (*ethgo.Address)(&contracts.ValidatorSetContract),
-		GasPrice: sidechainHelper.DefaultGasPrice,
+		From:  validatorAccount.Ecdsa.Address(),
+		Input: encoded,
+		To:    (*ethgo.Address)(&contracts.ValidatorSetContract),
 	}
 
 	receipt, err := txRelayer.SendTransaction(txn, validatorAccount.Ecdsa)

--- a/command/sidechain/withdraw/withdraw.go
+++ b/command/sidechain/withdraw/withdraw.go
@@ -77,10 +77,9 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	txn := &ethgo.Transaction{
-		From:     validatorAccount.Ecdsa.Address(),
-		Input:    encoded,
-		To:       (*ethgo.Address)(&contracts.ValidatorSetContract),
-		GasPrice: sidechainHelper.DefaultGasPrice,
+		From:  validatorAccount.Ecdsa.Address(),
+		Input: encoded,
+		To:    (*ethgo.Address)(&contracts.ValidatorSetContract),
 	}
 
 	receipt, err := txRelayer.SendTransaction(txn, validatorAccount.Ecdsa)

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer.go
@@ -196,11 +196,10 @@ func (r *StateSyncRelayer) executeStateSync(proof *types.Proof) error {
 
 	// execute the state sync
 	txn := &ethgo.Transaction{
-		From:     r.key.Address(),
-		To:       (*ethgo.Address)(&contracts.StateReceiverContract),
-		GasPrice: 0,
-		Gas:      types.StateTransactionGasLimit,
-		Input:    input,
+		From:  r.key.Address(),
+		To:    (*ethgo.Address)(&contracts.StateReceiverContract),
+		Gas:   types.StateTransactionGasLimit,
+		Input: input,
 	}
 
 	receipt, err := r.txRelayer.SendTransaction(txn, r.key)

--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -85,10 +85,9 @@ func TestE2E_JsonRPC(t *testing.T) {
 
 		toAddr := key1.Address()
 		msg := &ethgo.CallMsg{
-			From:     acct.Address(),
-			To:       &toAddr,
-			Value:    newBalance,
-			GasPrice: gasPrice,
+			From:  acct.Address(),
+			To:    &toAddr,
+			Value: newBalance,
 		}
 
 		estimatedGas, err := client.EstimateGas(msg)
@@ -99,10 +98,9 @@ func TestE2E_JsonRPC(t *testing.T) {
 		amountToSend := new(big.Int).Sub(newBalance, big.NewInt(int64(txPrice)))
 		targetAddr := acct.Address()
 		txn = cluster.SendTxn(t, key1, &ethgo.Transaction{
-			To:       &targetAddr,
-			Value:    amountToSend,
-			GasPrice: gasPrice,
-			Gas:      estimatedGas,
+			To:    &targetAddr,
+			Value: amountToSend,
+			Gas:   estimatedGas,
 		})
 		require.NoError(t, txn.Wait())
 		require.True(t, txn.Succeed())

--- a/e2e-polybft/e2e/migration_test.go
+++ b/e2e-polybft/e2e/migration_test.go
@@ -60,20 +60,18 @@ func TestE2E_Migration(t *testing.T) {
 	//send transaction to user2
 	sendAmount := ethgo.Gwei(10000)
 	receipt, err := relayer.SendTransaction(&ethgo.Transaction{
-		From:     userAddr,
-		To:       &userAddr2,
-		GasPrice: 1048576,
-		Gas:      1000000,
-		Value:    sendAmount,
+		From:  userAddr,
+		To:    &userAddr2,
+		Gas:   1000000,
+		Value: sendAmount,
 	}, userKey)
 	assert.NoError(t, err)
 	assert.NotNil(t, receipt)
 
 	receipt, err = relayer.SendTransaction(&ethgo.Transaction{
-		From:     userAddr,
-		GasPrice: 1048576,
-		Gas:      1000000,
-		Input:    contractsapi.TestWriteBlockMetadata.Bytecode,
+		From:  userAddr,
+		Gas:   1000000,
+		Input: contractsapi.TestWriteBlockMetadata.Bytecode,
 	}, userKey)
 	require.NoError(t, err)
 	require.NotNil(t, receipt)

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -910,7 +910,10 @@ func (c *TestCluster) SendTxn(t *testing.T, sender ethgo.Key, txn *ethgo.Transac
 	}
 
 	if txn.GasPrice == 0 {
-		txn.GasPrice = txrelayer.DefaultGasPrice
+		gasPrice, err := client.Eth().GasPrice()
+		require.NoError(t, err)
+
+		txn.GasPrice = gasPrice
 	}
 
 	if txn.Gas == 0 {

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -626,12 +626,6 @@ func (t *Txn) GasLimit(gas uint64) *Txn {
 	return t
 }
 
-func (t *Txn) GasPrice(price uint64) *Txn {
-	t.raw.GasPrice = price
-
-	return t
-}
-
 func (t *Txn) Nonce(nonce uint64) *Txn {
 	t.raw.Nonce = nonce
 
@@ -645,7 +639,12 @@ func (t *Txn) sendImpl() error {
 	}
 
 	if t.raw.GasPrice == 0 {
-		t.raw.GasPrice = 1048576
+		gasPrice, err := t.client.GasPrice()
+		if err != nil {
+			return fmt.Errorf("failed to get gas price: %w", err)
+		}
+
+		t.raw.GasPrice = gasPrice
 	}
 
 	if t.raw.Nonce == 0 {

--- a/e2e/jsonrpc_test.go
+++ b/e2e/jsonrpc_test.go
@@ -81,7 +81,6 @@ func TestJsonRPC(t *testing.T) {
 		amountToSend := new(big.Int).Sub(newBalance, big.NewInt(int64(txPrice)))
 		txn, err = srv.Txn(key1).Transfer(fund.Address(), amountToSend).
 			GasLimit(estimatedGas).
-			GasPrice(gasPrice).
 			Send()
 		require.NoError(t, err)
 		txn.NoFail(t)

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	DefaultGasPrice   = 1879048192 // 0x70000000
+	defaultGasPrice   = 1879048192 // 0x70000000
 	DefaultGasLimit   = 5242880    // 0x500000
 	DefaultRPCAddress = "http://127.0.0.1:8545"
 	numRetries        = 1000
@@ -147,7 +147,7 @@ func (t *TxRelayerImpl) SendTransactionLocal(txn *ethgo.Transaction) (*ethgo.Rec
 
 	txn.From = accounts[0]
 	txn.Gas = DefaultGasLimit
-	txn.GasPrice = DefaultGasPrice
+	txn.GasPrice = defaultGasPrice
 
 	txnHash, err := t.client.Eth().SendTransaction(txn)
 	if err != nil {

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -102,6 +102,11 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 
 	txn.Nonce = nonce
 
+	gasPrice, err := t.Client().Eth().GasPrice()
+	if err != nil {
+		return ethgo.ZeroHash, err
+	}
+
 	if txn.GasPrice == 0 {
 		txn.GasPrice = DefaultGasPrice
 	}

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -107,6 +107,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 		if err != nil {
 			return ethgo.ZeroHash, err
 		}
+		
 		txn.GasPrice = gasPrice
 	}
 

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -108,7 +108,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 	}
 
 	if txn.GasPrice == 0 {
-		txn.GasPrice = DefaultGasPrice
+		txn.GasPrice = gasPrice
 	}
 
 	if txn.Gas == 0 {

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -102,12 +102,11 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 
 	txn.Nonce = nonce
 
-	gasPrice, err := t.Client().Eth().GasPrice()
-	if err != nil {
-		return ethgo.ZeroHash, err
-	}
-
 	if txn.GasPrice == 0 {
+		gasPrice, err := t.Client().Eth().GasPrice()
+		if err != nil {
+			return ethgo.ZeroHash, err
+		}
 		txn.GasPrice = gasPrice
 	}
 

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -107,7 +107,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 		if err != nil {
 			return ethgo.ZeroHash, err
 		}
-		
+
 		txn.GasPrice = gasPrice
 	}
 


### PR DESCRIPTION
# Description

Fixes [issue 1551](https://github.com/0xPolygon/polygon-edge/issues/1551).

- Transaction relayer SendTransaction() function is modified to fetch the gas price from the current client, if the gas price for the transaction wasn't set.
- Setting the gas price explicitly on transactions before calling txRelayer.SendTransaction() was removed.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
