### PR TITLE
Docker requirements

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,8 +1,8 @@
 # Deploying local docker cluster
 
 ## Prerequisites
-* [Docker Desktop](https://www.docker.com/products/docker-desktop/) - Docker 17.12.0+
-* [Docker compose 2+](https://github.com/docker/compose/releases/tag/v2.14.1)
+* [Docker Engine](https://docs.docker.com/engine/install/) - Minimum version 20.10.23
+* [Docker compose v.1.x](https://docs.docker.com/compose/install/) - Minimum version 1.29
 
 ### `polybft` consensus
 When deploying with `polybft` consensus, there are some additional dependencies:


### PR DESCRIPTION
# Description
Updated docker requirements.

* Docker Desktop is not required. Docker engine is. 
* The minimum version of docker engine is no longer 17.12.0+ but 20.10.0. This is because the docker-compose file is using the format 3.9 that was introduced with docker 20.10.0
* Docker Compose requirement is version 1.29 not 2. Version 2 is no longer an independent binary and called with `docker compose`. With version 1.x of docker composer you call it with `docker-compose`. The scripts are currently using the older format of `docker-compose`.
