### PR TITLE
Allow providing mintable native token owner account

### DIFF
--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -223,7 +223,8 @@ func setFlags(cmd *cobra.Command) {
 			&params.nativeTokenConfigRaw,
 			nativeTokenConfigFlag,
 			"",
-			"configuration of native token in format <name:symbol:decimals count:mintable flag>",
+			"native token configuration, provided in the following format: "+
+				"<name:symbol:decimals count:mintable flag:[mintable token owner address]>",
 		)
 
 		cmd.Flags().StringVar(

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -43,7 +43,7 @@ const (
 	defaultNativeTokenName     = "Polygon"
 	defaultNativeTokenSymbol   = "MATIC"
 	defaultNativeTokenDecimals = uint8(18)
-	nativeTokenParamsNumber    = 4
+	minNativeTokenParamsNumber = 4
 )
 
 // Legacy flags that need to be preserved for running clients
@@ -60,7 +60,7 @@ var (
 	errUnsupportedConsensus   = errors.New("specified consensusRaw not supported")
 	errInvalidEpochSize       = errors.New("epoch size must be greater than 1")
 	errInvalidTokenParams     = errors.New("native token params were not submitted in proper format " +
-		"(<name:symbol:decimals count:mintable flag>)")
+		"(<name:symbol:decimals count:mintable flag:[mintable token owner address]>)")
 	errRewardWalletAmountZero = errors.New("reward wallet amount can not be zero or negative")
 )
 
@@ -481,41 +481,55 @@ func (p *genesisParams) extractNativeTokenMetadata() error {
 			Symbol:     defaultNativeTokenSymbol,
 			Decimals:   defaultNativeTokenDecimals,
 			IsMintable: false,
+			Owner:      types.ZeroAddress,
 		}
 
 		return nil
 	}
 
 	params := strings.Split(p.nativeTokenConfigRaw, ":")
-	if len(params) != nativeTokenParamsNumber {
+	if len(params) < minNativeTokenParamsNumber {
 		return errInvalidTokenParams
 	}
 
+	// name
 	name := strings.TrimSpace(params[0])
 	if name == "" {
 		return errInvalidTokenParams
 	}
 
+	// symbol
 	symbol := strings.TrimSpace(params[1])
 	if symbol == "" {
 		return errInvalidTokenParams
 	}
 
+	// decimals
 	decimals, err := strconv.ParseUint(strings.TrimSpace(params[2]), 10, 8)
 	if err != nil || decimals > math.MaxUint8 {
 		return errInvalidTokenParams
 	}
 
+	// is mintable native token used
 	isMintable, err := strconv.ParseBool(strings.TrimSpace(params[3]))
 	if err != nil {
 		return errInvalidTokenParams
 	}
+
+	// in case it is mintable native token, it is expected to have 5 parameters provided
+	if isMintable && len(params) != minNativeTokenParamsNumber+1 {
+		return errInvalidTokenParams
+	}
+
+	// owner address
+	owner := types.StringToAddress(strings.TrimSpace(params[4]))
 
 	p.nativeTokenConfig = &polybft.TokenConfig{
 		Name:       name,
 		Symbol:     symbol,
 		Decimals:   uint8(decimals),
 		IsMintable: isMintable,
+		Owner:      owner,
 	}
 
 	return nil

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -522,7 +522,10 @@ func (p *genesisParams) extractNativeTokenMetadata() error {
 	}
 
 	// owner address
-	owner := types.StringToAddress(strings.TrimSpace(params[4]))
+	owner := types.ZeroAddress
+	if isMintable {
+		owner = types.StringToAddress(strings.TrimSpace(params[4]))
+	}
 
 	p.nativeTokenConfig = &polybft.TokenConfig{
 		Name:       name,

--- a/command/genesis/params_test.go
+++ b/command/genesis/params_test.go
@@ -1,0 +1,118 @@
+package genesis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/0xPolygon/polygon-edge/consensus/polybft"
+	"github.com/0xPolygon/polygon-edge/types"
+)
+
+func Test_extractNativeTokenMetadata(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		rawConfig   string
+		expectedCfg *polybft.TokenConfig
+		expectErr   bool
+	}{
+		{
+			name:      "default token config",
+			rawConfig: "",
+			expectedCfg: &polybft.TokenConfig{
+				Name:       defaultNativeTokenName,
+				Symbol:     defaultNativeTokenSymbol,
+				Decimals:   defaultNativeTokenDecimals,
+				IsMintable: false,
+				Owner:      types.ZeroAddress,
+			},
+			expectErr: false,
+		},
+		{
+			name:      "not enough params provided",
+			rawConfig: "Test:TST:18",
+			expectErr: true,
+		},
+		{
+			name:      "empty name provided",
+			rawConfig: ":TST:18:false",
+			expectErr: true,
+		},
+		{
+			name:      "empty symbol provided",
+			rawConfig: "Test::18:false",
+			expectErr: true,
+		},
+		{
+			name:      "invalid decimals number provided",
+			rawConfig: "Test:TST:9999999999999999999999999999999999999999999999999999999999:false",
+			expectErr: true,
+		},
+		{
+			name:      "invalid mintable flag provided",
+			rawConfig: "Test:TST:18:bar",
+			expectErr: true,
+		},
+		{
+			name:      "mintable token not enough params provided",
+			rawConfig: "Test:TST:18:true",
+			expectErr: true,
+		},
+		{
+			name:      "non-mintable valid config",
+			rawConfig: "MyToken:MTK:9:false",
+			expectedCfg: &polybft.TokenConfig{
+				Name:       "MyToken",
+				Symbol:     "MTK",
+				Decimals:   9,
+				IsMintable: false,
+				Owner:      types.ZeroAddress,
+			},
+			expectErr: false,
+		},
+		{
+			name:      "non-mintable token config, owner provided but ignored",
+			rawConfig: "MyToken:MTK:9:false:0x123456789",
+			expectedCfg: &polybft.TokenConfig{
+				Name:       "MyToken",
+				Symbol:     "MTK",
+				Decimals:   9,
+				IsMintable: false,
+				Owner:      types.ZeroAddress,
+			},
+			expectErr: false,
+		},
+		{
+			name:      "mintable token valid config",
+			rawConfig: "MyMintToken:MMTK:9:true:0x123456789",
+			expectedCfg: &polybft.TokenConfig{
+				Name:       "MyMintToken",
+				Symbol:     "MMTK",
+				Decimals:   9,
+				IsMintable: true,
+				Owner:      types.StringToAddress("0x123456789"),
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &genesisParams{nativeTokenConfigRaw: c.rawConfig}
+			err := p.extractNativeTokenMetadata()
+
+			if c.expectErr {
+				require.Error(t, err)
+				require.Nil(t, p.nativeTokenConfig)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, c.expectedCfg, p.nativeTokenConfig)
+			}
+		})
+	}
+}

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -138,7 +138,7 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 		SprintSize:          p.sprintSize,
 		EpochReward:         p.epochReward,
 		// use 1st account as governance address
-		Governance:          initialValidators[0].Address,
+		Governance:          types.ZeroAddress,
 		InitialTrieRoot:     types.StringToHash(p.initialStateRoot),
 		NativeTokenConfig:   p.nativeTokenConfig,
 		MinValidatorSetSize: p.minNumValidators,

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -309,7 +309,7 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 			// initialize NativeERC20Mintable SC
 			params := &contractsapi.InitializeNativeERC20MintableFn{
 				Predicate_: contracts.ChildERC20PredicateContract,
-				Owner_:     polyBFTConfig.Governance,
+				Owner_:     polyBFTConfig.NativeTokenConfig.Owner,
 				RootToken_: polyBFTConfig.Bridge.RootNativeERC20Addr,
 				Name_:      polyBFTConfig.NativeTokenConfig.Name,
 				Symbol_:    polyBFTConfig.NativeTokenConfig.Symbol,

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -163,10 +163,11 @@ func (r *RootchainConfig) ToBridgeConfig() *BridgeConfig {
 
 // TokenConfig is the configuration of native token used by edge network
 type TokenConfig struct {
-	Name       string `json:"name"`
-	Symbol     string `json:"symbol"`
-	Decimals   uint8  `json:"decimals"`
-	IsMintable bool   `json:"isMintable"`
+	Name       string        `json:"name"`
+	Symbol     string        `json:"symbol"`
+	Decimals   uint8         `json:"decimals"`
+	IsMintable bool          `json:"isMintable"`
+	Owner      types.Address `json:"owner"`
 }
 
 type RewardsConfig struct {

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -608,7 +608,7 @@ func TestE2E_Bridge_ChildChainMintableTokensTransfer(t *testing.T) {
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithNumBlockConfirmations(0),
 		framework.WithEpochSize(epochSize),
-		framework.WithNativeTokenConfig("Mintable Edge Coin:MEC:18:true"),
+		framework.WithNativeTokenConfig(fmt.Sprintf("Mintable Edge Coin:MEC:18:true:%s", adminAddr)),
 		framework.WithBridgeAllowListAdmin(adminAddr),
 		framework.WithBridgeBlockListAdmin(adminAddr),
 		framework.WithPremine(append(depositors, adminAddr)...)) //nolint:makezero

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -453,7 +453,7 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 	}
 
 	validatorsAddrs := make([]types.Address, validatorCount)
-	initValidatorsBalance := ethgo.Gwei(1)
+	initValidatorsBalance := ethgo.Ether(1)
 	initMinterBalance := ethgo.Ether(100000)
 
 	minter, err := wallet.GenerateKey()


### PR DESCRIPTION
# Description

The `genesis` command's `--native-token-config` flag is expanded with another parameter that allows specifying the owner of a mintable native token. Prior to this PR, the first validator from the initial validator set was set as the owner of the mintable native token, which means that it was able to do the minting and burning.

In case a non-mintable native token is used, the owner account address should be omitted (since it is not applicable in that case).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
