### PR TITLE
EVM-680 Dial queue issues fixes

### DIFF
--- a/network/server_discovery.go
+++ b/network/server_discovery.go
@@ -226,8 +226,8 @@ func (s *Server) setupDiscovery() error {
 	)
 
 	// Register a network event handler
-	if subscribeErr := s.Subscribe(context.Background(), discoveryService.HandleNetworkEvent); subscribeErr != nil {
-		return fmt.Errorf("unable to subscribe to network events, %w", subscribeErr)
+	if err := s.Subscribe(context.Background(), discoveryService.HandleNetworkEvent); err != nil {
+		return fmt.Errorf("unable to subscribe to network events, %w", err)
 	}
 
 	// Register the actual discovery service as a valid protocol

--- a/network/server_discovery.go
+++ b/network/server_discovery.go
@@ -206,7 +206,7 @@ func (s *Server) setupDiscovery() error {
 
 	// Set the PeerAdded event handler
 	routingTable.PeerAdded = func(p peer.ID) {
-		// this is called from the lock. because of that execute addToDialQueue on separated routine
+		// spawn routine because PeerAdded is called from event handler and s.addToDialQueue emits event again
 		go func() {
 			info := s.host.Peerstore().PeerInfo(p)
 			s.addToDialQueue(&info, common.PriorityRandomDial)
@@ -226,7 +226,7 @@ func (s *Server) setupDiscovery() error {
 	)
 
 	// Register a network event handler
-	if subscribeErr := s.SubscribeFn(context.Background(), discoveryService.HandleNetworkEvent); subscribeErr != nil {
+	if subscribeErr := s.Subscribe(context.Background(), discoveryService.HandleNetworkEvent); subscribeErr != nil {
 		return fmt.Errorf("unable to subscribe to network events, %w", subscribeErr)
 	}
 


### PR DESCRIPTION
# Description

There are multiple small bugs inside dial queue that need to be addressed
For example:
- after deleting task from the queue, corresponding map is not updated, only binary heap is
- if task is added to queue, there is no check that same task is already on the queue
- some other small issues
- remove unnecessary network server subscriptions, simplify code

Slots will be added through separated pr

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
