### PR TITLE
[EVM-722]: Full nodes should not send votes for commitments

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -180,6 +180,7 @@ func (c *consensusRuntime) initStateSyncManager(logger hcf.Logger) error {
 				maxCommitmentSize:     maxCommitmentSize,
 				numBlockConfirmations: c.config.numBlockConfirmations,
 			},
+			c,
 		)
 
 		c.stateSyncManager = stateSyncManager
@@ -604,7 +605,7 @@ func (c *consensusRuntime) setIsActiveValidator(isActiveValidator bool) {
 }
 
 // isActiveValidator indicates if node is in validator set or not
-func (c *consensusRuntime) isActiveValidator() bool {
+func (c *consensusRuntime) IsActiveValidator() bool {
 	return c.activeValidatorFlag.Load()
 }
 

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -360,7 +360,7 @@ func TestConsensusRuntime_FSM_NotEndOfEpoch_NotEndOfSprint(t *testing.T) {
 	err := runtime.FSM()
 	require.NoError(t, err)
 
-	assert.True(t, runtime.isActiveValidator())
+	assert.True(t, runtime.IsActiveValidator())
 	assert.False(t, runtime.fsm.isEndOfEpoch)
 	assert.False(t, runtime.fsm.isEndOfSprint)
 	assert.Equal(t, lastBlock.Number, runtime.fsm.parent.Number)
@@ -482,7 +482,7 @@ func Test_NewConsensusRuntime(t *testing.T) {
 	runtime, err := newConsensusRuntime(hclog.NewNullLogger(), config)
 	require.NoError(t, err)
 
-	assert.False(t, runtime.isActiveValidator())
+	assert.False(t, runtime.IsActiveValidator())
 	assert.Equal(t, runtime.config.DataDir, tmpDir)
 	assert.Equal(t, uint64(10), runtime.config.PolyBFTConfig.SprintSize)
 	assert.Equal(t, uint64(10), runtime.config.PolyBFTConfig.EpochSize)

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
-func newTestStateSyncManager(t *testing.T, key *validator.TestValidator) *stateSyncManager {
+func newTestStateSyncManager(t *testing.T, key *validator.TestValidator, runtime Runtime) *stateSyncManager {
 	t.Helper()
 
 	tmpDir, err := os.MkdirTemp("/tmp", "test-data-dir-state-sync")
@@ -41,7 +41,7 @@ func newTestStateSyncManager(t *testing.T, key *validator.TestValidator) *stateS
 			topic:             topic,
 			key:               key.Key(),
 			maxCommitmentSize: maxCommitmentSize,
-		})
+		}, runtime)
 
 	t.Cleanup(func() {
 		os.RemoveAll(tmpDir)
@@ -51,185 +51,180 @@ func newTestStateSyncManager(t *testing.T, key *validator.TestValidator) *stateS
 }
 
 func TestStateSyncManager_PostEpoch_BuildCommitment(t *testing.T) {
-	vals := validator.NewTestValidators(t, 5)
-	s := newTestStateSyncManager(t, vals.GetValidator("0"))
-
-	// there are no state syncs
-	require.NoError(t, s.buildCommitment())
-	require.Nil(t, s.pendingCommitments)
-
-	stateSyncs10 := generateStateSyncEvents(t, 10, 0)
-
-	// add 5 state syncs starting in index 0, it will generate one smaller commitment
-	for i := 0; i < 5; i++ {
-		require.NoError(t, s.state.StateSyncStore.insertStateSyncEvent(stateSyncs10[i]))
-	}
-
-	require.NoError(t, s.buildCommitment())
-	require.Len(t, s.pendingCommitments, 1)
-	require.Equal(t, uint64(0), s.pendingCommitments[0].StartID.Uint64())
-	require.Equal(t, uint64(4), s.pendingCommitments[0].EndID.Uint64())
-	require.Equal(t, uint64(0), s.pendingCommitments[0].Epoch)
-
-	// add the next 5 state syncs, at that point, so that it generates a larger commitment
-	for i := 5; i < 10; i++ {
-		require.NoError(t, s.state.StateSyncStore.insertStateSyncEvent(stateSyncs10[i]))
-	}
-
-	require.NoError(t, s.buildCommitment())
-	require.Len(t, s.pendingCommitments, 2)
-	require.Equal(t, uint64(0), s.pendingCommitments[1].StartID.Uint64())
-	require.Equal(t, uint64(9), s.pendingCommitments[1].EndID.Uint64())
-	require.Equal(t, uint64(0), s.pendingCommitments[1].Epoch)
-
-	// the message was sent
-	require.NotNil(t, s.config.topic.(*mockTopic).consume()) //nolint
-}
-
-func TestStateSyncManager_MessagePool_OldEpoch(t *testing.T) {
-	vals := validator.NewTestValidators(t, 5)
-
-	s := newTestStateSyncManager(t, vals.GetValidator("0"))
-	s.epoch = 1
-
-	msg := &TransportMessage{
-		EpochNumber: 0,
-	}
-	err := s.saveVote(msg)
-	require.NoError(t, err)
-}
-
-type mockMsg struct {
-	hash  []byte
-	epoch uint64
-}
-
-func newMockMsg() *mockMsg {
-	hash := make([]byte, 32)
-	rand.Read(hash)
-
-	return &mockMsg{hash: hash}
-}
-
-func (m *mockMsg) WithHash(hash []byte) *mockMsg {
-	m.hash = hash
-
-	return m
-}
-
-func (m *mockMsg) sign(val *validator.TestValidator, domain []byte) (*TransportMessage, error) {
-	signature, err := val.MustSign(m.hash, domain).Marshal()
-	if err != nil {
-		return nil, err
-	}
-
-	return &TransportMessage{
-		Hash:        m.hash,
-		Signature:   signature,
-		From:        val.Address().String(),
-		EpochNumber: m.epoch,
-	}, nil
-}
-
-func TestStateSyncManager_MessagePool_SenderIsNoValidator(t *testing.T) {
-	vals := validator.NewTestValidators(t, 5)
-
-	s := newTestStateSyncManager(t, vals.GetValidator("0"))
-	s.validatorSet = vals.ToValidatorSet()
-
-	badVal := validator.NewTestValidator(t, "a", 0)
-	msg, err := newMockMsg().sign(badVal, bls.DomainStateReceiver)
-	require.NoError(t, err)
-
-	require.Error(t, s.saveVote(msg))
-}
-
-func TestStateSyncManager_MessagePool_InvalidEpoch(t *testing.T) {
 	t.Parallel()
 
 	vals := validator.NewTestValidators(t, 5)
 
-	s := newTestStateSyncManager(t, vals.GetValidator("0"))
-	s.validatorSet = vals.ToValidatorSet()
+	t.Run("When node is validator", func(t *testing.T) {
+		t.Parallel()
 
-	val := newMockMsg()
-	msg, err := val.sign(vals.GetValidator("0"), bls.DomainStateReceiver)
-	require.NoError(t, err)
+		s := newTestStateSyncManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true})
 
-	msg.EpochNumber = 1
+		// there are no state syncs
+		require.NoError(t, s.buildCommitment())
+		require.Nil(t, s.pendingCommitments)
 
-	require.NoError(t, s.saveVote(msg))
+		stateSyncs10 := generateStateSyncEvents(t, 10, 0)
 
-	// no votes for the current epoch
-	votes, err := s.state.StateSyncStore.getMessageVotes(0, msg.Hash)
-	require.NoError(t, err)
-	require.Len(t, votes, 0)
+		// add 5 state syncs starting in index 0, it will generate one smaller commitment
+		for i := 0; i < 5; i++ {
+			require.NoError(t, s.state.StateSyncStore.insertStateSyncEvent(stateSyncs10[i]))
+		}
 
-	// returns an error for the invalid epoch
-	_, err = s.state.StateSyncStore.getMessageVotes(1, msg.Hash)
-	require.Error(t, err)
+		require.NoError(t, s.buildCommitment())
+		require.Len(t, s.pendingCommitments, 1)
+		require.Equal(t, uint64(0), s.pendingCommitments[0].StartID.Uint64())
+		require.Equal(t, uint64(4), s.pendingCommitments[0].EndID.Uint64())
+		require.Equal(t, uint64(0), s.pendingCommitments[0].Epoch)
+
+		// add the next 5 state syncs, at that point, so that it generates a larger commitment
+		for i := 5; i < 10; i++ {
+			require.NoError(t, s.state.StateSyncStore.insertStateSyncEvent(stateSyncs10[i]))
+		}
+
+		require.NoError(t, s.buildCommitment())
+		require.Len(t, s.pendingCommitments, 2)
+		require.Equal(t, uint64(0), s.pendingCommitments[1].StartID.Uint64())
+		require.Equal(t, uint64(9), s.pendingCommitments[1].EndID.Uint64())
+		require.Equal(t, uint64(0), s.pendingCommitments[1].Epoch)
+
+		// the message was sent
+		require.NotNil(t, s.config.topic.(*mockTopic).consume()) //nolint
+	})
+
+	t.Run("When node is not validator", func(t *testing.T) {
+		t.Parallel()
+
+		s := newTestStateSyncManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: false})
+
+		stateSyncs10 := generateStateSyncEvents(t, 10, 0)
+
+		// add 5 state syncs starting in index 0, they will be saved to db
+		for i := 0; i < 5; i++ {
+			require.NoError(t, s.state.StateSyncStore.insertStateSyncEvent(stateSyncs10[i]))
+		}
+
+		// I am not a validator so no commitments should be built
+		require.NoError(t, s.buildCommitment())
+		require.Len(t, s.pendingCommitments, 0)
+	})
 }
 
