### PR TITLE
EVM-689 The impact of database saving failures on Stake Manager func

### DIFF
--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -60,6 +60,9 @@ type blockchainBackend interface {
 
 	// GetChainID returns chain id of the current blockchain
 	GetChainID() uint64
+
+	// GetReceiptsByHash retrieves receipts by hash
+	GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error)
 }
 
 var _ blockchainBackend = &blockchainWrapper{}
@@ -185,6 +188,10 @@ func (p *blockchainWrapper) SubscribeEvents() blockchain.Subscription {
 
 func (p *blockchainWrapper) GetChainID() uint64 {
 	return uint64(p.blockchain.Config().ChainID)
+}
+
+func (p *blockchainWrapper) GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error) {
+	return p.blockchain.GetReceiptsByHash(hash)
 }
 
 var _ contract.Provider = &stateProvider{}

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -234,6 +234,7 @@ func (c *consensusRuntime) initStakeManager(logger hcf.Logger) error {
 		wallet.NewEcdsaSigner(c.config.Key),
 		contracts.ValidatorSetContract,
 		c.config.PolyBFTConfig.Bridge.CustomSupernetManagerAddr,
+		c.config.blockchain,
 		int(c.config.PolyBFTConfig.MaxValidatorSetSize),
 	)
 

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -125,6 +125,12 @@ func (m *blockchainMock) GetChainID() uint64 {
 	return 0
 }
 
+func (m *blockchainMock) GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error) {
+	args := m.Called(hash)
+
+	return args.Get(0).([]*types.Receipt), args.Error(1) //nolint:forcetypeassert
+}
+
 var _ polybftBackend = (*polybftBackendMock)(nil)
 
 type polybftBackendMock struct {

--- a/consensus/polybft/stake_manager_fuzz_test.go
+++ b/consensus/polybft/stake_manager_fuzz_test.go
@@ -154,6 +154,7 @@ func FuzzTestStakeManagerPostBlock(f *testing.F) {
 			wallet.NewEcdsaSigner(validators.GetValidator("A").Key()),
 			types.StringToAddress("0x0001"),
 			types.StringToAddress("0x0002"),
+			nil,
 			5,
 		)
 
@@ -200,6 +201,7 @@ func FuzzTestStakeManagerUpdateValidatorSet(f *testing.F) {
 		nil,
 		wallet.NewEcdsaSigner(validators.GetValidator("A").Key()),
 		types.StringToAddress("0x0001"), types.StringToAddress("0x0002"),
+		nil,
 		10,
 	)
 


### PR DESCRIPTION
# Description

There is a possibility that if saving to the database fails, the stake manager may not function correctly, as it will permanently omit the events from the block on which the database saving failed.

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
