### PR TITLE
modified the script to log message when jq is not installed

### DIFF
--- a/scripts/cluster
+++ b/scripts/cluster
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# Check if jq is installed
+if [[ "$1" == "polybft" ]] && ! command -v jq >/dev/null 2>&1; then
+  echo "jq is not installed. Please install it manually and run the script again."
+  echo "Manual installation instructions: Visit https://jqlang.github.io/jq/ for more information."
+  exit 1
+fi
+
 function initIbftConsensus() {
   echo "Running with ibft consensus"
   ./polygon-edge secrets init --insecure --data-dir test-chain- --num 4


### PR DESCRIPTION
# Description

The cluster script has been modified to include a check for the presence of` jq `before setting up a `polybft` cluster.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually
