### PR TITLE
EVM-687 Dial queue slots

### DIFF
--- a/network/slots.go
+++ b/network/slots.go
@@ -1,0 +1,72 @@
+package network
+
+import (
+	"context"
+	"sync"
+)
+
+// Slots is synchronization structure
+// A routine can invoke the TakeSlot method, which will block until at least one slot becomes available
+// The ReturnSlot method can be called by other routines to increase the count of available slots by one
+type Slots struct {
+	ch        chan struct{}
+	maximal   int64
+	available int64
+
+	lock sync.Mutex
+}
+
+// NewSlots creates *Slots object with maximal slots available
+func NewSlots(maximal int64) *Slots {
+	ch := make(chan struct{}, maximal)
+	// add slots
+	for i := int64(0); i < maximal; i++ {
+		ch <- struct{}{}
+	}
+
+	return &Slots{
+		ch:        ch,
+		maximal:   maximal,
+		available: maximal,
+		lock:      sync.Mutex{},
+	}
+}
+
+// TakeSlot takes slot if available or blocks until slot is available or context is done
+func (s *Slots) TakeSlot(ctx context.Context) (int64, bool) {
+	select {
+	case <-ctx.Done():
+		return -1, true
+	case <-s.ch:
+		s.lock.Lock()
+		defer s.lock.Unlock()
+
+		s.available--
+
+		return s.available, false
+	}
+}
+
+// ReturnSlot returns back one slot. There is guarantee that available slots must be <= than maximal slots
+func (s *Slots) ReturnSlot() int64 {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// prevent to return more slots than maximal
+	if s.available == s.maximal {
+		return s.available
+	}
+
+	s.ch <- struct{}{}
+	s.available++
+
+	return s.available
+}
+
+// GetAvailableCount returns currently available slots count
+func (s *Slots) GetAvailableCount() int64 {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return s.available
+}

--- a/network/slots_test.go
+++ b/network/slots_test.go
@@ -13,31 +13,29 @@ func TestSlots(t *testing.T) {
 
 	slots := NewSlots(4)
 
-	assert.Equal(t, int64(4), slots.GetAvailableCount())
-
-	num := slots.ReturnSlot() // should do nothing
-
-	assert.Equal(t, int64(4), num)
-	assert.Equal(t, int64(4), slots.GetAvailableCount())
+	for i := 0; i < 4; i++ {
+		slots.Release() // should do nothing
+	}
 
 	for i := 3; i >= 0; i-- {
-		num, closed := slots.TakeSlot(context.Background())
-
+		closed := slots.Take(context.Background())
 		assert.False(t, closed)
-		assert.Equal(t, int64(i), num)
 	}
 
 	go func() {
-		<-time.After(time.Second * 1)
-
-		_ = slots.ReturnSlot() // return one slot after 2 seconds
+		time.Sleep(time.Millisecond * 500)
+		slots.Release() // return one slot after 500 milis
+		time.Sleep(time.Millisecond * 500)
+		slots.Release() // return another slot after 1 seconds
 	}()
 
 	tm := time.Now().UTC()
 
-	num, closed := slots.TakeSlot(context.Background())
+	closed1 := slots.Take(context.Background())
+	closed2 := slots.Take(context.Background())
 
-	assert.False(t, closed)
-	assert.Equal(t, int64(0), num)
-	assert.GreaterOrEqual(t, time.Now().UTC(), tm.Add(time.Second*1))
+	assert.False(t, closed1)
+	assert.GreaterOrEqual(t, time.Now().UTC(), tm.Add(time.Millisecond*500))
+	assert.False(t, closed2)
+	assert.GreaterOrEqual(t, time.Now().UTC(), tm.Add(time.Millisecond*500*2))
 }

--- a/network/slots_test.go
+++ b/network/slots_test.go
@@ -1,0 +1,43 @@
+package network
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSlots(t *testing.T) {
+	t.Parallel()
+
+	slots := NewSlots(4)
+
+	assert.Equal(t, int64(4), slots.GetAvailableCount())
+
+	num := slots.ReturnSlot() // should do nothing
+
+	assert.Equal(t, int64(4), num)
+	assert.Equal(t, int64(4), slots.GetAvailableCount())
+
+	for i := 3; i >= 0; i-- {
+		num, closed := slots.TakeSlot(context.Background())
+
+		assert.False(t, closed)
+		assert.Equal(t, int64(i), num)
+	}
+
+	go func() {
+		<-time.After(time.Second * 1)
+
+		_ = slots.ReturnSlot() // return one slot after 2 seconds
+	}()
+
+	tm := time.Now().UTC()
+
+	num, closed := slots.TakeSlot(context.Background())
+
+	assert.False(t, closed)
+	assert.Equal(t, int64(0), num)
+	assert.GreaterOrEqual(t, time.Now().UTC(), tm.Add(time.Second*1))
+}


### PR DESCRIPTION
# Description

slots concept in order to limit maximal outbound connections:
- `func (s *Server) runDial()` waits for something to be inserted into the queue 
- after task has been poped from the queue, it tries to take one slot for new outbound connection. If there are no available slots the routine is blocked
- whenever disconnect/failed to connect events occurs, one slot is released and becomes available

This task is necessary in order to finish EVM-543

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
