### PR TITLE
Fix predeploy command to deploy contracts without a constructor

### DIFF
--- a/helper/predeployment/predeployment.go
+++ b/helper/predeployment/predeployment.go
@@ -182,24 +182,29 @@ func GenerateGenesisAccountFromFile(
 		return nil, fmt.Errorf("unable to create contract ABI, %w", err)
 	}
 
-	// Constructor arguments are passed in as an array of values.
-	// Structs are treated as sub-arrays with their corresponding values laid out
-	// in ABI encoding
-	parsedArguments, err := ParseArguments(constructorArgs)
-	if err != nil {
-		return nil, err
-	}
+	finalBytecode := artifact.Bytecode
+	constructorInfo := contractABI.Constructor
 
-	// Encode the constructor params
-	constructor, err := abi.Encode(
-		parsedArguments,
-		contractABI.Constructor.Inputs,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("unable to encode constructor arguments, %w", err)
-	}
+	if constructorInfo != nil {
+		// Constructor arguments are passed in as an array of values.
+		// Structs are treated as sub-arrays with their corresponding values laid out
+		// in ABI encoding
+		parsedArguments, err := ParseArguments(constructorArgs)
+		if err != nil {
+			return nil, err
+		}
 
-	finalBytecode := append(artifact.Bytecode, constructor...)
+		// Encode the constructor params
+		constructor, err := abi.Encode(
+			parsedArguments,
+			contractABI.Constructor.Inputs,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("unable to encode constructor arguments, %w", err)
+		}
+
+		finalBytecode = append(artifact.Bytecode, constructor...)
+	}
 
 	return getPredeployAccount(predeployAddress, finalBytecode, artifact.DeployedBytecode)
 }


### PR DESCRIPTION
# Description

This PR fixes genesis predeploy command, by allowing deployment of contracts that do not define constructor.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
