### PR TITLE
[EVM-685]: Remove premining of validator balances on L2 for non-mintable tokens

### DIFF
--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -175,16 +175,6 @@ func setFlags(cmd *cobra.Command) {
 			"validators defined by user (format: <P2P multi address>:<ECDSA address>:<public BLS key>)",
 		)
 
-		cmd.Flags().StringArrayVar(
-			&params.stakes,
-			stakeFlag,
-			[]string{},
-			fmt.Sprintf(
-				"validators staked amount (format: <address>[:<amount>]). Default stake amount: %d",
-				command.DefaultStake,
-			),
-		)
-
 		cmd.MarkFlagsMutuallyExclusive(validatorsFlag, validatorsPathFlag)
 		cmd.MarkFlagsMutuallyExclusive(validatorsFlag, validatorsPrefixFlag)
 

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -99,7 +99,6 @@ type genesisParams struct {
 	// PolyBFT
 	validatorsPath       string
 	validatorsPrefixPath string
-	stakes               []string
 	validators           []string
 	sprintSize           uint64
 	blockTime            time.Duration

--- a/command/genesis/utils.go
+++ b/command/genesis/utils.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 
 	"github.com/0xPolygon/polygon-edge/command"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/secrets"
@@ -227,4 +229,16 @@ func getSecrets(directory string) (*wallet.Account, string, error) {
 	}
 
 	return account, nodeID, err
+}
+
+// GenerateExtraDataPolyBft populates Extra with specific fields required for polybft consensus protocol
+func GenerateExtraDataPolyBft(validators []*validator.ValidatorMetadata) ([]byte, error) {
+	delta := &validator.ValidatorSetDelta{
+		Added:   validators,
+		Removed: bitmap.Bitmap{},
+	}
+
+	extra := polybft.Extra{Validators: delta, Checkpoint: &polybft.CheckpointData{}}
+
+	return extra.MarshalRLPTo(nil), nil
 }

--- a/command/rootchain/deploy/deploy.go
+++ b/command/rootchain/deploy/deploy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 
 	"github.com/spf13/cobra"
 	"github.com/umbracle/ethgo"
@@ -636,24 +635,6 @@ func deployContracts(outputter command.OutputFormatter, client *jsonrpc.Client, 
 		return nil, 0, err
 	}
 
-	// initialize CheckpointManager
-	validatorSet, err := validatorSetToABISlice(outputter, initialValidators)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to convert validators to map: %w", err)
-	}
-
-	initParams := &contractsapi.InitializeCheckpointManagerFn{
-		ChainID_:        big.NewInt(chainID),
-		NewBls:          rootchainConfig.BLSAddress,
-		NewBn256G2:      rootchainConfig.BN256G2Address,
-		NewValidatorSet: validatorSet,
-	}
-
-	if err := initContract(outputter, txRelayer, initParams,
-		rootchainConfig.CheckpointManagerAddress, checkpointManagerName, deployerKey); err != nil {
-		return nil, 0, err
-	}
-
 	return rootchainConfig, supernetID, nil
 }
 
@@ -748,43 +729,4 @@ func initContract(cmdOutput command.OutputFormatter, txRelayer txrelayer.TxRelay
 		})
 
 	return nil
-}
-
-// validatorSetToABISlice converts given validators to generic map
-// which is used for ABI encoding validator set being sent to the rootchain contract
-func validatorSetToABISlice(o command.OutputFormatter,
-	validators []*validator.GenesisValidator) ([]*contractsapi.Validator, error) {
-	accSet := make(validator.AccountSet, len(validators))
-
-	if _, err := o.Write([]byte(fmt.Sprintf("%s [VALIDATORS]\n", contractsDeploymentTitle))); err != nil {
-		return nil, err
-	}
-
-	for i, val := range validators {
-		if _, err := o.Write([]byte(fmt.Sprintf("%v\n", val))); err != nil {
-			return nil, err
-		}
-
-		blsKey, err := val.UnmarshalBLSPublicKey()
-		if err != nil {
-			return nil, err
-		}
-
-		accSet[i] = &validator.ValidatorMetadata{
-			Address:     val.Address,
-			BlsKey:      blsKey,
-			VotingPower: new(big.Int).Set(val.Stake),
-		}
-	}
-
-	hash, err := accSet.Hash()
-	if err != nil {
-		return nil, err
-	}
-
-	if _, err := o.Write([]byte(fmt.Sprintf("%s Validators hash: %s\n", contractsDeploymentTitle, hash))); err != nil {
-		return nil, err
-	}
-
-	return accSet.ToAPIBinding(), nil
 }

--- a/command/rootchain/staking/params.go
+++ b/command/rootchain/staking/params.go
@@ -38,7 +38,7 @@ func (sp *stakeParams) validateFlags() (err error) {
 
 type stakeResult struct {
 	validatorAddress string
-	amount           uint64
+	amount           *big.Int
 }
 
 func (sr stakeResult) GetOutput() string {
@@ -48,7 +48,7 @@ func (sr stakeResult) GetOutput() string {
 
 	vals := make([]string, 0, 2)
 	vals = append(vals, fmt.Sprintf("Validator Address|%s", sr.validatorAddress))
-	vals = append(vals, fmt.Sprintf("Amount Staked|%v", sr.amount))
+	vals = append(vals, fmt.Sprintf("Amount Staked|%d", sr.amount))
 
 	buffer.WriteString(helper.FormatKV(vals))
 	buffer.WriteString("\n")

--- a/command/rootchain/staking/stake.go
+++ b/command/rootchain/staking/stake.go
@@ -163,7 +163,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 			continue
 		}
 
-		result.amount = stakeAddedEvent.Amount.Uint64()
+		result.amount = stakeAddedEvent.Amount
 		result.validatorAddress = stakeAddedEvent.Validator.String()
 		foundLog = true
 

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -104,6 +104,8 @@ type BridgeConfig struct {
 	StakeManagerAddr                  types.Address `json:"stakeManagerAddr"`
 	// only populated if stake-manager-deploy command is executed, and used for e2e tests
 	StakeTokenAddr types.Address `json:"stakeTokenAddr,omitempty"`
+	BLSAddress     types.Address `json:"blsAddr"`
+	BN256G2Address types.Address `json:"bn256G2Addr"`
 
 	JSONRPCEndpoint         string                   `json:"jsonRPCEndpoint"`
 	EventTrackerStartBlocks map[types.Address]uint64 `json:"eventTrackerStartBlocks"`
@@ -158,6 +160,8 @@ func (r *RootchainConfig) ToBridgeConfig() *BridgeConfig {
 		ChildMintableERC1155PredicateAddr: r.ChildMintableERC1155PredicateAddress,
 		CustomSupernetManagerAddr:         r.CustomSupernetManagerAddress,
 		StakeManagerAddr:                  r.StakeManagerAddress,
+		BLSAddress:                        r.BLSAddress,
+		BN256G2Address:                    r.BN256G2Address,
 	}
 }
 

--- a/consensus/polybft/validator/genesis_validator.go
+++ b/consensus/polybft/validator/genesis_validator.go
@@ -92,6 +92,6 @@ func (v *GenesisValidator) ToValidatorMetadata() (*ValidatorMetadata, error) {
 
 // String implements fmt.Stringer interface
 func (v *GenesisValidator) String() string {
-	return fmt.Sprintf("Address=%s; Balance=%d; P2P Multi addr=%s; BLS Key=%s;",
-		v.Address, v.Balance, v.MultiAddr, v.BlsKey)
+	return fmt.Sprintf("Address=%s; Balance=%d; Stake=%d; P2P Multi addr=%s; BLS Key=%s;",
+		v.Address, v.Balance, v.Stake, v.MultiAddr, v.BlsKey)
 }

--- a/e2e-polybft/e2e/acls_test.go
+++ b/e2e-polybft/e2e/acls_test.go
@@ -43,6 +43,7 @@ func TestE2E_AllowList_ContractDeployment(t *testing.T) {
 	otherAddr := types.Address{0x1}
 
 	cluster := framework.NewTestCluster(t, 5,
+		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
 		framework.WithPremine(adminAddr, targetAddr),
 		framework.WithContractDeployerAllowListAdmin(adminAddr),
 		framework.WithContractDeployerAllowListEnabled(otherAddr),
@@ -141,6 +142,7 @@ func TestE2E_BlockList_ContractDeployment(t *testing.T) {
 	otherAddr := types.Address{0x1}
 
 	cluster := framework.NewTestCluster(t, 5,
+		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
 		framework.WithPremine(adminAddr, targetAddr),
 		framework.WithContractDeployerBlockListAdmin(adminAddr),
 		framework.WithContractDeployerBlockListEnabled(otherAddr),
@@ -224,6 +226,7 @@ func TestE2E_AllowList_Transactions(t *testing.T) {
 	otherAddr := types.Address(other.Address())
 
 	cluster := framework.NewTestCluster(t, 5,
+		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
 		framework.WithPremine(adminAddr, targetAddr, otherAddr),
 		framework.WithTransactionsAllowListAdmin(adminAddr),
 		framework.WithTransactionsAllowListEnabled(otherAddr),
@@ -317,6 +320,7 @@ func TestE2E_BlockList_Transactions(t *testing.T) {
 	otherAddr := types.Address(other.Address())
 
 	cluster := framework.NewTestCluster(t, 5,
+		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
 		framework.WithPremine(adminAddr, targetAddr, otherAddr),
 		framework.WithTransactionsBlockListAdmin(adminAddr),
 		framework.WithTransactionsBlockListEnabled(otherAddr),
@@ -387,6 +391,7 @@ func TestE2E_AddressLists_Bridge(t *testing.T) {
 	otherAddr := types.Address(other.Address())
 
 	cluster := framework.NewTestCluster(t, 5,
+		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
 		framework.WithPremine(adminAddr, targetAddr, otherAddr),
 		framework.WithBridgeAllowListAdmin(adminAddr),
 		framework.WithBridgeAllowListEnabled(otherAddr),

--- a/e2e-polybft/e2e/acls_test.go
+++ b/e2e-polybft/e2e/acls_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -43,7 +44,7 @@ func TestE2E_AllowList_ContractDeployment(t *testing.T) {
 	otherAddr := types.Address{0x1}
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
+		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, adminAddr)),
 		framework.WithPremine(adminAddr, targetAddr),
 		framework.WithContractDeployerAllowListAdmin(adminAddr),
 		framework.WithContractDeployerAllowListEnabled(otherAddr),
@@ -142,7 +143,7 @@ func TestE2E_BlockList_ContractDeployment(t *testing.T) {
 	otherAddr := types.Address{0x1}
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
+		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, adminAddr)),
 		framework.WithPremine(adminAddr, targetAddr),
 		framework.WithContractDeployerBlockListAdmin(adminAddr),
 		framework.WithContractDeployerBlockListEnabled(otherAddr),
@@ -226,7 +227,7 @@ func TestE2E_AllowList_Transactions(t *testing.T) {
 	otherAddr := types.Address(other.Address())
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
+		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, adminAddr)),
 		framework.WithPremine(adminAddr, targetAddr, otherAddr),
 		framework.WithTransactionsAllowListAdmin(adminAddr),
 		framework.WithTransactionsAllowListEnabled(otherAddr),
@@ -320,7 +321,7 @@ func TestE2E_BlockList_Transactions(t *testing.T) {
 	otherAddr := types.Address(other.Address())
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
+		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, adminAddr)),
 		framework.WithPremine(adminAddr, targetAddr, otherAddr),
 		framework.WithTransactionsBlockListAdmin(adminAddr),
 		framework.WithTransactionsBlockListEnabled(otherAddr),
@@ -391,7 +392,7 @@ func TestE2E_AddressLists_Bridge(t *testing.T) {
 	otherAddr := types.Address(other.Address())
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
+		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, adminAddr)),
 		framework.WithPremine(adminAddr, targetAddr, otherAddr),
 		framework.WithBridgeAllowListAdmin(adminAddr),
 		framework.WithBridgeAllowListEnabled(otherAddr),

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/umbracle/ethgo"
+	"github.com/umbracle/ethgo/wallet"
 	ethgow "github.com/umbracle/ethgo/wallet"
 
 	"github.com/0xPolygon/polygon-edge/command"
@@ -303,6 +304,9 @@ func TestE2E_Bridge_ERC721Transfer(t *testing.T) {
 		epochSize      = 5
 	)
 
+	minter, err := wallet.GenerateKey()
+	require.NoError(t, err)
+
 	receiverKeys := make([]string, transfersCount)
 	receivers := make([]string, transfersCount)
 	receiversAddrs := make([]types.Address, transfersCount)
@@ -325,7 +329,8 @@ func TestE2E_Bridge_ERC721Transfer(t *testing.T) {
 
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithEpochSize(epochSize),
-		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
+		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, minter.Address())),
+		framework.WithPremine(types.Address(minter.Address())),
 		framework.WithPremine(receiversAddrs...))
 	defer cluster.Stop()
 
@@ -441,6 +446,9 @@ func TestE2E_Bridge_ERC1155Transfer(t *testing.T) {
 		epochSize      = 5
 	)
 
+	minter, err := wallet.GenerateKey()
+	require.NoError(t, err)
+
 	receiverKeys := make([]string, transfersCount)
 	receivers := make([]string, transfersCount)
 	receiversAddrs := make([]types.Address, transfersCount)
@@ -466,7 +474,8 @@ func TestE2E_Bridge_ERC1155Transfer(t *testing.T) {
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithNumBlockConfirmations(0),
 		framework.WithEpochSize(epochSize),
-		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
+		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, minter.Address())),
+		framework.WithPremine(types.Address(minter.Address())),
 		framework.WithPremine(receiversAddrs...))
 	defer cluster.Stop()
 

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/umbracle/ethgo"
-	"github.com/umbracle/ethgo/wallet"
 	ethgow "github.com/umbracle/ethgo/wallet"
 
 	"github.com/0xPolygon/polygon-edge/command"
@@ -304,7 +303,7 @@ func TestE2E_Bridge_ERC721Transfer(t *testing.T) {
 		epochSize      = 5
 	)
 
-	minter, err := wallet.GenerateKey()
+	minter, err := ethgow.GenerateKey()
 	require.NoError(t, err)
 
 	receiverKeys := make([]string, transfersCount)
@@ -446,7 +445,7 @@ func TestE2E_Bridge_ERC1155Transfer(t *testing.T) {
 		epochSize      = 5
 	)
 
-	minter, err := wallet.GenerateKey()
+	minter, err := ethgow.GenerateKey()
 	require.NoError(t, err)
 
 	receiverKeys := make([]string, transfersCount)

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -121,6 +121,7 @@ func TestE2E_Consensus_RegisterValidator(t *testing.T) {
 	cluster := framework.NewTestCluster(t, validatorSetSize,
 		framework.WithEpochSize(epochSize),
 		framework.WithEpochReward(int(ethgo.Ether(1).Uint64())),
+		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
 		framework.WithSecretsCallback(func(addresses []types.Address, config *framework.TestClusterConfig) {
 			for _, a := range addresses {
 				config.Premine = append(config.Premine, fmt.Sprintf("%s:%s", a, premineBalance))
@@ -302,10 +303,11 @@ func TestE2E_Consensus_Validator_Unstake(t *testing.T) {
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithEpochReward(int(ethgo.Ether(1).Uint64())),
 		framework.WithEpochSize(5),
+		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
 		framework.WithSecretsCallback(func(addresses []types.Address, config *framework.TestClusterConfig) {
 			for _, a := range addresses {
 				config.Premine = append(config.Premine, fmt.Sprintf("%s:%d", a, premineAmount))
-				config.StakeAmounts = append(config.StakeAmounts, fmt.Sprintf("%s:%d", a, premineAmount))
+				config.StakeAmounts = append(config.StakeAmounts, new(big.Int).Set(premineAmount))
 			}
 		}),
 	)
@@ -468,7 +470,7 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 			config.Premine = append(config.Premine, fmt.Sprintf("%s:%d", minter.Address(), initMinterBalance))
 			for i, addr := range addrs {
 				config.Premine = append(config.Premine, fmt.Sprintf("%s:%d", addr, initValidatorsBalance))
-				config.StakeAmounts = append(config.StakeAmounts, fmt.Sprintf("%s:%d", addr, initValidatorsBalance))
+				config.StakeAmounts = append(config.StakeAmounts, new(big.Int).Set(initValidatorsBalance))
 				validatorsAddrs[i] = addr
 			}
 		}))

--- a/e2e-polybft/e2e/helpers_test.go
+++ b/e2e-polybft/e2e/helpers_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
+const nativeTokenMintableTestCfg = "Mintable Edge Coin:MEC:18:true"
+
 type e2eStateProvider struct {
 	txRelayer txrelayer.TxRelayer
 }

--- a/e2e-polybft/e2e/helpers_test.go
+++ b/e2e-polybft/e2e/helpers_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
-const nativeTokenMintableTestCfg = "Mintable Edge Coin:MEC:18:true"
+const nativeTokenMintableTestCfg = "Mintable Edge Coin:MEC:18:true:%s"
 
 type e2eStateProvider struct {
 	txRelayer txrelayer.TxRelayer

--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -23,6 +23,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 3,
+		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
 		framework.WithPremine(types.Address(acct.Address())),
 	)
 	defer cluster.Stop()

--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -23,7 +24,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 3,
-		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
+		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, acct.Address())),
 		framework.WithPremine(types.Address(acct.Address())),
 	)
 	defer cluster.Stop()

--- a/e2e-polybft/e2e/txpool_test.go
+++ b/e2e-polybft/e2e/txpool_test.go
@@ -23,7 +23,10 @@ func TestE2E_TxPool_Transfer(t *testing.T) {
 	sender, err := wallet.GenerateKey()
 	require.NoError(t, err)
 
-	cluster := framework.NewTestCluster(t, 5, framework.WithPremine(types.Address(sender.Address())))
+	cluster := framework.NewTestCluster(t, 5,
+		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
+		framework.WithPremine(types.Address(sender.Address())),
+	)
 	defer cluster.Stop()
 
 	cluster.WaitForReady(t)
@@ -99,7 +102,10 @@ func TestE2E_TxPool_Transfer_Linear(t *testing.T) {
 	require.NoError(t, err)
 
 	// first account should have some matics premined
-	cluster := framework.NewTestCluster(t, 5, framework.WithPremine(types.Address(premine.Address())))
+	cluster := framework.NewTestCluster(t, 5,
+		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
+		framework.WithPremine(types.Address(premine.Address())),
+	)
 	defer cluster.Stop()
 
 	cluster.WaitForReady(t)
@@ -192,6 +198,7 @@ func TestE2E_TxPool_TransactionWithHeaderInstructions(t *testing.T) {
 	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 4,
+		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
 		framework.WithPremine(types.Address(sidechainKey.Address())),
 	)
 	defer cluster.Stop()
@@ -237,6 +244,7 @@ func TestE2E_TxPool_BroadcastTransactions(t *testing.T) {
 
 	// First account should have some matics premined
 	cluster := framework.NewTestCluster(t, 5,
+		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
 		framework.WithPremine(types.Address(sender.Address())),
 	)
 	defer cluster.Stop()

--- a/e2e-polybft/e2e/txpool_test.go
+++ b/e2e-polybft/e2e/txpool_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"fmt"
 	"math/big"
 	"sync"
 	"testing"
@@ -24,7 +25,7 @@ func TestE2E_TxPool_Transfer(t *testing.T) {
 	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
+		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, sender.Address())),
 		framework.WithPremine(types.Address(sender.Address())),
 	)
 	defer cluster.Stop()
@@ -103,7 +104,7 @@ func TestE2E_TxPool_Transfer_Linear(t *testing.T) {
 
 	// first account should have some matics premined
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
+		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, premine.Address())),
 		framework.WithPremine(types.Address(premine.Address())),
 	)
 	defer cluster.Stop()
@@ -198,7 +199,7 @@ func TestE2E_TxPool_TransactionWithHeaderInstructions(t *testing.T) {
 	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 4,
-		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
+		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, sidechainKey.Address())),
 		framework.WithPremine(types.Address(sidechainKey.Address())),
 	)
 	defer cluster.Stop()
@@ -244,7 +245,7 @@ func TestE2E_TxPool_BroadcastTransactions(t *testing.T) {
 
 	// First account should have some matics premined
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithNativeTokenConfig(nativeTokenMintableTestCfg),
+		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, sender.Address())),
 		framework.WithPremine(types.Address(sender.Address())),
 	)
 	defer cluster.Stop()

--- a/e2e-polybft/framework/test-bridge.go
+++ b/e2e-polybft/framework/test-bridge.go
@@ -13,6 +13,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/0xPolygon/polygon-edge/command"
 	bridgeCommon "github.com/0xPolygon/polygon-edge/command/bridge/common"
 	"github.com/0xPolygon/polygon-edge/command/genesis"
 	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
@@ -338,7 +339,7 @@ func (t *TestBridge) fundRootchainValidators(polybftConfig polybft.PolyBFTConfig
 
 	for i, secret := range validatorSecrets {
 		secrets[i] = path.Join(t.clusterConfig.TmpDir, secret)
-		balances[i] = polybftConfig.InitialValidatorSet[i].Balance
+		balances[i] = command.DefaultPremineBalance
 	}
 
 	if err := t.FundValidators(polybftConfig.Bridge.StakeTokenAddr,
@@ -416,9 +417,8 @@ func (t *TestBridge) initialStakingOfGenesisValidators(polybftConfig polybft.Pol
 
 	g, ctx := errgroup.WithContext(context.Background())
 
-	for i, secret := range validatorSecrets {
+	for _, secret := range validatorSecrets {
 		secret := secret
-		i := i
 
 		g.Go(func() error {
 			select {
@@ -431,7 +431,7 @@ func (t *TestBridge) initialStakingOfGenesisValidators(polybftConfig polybft.Pol
 					"--jsonrpc", t.JSONRPCAddr(),
 					"--stake-manager", polybftConfig.Bridge.StakeManagerAddr.String(),
 					"--" + polybftsecrets.AccountDirFlag, path.Join(t.clusterConfig.TmpDir, secret),
-					"--amount", polybftConfig.InitialValidatorSet[i].Stake.String(),
+					"--amount", command.DefaultStake.String(),
 					"--supernet-id", strconv.FormatInt(polybftConfig.SupernetID, 10),
 					"--stake-token", polybftConfig.Bridge.StakeTokenAddr.String(),
 				}

--- a/e2e-polybft/framework/test-bridge.go
+++ b/e2e-polybft/framework/test-bridge.go
@@ -417,8 +417,9 @@ func (t *TestBridge) initialStakingOfGenesisValidators(polybftConfig polybft.Pol
 
 	g, ctx := errgroup.WithContext(context.Background())
 
-	for _, secret := range validatorSecrets {
+	for i, secret := range validatorSecrets {
 		secret := secret
+		i := i
 
 		g.Go(func() error {
 			select {
@@ -431,7 +432,7 @@ func (t *TestBridge) initialStakingOfGenesisValidators(polybftConfig polybft.Pol
 					"--jsonrpc", t.JSONRPCAddr(),
 					"--stake-manager", polybftConfig.Bridge.StakeManagerAddr.String(),
 					"--" + polybftsecrets.AccountDirFlag, path.Join(t.clusterConfig.TmpDir, secret),
-					"--amount", command.DefaultStake.String(),
+					"--amount", t.getStakeAmount(i).String(),
 					"--supernet-id", strconv.FormatInt(polybftConfig.SupernetID, 10),
 					"--stake-token", polybftConfig.Bridge.StakeTokenAddr.String(),
 				}
@@ -446,6 +447,15 @@ func (t *TestBridge) initialStakingOfGenesisValidators(polybftConfig polybft.Pol
 	}
 
 	return g.Wait()
+}
+
+func (t *TestBridge) getStakeAmount(validatorIndex int) *big.Int {
+	l := len(t.clusterConfig.StakeAmounts)
+	if l == 0 || l <= validatorIndex {
+		return command.DefaultStake
+	}
+
+	return t.clusterConfig.StakeAmounts[validatorIndex]
 }
 
 func (t *TestBridge) finalizeGenesis(genesisPath string, polybftConfig polybft.PolyBFTConfig) error {

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -75,7 +75,7 @@ type TestClusterConfig struct {
 	Name                 string
 	Premine              []string // address[:amount]
 	PremineValidators    []string // address[:amount]
-	StakeAmounts         []string // address[:amount]
+	StakeAmounts         []*big.Int
 	WithoutBridge        bool
 	BootnodeCount        int
 	NonValidatorCount    int
@@ -385,7 +385,7 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 		EpochSize:     10,
 		EpochReward:   1,
 		BlockGasLimit: 1e7, // 10M
-		StakeAmounts:  []string{},
+		StakeAmounts:  []*big.Int{},
 	}
 
 	if config.ValidatorPrefix == "" {
@@ -493,11 +493,6 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 			for i := 0; i < bootNodesCnt; i++ {
 				args = append(args, "--bootnode", validators[i].MultiAddr)
 			}
-		}
-
-		// provide validators' stakes
-		for _, validatorStake := range cluster.Config.StakeAmounts {
-			args = append(args, "--stake", validatorStake)
 		}
 
 		if len(cluster.Config.ContractDeployerAllowListAdmin) != 0 {


### PR DESCRIPTION
# Description

There was a misuse of `premine` flag in `genesis` if native child token is not mintable. Basically, we premined balances of validators, creating a situation where we minted tokens "out of thin air" on `childchain`. If native child token is not mintable, then validators need to bridge their tokens once the `childchain` is started.
Exceptions are zero address (since it is used to transfer tokens from it to the account address in bridge), and address of reward wallet, if native reward token is used as reward token.

If native child token is mintable, then we allow premining of any address.

Since we finalize stake of genesis validators on `rootchain` on `supernet` command, there was also a gap in initializing `CheckpointManager` contract, since it holds the current validator set for checkpoint submission, and `VotingPower` (`Stake`) is a crucial part of it, we must initialize `CheckpointManager` only after we finalize stake of genesis validators on `supernet` command. Because of that, `supernet` command is modified to initialize `CheckpointManager` with correct data (`VotingPower`) after it finalizes the genesis validators stake on `rootchain` (keep in mind that deployment of `CheckpointManager` is still in the `deploy` command. Only its `initialization` is in `supernet` command).

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually