### PR TITLE
Print exit event id in the withdraw-child CLI command output

### DIFF
--- a/command/sidechain/withdraw/params.go
+++ b/command/sidechain/withdraw/params.go
@@ -3,6 +3,7 @@ package withdraw
 import (
 	"bytes"
 	"fmt"
+	"math/big"
 
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
@@ -14,23 +15,27 @@ type withdrawParams struct {
 	jsonRPC       string
 }
 
+func (w *withdrawParams) validateFlags() error {
+	return sidechainHelper.ValidateSecretFlags(w.accountDir, w.accountConfig)
+}
+
 type withdrawResult struct {
 	validatorAddress string
-	amount           uint64
+	amount           *big.Int
+	exitEventID      *big.Int
+	blockNumber      uint64
 }
 
-func (v *withdrawParams) validateFlags() error {
-	return sidechainHelper.ValidateSecretFlags(v.accountDir, v.accountConfig)
-}
-
-func (ur withdrawResult) GetOutput() string {
+func (r *withdrawResult) GetOutput() string {
 	var buffer bytes.Buffer
 
 	buffer.WriteString("\n[WITHDRAWAL]\n")
 
-	vals := make([]string, 0, 2)
-	vals = append(vals, fmt.Sprintf("Validator Address|%s", ur.validatorAddress))
-	vals = append(vals, fmt.Sprintf("Amount Withdrawn|%v", ur.amount))
+	vals := make([]string, 0, 4)
+	vals = append(vals, fmt.Sprintf("Validator Address|%s", r.validatorAddress))
+	vals = append(vals, fmt.Sprintf("Amount Withdrawn|%d", r.amount))
+	vals = append(vals, fmt.Sprintf("Exit Event ID|%d", r.exitEventID))
+	vals = append(vals, fmt.Sprintf("Inclusion Block Number|%d", r.blockNumber))
 
 	buffer.WriteString(helper.FormatKV(vals))
 	buffer.WriteString("\n")


### PR DESCRIPTION
# Description

Withdraw command (`polybft withdraw-child`) now prints out the exit event id and inclusion block number. That information is necessary in order to be able to send exit transactions manually and bridge unstake information back to the root chain.

The output of that command now looks like this:
```go
[WITHDRAWAL]
Validator Address      = 0xc589d95fFe43AD2EF42fC63CEc0e7F492bf32679
Amount Withdrawn       = 10000000000000000000
Exit Event ID          = 1  // added
Inclusion Block Number = 22 // added
```

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
