### PR TITLE
Fix/evm 719

### DIFF
--- a/syncer/client.go
+++ b/syncer/client.go
@@ -161,6 +161,7 @@ func (m *syncPeerClient) GetConnectedPeerStatuses() []*NoForkPeer {
 			status, err := m.GetPeerStatus(peerID)
 			if err != nil {
 				m.logger.Warn("failed to get status from a peer, skip", "id", peerID, "err", err)
+
 				return //Skip appending nil status
 			}
 

--- a/syncer/client.go
+++ b/syncer/client.go
@@ -165,7 +165,9 @@ func (m *syncPeerClient) GetConnectedPeerStatuses() []*NoForkPeer {
 
 			syncPeersLock.Lock()
 
-			syncPeers = append(syncPeers, status)
+			if status != nil {
+				syncPeers = append(syncPeers, status)
+			}
 
 			syncPeersLock.Unlock()
 		}()

--- a/syncer/client.go
+++ b/syncer/client.go
@@ -161,13 +161,12 @@ func (m *syncPeerClient) GetConnectedPeerStatuses() []*NoForkPeer {
 			status, err := m.GetPeerStatus(peerID)
 			if err != nil {
 				m.logger.Warn("failed to get status from a peer, skip", "id", peerID, "err", err)
+				return //Skip appending nil status
 			}
 
 			syncPeersLock.Lock()
 
-			if status != nil {
-				syncPeers = append(syncPeers, status)
-			}
+			syncPeers = append(syncPeers, status)
 
 			syncPeersLock.Unlock()
 		}()


### PR DESCRIPTION
# Description

This PR solved the `nil` pointer dereference issue for [PeerMap](https://github.com/0xPolygon/polygon-edge/blob/develop/syncer/peers.go#L27) 

Logs of the noticed behavior:
```
[WARN]  polygon.server.syncer.sync-peer-client: failed to get status from a peer, skip: id=16Uiu2HAmEKVGNXmVM6gMwL9XBLc1LmS1cCWMBdnwVvKJwmJegUSf err="rpc error: code = Unavailable desc = connection error: desc = \"error reading server preface: stream reset\""
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x15a5759]
```

Jira Issue:[Here](https://polygon.atlassian.net/browse/EVM-719)

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

