### PR TITLE
EVM-713 Fork manager params

### DIFF
--- a/chain/params.go
+++ b/chain/params.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"sort"
 
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
@@ -117,17 +118,32 @@ func (f *Forks) At(block uint64) ForksInTime {
 	}
 }
 
+// ForkParams hard-coded fork params
+type ForkParams struct {
+	// MaxValidatorSetSize indicates the maximum size of validator set
+	MaxValidatorSetSize uint64 `json:"maxValidatorSetSize"`
+
+	EpochSize uint64 `json:"epochSize"`
+
+	// SprintSize is size of sprint
+	SprintSize uint64 `json:"sprintSize"`
+
+	// BlockTime is target frequency of blocks production
+	BlockTime common.Duration `json:"blockTime"`
+
+	// BlockTimeDrift defines the time slot in which a new block can be created
+	BlockTimeDrift uint64 `json:"blockTimeDrift"`
+}
+
 type Fork struct {
 	Block  uint64      `json:"block"`
-	Params interface{} `json:"params"`
+	Params *ForkParams `json:"params"`
 }
 
 func NewFork(n uint64) *Fork {
-	f := Fork{
+	return &Fork{
 		Block: n,
 	}
-
-	return &f
 }
 
 func (f Fork) Active(block uint64) bool {

--- a/chain/params.go
+++ b/chain/params.go
@@ -117,20 +117,25 @@ func (f *Forks) At(block uint64) ForksInTime {
 	}
 }
 
-type Fork uint64
+type Fork struct {
+	Block  uint64      `json:"block"`
+	Params interface{} `json:"params"`
+}
 
 func NewFork(n uint64) *Fork {
-	f := Fork(n)
+	f := Fork{
+		Block: n,
+	}
 
 	return &f
 }
 
 func (f Fork) Active(block uint64) bool {
-	return block >= uint64(f)
+	return block >= f.Block
 }
 
-func (f Fork) Int() *big.Int {
-	return big.NewInt(int64(f))
+func (f Fork) BigInt() *big.Int {
+	return new(big.Int).SetUint64(f.Block)
 }
 
 // ForksInTime should contain all supported forks by current edge version

--- a/chain/params.go
+++ b/chain/params.go
@@ -2,7 +2,6 @@ package chain
 
 import (
 	"errors"
-	"math/big"
 	"sort"
 
 	"github.com/0xPolygon/polygon-edge/helper/common"
@@ -89,18 +88,22 @@ const (
 )
 
 // Forks is map which contains all forks and their starting blocks from genesis
-type Forks map[string]*Fork
+type Forks map[string]Fork
 
 // IsActive returns true if fork defined by name exists and defined for the block
 func (f *Forks) IsActive(name string, block uint64) bool {
-	ff := (*f)[name]
+	ff, exists := (*f)[name]
 
-	return ff != nil && ff.Active(block)
+	return exists && ff.Active(block)
 }
 
 // SetFork adds/updates fork defined by name
-func (f *Forks) SetFork(name string, value *Fork) {
+func (f *Forks) SetFork(name string, value Fork) {
 	(*f)[name] = value
+}
+
+func (f *Forks) RemoveFork(name string) {
+	delete(*f, name)
 }
 
 // At returns ForksInTime instance that shows which supported forks are enabled for the block
@@ -123,6 +126,7 @@ type ForkParams struct {
 	// MaxValidatorSetSize indicates the maximum size of validator set
 	MaxValidatorSetSize *uint64 `json:"maxValidatorSetSize,omitempty"`
 
+	// EpochSize is size of epoch
 	EpochSize *uint64 `json:"epochSize,omitempty"`
 
 	// SprintSize is size of sprint
@@ -140,18 +144,12 @@ type Fork struct {
 	Params *ForkParams `json:"params,omitempty"`
 }
 
-func NewFork(n uint64) *Fork {
-	return &Fork{
-		Block: n,
-	}
+func NewFork(n uint64) Fork {
+	return Fork{Block: n}
 }
 
 func (f Fork) Active(block uint64) bool {
 	return block >= f.Block
-}
-
-func (f Fork) BigInt() *big.Int {
-	return new(big.Int).SetUint64(f.Block)
 }
 
 // ForksInTime should contain all supported forks by current edge version

--- a/chain/params.go
+++ b/chain/params.go
@@ -121,23 +121,23 @@ func (f *Forks) At(block uint64) ForksInTime {
 // ForkParams hard-coded fork params
 type ForkParams struct {
 	// MaxValidatorSetSize indicates the maximum size of validator set
-	MaxValidatorSetSize uint64 `json:"maxValidatorSetSize"`
+	MaxValidatorSetSize *uint64 `json:"maxValidatorSetSize,omitempty"`
 
-	EpochSize uint64 `json:"epochSize"`
+	EpochSize *uint64 `json:"epochSize,omitempty"`
 
 	// SprintSize is size of sprint
-	SprintSize uint64 `json:"sprintSize"`
+	SprintSize *uint64 `json:"sprintSize,omitempty"`
 
 	// BlockTime is target frequency of blocks production
-	BlockTime common.Duration `json:"blockTime"`
+	BlockTime *common.Duration `json:"blockTime,omitempty"`
 
 	// BlockTimeDrift defines the time slot in which a new block can be created
-	BlockTimeDrift uint64 `json:"blockTimeDrift"`
+	BlockTimeDrift *uint64 `json:"blockTimeDrift,omitempty"`
 }
 
 type Fork struct {
 	Block  uint64      `json:"block"`
-	Params *ForkParams `json:"params"`
+	Params *ForkParams `json:"params,omitempty"`
 }
 
 func NewFork(n uint64) *Fork {

--- a/chain/params_test.go
+++ b/chain/params_test.go
@@ -17,7 +17,7 @@ func TestParamsForks(t *testing.T) {
 	}{
 		{
 			input: `{
-				"homestead": 1000
+				"homestead": { "block": 1000 }
 			}`,
 			output: &Forks{
 				Homestead: NewFork(1000),

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -369,7 +369,7 @@ func (p *genesisParams) initGenesisConfig() error {
 	// Disable london hardfork if burn contract address is not provided
 	enabledForks := chain.AllForksEnabled
 	if len(p.burnContracts) == 0 {
-		enabledForks.SetFork(chain.London, nil)
+		enabledForks.RemoveFork(chain.London)
 	}
 
 	chainConfig := &chain.Chain{

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -19,7 +19,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi/artifact"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
 	"github.com/0xPolygon/polygon-edge/contracts"
-	"github.com/0xPolygon/polygon-edge/forkmanager"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/server"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -72,10 +71,6 @@ var (
 
 // generatePolyBftChainConfig creates and persists polybft chain configuration to the provided file path
 func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) error {
-	if err := forkmanager.ForkManagerInit(nil, polybft.ForkManagerFactory, chain.AllForksEnabled); err != nil {
-		return err
-	}
-
 	// populate premine balance map
 	premineBalances := make(map[types.Address]*premineInfo, len(p.premine))
 

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -159,7 +159,7 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 	// Disable london hardfork if burn contract address is not provided
 	enabledForks := chain.AllForksEnabled
 	if len(p.burnContracts) == 0 {
-		enabledForks.SetFork(chain.London, nil)
+		enabledForks.RemoveFork(chain.London)
 	}
 
 	chainConfig := &chain.Chain{

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -72,7 +72,7 @@ var (
 
 // generatePolyBftChainConfig creates and persists polybft chain configuration to the provided file path
 func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) error {
-	if err := forkmanager.ForkManagerInit(polybft.ForkManagerFactory, chain.AllForksEnabled); err != nil {
+	if err := forkmanager.ForkManagerInit(nil, polybft.ForkManagerFactory, chain.AllForksEnabled); err != nil {
 		return err
 	}
 

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -442,11 +442,11 @@ func ForkManagerInitialParamsFactory(config *chain.Chain) (*chain.ForkParams, er
 	}
 
 	return &chain.ForkParams{
-		MaxValidatorSetSize: pbftConfig.MaxValidatorSetSize,
-		EpochSize:           pbftConfig.EpochSize,
-		SprintSize:          pbftConfig.SprintSize,
-		BlockTime:           pbftConfig.BlockTime,
-		BlockTimeDrift:      pbftConfig.BlockTimeDrift,
+		MaxValidatorSetSize: &pbftConfig.MaxValidatorSetSize,
+		EpochSize:           &pbftConfig.EpochSize,
+		SprintSize:          &pbftConfig.SprintSize,
+		BlockTime:           &pbftConfig.BlockTime,
+		BlockTimeDrift:      &pbftConfig.BlockTimeDrift,
 	}, nil
 }
 

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -435,6 +435,21 @@ func (p *Polybft) Initialize() error {
 	return nil
 }
 
+func ForkManagerInitialParamsFactory(config *chain.Chain) (*chain.ForkParams, error) {
+	pbftConfig, err := GetPolyBFTConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &chain.ForkParams{
+		MaxValidatorSetSize: pbftConfig.MaxValidatorSetSize,
+		EpochSize:           pbftConfig.EpochSize,
+		SprintSize:          pbftConfig.SprintSize,
+		BlockTime:           pbftConfig.BlockTime,
+		BlockTimeDrift:      pbftConfig.BlockTimeDrift,
+	}, nil
+}
+
 // Start starts the consensus and servers
 func (p *Polybft) Start() error {
 	p.logger.Info("starting polybft consensus", "signer", p.key.String())

--- a/forkmanager/fork.go
+++ b/forkmanager/fork.go
@@ -1,9 +1,11 @@
 package forkmanager
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/0xPolygon/polygon-edge/chain"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 )
 
 const InitialFork = "initialfork"
@@ -12,12 +14,30 @@ const InitialFork = "initialfork"
 // eq: "extra", "proposer_calculator", etc
 type HandlerDesc string
 
+// ForkParams hard-coded fork params
+type ForkParams struct {
+	// MaxValidatorSetSize indicates the maximum size of validator set
+	MaxValidatorSetSize uint64 `json:"maxValidatorSetSize"`
+
+	EpochSize uint64 `json:"epochSize"`
+
+	// SprintSize is size of sprint
+	SprintSize uint64 `json:"sprintSize"`
+
+	// BlockTime is target frequency of blocks production
+	BlockTime common.Duration `json:"blockTime"`
+
+	// BlockTimeDrift defines the time slot in which a new block can be created
+	BlockTimeDrift uint64 `json:"blockTimeDrift"`
+}
+
 // Fork structure defines one fork
 type Fork struct {
 	// name of the fork
 	Name string
 	// after the fork is activated, `FromBlockNumber` shows from which block is enabled
 	FromBlockNumber uint64
+	Params          *ForkParams
 	// this value is false if fork is registered but not activated
 	IsActive bool
 	// map of all handlers registered for this fork
@@ -32,6 +52,13 @@ type Handler struct {
 	Handler interface{}
 }
 
+type ForkParamsBlock struct {
+	// Params should be active from block `FromBlockNumber``
+	FromBlockNumber uint64
+	// actual params
+	Params *ForkParams
+}
+
 func ForkManagerInit(factory func(*chain.Forks) error, forks *chain.Forks) error {
 	if factory == nil {
 		return nil
@@ -41,21 +68,39 @@ func ForkManagerInit(factory func(*chain.Forks) error, forks *chain.Forks) error
 	fm.Clear()
 
 	// register initial fork
-	fm.RegisterFork(InitialFork)
+	fm.RegisterFork(InitialFork, nil)
+
+	var (
+		forkParams *ForkParams
+		ok         bool
+	)
 
 	// Register forks
-	for name := range *forks {
+	for name, f := range *forks {
 		// check if fork is not supported by current edge version
-		if _, found := (*chain.AllForksEnabled)[name]; !found {
+		if _, ok = (*chain.AllForksEnabled)[name]; !ok {
 			return fmt.Errorf("fork is not available: %s", name)
 		}
 
-		fm.RegisterFork(name)
+		if dt := f.Params; dt != nil {
+			customJSON, err := json.Marshal(dt)
+			if err != nil {
+				return fmt.Errorf("fork params error: %s, %w", name, err)
+			}
+
+			if err = json.Unmarshal(customJSON, &forkParams); err != nil {
+				return fmt.Errorf("fork params error: %s, %w", name, err)
+			}
+		}
+
+		fm.RegisterFork(name, forkParams)
 	}
 
 	// Register handlers and additional forks here
-	if err := factory(forks); err != nil {
-		return err
+	if factory != nil {
+		if err := factory(forks); err != nil {
+			return err
+		}
 	}
 
 	// Activate initial fork
@@ -64,12 +109,12 @@ func ForkManagerInit(factory func(*chain.Forks) error, forks *chain.Forks) error
 	}
 
 	// Activate forks
-	for name, blockNumber := range *forks {
-		if blockNumber == nil {
+	for name, f := range *forks {
+		if f == nil {
 			continue
 		}
 
-		if err := fm.ActivateFork(name, (uint64)(*blockNumber)); err != nil {
+		if err := fm.ActivateFork(name, f.Block); err != nil {
 			return err
 		}
 	}

--- a/forkmanager/fork.go
+++ b/forkmanager/fork.go
@@ -18,7 +18,8 @@ type Fork struct {
 	Name string
 	// after the fork is activated, `FromBlockNumber` shows from which block is enabled
 	FromBlockNumber uint64
-	Params          *chain.ForkParams
+	// fork consensus parameters
+	Params *chain.ForkParams
 	// this value is false if fork is registered but not activated
 	IsActive bool
 	// map of all handlers registered for this fork
@@ -62,11 +63,7 @@ func ForkManagerInit(
 			return fmt.Errorf("fork is not available: %s", name)
 		}
 
-		if f != nil {
-			fm.RegisterFork(name, f.Params)
-		} else {
-			fm.RegisterFork(name, nil)
-		}
+		fm.RegisterFork(name, f.Params)
 	}
 
 	// Register handlers and additional forks here
@@ -81,10 +78,6 @@ func ForkManagerInit(
 
 	// Activate forks
 	for name, f := range *forks {
-		if f == nil {
-			continue
-		}
-
 		if err := fm.ActivateFork(name, f.Block); err != nil {
 			return err
 		}

--- a/forkmanager/fork.go
+++ b/forkmanager/fork.go
@@ -25,18 +25,19 @@ type Fork struct {
 	Handlers map[HandlerDesc]interface{}
 }
 
-// Handler defines one custom handler
-type Handler struct {
+// forkHandler defines one custom handler
+type forkHandler struct {
 	// Handler should be active from block `FromBlockNumber``
 	FromBlockNumber uint64
 	// instance of some structure, function etc
 	Handler interface{}
 }
 
-type ForkParamsBlock struct {
+// forkParamsBlock encapsulates block and actual fork params
+type forkParamsBlock struct {
 	// Params should be active from block `FromBlockNumber``
 	FromBlockNumber uint64
-	// actual params
+	// pointer to fork params
 	Params *chain.ForkParams
 }
 

--- a/forkmanager/fork_manager.go
+++ b/forkmanager/fork_manager.go
@@ -9,17 +9,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/chain"
 )
 
-/*
-Regarding whether it is okay to use the Singleton pattern in Go, it's a topic of some debate.
-The Singleton pattern can introduce global state and make testing and concurrent programming more challenging.
-It can also make code tightly coupled and harder to maintain.
-In general, it's recommended to favor dependency injection and explicit collaboration over singletons.
-
-However, there might be scenarios where the Singleton pattern is still useful,
-such as managing shared resources or maintaining a global configuration.
-Just be mindful of the potential drawbacks and consider alternative patterns when appropriate.
-*/
-
 var (
 	forkManagerInstance     *forkManager
 	forkManagerInstanceLock sync.Mutex
@@ -84,7 +73,7 @@ func (fm *forkManager) RegisterHandler(forkName string, handlerName HandlerDesc,
 }
 
 // ActivateFork activates fork from some block number
-// All handlers and parameters belong to this fork are also activated
+// All handlers and parameters belonging to this fork are also activated
 func (fm *forkManager) ActivateFork(forkName string, blockNumber uint64) error {
 	fm.lock.Lock()
 	defer fm.lock.Unlock()

--- a/forkmanager/fork_manager_test.go
+++ b/forkmanager/fork_manager_test.go
@@ -24,10 +24,10 @@ func TestForkManager(t *testing.T) {
 
 	forkManager := GetInstance()
 
-	forkManager.RegisterFork(ForkA)
-	forkManager.RegisterFork(ForkB)
-	forkManager.RegisterFork(ForkC)
-	forkManager.RegisterFork(ForkD)
+	forkManager.RegisterFork(ForkA, &ForkParams{EpochSize: 100})
+	forkManager.RegisterFork(ForkB, &ForkParams{EpochSize: 300})
+	forkManager.RegisterFork(ForkC, nil)
+	forkManager.RegisterFork(ForkD, &ForkParams{EpochSize: 200})
 
 	assert.NoError(t, forkManager.RegisterHandler(ForkA, HandlerA, func() string { return "AAH" }))
 	assert.NoError(t, forkManager.RegisterHandler(ForkC, HandlerA, func() string { return "ACH" }))
@@ -156,6 +156,17 @@ func TestForkManager(t *testing.T) {
 
 		assert.Nil(t, forkManager.GetHandler(HandlerD, 0))
 	})
+
+	t.Run("get params", func(t *testing.T) {
+		t.Parallel()
+
+		for i := uint64(0); i < uint64(4); i++ {
+			assert.Equal(t, uint64(100), forkManager.GetParams(i).EpochSize)
+			assert.Equal(t, uint64(300), forkManager.GetParams(i+100).EpochSize)
+			assert.Equal(t, uint64(300), forkManager.GetParams(i+200).EpochSize)
+			assert.Equal(t, uint64(200), forkManager.GetParams(i+300).EpochSize)
+		}
+	})
 }
 
 func TestForkManager_Deactivate(t *testing.T) {
@@ -166,8 +177,8 @@ func TestForkManager_Deactivate(t *testing.T) {
 		handlersMap: map[HandlerDesc][]Handler{},
 	}
 
-	forkManager.RegisterFork(ForkA)
-	forkManager.RegisterFork(ForkB)
+	forkManager.RegisterFork(ForkA, nil)
+	forkManager.RegisterFork(ForkB, nil)
 
 	assert.NoError(t, forkManager.RegisterHandler(ForkA, HandlerA, func() string { return "AAH" }))
 	assert.NoError(t, forkManager.RegisterHandler(ForkB, HandlerA, func() string { return "ABH" }))

--- a/forkmanager/fork_manager_test.go
+++ b/forkmanager/fork_manager_test.go
@@ -3,6 +3,7 @@ package forkmanager
 import (
 	"testing"
 
+	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,10 +25,10 @@ func TestForkManager(t *testing.T) {
 
 	forkManager := GetInstance()
 
-	forkManager.RegisterFork(ForkA, &ForkParams{EpochSize: 100})
-	forkManager.RegisterFork(ForkB, &ForkParams{EpochSize: 300})
+	forkManager.RegisterFork(ForkA, &chain.ForkParams{EpochSize: 100})
+	forkManager.RegisterFork(ForkB, &chain.ForkParams{EpochSize: 300})
 	forkManager.RegisterFork(ForkC, nil)
-	forkManager.RegisterFork(ForkD, &ForkParams{EpochSize: 200})
+	forkManager.RegisterFork(ForkD, &chain.ForkParams{EpochSize: 200})
 
 	assert.NoError(t, forkManager.RegisterHandler(ForkA, HandlerA, func() string { return "AAH" }))
 	assert.NoError(t, forkManager.RegisterHandler(ForkC, HandlerA, func() string { return "ACH" }))
@@ -177,8 +178,8 @@ func TestForkManager_Deactivate(t *testing.T) {
 		handlersMap: map[HandlerDesc][]Handler{},
 	}
 
-	forkManager.RegisterFork(ForkA, nil)
-	forkManager.RegisterFork(ForkB, nil)
+	forkManager.RegisterFork(ForkA, &chain.ForkParams{MaxValidatorSetSize: 1})
+	forkManager.RegisterFork(ForkB, &chain.ForkParams{MaxValidatorSetSize: 2})
 
 	assert.NoError(t, forkManager.RegisterHandler(ForkA, HandlerA, func() string { return "AAH" }))
 	assert.NoError(t, forkManager.RegisterHandler(ForkB, HandlerA, func() string { return "ABH" }))
@@ -187,12 +188,15 @@ func TestForkManager_Deactivate(t *testing.T) {
 	assert.NoError(t, forkManager.ActivateFork(ForkB, 0))
 
 	assert.Equal(t, 2, len(forkManager.handlersMap[HandlerA]))
+	assert.Equal(t, 2, len(forkManager.params))
 
 	assert.NoError(t, forkManager.DeactivateFork(ForkA))
 
 	assert.Equal(t, 1, len(forkManager.handlersMap[HandlerA]))
+	assert.Equal(t, 1, len(forkManager.params))
 
 	assert.NoError(t, forkManager.DeactivateFork(ForkB))
 
 	assert.Equal(t, 0, len(forkManager.handlersMap[HandlerA]))
+	assert.Equal(t, 0, len(forkManager.params))
 }

--- a/forkmanager/fork_manager_test.go
+++ b/forkmanager/fork_manager_test.go
@@ -2,8 +2,10 @@ package forkmanager
 
 import (
 	"testing"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/chain"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,12 +25,16 @@ const (
 func TestForkManager(t *testing.T) {
 	t.Parallel()
 
+	es1, es2, es3 := uint64(100), uint64(300), uint64(200)
+	mss1 := uint64(10002)
+	bt1, bt2 := common.Duration{Duration: time.Second * 5}, common.Duration{Duration: time.Second * 12}
+
 	forkManager := GetInstance()
 
-	forkManager.RegisterFork(ForkA, &chain.ForkParams{EpochSize: 100})
-	forkManager.RegisterFork(ForkB, &chain.ForkParams{EpochSize: 300})
+	forkManager.RegisterFork(ForkA, &chain.ForkParams{EpochSize: &es1, BlockTime: &bt1})
+	forkManager.RegisterFork(ForkB, &chain.ForkParams{EpochSize: &es2, MaxValidatorSetSize: &mss1})
 	forkManager.RegisterFork(ForkC, nil)
-	forkManager.RegisterFork(ForkD, &chain.ForkParams{EpochSize: 200})
+	forkManager.RegisterFork(ForkD, &chain.ForkParams{EpochSize: &es3, BlockTime: &bt2})
 
 	assert.NoError(t, forkManager.RegisterHandler(ForkA, HandlerA, func() string { return "AAH" }))
 	assert.NoError(t, forkManager.RegisterHandler(ForkC, HandlerA, func() string { return "ACH" }))
@@ -37,10 +43,10 @@ func TestForkManager(t *testing.T) {
 	assert.NoError(t, forkManager.RegisterHandler(ForkD, HandlerB, func() string { return "BDH" }))
 	assert.NoError(t, forkManager.RegisterHandler(ForkC, HandlerC, func() string { return "CCH" }))
 
-	assert.NoError(t, forkManager.ActivateFork(ForkA, 0))
-	assert.NoError(t, forkManager.ActivateFork(ForkB, 100))
-	assert.NoError(t, forkManager.ActivateFork(ForkC, 200))
 	assert.NoError(t, forkManager.ActivateFork(ForkD, 300))
+	assert.NoError(t, forkManager.ActivateFork(ForkA, 0))
+	assert.NoError(t, forkManager.ActivateFork(ForkC, 200))
+	assert.NoError(t, forkManager.ActivateFork(ForkB, 100))
 
 	handlersACnt := len(forkManager.handlersMap[HandlerA])
 	handlersBCnt := len(forkManager.handlersMap[HandlerB])
@@ -162,10 +168,20 @@ func TestForkManager(t *testing.T) {
 		t.Parallel()
 
 		for i := uint64(0); i < uint64(4); i++ {
-			assert.Equal(t, uint64(100), forkManager.GetParams(i).EpochSize)
-			assert.Equal(t, uint64(300), forkManager.GetParams(i+100).EpochSize)
-			assert.Equal(t, uint64(300), forkManager.GetParams(i+200).EpochSize)
-			assert.Equal(t, uint64(200), forkManager.GetParams(i+300).EpochSize)
+			assert.Equal(t, es1, *forkManager.GetParams(i).EpochSize)
+			assert.Equal(t, es2, *forkManager.GetParams(i + 100).EpochSize)
+			assert.Equal(t, es2, *forkManager.GetParams(i + 200).EpochSize)
+			assert.Equal(t, es3, *forkManager.GetParams(i + 300).EpochSize)
+
+			assert.Nil(t, forkManager.GetParams(i).MaxValidatorSetSize)
+			assert.Equal(t, mss1, *forkManager.GetParams(i + 100).MaxValidatorSetSize)
+			assert.Equal(t, mss1, *forkManager.GetParams(i + 200).MaxValidatorSetSize)
+			assert.Equal(t, mss1, *forkManager.GetParams(i + 300).MaxValidatorSetSize)
+
+			assert.Equal(t, bt1, *forkManager.GetParams(i).BlockTime)
+			assert.Equal(t, bt1, *forkManager.GetParams(i + 100).BlockTime)
+			assert.Equal(t, bt1, *forkManager.GetParams(i + 200).BlockTime)
+			assert.Equal(t, bt2, *forkManager.GetParams(i + 300).BlockTime)
 		}
 	})
 }
@@ -175,22 +191,32 @@ func TestForkManager_Deactivate(t *testing.T) {
 
 	forkManager := &forkManager{
 		forkMap:     map[string]*Fork{},
-		handlersMap: map[HandlerDesc][]Handler{},
+		handlersMap: map[HandlerDesc][]forkHandler{},
 	}
+	mvs1, mvs2 := uint64(1), uint64(2)
 
-	forkManager.RegisterFork(ForkA, &chain.ForkParams{MaxValidatorSetSize: 1})
-	forkManager.RegisterFork(ForkB, &chain.ForkParams{MaxValidatorSetSize: 2})
+	forkManager.RegisterFork(ForkA, &chain.ForkParams{MaxValidatorSetSize: &mvs1})
+	forkManager.RegisterFork(ForkB, &chain.ForkParams{MaxValidatorSetSize: &mvs2})
+	forkManager.RegisterFork(ForkC, &chain.ForkParams{})
 
 	assert.NoError(t, forkManager.RegisterHandler(ForkA, HandlerA, func() string { return "AAH" }))
 	assert.NoError(t, forkManager.RegisterHandler(ForkB, HandlerA, func() string { return "ABH" }))
 
+	assert.NoError(t, forkManager.ActivateFork(ForkB, 10))
+	assert.NoError(t, forkManager.ActivateFork(ForkC, 20))
 	assert.NoError(t, forkManager.ActivateFork(ForkA, 0))
-	assert.NoError(t, forkManager.ActivateFork(ForkB, 0))
 
 	assert.Equal(t, 2, len(forkManager.handlersMap[HandlerA]))
-	assert.Equal(t, 2, len(forkManager.params))
+	assert.Equal(t, 3, len(forkManager.params))
+	assert.Equal(t, mvs2, *forkManager.GetParams(30).MaxValidatorSetSize)
 
 	assert.NoError(t, forkManager.DeactivateFork(ForkA))
+
+	assert.Equal(t, 1, len(forkManager.handlersMap[HandlerA]))
+	assert.Equal(t, 2, len(forkManager.params))
+	assert.Nil(t, forkManager.GetParams(0))
+
+	assert.NoError(t, forkManager.DeactivateFork(ForkC))
 
 	assert.Equal(t, 1, len(forkManager.handlersMap[HandlerA]))
 	assert.Equal(t, 1, len(forkManager.params))

--- a/server/builtin.go
+++ b/server/builtin.go
@@ -21,6 +21,8 @@ type ConsensusType string
 
 type ForkManagerFactory func(forks *chain.Forks) error
 
+type ForkManagerInitialParamsFactory func(config *chain.Chain) (*chain.ForkParams, error)
+
 const (
 	DevConsensus     ConsensusType = "dev"
 	IBFTConsensus    ConsensusType = "ibft"
@@ -50,6 +52,10 @@ var genesisCreationFactory = map[ConsensusType]GenesisFactoryHook{
 
 var forkManagerFactory = map[ConsensusType]ForkManagerFactory{
 	PolyBFTConsensus: consensusPolyBFT.ForkManagerFactory,
+}
+
+var forkManagerInitialParamsFactory = map[ConsensusType]ForkManagerInitialParamsFactory{
+	PolyBFTConsensus: consensusPolyBFT.ForkManagerInitialParamsFactory,
 }
 
 func ConsensusSupported(value string) bool {

--- a/server/server.go
+++ b/server/server.go
@@ -277,7 +277,16 @@ func NewServer(config *Config) (*Server, error) {
 		return nil, err
 	}
 
+	var initialParams *chain.ForkParams
+
+	if pf := forkManagerInitialParamsFactory[ConsensusType(engineName)]; pf != nil {
+		if initialParams, err = pf(config.Chain); err != nil {
+			return nil, err
+		}
+	}
+
 	if err := forkmanager.ForkManagerInit(
+		initialParams,
 		forkManagerFactory[ConsensusType(engineName)],
 		config.Chain.Params.Forks); err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

Forks inside `genesis.json` now will look like:
```
forks": {
            "Dummy1": {
                "block": 10,
                "params": {
                    "maxValidatorSetSize": 30
                }
            },
            "EIP150": {
                "block": 0,
            },
            ...
}
```

Currently there are 5 predefined parameters for forks

```
type ForkParams struct {
	// MaxValidatorSetSize indicates the maximum size of validator set
	MaxValidatorSetSize *uint64 `json:"maxValidatorSetSize,omitempty"`

	EpochSize *uint64 `json:"epochSize,omitempty"`

	// SprintSize is size of sprint
	SprintSize *uint64 `json:"sprintSize,omitempty"`

	// BlockTime is target frequency of blocks production
	BlockTime *common.Duration `json:"blockTime,omitempty"`

	// BlockTimeDrift defines the time slot in which a new block can be created
	BlockTimeDrift *uint64 `json:"blockTimeDrift,omitempty"`
}
```

We can specify some or all of those parameters for some fork in `genesis.json`. The parameters need to be pointers because some of them can be omitted. If some parameter is omitted for specific fork, then its values is picked from first fork with smaller block number or from initial fork parameters.

During the execution, parameter can be retrieved by using fork manager `func (fm *forkManager) GetParams(blockNumber uint64) *chain.ForkParams`

Initial parameters for polybft are set via `builtin.go` mapping function inside `polybft.go`
```
func ForkManagerInitialParamsFactory(config *chain.Chain) (*chain.ForkParams, error) {
	pbftConfig, err := GetPolyBFTConfig(config)
	if err != nil {
		return nil, err
	}

	return &chain.ForkParams{
		MaxValidatorSetSize: &pbftConfig.MaxValidatorSetSize,
		EpochSize:           &pbftConfig.EpochSize,
		SprintSize:          &pbftConfig.SprintSize,
		BlockTime:           &pbftConfig.BlockTime,
		BlockTimeDrift:      &pbftConfig.BlockTimeDrift,
	}, nil
}
```
If we want to add new parameter, then we need to add that parameter (as a pointer) to `ForkParams` and change its value in `genesis.json`. In that case its probably good to change `ForkManagerInitialParamsFactory` too

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually

