### PR TITLE
feat: match runtime errors with geth

### DIFF
--- a/state/runtime/evm/evm_test.go
+++ b/state/runtime/evm/evm_test.go
@@ -156,7 +156,7 @@ func TestRun(t *testing.T) {
 				ReturnValue: nil,
 				GasLeft:     0,
 				GasUsed:     5000,
-				Err:         errStackUnderflow,
+				Err:         &runtime.ErrStackUnderflow{StackLen: 0, Required: 2},
 			},
 		},
 		{
@@ -339,7 +339,7 @@ func TestRunWithTracer(t *testing.T) {
 						"cost":            uint64(2),
 						"lastReturnData":  []byte{},
 						"depth":           1,
-						"err":             errStackUnderflow,
+						"err":             &runtime.ErrStackUnderflow{StackLen: 0, Required: 1},
 					},
 				},
 			},

--- a/state/runtime/evm/evm_test.go
+++ b/state/runtime/evm/evm_test.go
@@ -156,7 +156,7 @@ func TestRun(t *testing.T) {
 				ReturnValue: nil,
 				GasLeft:     0,
 				GasUsed:     5000,
-				Err:         &runtime.ErrStackUnderflow{StackLen: 0, Required: 2},
+				Err:         &runtime.StackUnderflowError{StackLen: 0, Required: 2},
 			},
 		},
 		{
@@ -339,7 +339,7 @@ func TestRunWithTracer(t *testing.T) {
 						"cost":            uint64(2),
 						"lastReturnData":  []byte{},
 						"depth":           1,
-						"err":             &runtime.ErrStackUnderflow{StackLen: 0, Required: 1},
+						"err":             &runtime.StackUnderflowError{StackLen: 0, Required: 1},
 					},
 				},
 			},

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -994,7 +994,7 @@ func opPush(n int) instruction {
 func opDup(n int) instruction {
 	return func(c *state) {
 		if !c.stackAtLeast(n) {
-			c.exit(errStackUnderflow)
+			c.exit(&runtime.ErrStackUnderflow{StackLen: c.sp, Required: n})
 		} else {
 			val := c.peekAt(n)
 			c.push1().Set(val)
@@ -1005,7 +1005,7 @@ func opDup(n int) instruction {
 func opSwap(n int) instruction {
 	return func(c *state) {
 		if !c.stackAtLeast(n + 1) {
-			c.exit(errStackUnderflow)
+			c.exit(&runtime.ErrStackUnderflow{StackLen: c.sp, Required: n + 1})
 		} else {
 			c.swap(n)
 		}
@@ -1023,8 +1023,7 @@ func opLog(size int) instruction {
 		}
 
 		if !c.stackAtLeast(2 + size) {
-			c.exit(errStackUnderflow)
-
+			c.exit(&runtime.ErrStackUnderflow{StackLen: c.sp, Required: 2 + size})
 			return
 		}
 

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -994,7 +994,7 @@ func opPush(n int) instruction {
 func opDup(n int) instruction {
 	return func(c *state) {
 		if !c.stackAtLeast(n) {
-			c.exit(&runtime.ErrStackUnderflow{StackLen: c.sp, Required: n})
+			c.exit(&runtime.StackUnderflowError{StackLen: c.sp, Required: n})
 		} else {
 			val := c.peekAt(n)
 			c.push1().Set(val)
@@ -1005,7 +1005,7 @@ func opDup(n int) instruction {
 func opSwap(n int) instruction {
 	return func(c *state) {
 		if !c.stackAtLeast(n + 1) {
-			c.exit(&runtime.ErrStackUnderflow{StackLen: c.sp, Required: n + 1})
+			c.exit(&runtime.StackUnderflowError{StackLen: c.sp, Required: n + 1})
 		} else {
 			c.swap(n)
 		}
@@ -1023,7 +1023,8 @@ func opLog(size int) instruction {
 		}
 
 		if !c.stackAtLeast(2 + size) {
-			c.exit(&runtime.ErrStackUnderflow{StackLen: c.sp, Required: 2 + size})
+			c.exit(&runtime.StackUnderflowError{StackLen: c.sp, Required: 2 + size})
+
 			return
 		}
 

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -38,8 +38,6 @@ const stackSize = 1024
 
 var (
 	errOutOfGas              = runtime.ErrOutOfGas
-	errStackUnderflow        = runtime.ErrStackUnderflow
-	errStackOverflow         = runtime.ErrStackOverflow
 	errRevert                = runtime.ErrExecutionReverted
 	errGasUintOverflow       = errors.New("gas uint64 overflow")
 	errWriteProtection       = errors.New("write protection")
@@ -245,7 +243,7 @@ func (c *state) Run() ([]byte, error) {
 
 		// check if the depth of the stack is enough for the instruction
 		if c.sp < inst.stack {
-			c.exit(errStackUnderflow)
+			c.exit(&runtime.ErrStackUnderflow{StackLen: c.sp, Required: inst.stack})
 			c.captureExecutionError(op.String(), c.ip, gasCopy, inst.gas)
 
 			break
@@ -266,8 +264,7 @@ func (c *state) Run() ([]byte, error) {
 
 		// check if stack size exceeds the max size
 		if c.sp > stackSize {
-			c.exit(errStackOverflow)
-
+			c.exit(&runtime.ErrStackOverflow{StackLen: c.sp, Limit: stackSize})
 			break
 		}
 

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -243,7 +243,7 @@ func (c *state) Run() ([]byte, error) {
 
 		// check if the depth of the stack is enough for the instruction
 		if c.sp < inst.stack {
-			c.exit(&runtime.ErrStackUnderflow{StackLen: c.sp, Required: inst.stack})
+			c.exit(&runtime.StackUnderflowError{StackLen: c.sp, Required: inst.stack})
 			c.captureExecutionError(op.String(), c.ip, gasCopy, inst.gas)
 
 			break
@@ -264,7 +264,8 @@ func (c *state) Run() ([]byte, error) {
 
 		// check if stack size exceeds the max size
 		if c.sp > stackSize {
-			c.exit(&runtime.ErrStackOverflow{StackLen: c.sp, Limit: stackSize})
+			c.exit(&runtime.StackOverflowError{StackLen: c.sp, Limit: stackSize})
+
 			break
 		}
 

--- a/state/runtime/evm/state_test.go
+++ b/state/runtime/evm/state_test.go
@@ -70,7 +70,7 @@ func TestStackOverflow(t *testing.T) {
 	s.host = &mockHost{}
 
 	_, err = s.Run()
-	assert.Equal(t, &runtime.ErrStackOverflow{StackLen: stackSize + 1, Limit: stackSize}, err)
+	assert.Equal(t, &runtime.StackOverflowError{StackLen: stackSize + 1, Limit: stackSize}, err)
 }
 
 func TestStackUnderflow(t *testing.T) {
@@ -102,7 +102,7 @@ func TestStackUnderflow(t *testing.T) {
 
 	_, err = s.Run()
 	// need at least one operation on the stack
-	assert.Equal(t, &runtime.ErrStackUnderflow{StackLen: 0, Required: 1}, err)
+	assert.Equal(t, &runtime.StackUnderflowError{StackLen: 0, Required: 1}, err)
 }
 
 func TestOpcodeNotFound(t *testing.T) {

--- a/state/runtime/evm/state_test.go
+++ b/state/runtime/evm/state_test.go
@@ -3,6 +3,8 @@ package evm
 import (
 	"testing"
 
+	"github.com/0xPolygon/polygon-edge/state/runtime"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -68,7 +70,7 @@ func TestStackOverflow(t *testing.T) {
 	s.host = &mockHost{}
 
 	_, err = s.Run()
-	assert.Equal(t, errStackOverflow, err)
+	assert.Equal(t, &runtime.ErrStackOverflow{StackLen: stackSize + 1, Limit: stackSize}, err)
 }
 
 func TestStackUnderflow(t *testing.T) {
@@ -99,7 +101,8 @@ func TestStackUnderflow(t *testing.T) {
 	s.host = &mockHost{}
 
 	_, err = s.Run()
-	assert.Equal(t, errStackUnderflow, err)
+	// need at least one operation on the stack
+	assert.Equal(t, &runtime.ErrStackUnderflow{StackLen: 0, Required: 1}, err)
 }
 
 func TestOpcodeNotFound(t *testing.T) {

--- a/state/runtime/runtime.go
+++ b/state/runtime/runtime.go
@@ -143,25 +143,25 @@ var (
 	ErrNotAuth                  = errors.New("not in allow list")
 )
 
-// ErrStackUnderflow wraps an evm error when the items on the stack less
+// StackUnderflowError wraps an evm error when the items on the stack less
 // than the minimal requirement.
-type ErrStackUnderflow struct {
+type StackUnderflowError struct {
 	StackLen int
 	Required int
 }
 
-func (e *ErrStackUnderflow) Error() string {
+func (e *StackUnderflowError) Error() string {
 	return fmt.Sprintf("stack underflow (%d <=> %d)", e.StackLen, e.Required)
 }
 
-// ErrStackOverflow wraps an evm error when the items on the stack exceeds
+// StackOverflowError wraps an evm error when the items on the stack exceeds
 // the maximum allowance.
-type ErrStackOverflow struct {
+type StackOverflowError struct {
 	StackLen int
 	Limit    int
 }
 
-func (e *ErrStackOverflow) Error() string {
+func (e *StackOverflowError) Error() string {
 	return fmt.Sprintf("stack limit reached %d (%d)", e.StackLen, e.Limit)
 }
 

--- a/state/runtime/runtime.go
+++ b/state/runtime/runtime.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/0xPolygon/polygon-edge/chain"
@@ -130,19 +131,39 @@ func (r *ExecutionResult) UpdateGasUsed(gasLimit uint64, refund uint64) {
 
 var (
 	ErrOutOfGas                 = errors.New("out of gas")
-	ErrStackOverflow            = errors.New("stack overflow")
-	ErrStackUnderflow           = errors.New("stack underflow")
 	ErrNotEnoughFunds           = errors.New("not enough funds")
 	ErrInsufficientBalance      = errors.New("insufficient balance for transfer")
-	ErrMaxCodeSizeExceeded      = errors.New("evm: max code size exceeded")
+	ErrMaxCodeSizeExceeded      = errors.New("max code size exceeded")
 	ErrContractAddressCollision = errors.New("contract address collision")
 	ErrDepth                    = errors.New("max call depth exceeded")
-	ErrExecutionReverted        = errors.New("execution was reverted")
+	ErrExecutionReverted        = errors.New("execution reverted")
 	ErrCodeStoreOutOfGas        = errors.New("contract creation code storage out of gas")
 	ErrUnauthorizedCaller       = errors.New("unauthorized caller")
 	ErrInvalidInputData         = errors.New("invalid input data")
 	ErrNotAuth                  = errors.New("not in allow list")
 )
+
+// ErrStackUnderflow wraps an evm error when the items on the stack less
+// than the minimal requirement.
+type ErrStackUnderflow struct {
+	StackLen int
+	Required int
+}
+
+func (e *ErrStackUnderflow) Error() string {
+	return fmt.Sprintf("stack underflow (%d <=> %d)", e.StackLen, e.Required)
+}
+
+// ErrStackOverflow wraps an evm error when the items on the stack exceeds
+// the maximum allowance.
+type ErrStackOverflow struct {
+	StackLen int
+	Limit    int
+}
+
+func (e *ErrStackOverflow) Error() string {
+	return fmt.Sprintf("stack limit reached %d (%d)", e.StackLen, e.Limit)
+}
 
 type CallType int
 


### PR DESCRIPTION
# Description

Edge errors match verbatim with geth. It makes scanning for exact errors difficult. Made the following modifications to match this:  https://github.com/ethereum/go-ethereum/blob/master/core/vm/errors.go#L25-L39
* Updated `ErrMaxCodeSizeExceeded` string
* Updated `ErrExecutionReverted` string 
*  Added custom `ErrStackUnderflow` and `ErrStackOverflow` errors to match geth


# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually


# Additional comments

Some tooling relies on reading exact error runtime messages. Inconsistencies require custom tooling between geth / polygon-edge. 