-func TestStateSyncManager_MessagePool_SenderAndSignatureMissmatch(t *testing.T) {
+func TestStateSyncManager_MessagePool(t *testing.T) {
 	t.Parallel()
 
 	vals := validator.NewTestValidators(t, 5)
 
-	s := newTestStateSyncManager(t, vals.GetValidator("0"))
-	s.validatorSet = vals.ToValidatorSet()
+	t.Run("Old epoch", func(t *testing.T) {
+		t.Parallel()
 
-	// validator signs the msg in behalf of another validator
-	val := newMockMsg()
-	msg, err := val.sign(vals.GetValidator("0"), bls.DomainStateReceiver)
-	require.NoError(t, err)
+		s := newTestStateSyncManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true})
 
-	msg.From = vals.GetValidator("1").Address().String()
-	require.Error(t, s.saveVote(msg))
+		s.epoch = 1
+		msg := &TransportMessage{
+			EpochNumber: 0,
+		}
 
-	// non validator signs the msg in behalf of a validator
-	badVal := validator.NewTestValidator(t, "a", 0)
-	msg, err = newMockMsg().sign(badVal, bls.DomainStateReceiver)
-	require.NoError(t, err)
+		err := s.saveVote(msg)
+		require.NoError(t, err)
+	})
 
-	msg.From = vals.GetValidator("1").Address().String()
-	require.Error(t, s.saveVote(msg))
-}
+	t.Run("Sender is not a validator", func(t *testing.T) {
+		t.Parallel()
 
-func TestStateSyncManager_MessagePool_SenderVotes(t *testing.T) {
-	vals := validator.NewTestValidators(t, 5)
+		s := newTestStateSyncManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true})
+		s.validatorSet = vals.ToValidatorSet()
 
-	s := newTestStateSyncManager(t, vals.GetValidator("0"))
-	s.validatorSet = vals.ToValidatorSet()
+		badVal := validator.NewTestValidator(t, "a", 0)
+		msg, err := newMockMsg().sign(badVal, bls.DomainStateReceiver)
+		require.NoError(t, err)
 
-	msg := newMockMsg()
-	val1signed, err := msg.sign(vals.GetValidator("1"), bls.DomainStateReceiver)
-	require.NoError(t, err)
+		require.Error(t, s.saveVote(msg))
+	})
 
-	val2signed, err := msg.sign(vals.GetValidator("2"), bls.DomainStateReceiver)
-	require.NoError(t, err)
+	t.Run("Invalid epoch", func(t *testing.T) {
+		t.Parallel()
 
-	// vote with validator 1
-	require.NoError(t, s.saveVote(val1signed))
+		s := newTestStateSyncManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true})
+		s.validatorSet = vals.ToValidatorSet()
 
-	votes, err := s.state.StateSyncStore.getMessageVotes(0, msg.hash)
-	require.NoError(t, err)
-	require.Len(t, votes, 1)
+		val := newMockMsg()
+		msg, err := val.sign(vals.GetValidator("0"), bls.DomainStateReceiver)
+		require.NoError(t, err)
 
-	// vote with validator 1 again (the votes do not increase)
-	require.NoError(t, s.saveVote(val1signed))
-	votes, _ = s.state.StateSyncStore.getMessageVotes(0, msg.hash)
-	require.Len(t, votes, 1)
+		msg.EpochNumber = 1
 
-	// vote with validator 2
-	require.NoError(t, s.saveVote(val2signed))
-	votes, _ = s.state.StateSyncStore.getMessageVotes(0, msg.hash)
-	require.Len(t, votes, 2)
+		require.NoError(t, s.saveVote(msg))
+
+		// no votes for the current epoch
+		votes, err := s.state.StateSyncStore.getMessageVotes(0, msg.Hash)
+		require.NoError(t, err)
+		require.Len(t, votes, 0)
+
+		// returns an error for the invalid epoch
+		_, err = s.state.StateSyncStore.getMessageVotes(1, msg.Hash)
+		require.Error(t, err)
+	})
+
+	t.Run("Sender and signature mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		s := newTestStateSyncManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true})
+		s.validatorSet = vals.ToValidatorSet()
+
+		// validator signs the msg in behalf of another validator
+		val := newMockMsg()
+		msg, err := val.sign(vals.GetValidator("0"), bls.DomainStateReceiver)
+		require.NoError(t, err)
+
+		msg.From = vals.GetValidator("1").Address().String()
+		require.Error(t, s.saveVote(msg))
+
+		// non validator signs the msg in behalf of a validator
+		badVal := validator.NewTestValidator(t, "a", 0)
+		msg, err = newMockMsg().sign(badVal, bls.DomainStateReceiver)
+		require.NoError(t, err)
+
+		msg.From = vals.GetValidator("1").Address().String()
+		require.Error(t, s.saveVote(msg))
+	})
+
+	t.Run("Sender votes", func(t *testing.T) {
+		t.Parallel()
+
+		s := newTestStateSyncManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true})
+		s.validatorSet = vals.ToValidatorSet()
+
+		msg := newMockMsg()
+		val1signed, err := msg.sign(vals.GetValidator("1"), bls.DomainStateReceiver)
+		require.NoError(t, err)
+
+		val2signed, err := msg.sign(vals.GetValidator("2"), bls.DomainStateReceiver)
+		require.NoError(t, err)
+
+		// vote with validator 1
+		require.NoError(t, s.saveVote(val1signed))
+
+		votes, err := s.state.StateSyncStore.getMessageVotes(0, msg.hash)
+		require.NoError(t, err)
+		require.Len(t, votes, 1)
+
+		// vote with validator 1 again (the votes do not increase)
+		require.NoError(t, s.saveVote(val1signed))
+		votes, _ = s.state.StateSyncStore.getMessageVotes(0, msg.hash)
+		require.Len(t, votes, 1)
+
+		// vote with validator 2
+		require.NoError(t, s.saveVote(val2signed))
+		votes, _ = s.state.StateSyncStore.getMessageVotes(0, msg.hash)
+		require.Len(t, votes, 2)
+	})
 }
 
 func TestStateSyncManager_BuildCommitment(t *testing.T) {
 	vals := validator.NewTestValidators(t, 5)
 
-	s := newTestStateSyncManager(t, vals.GetValidator("0"))
+	s := newTestStateSyncManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true})
 	s.validatorSet = vals.ToValidatorSet()
 
 	// commitment is empty
@@ -290,7 +285,7 @@ func TestStateSyncManager_BuildCommitment(t *testing.T) {
 func TestStateSyncerManager_BuildProofs(t *testing.T) {
 	vals := validator.NewTestValidators(t, 5)
 
-	s := newTestStateSyncManager(t, vals.GetValidator("0"))
+	s := newTestStateSyncManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true})
 
 	for _, evnt := range generateStateSyncEvents(t, 20, 0) {
 		require.NoError(t, s.state.StateSyncStore.insertStateSyncEvent(evnt))
@@ -330,79 +325,116 @@ func TestStateSyncerManager_BuildProofs(t *testing.T) {
 }
 
 func TestStateSyncerManager_AddLog_BuildCommitments(t *testing.T) {
+	t.Parallel()
+
 	vals := validator.NewTestValidators(t, 5)
 
-	s := newTestStateSyncManager(t, vals.GetValidator("0"))
+	t.Run("Node is a validator", func(t *testing.T) {
+		t.Parallel()
 
-	// empty log which is not an state sync
-	s.AddLog(&ethgo.Log{})
-	stateSyncs, err := s.state.StateSyncStore.list()
+		s := newTestStateSyncManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true})
 
-	require.NoError(t, err)
-	require.Len(t, stateSyncs, 0)
+		// empty log which is not an state sync
+		s.AddLog(&ethgo.Log{})
+		stateSyncs, err := s.state.StateSyncStore.list()
 
-	var stateSyncedEvent contractsapi.StateSyncedEvent
+		require.NoError(t, err)
+		require.Len(t, stateSyncs, 0)
 
-	stateSyncEventID := stateSyncedEvent.Sig()
+		var stateSyncedEvent contractsapi.StateSyncedEvent
 
-	// log with the state sync topic but incorrect content
-	s.AddLog(&ethgo.Log{Topics: []ethgo.Hash{stateSyncEventID}})
-	stateSyncs, err = s.state.StateSyncStore.list()
+		stateSyncEventID := stateSyncedEvent.Sig()
 
-	require.NoError(t, err)
-	require.Len(t, stateSyncs, 0)
+		// log with the state sync topic but incorrect content
+		s.AddLog(&ethgo.Log{Topics: []ethgo.Hash{stateSyncEventID}})
+		stateSyncs, err = s.state.StateSyncStore.list()
 
-	// correct event log
-	data, err := abi.MustNewType("tuple(string a)").Encode([]string{"data"})
-	require.NoError(t, err)
+		require.NoError(t, err)
+		require.Len(t, stateSyncs, 0)
 
-	goodLog := &ethgo.Log{
-		Topics: []ethgo.Hash{
-			stateSyncEventID,
-			ethgo.BytesToHash([]byte{0x0}), // state sync index 0
-			ethgo.ZeroHash,
-			ethgo.ZeroHash,
-		},
-		Data: data,
-	}
+		// correct event log
+		data, err := abi.MustNewType("tuple(string a)").Encode([]string{"data"})
+		require.NoError(t, err)
 
-	s.AddLog(goodLog)
+		goodLog := &ethgo.Log{
+			Topics: []ethgo.Hash{
+				stateSyncEventID,
+				ethgo.BytesToHash([]byte{0x0}), // state sync index 0
+				ethgo.ZeroHash,
+				ethgo.ZeroHash,
+			},
+			Data: data,
+		}
 
-	stateSyncs, err = s.state.StateSyncStore.getStateSyncEventsForCommitment(0, 0)
-	require.NoError(t, err)
-	require.Len(t, stateSyncs, 1)
-	require.Len(t, s.pendingCommitments, 1)
-	require.Equal(t, uint64(0), s.pendingCommitments[0].StartID.Uint64())
-	require.Equal(t, uint64(0), s.pendingCommitments[0].EndID.Uint64())
+		s.AddLog(goodLog)
 
-	// add one more log to have a minimum commitment
-	goodLog2 := goodLog.Copy()
-	goodLog2.Topics[1] = ethgo.BytesToHash([]byte{0x1}) // state sync index 1
-	s.AddLog(goodLog2)
+		stateSyncs, err = s.state.StateSyncStore.getStateSyncEventsForCommitment(0, 0)
+		require.NoError(t, err)
+		require.Len(t, stateSyncs, 1)
+		require.Len(t, s.pendingCommitments, 1)
+		require.Equal(t, uint64(0), s.pendingCommitments[0].StartID.Uint64())
+		require.Equal(t, uint64(0), s.pendingCommitments[0].EndID.Uint64())
 
-	require.Len(t, s.pendingCommitments, 2)
-	require.Equal(t, uint64(0), s.pendingCommitments[1].StartID.Uint64())
-	require.Equal(t, uint64(1), s.pendingCommitments[1].EndID.Uint64())
+		// add one more log to have a minimum commitment
+		goodLog2 := goodLog.Copy()
+		goodLog2.Topics[1] = ethgo.BytesToHash([]byte{0x1}) // state sync index 1
+		s.AddLog(goodLog2)
 
-	// add two more logs to have larger commitments
-	goodLog3 := goodLog.Copy()
-	goodLog3.Topics[1] = ethgo.BytesToHash([]byte{0x2}) // state sync index 2
-	s.AddLog(goodLog3)
+		require.Len(t, s.pendingCommitments, 2)
+		require.Equal(t, uint64(0), s.pendingCommitments[1].StartID.Uint64())
+		require.Equal(t, uint64(1), s.pendingCommitments[1].EndID.Uint64())
 
-	goodLog4 := goodLog.Copy()
-	goodLog4.Topics[1] = ethgo.BytesToHash([]byte{0x3}) // state sync index 3
-	s.AddLog(goodLog4)
+		// add two more logs to have larger commitments
+		goodLog3 := goodLog.Copy()
+		goodLog3.Topics[1] = ethgo.BytesToHash([]byte{0x2}) // state sync index 2
+		s.AddLog(goodLog3)
 
-	require.Len(t, s.pendingCommitments, 4)
-	require.Equal(t, uint64(0), s.pendingCommitments[3].StartID.Uint64())
-	require.Equal(t, uint64(3), s.pendingCommitments[3].EndID.Uint64())
+		goodLog4 := goodLog.Copy()
+		goodLog4.Topics[1] = ethgo.BytesToHash([]byte{0x3}) // state sync index 3
+		s.AddLog(goodLog4)
+
+		require.Len(t, s.pendingCommitments, 4)
+		require.Equal(t, uint64(0), s.pendingCommitments[3].StartID.Uint64())
+		require.Equal(t, uint64(3), s.pendingCommitments[3].EndID.Uint64())
+	})
+
+	t.Run("Node is not a validator", func(t *testing.T) {
+		t.Parallel()
+
+		s := newTestStateSyncManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: false})
+
+		// correct event log
+		data, err := abi.MustNewType("tuple(string a)").Encode([]string{"data"})
+		require.NoError(t, err)
+
+		var stateSyncedEvent contractsapi.StateSyncedEvent
+
+		goodLog := &ethgo.Log{
+			Topics: []ethgo.Hash{
+				stateSyncedEvent.Sig(),
+				ethgo.BytesToHash([]byte{0x0}), // state sync index 0
+				ethgo.ZeroHash,
+				ethgo.ZeroHash,
+			},
+			Data: data,
+		}
+
+		s.AddLog(goodLog)
+
+		// node should have inserted given state sync event, but it shouldn't build any commitment
+		stateSyncs, err := s.state.StateSyncStore.getStateSyncEventsForCommitment(0, 0)
+		require.NoError(t, err)
+		require.Len(t, stateSyncs, 1)
+		require.Equal(t, uint64(0), stateSyncs[0].ID.Uint64())
+		require.Len(t, s.pendingCommitments, 0)
+	})
 }
 
 func TestStateSyncerManager_EventTracker_Sync(t *testing.T) {
 	t.Parallel()
 
 	vals := validator.NewTestValidators(t, 5)
-	s := newTestStateSyncManager(t, vals.GetValidator("0"))
+	s := newTestStateSyncManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true})
 
 	server := testutil.DeployTestServer(t, nil)
 
@@ -444,7 +476,7 @@ func TestStateSyncerManager_EventTracker_Sync(t *testing.T) {
 func TestStateSyncManager_Close(t *testing.T) {
 	t.Parallel()
 
-	mgr := newTestStateSyncManager(t, validator.NewTestValidator(t, "A", 100))
+	mgr := newTestStateSyncManager(t, validator.NewTestValidator(t, "A", 100), &mockRuntime{isActiveValidator: true})
 	require.NotPanics(t, func() { mgr.Close() })
 }
 
@@ -561,4 +593,44 @@ func (m *mockTopic) Publish(obj proto.Message) error {
 
 func (m *mockTopic) Subscribe(handler func(obj interface{}, from peer.ID)) error {
 	return nil
+}
+
+type mockMsg struct {
+	hash  []byte
+	epoch uint64
+}
+
+func newMockMsg() *mockMsg {
+	hash := make([]byte, 32)
+	rand.Read(hash)
+
+	return &mockMsg{hash: hash}
+}
+
+func (m *mockMsg) WithHash(hash []byte) *mockMsg {
+	m.hash = hash
+
+	return m
+}
+
+func (m *mockMsg) sign(val *validator.TestValidator, domain []byte) (*TransportMessage, error) {
+	signature, err := val.MustSign(m.hash, domain).Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	return &TransportMessage{
+		Hash:        m.hash,
+		Signature:   signature,
+		From:        val.Address().String(),
+		EpochNumber: m.epoch,
+	}, nil
+}
+
+type mockRuntime struct {
+	isActiveValidator bool
+}
+
+func (m *mockRuntime) IsActiveValidator() bool {
+	return m.isActiveValidator
 }

--- a/consensus/polybft/transport.go
+++ b/consensus/polybft/transport.go
@@ -17,7 +17,7 @@ type BridgeTransport interface {
 // subscribeToIbftTopic subscribes to ibft topic
 func (p *Polybft) subscribeToIbftTopic() error {
 	return p.consensusTopic.Subscribe(func(obj interface{}, _ peer.ID) {
-		if !p.runtime.isActiveValidator() {
+		if !p.runtime.IsActiveValidator() {
 			return
 		}
 


### PR DESCRIPTION
# Description

This PR fixes the issue where full nodes sent votes for commitments.

Since full nodes can become validators at some point, saving state sync events is done on full nodes as well, but those nodes will not build nor vote for state sync commitments, until and if they become a validator.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually