### PR TITLE
Handle state sync execution failures properly

### DIFF
--- a/consensus/polybft/statesyncrelayer/state_sync_relayer.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer.go
@@ -138,7 +138,7 @@ func (r *StateSyncRelayer) AddLog(log *ethgo.Log) {
 		}
 
 		if err := r.executeStateSync(stateSyncProof); err != nil {
-			r.logger.Error("Failed to execute state sync", "err", err)
+			r.logger.Error("State sync execution failed", "err", err)
 
 			continue
 		}
@@ -204,11 +204,23 @@ func (r *StateSyncRelayer) executeStateSync(proof *types.Proof) error {
 
 	receipt, err := r.txRelayer.SendTransaction(txn, r.key)
 	if err != nil {
-		return fmt.Errorf("failed to send state sync transaction: %w", err)
+		return fmt.Errorf("failed to send execute state sync transaction for id %d: %w", sse.ID, err)
 	}
 
 	if receipt.Status == uint64(types.ReceiptFailed) {
-		return fmt.Errorf("state sync execution failed: %d", execute.Obj.ID)
+		return fmt.Errorf("transaction execution reverted for state sync id: %d", sse.ID)
+	}
+
+	var stateSyncResult contractsapi.StateSyncResultEvent
+	for _, log := range receipt.Logs {
+		matches, err := stateSyncResult.ParseLog(log)
+		if err != nil || !matches {
+			return fmt.Errorf("failed to find state sync event result log for state sync id: %d", sse.ID)
+		}
+
+		if !stateSyncResult.Status {
+			return fmt.Errorf("failed to execute state sync id: %d", sse.ID)
+		}
 	}
 
 	return nil

--- a/consensus/polybft/statesyncrelayer/state_sync_relayer.go
+++ b/consensus/polybft/statesyncrelayer/state_sync_relayer.go
@@ -214,8 +214,12 @@ func (r *StateSyncRelayer) executeStateSync(proof *types.Proof) error {
 	var stateSyncResult contractsapi.StateSyncResultEvent
 	for _, log := range receipt.Logs {
 		matches, err := stateSyncResult.ParseLog(log)
-		if err != nil || !matches {
+		if err != nil {
 			return fmt.Errorf("failed to find state sync event result log for state sync id: %d", sse.ID)
+		}
+
+		if !matches {
+			continue
 		}
 
 		if !stateSyncResult.Status {

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -16,10 +16,10 @@ if [[ "$1" == "polybft" ]] && ! command -v nc >/dev/null 2>&1; then
 fi
 
 # Stop script if any of the dependencies have failed
-if [[ "$dp_error_flag" -eq 1]]; then
+if [[ "$dp_error_flag" -eq 1 ]]; then
   echo "Missing dependencies. Please install them and run the script again."
   exit 1
-fi	
+fi
 
 function initIbftConsensus() {
   echo "Running with ibft consensus"
@@ -163,8 +163,7 @@ function startServerFromBinary() {
 }
 
 function startServerFromDockerCompose() {
-  if [ "$1" != "polybft" ]
-  then
+  if [ "$1" != "polybft" ]; then
     export EDGE_CONSENSUS="$1"
   fi
 


### PR DESCRIPTION
# Description

Failed state sync events execution is handled properly now. Instead of expecting only failed transaction receipt, we should attest whether there is `StateSyncResult` with the `Success` field set to `false`. Those state sync events are also considered as failed state sync events.

The reason behind it is that `StateReceiver` invokes a target contract (in this case `NativeERC20`), without having a require, but instead only marking it as failed and emitting appropriate `StateSyncResult`:
https://github.com/0xPolygon/core-contracts/blob/main/contracts/child/StateReceiver.sol#L165-L170

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

1. remove premining `0x0` address from cluster script and run it
2.  when the cluster it is up and running, send deposit transactions using the following command:
```go
go run . bridge deposit-erc20 --sender-key aa75e9a7d427efc732f8e4f1a5b7646adcc61fd5bae40f80d13c8419c9f43d6d \
	--amounts 1000000000000000000 \
	--receivers <receiver address on Supernets> \
	--root-token <native erc20 address retrieved from genesis.json> \
	--root-predicate <erc20 predicate address retrieved from genesis.json> \
	--json-rpc http://localhost:8545 \
	--minter-key aa75e9a7d427efc732f8e4f1a5b7646adcc61fd5bae40f80d13c8419c9f43d6d
```
3. notice that there is the following error displayed in the state sync relayer log:
"State sync execution failed. err=failed to execute state sync id..."
