### PR TITLE
EVM-716 Check if the error is produced for duplicate TXs

### DIFF
--- a/txpool/event_manager.go
+++ b/txpool/event_manager.go
@@ -41,7 +41,7 @@ func (em *eventManager) subscribe(eventTypes []proto.EventType) *subscribeResult
 		eventTypes: eventTypes,
 		outputCh:   make(chan *proto.TxPoolEvent),
 		doneCh:     make(chan struct{}),
-		notifyCh:   make(chan struct{}, 1),
+		notifyCh:   make(chan struct{}, 10),
 		eventStore: &eventQueue{
 			events: make([]*proto.TxPoolEvent, 0),
 		},

--- a/txpool/event_subscription.go
+++ b/txpool/event_subscription.go
@@ -38,12 +38,12 @@ func (es *eventSubscription) eventSupported(eventType proto.EventType) bool {
 // close stops the event subscription
 func (es *eventSubscription) close() {
 	close(es.doneCh)
-	close(es.outputCh)
-	close(es.notifyCh)
 }
 
 // runLoop is the main loop that listens for notifications and handles the event / close signals
 func (es *eventSubscription) runLoop() {
+	defer close(es.outputCh)
+
 	for {
 		select {
 		case <-es.doneCh: // Break if a close signal has been received

--- a/txpool/queue_account.go
+++ b/txpool/queue_account.go
@@ -144,10 +144,11 @@ func (q *minNonceQueue) Push(x interface{}) {
 }
 
 func (q *minNonceQueue) Pop() interface{} {
-	old := q
-	n := len(*old)
-	x := (*old)[n-1]
-	*q = (*old)[0 : n-1]
+	old := *q
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil // avoid memory leak
+	*q = old[0 : n-1]
 
-	return x
+	return item
 }

--- a/txpool/slot_gauge.go
+++ b/txpool/slot_gauge.go
@@ -40,6 +40,11 @@ func (g *slotGauge) highPressure() bool {
 	return g.read() > (highPressureMark*g.max)/100
 }
 
+// free slots returns how many slots are currently available
+func (g *slotGauge) freeSlots() uint64 {
+	return g.max - g.read()
+}
+
 // slotsRequired calculates the number of slots required for given transaction(s).
 func slotsRequired(txs ...*types.Transaction) uint64 {
 	slots := uint64(0)

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -709,6 +709,9 @@ func (p *TxPool) pruneAccountsWithNonceHoles() {
 			account.enqueued.lock(true)
 			defer account.enqueued.unlock()
 
+			account.nonceToTx.lock()
+			defer account.nonceToTx.unlock()
+
 			firstTx := account.enqueued.peek()
 
 			if firstTx == nil {
@@ -721,6 +724,7 @@ func (p *TxPool) pruneAccountsWithNonceHoles() {
 
 			removed := account.enqueued.clear()
 
+			account.nonceToTx.remove(removed...)
 			p.index.remove(removed...)
 			p.gauge.decrease(slotsRequired(removed...))
 

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -753,7 +753,7 @@ func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 	// initialize account for this address once or retrieve existing one
 	account := p.getOrCreateAccount(tx.From)
 	// populate currently free slots
-	slotsFree := p.gauge.max - p.gauge.read()
+	slotsFree := p.gauge.freeSlots()
 
 	account.promoted.lock(true)
 	account.enqueued.lock(true)
@@ -824,7 +824,7 @@ func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 	account.enqueue(tx, oldTxWithSameNonce != nil) // add or replace tx into account
 	p.gauge.increase(slotsRequired(tx))
 
-	go p.invokePromotion(tx, tx.Nonce == accountNonce) // don't signal promotion for higher nonce txs
+	go p.invokePromotion(tx, tx.Nonce <= accountNonce) // don't signal promotion for higher nonce txs
 
 	return nil
 }

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -389,7 +389,7 @@ func TestPruneAccountsWithNonceHoles(t *testing.T) {
 			assert.NoError(t, err)
 			pool.SetSigner(&mockSigner{})
 
-			pool.createAccountOnce(addr1)
+			pool.getOrCreateAccount(addr1)
 
 			assert.Equal(t, uint64(0), pool.gauge.read())
 			assert.Equal(t, uint64(0), pool.accounts.get(addr1).getNonce())
@@ -509,7 +509,7 @@ func TestAddTxHighPressure(t *testing.T) {
 			assert.NoError(t, err)
 			pool.SetSigner(&mockSigner{})
 
-			pool.createAccountOnce(addr1)
+			pool.getOrCreateAccount(addr1)
 			pool.accounts.get(addr1).nextNonce = 5
 
 			//	mock high pressure
@@ -536,7 +536,7 @@ func TestAddTxHighPressure(t *testing.T) {
 			assert.NoError(t, err)
 			pool.SetSigner(&mockSigner{})
 
-			pool.createAccountOnce(addr1)
+			pool.getOrCreateAccount(addr1)
 			pool.accounts.get(addr1).nextNonce = 5
 
 			//	mock high pressure
@@ -598,7 +598,7 @@ func TestAddGossipTx(t *testing.T) {
 
 		pool.SetSealing(false)
 
-		pool.createAccountOnce(sender)
+		pool.getOrCreateAccount(sender)
 
 		signedTx, err := signer.SignTx(tx, key)
 		if err != nil {
@@ -674,9 +674,7 @@ func TestEnqueueHandler(t *testing.T) {
 			pool.SetSigner(&mockSigner{})
 
 			// setup prestate
-			acc, created := pool.createAccountOnce(addr1)
-			assert.True(t, created)
-
+			acc := pool.getOrCreateAccount(addr1)
 			acc.setNonce(20)
 
 			// send tx
@@ -1153,7 +1151,7 @@ func TestPromoteHandler(t *testing.T) {
 		}
 
 		// fresh account (queues are empty)
-		acc, _ := pool.createAccountOnce(addr1)
+		acc := pool.getOrCreateAccount(addr1)
 		acc.setNonce(7)
 
 		// fake a promotion
@@ -1399,9 +1397,7 @@ func TestResetAccount(t *testing.T) {
 				pool.SetSigner(&mockSigner{})
 
 				// setup prestate
-				acc, created := pool.createAccountOnce(addr1)
-				assert.True(t, created)
-
+				acc := pool.getOrCreateAccount(addr1)
 				acc.setNonce(test.txs[0].Nonce)
 
 				err = pool.addTx(local, test.txs[0])
@@ -1697,9 +1693,7 @@ func TestResetAccount(t *testing.T) {
 				pool.SetSigner(&mockSigner{})
 
 				// setup prestate
-				acc, created := pool.createAccountOnce(addr1)
-				assert.True(t, created)
-
+				acc := pool.getOrCreateAccount(addr1)
 				acc.setNonce(test.txs[0].Nonce)
 
 				err = pool.addTx(local, test.txs[0])
@@ -2924,9 +2918,7 @@ func TestRecovery(t *testing.T) {
 			expectedEnqueued := uint64(0)
 			for addr, txs := range test.allTxs {
 				// preset nonce so promotions can happen
-				acc, created := pool.createAccountOnce(addr)
-				assert.True(t, created)
-
+				acc := pool.getOrCreateAccount(addr)
 				acc.setNonce(txs[0].tx.Nonce)
 
 				expectedEnqueued += test.expected.accounts[addr].enqueued

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -673,7 +673,6 @@ func TestEnqueueHandler(t *testing.T) {
 				err := pool.addTx(local, newTx(addr1, 10, 1)) // 10 < 20
 				assert.EqualError(t, err, "nonce too low")
 			}()
-			pool.handleEnqueueRequest(<-pool.enqueueReqCh)
 
 			assert.Equal(t, uint64(0), pool.gauge.read())
 			assert.Equal(t, uint64(0), pool.accounts.get(addr1).enqueued.length())
@@ -683,7 +682,7 @@ func TestEnqueueHandler(t *testing.T) {
 	t.Run(
 		"signal promotion for new tx with expected nonce",
 		func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			pool, err := newTestPool()
 			assert.NoError(t, err)
@@ -708,7 +707,7 @@ func TestEnqueueHandler(t *testing.T) {
 	t.Run(
 		"reject new tx when enqueued is full",
 		func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			fillEnqueued := func(pool *TxPool, num uint64) {
 				//	first tx will signal promotion, grab the signal
@@ -750,8 +749,6 @@ func TestEnqueueHandler(t *testing.T) {
 				err := pool.addTx(local, newTx(addr1, 1, 1))
 				assert.True(t, errors.Is(err, ErrMaxEnqueuedLimitReached))
 			}()
-
-			pool.handleEnqueueRequest(<-pool.enqueueReqCh)
 
 			//	assert the transaction was rejected
 			assert.Equal(t, uint64(1), pool.accounts.get(addr1).enqueued.length())

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -112,15 +112,13 @@ func (t *Transaction) Copy() *Transaction {
 	}
 
 	if t.R != nil {
-		tt.R = new(big.Int).SetBytes(t.R.Bytes())
+		tt.R = new(big.Int)
+		tt.R = big.NewInt(0).SetBits(t.R.Bits())
 	}
 
 	if t.S != nil {
-		tt.S = new(big.Int).SetBytes(t.S.Bytes())
-	}
-
-	if t.V != nil {
-		tt.V = new(big.Int).SetBytes(t.V.Bytes())
+		tt.S = new(big.Int)
+		tt.S = big.NewInt(0).SetBits(t.S.Bits())
 	}
 
 	tt.Input = make([]byte, len(t.Input))

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -89,7 +89,15 @@ func (t *Transaction) ComputeHash() *Transaction {
 
 func (t *Transaction) Copy() *Transaction {
 	tt := new(Transaction)
+	t.CopyTo(tt)
+
+	return tt
+}
+
+func (t *Transaction) CopyTo(tt *Transaction) {
 	*tt = *t
+
+	tt.size = atomic.Pointer[uint64]{} // clear size pointer
 
 	tt.GasPrice = new(big.Int)
 	if t.GasPrice != nil {
@@ -112,19 +120,19 @@ func (t *Transaction) Copy() *Transaction {
 	}
 
 	if t.R != nil {
-		tt.R = new(big.Int)
-		tt.R = big.NewInt(0).SetBits(t.R.Bits())
+		tt.R = new(big.Int).SetBytes(t.R.Bytes())
 	}
 
 	if t.S != nil {
-		tt.S = new(big.Int)
-		tt.S = big.NewInt(0).SetBits(t.S.Bits())
+		tt.S = new(big.Int).SetBytes(t.S.Bytes())
+	}
+
+	if t.V != nil {
+		tt.V = new(big.Int).SetBytes(t.V.Bytes())
 	}
 
 	tt.Input = make([]byte, len(t.Input))
 	copy(tt.Input[:], t.Input[:])
-
-	return tt
 }
 
 // Cost returns gas * gasPrice + value

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -89,15 +89,7 @@ func (t *Transaction) ComputeHash() *Transaction {
 
 func (t *Transaction) Copy() *Transaction {
 	tt := new(Transaction)
-	t.CopyTo(tt)
-
-	return tt
-}
-
-func (t *Transaction) CopyTo(tt *Transaction) {
 	*tt = *t
-
-	tt.size = atomic.Pointer[uint64]{} // clear size pointer
 
 	tt.GasPrice = new(big.Int)
 	if t.GasPrice != nil {
@@ -133,6 +125,8 @@ func (t *Transaction) CopyTo(tt *Transaction) {
 
 	tt.Input = make([]byte, len(t.Input))
 	copy(tt.Input[:], t.Input[:])
+
+	return tt
 }
 
 // Cost returns gas * gasPrice + value


### PR DESCRIPTION
# Description

The PR includes the following changes:
-   Introduction of account level nonce to transaction lookup, along with the required methods: get, set, remove, and reset.
-   Change in the handling of enqueue requests (`addTx`). That process is now synchronous - first goes basic validation, then more complicated validations that require locks  and then all the changes in txpool structures
-   Modification of a unit test that validates the expected behavior when a cheaper transaction needs to be discarded. This change was necessary because transactions with the same nonce are no longer enqueued at all.
- Some additional unit tests

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
