### PR TITLE
Upgraded script to check both dependencies

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,4 +1,4 @@
-# Run servers form local binary
+# Run servers from local binary
 
 ## Prerequisites
 
@@ -6,6 +6,7 @@ When deploying with `polybft` consensus, there are some additional dependencies:
 * [npm](https://nodejs.org/en/)
 * [go 1.19.x](https://go.dev/dl/)
 * [jq](https://jqlang.github.io/jq)
+* Netcat (nc)
 
 ## Local development
 Running `polygon-edge` from local binary can be done very easily by using provided `scripts` folder.

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -1,11 +1,25 @@
 #!/usr/bin/env bash
 
+dp_error_flag=0
+
 # Check if jq is installed
 if [[ "$1" == "polybft" ]] && ! command -v jq >/dev/null 2>&1; then
-  echo "jq is not installed. Please install it manually and run the script again."
+  echo "jq is not installed."
   echo "Manual installation instructions: Visit https://jqlang.github.io/jq/ for more information."
-  exit 1
+  dp_error_flag=1
 fi
+
+# Check if nc is installed
+if [[ "$1" == "polybft" ]] && ! command -v nc >/dev/null 2>&1; then
+  echo "Netcat (nc) is not installed."
+  dp_error_flag=1
+fi
+
+# Stop script if any of the dependencies have failed
+if [[ "$dp_error_flag" -eq 1]]; then
+  echo "Missing dependencies. Please install them and run the script again."
+  exit 1
+fi	
 
 function initIbftConsensus() {
   echo "Running with ibft consensus"


### PR DESCRIPTION
# Description

Upgraded cluster script to check both dependencies and display all missing ones before exiting.
It was checking for `jq` but not for `nc`.

# Changes include

- [x ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


