### PR TITLE
Cluster script fix for premine

### DIFF
--- a/scripts/cluster
+++ b/scripts/cluster
@@ -29,7 +29,8 @@ function createGenesis() {
     --premine 0x0000000000000000000000000000000000000000 \
     --epoch-size 10 \
     --burn-contract 0:0x0000000000000000000000000000000000000000 \
-    --reward-wallet 0xDEADBEEF:1000000
+    --reward-wallet 0xDEADBEEF:1000000 \
+    --native-token-config "Polygon:MATIC:18:true:$address1"
 }
 
 function initRootchain() {


### PR DESCRIPTION
# Description

In https://github.com/0xPolygon/polygon-edge/pull/1598 we are forbidding premine for any address if the native child token is not mintable (except for the zero address and reward wallet), but we didn't update the `cluster` script.

This PR fixes the `cluster` script by configuring it to provide a mintable native child token to `genesis` command

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually