### PR TITLE
TX pool debug level logging optimizations

### DIFF
--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -427,11 +427,14 @@ func (p *TxPool) Drop(tx *types.Transaction) {
 	clearAccountQueue(dropped)
 
 	p.eventManager.signalEvent(proto.EventType_DROPPED, tx.Hash)
-	p.logger.Debug("dropped account txs",
-		"num", droppedCount,
-		"next_nonce", nextNonce,
-		"address", tx.From.String(),
-	)
+
+	if p.logger.IsDebug() {
+		p.logger.Debug("dropped account txs",
+			"num", droppedCount,
+			"next_nonce", nextNonce,
+			"address", tx.From.String(),
+		)
+	}
 }
 
 // Demote excludes an account from being further processed during block building
@@ -440,10 +443,12 @@ func (p *TxPool) Drop(tx *types.Transaction) {
 func (p *TxPool) Demote(tx *types.Transaction) {
 	account := p.accounts.get(tx.From)
 	if account.Demotions() >= maxAccountDemotions {
-		p.logger.Debug(
-			"Demote: threshold reached - dropping account",
-			"addr", tx.From.String(),
-		)
+		if p.logger.IsDebug() {
+			p.logger.Debug(
+				"Demote: threshold reached - dropping account",
+				"addr", tx.From.String(),
+			)
+		}
 
 		p.Drop(tx)
 
@@ -718,10 +723,12 @@ func (p *TxPool) pruneAccountsWithNonceHoles() {
 // successful, an account is created for this address
 // (only once) and an enqueueRequest is signaled.
 func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
-	p.logger.Debug("add tx",
-		"origin", origin.String(),
-		"hash", tx.Hash.String(),
-	)
+	if p.logger.IsDebug() {
+		p.logger.Debug("add tx",
+			"origin", origin.String(),
+			"hash", tx.Hash.String(),
+		)
+	}
 
 	// validate incoming tx
 	if err := p.validateTx(tx); err != nil {
@@ -786,7 +793,9 @@ func (p *TxPool) handleEnqueueRequest(req enqueueRequest) {
 		return
 	}
 
-	p.logger.Debug("enqueue request", "hash", tx.Hash.String())
+	if p.logger.IsDebug() {
+		p.logger.Debug("enqueue request", "hash", tx.Hash.String())
+	}
 
 	p.gauge.increase(slotsRequired(tx))
 
@@ -810,7 +819,9 @@ func (p *TxPool) handlePromoteRequest(req promoteRequest) {
 
 	// promote enqueued txs
 	promoted, pruned := account.promote()
-	p.logger.Debug("promote request", "promoted", promoted, "addr", addr.String())
+	if p.logger.IsDebug() {
+		p.logger.Debug("promote request", "promoted", promoted, "addr", addr.String())
+	}
 
 	p.index.remove(pruned...)
 	p.gauge.decrease(slotsRequired(pruned...))
@@ -854,7 +865,9 @@ func (p *TxPool) addGossipTx(obj interface{}, _ peer.ID) {
 	// add tx
 	if err := p.addTx(gossip, tx); err != nil {
 		if errors.Is(err, ErrAlreadyKnown) {
-			p.logger.Debug("rejecting known tx (gossip)", "hash", tx.Hash.String())
+			if p.logger.IsDebug() {
+				p.logger.Debug("rejecting known tx (gossip)", "hash", tx.Hash.String())
+			}
 
 			return
 		}


### PR DESCRIPTION
# Description

When there are a lot of txs being added to the tx pool, converting TX hash into string for logging takes a lot of time. If the log level isn't Debug or lower, this is unnecessary. Now we first check if the log level is Debug or lower before performing the conversion. Also added this check in couple places where sender address is logged on Debug level.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
