### PR TITLE
TestPoAPoSSwitch fixed

### DIFF
--- a/e2e/pos_poa_switch_test.go
+++ b/e2e/pos_poa_switch_test.go
@@ -113,8 +113,8 @@ func TestPoAPoSSwitch(t *testing.T) {
 	}
 
 	// Stake balance
-	// 3 genesis validators will stake but 1 gensis validator won't
-	numStakedValidators := 3
+	// 4 genesis validators will stake but 1 gensis validator won't
+	numStakedValidators := 4
 	wg = sync.WaitGroup{}
 
 	for idx := 0; idx < numStakedValidators; idx++ {
@@ -143,7 +143,7 @@ func TestPoAPoSSwitch(t *testing.T) {
 		t.Fatalf("Unable to wait for all nodes to seal blocks, %v", waitErrors)
 	}
 
-	expectedPoSValidators := genesisValidatorAddrs[:3]
+	expectedPoSValidators := genesisValidatorAddrs[:4]
 
 	// Test in PoS
 	wg = sync.WaitGroup{}
@@ -159,7 +159,7 @@ func TestPoAPoSSwitch(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), framework.DefaultTimeout)
 			defer cancel()
 
-			// every validator should have only 3 validators in validator set
+			// every validator should have only 4 validators in validator set
 			validateSnapshot(ctx, srv, posStartAt, expectedPoSValidators)
 		}(srv)
 	}


### PR DESCRIPTION
# Description

go-ibft supports 4 and more nodes. For those purposes the TestPoAPoSSwitch test was modified to run with 4 validators.

https://arxiv.org/pdf/1909.10194.pdf (page 16, definition 7)
https://groups.csail.mit.edu/tds/papers/Lynch/jacm88.pdf

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
