### PR TITLE
Small balance fix in genesis

### DIFF
--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -505,7 +505,7 @@ func (p *genesisParams) getValidatorAccounts(
 				MultiAddr: parts[0],
 				Address:   addr,
 				BlsKey:    trimmedBLSKey,
-				Balance:   big.NewInt(0),
+				Balance:   getPremineAmount(addr, premineBalances, big.NewInt(0)),
 				Stake:     big.NewInt(0),
 			}
 		}
@@ -524,7 +524,7 @@ func (p *genesisParams) getValidatorAccounts(
 	}
 
 	for _, v := range validators {
-		v.Balance = big.NewInt(0)
+		v.Balance = getPremineAmount(v.Address, premineBalances, big.NewInt(0))
 		v.Stake = big.NewInt(0)
 	}
 


### PR DESCRIPTION
# Description

It's a small continuation of: https://github.com/0xPolygon/polygon-edge/pull/1598.

Premine for mintable tokens was not written to genesis properly for initial validator set - `Balance` field in the `initialValidatorSet` section in `genesis.json`.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually