### PR TITLE
Ensure premining reserve account (0x0 address)

### DIFF
--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -61,8 +61,8 @@ var (
 	errInvalidEpochSize       = errors.New("epoch size must be greater than 1")
 	errInvalidTokenParams     = errors.New("native token params were not submitted in proper format " +
 		"(<name:symbol:decimals count:mintable flag:[mintable token owner address]>)")
-	errRewardWalletAmountZero  = errors.New("reward wallet amount can not be zero or negative")
-	errEscrowAccMustBePremined = errors.New("it is mandatory to premine escrow account (0x0 address)")
+	errRewardWalletAmountZero   = errors.New("reward wallet amount can not be zero or negative")
+	errReserveAccMustBePremined = errors.New("it is mandatory to premine reserve account (0x0 address)")
 )
 
 type genesisParams struct {
@@ -478,10 +478,10 @@ func (p *genesisParams) validateRewardWallet() error {
 	return nil
 }
 
-// validatePremineInfo validates whether escrow account (0x0 address) is premined
+// validatePremineInfo validates whether reserve account (0x0 address) is premined
 func (p *genesisParams) validatePremineInfo() error {
 	p.premineInfos = make([]*premineInfo, 0, len(p.premine))
-	isEscrowAccPremined := false
+	isReserveAccPremined := false
 
 	for _, premine := range p.premine {
 		premineInfo, err := parsePremineInfo(premine)
@@ -492,12 +492,12 @@ func (p *genesisParams) validatePremineInfo() error {
 		p.premineInfos = append(p.premineInfos, premineInfo)
 
 		if premineInfo.address == types.ZeroAddress {
-			isEscrowAccPremined = true
+			isReserveAccPremined = true
 		}
 	}
 
-	if !isEscrowAccPremined {
-		return errEscrowAccMustBePremined
+	if !isReserveAccPremined {
+		return errReserveAccMustBePremined
 	}
 
 	return nil

--- a/command/genesis/params_test.go
+++ b/command/genesis/params_test.go
@@ -141,7 +141,7 @@ func Test_validatePremineInfo(t *testing.T) {
 			expectedPremines: []*premineInfo{
 				{address: types.StringToAddress("12"), amount: command.DefaultPremineBalance},
 			},
-			expectErrMsg: errEscrowAccMustBePremined.Error(),
+			expectErrMsg: errReserveAccMustBePremined.Error(),
 		},
 		{
 			name: "valid premine information",

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -74,13 +74,8 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 	// populate premine balance map
 	premineBalances := make(map[types.Address]*premineInfo, len(p.premine))
 
-	for _, premine := range p.premine {
-		premineInfo, err := parsePremineInfo(premine)
-		if err != nil {
-			return fmt.Errorf("invalid balance amount provided '%s' : %w", premine, err)
-		}
-
-		premineBalances[premineInfo.address] = premineInfo
+	for _, premine := range p.premineInfos {
+		premineBalances[premine.address] = premine
 	}
 
 	walletPremineInfo, err := parsePremineInfo(p.rewardWallet)


### PR DESCRIPTION
# Description

This PR introduces a validation to the genesis command, which ensures that escrow account is premined with some tokens inside genesis. This is important for minting and burning native tokens.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
