### PR TITLE
EVM-728 Gas price comparison for executable transactions in `pricedQueue`

### DIFF
--- a/gasprice/feehistory.go
+++ b/gasprice/feehistory.go
@@ -130,12 +130,13 @@ func (g *GasHelper) FeeHistory(blockCount uint64, newestBlock uint64, rewardPerc
 		}
 
 		sorter := make([]*txGasAndReward, len(block.Transactions))
+		baseFee := new(big.Int).SetUint64(block.Header.BaseFee)
 
 		for j, tx := range block.Transactions {
 			cost := tx.Cost()
 			sorter[j] = &txGasAndReward{
 				gasUsed: cost.Sub(cost, tx.Value),
-				reward:  tx.EffectiveTip(block.Header.BaseFee),
+				reward:  tx.EffectiveGasTip(baseFee),
 			}
 		}
 

--- a/gasprice/gasprice.go
+++ b/gasprice/gasprice.go
@@ -140,7 +140,7 @@ func (g *GasHelper) MaxPriorityFeePerGas() (*big.Int, error) {
 	var allPrices []*big.Int
 
 	collectPrices := func(block *types.Block) error {
-		baseFee := block.Header.BaseFee
+		baseFee := new(big.Int).SetUint64(block.Header.BaseFee)
 		txSorter := newTxByEffectiveTipSorter(block.Transactions, baseFee)
 		sort.Sort(txSorter)
 
@@ -150,7 +150,7 @@ func (g *GasHelper) MaxPriorityFeePerGas() (*big.Int, error) {
 		blockTxPrices := make([]*big.Int, 0)
 
 		for _, tx := range txSorter.txs {
-			tip := tx.EffectiveTip(baseFee)
+			tip := tx.EffectiveGasTip(baseFee)
 
 			if tip.Cmp(g.ignorePrice) == -1 {
 				// ignore transactions with tip lower than ignore price
@@ -238,11 +238,11 @@ func (g *GasHelper) MaxPriorityFeePerGas() (*big.Int, error) {
 // txSortedByEffectiveTip sorts transactions by effective tip from smallest to largest
 type txSortedByEffectiveTip struct {
 	txs     []*types.Transaction
-	baseFee uint64
+	baseFee *big.Int
 }
 
 // newTxByEffectiveTipSorter is constructor function for txSortedByEffectiveTip
-func newTxByEffectiveTipSorter(txs []*types.Transaction, baseFee uint64) *txSortedByEffectiveTip {
+func newTxByEffectiveTipSorter(txs []*types.Transaction, baseFee *big.Int) *txSortedByEffectiveTip {
 	return &txSortedByEffectiveTip{
 		txs:     txs,
 		baseFee: baseFee,
@@ -259,8 +259,8 @@ func (t *txSortedByEffectiveTip) Swap(i, j int) {
 
 // Less is implementation of sort.Interface
 func (t *txSortedByEffectiveTip) Less(i, j int) bool {
-	tip1 := t.txs[i].EffectiveTip(t.baseFee)
-	tip2 := t.txs[j].EffectiveTip(t.baseFee)
+	tip1 := t.txs[i].EffectiveGasTip(t.baseFee)
+	tip2 := t.txs[j].EffectiveGasTip(t.baseFee)
 
 	return tip1.Cmp(tip2) < 0
 }

--- a/txpool/queue_priced.go
+++ b/txpool/queue_priced.go
@@ -11,22 +11,26 @@ type pricedQueue struct {
 	queue *maxPriceQueue
 }
 
-func newPricedQueue(baseFee uint64, initialTxs []*types.Transaction) *pricedQueue {
-	q := pricedQueue{
-		queue: &maxPriceQueue{
-			baseFee: new(big.Int).SetUint64(baseFee),
-			txs:     initialTxs,
-		},
+// init initializes the underlying queue
+func (q *pricedQueue) init(baseFee uint64) *pricedQueue {
+	q.queue = &maxPriceQueue{
+		baseFee: new(big.Int).SetUint64(baseFee),
+		txs:     nil,
+	}
+
+	return q
+}
+
+// initWithTxs initializes the underlying queue with initial transactions
+func (q *pricedQueue) initWithTxs(baseFee uint64, initialTxs []*types.Transaction) *pricedQueue {
+	q.queue = &maxPriceQueue{
+		baseFee: new(big.Int).SetUint64(baseFee),
+		txs:     initialTxs,
 	}
 
 	heap.Init(q.queue)
 
-	return &q
-}
-
-// clear empties the underlying queue.
-func (q *pricedQueue) clear() {
-	q.queue.txs = make([]*types.Transaction, 0) // q.queue.txt[:0] can create memory leaks
+	return q
 }
 
 // Pushes the given transactions onto the queue.
@@ -52,10 +56,6 @@ func (q *pricedQueue) pop() *types.Transaction {
 // length returns the number of transactions in the queue.
 func (q *pricedQueue) length() int {
 	return q.queue.Len()
-}
-
-func (q *pricedQueue) updateBaseFee(baseFee *big.Int) {
-	q.queue.baseFee = baseFee
 }
 
 // transactions sorted by gas price (descending)

--- a/txpool/queue_priced.go
+++ b/txpool/queue_priced.go
@@ -11,11 +11,13 @@ type pricedQueue struct {
 	queue *maxPriceQueue
 }
 
-// init initializes the underlying queue with initial transactions
-func (q *pricedQueue) init(baseFee uint64, initialTxs []*types.Transaction) *pricedQueue {
-	q.queue = &maxPriceQueue{
-		baseFee: new(big.Int).SetUint64(baseFee),
-		txs:     initialTxs,
+// newPricesQueue creates the priced queue with initial transactions and base fee
+func newPricesQueue(baseFee uint64, initialTxs []*types.Transaction) *pricedQueue {
+	q := &pricedQueue{
+		queue: &maxPriceQueue{
+			baseFee: new(big.Int).SetUint64(baseFee),
+			txs:     initialTxs,
+		},
 	}
 
 	heap.Init(q.queue)

--- a/txpool/queue_priced.go
+++ b/txpool/queue_priced.go
@@ -3,7 +3,6 @@ package txpool
 import (
 	"container/heap"
 	"math/big"
-	"sync/atomic"
 
 	"github.com/0xPolygon/polygon-edge/types"
 )
@@ -12,9 +11,12 @@ type pricedQueue struct {
 	queue *maxPriceQueue
 }
 
-func newPricedQueue() *pricedQueue {
+func newPricedQueue(baseFee uint64, initialTxs []*types.Transaction) *pricedQueue {
 	q := pricedQueue{
-		queue: &maxPriceQueue{},
+		queue: &maxPriceQueue{
+			baseFee: new(big.Int).SetUint64(baseFee),
+			txs:     initialTxs,
+		},
 	}
 
 	heap.Init(q.queue)
@@ -24,7 +26,7 @@ func newPricedQueue() *pricedQueue {
 
 // clear empties the underlying queue.
 func (q *pricedQueue) clear() {
-	q.queue.txs = q.queue.txs[:0]
+	q.queue.txs = make([]*types.Transaction, 0) // q.queue.txt[:0] can create memory leaks
 }
 
 // Pushes the given transactions onto the queue.
@@ -48,13 +50,17 @@ func (q *pricedQueue) pop() *types.Transaction {
 }
 
 // length returns the number of transactions in the queue.
-func (q *pricedQueue) length() uint64 {
-	return uint64(q.queue.Len())
+func (q *pricedQueue) length() int {
+	return q.queue.Len()
+}
+
+func (q *pricedQueue) updateBaseFee(baseFee *big.Int) {
+	q.queue.baseFee = baseFee
 }
 
 // transactions sorted by gas price (descending)
 type maxPriceQueue struct {
-	baseFee uint64
+	baseFee *big.Int
 	txs     []*types.Transaction
 }
 
@@ -76,17 +82,6 @@ func (q *maxPriceQueue) Swap(i, j int) {
 	q.txs[i], q.txs[j] = q.txs[j], q.txs[i]
 }
 
-func (q *maxPriceQueue) Less(i, j int) bool {
-	switch q.cmp(q.txs[i], q.txs[j]) {
-	case -1:
-		return true
-	case 1:
-		return false
-	default:
-		return q.txs[i].Nonce > q.txs[j].Nonce
-	}
-}
-
 func (q *maxPriceQueue) Push(x interface{}) {
 	transaction, ok := x.(*types.Transaction)
 	if !ok {
@@ -105,45 +100,32 @@ func (q *maxPriceQueue) Pop() interface{} {
 	return x
 }
 
-// cmp compares the given transactions by their fees and returns:
-//   - 0 if they have same fees
-//   - 1 if a has higher fees than b
-//   - -1 if b has higher fees than a
-func (q *maxPriceQueue) cmp(a, b *types.Transaction) int {
-	baseFee := atomic.LoadUint64(&q.baseFee)
-	effectiveTipA := a.EffectiveTip(baseFee)
-	effectiveTipB := b.EffectiveTip(baseFee)
-
-	// Compare effective tips if baseFee is specified
-	if c := effectiveTipA.Cmp(effectiveTipB); c != 0 {
-		return c
+// @see https://github.com/etclabscore/core-geth/blob/4e2b0e37f89515a4e7b6bafaa40910a296cb38c0/core/txpool/list.go#L458
+// for details why is something implemented like it is
+func (q *maxPriceQueue) Less(i, j int) bool {
+	switch cmp(q.txs[i], q.txs[j], q.baseFee) {
+	case -1:
+		return false
+	case 1:
+		return true
+	default:
+		return q.txs[i].Nonce < q.txs[j].Nonce
 	}
+}
 
-	aGasFeeCap, bGasFeeCap := new(big.Int), new(big.Int)
-
-	if a.GasFeeCap != nil {
-		aGasFeeCap = aGasFeeCap.Set(a.GasFeeCap)
-	}
-
-	if b.GasFeeCap != nil {
-		bGasFeeCap = bGasFeeCap.Set(b.GasFeeCap)
+func cmp(a, b *types.Transaction, baseFee *big.Int) int {
+	if baseFee.BitLen() > 0 {
+		// Compare effective tips if baseFee is specified
+		if c := a.EffectiveGasTip(baseFee).Cmp(b.EffectiveGasTip(baseFee)); c != 0 {
+			return c
+		}
 	}
 
 	// Compare fee caps if baseFee is not specified or effective tips are equal
-	if c := aGasFeeCap.Cmp(bGasFeeCap); c != 0 {
+	if c := a.GetGasFeeCap().Cmp(b.GetGasFeeCap()); c != 0 {
 		return c
 	}
 
-	aGasTipCap, bGasTipCap := new(big.Int), new(big.Int)
-
-	if a.GasTipCap != nil {
-		aGasTipCap = aGasTipCap.Set(a.GasTipCap)
-	}
-
-	if b.GasTipCap != nil {
-		bGasTipCap = bGasTipCap.Set(b.GasTipCap)
-	}
-
 	// Compare tips if effective tips and fee caps are equal
-	return aGasTipCap.Cmp(bGasTipCap)
+	return a.GetGasTipCap().Cmp(b.GetGasTipCap())
 }

--- a/txpool/queue_priced.go
+++ b/txpool/queue_priced.go
@@ -11,18 +11,8 @@ type pricedQueue struct {
 	queue *maxPriceQueue
 }
 
-// init initializes the underlying queue
-func (q *pricedQueue) init(baseFee uint64) *pricedQueue {
-	q.queue = &maxPriceQueue{
-		baseFee: new(big.Int).SetUint64(baseFee),
-		txs:     nil,
-	}
-
-	return q
-}
-
-// initWithTxs initializes the underlying queue with initial transactions
-func (q *pricedQueue) initWithTxs(baseFee uint64, initialTxs []*types.Transaction) *pricedQueue {
+// init initializes the underlying queue with initial transactions
+func (q *pricedQueue) init(baseFee uint64, initialTxs []*types.Transaction) *pricedQueue {
 	q.queue = &maxPriceQueue{
 		baseFee: new(big.Int).SetUint64(baseFee),
 		txs:     initialTxs,

--- a/txpool/queue_priced_test.go
+++ b/txpool/queue_priced_test.go
@@ -3,12 +3,10 @@ package txpool
 import (
 	"math/big"
 	"math/rand"
-	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_maxPriceQueue(t *testing.T) {
@@ -224,6 +222,12 @@ func Test_maxPriceQueue(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "empty",
+			baseFee:  0,
+			unsorted: nil,
+			sorted:   []*types.Transaction{},
+		},
 	}
 
 	for _, tt := range testTable {
@@ -232,15 +236,10 @@ func Test_maxPriceQueue(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			queue := &maxPriceQueue{
-				baseFee: tt.baseFee,
-				txs:     tt.unsorted,
-			}
-
-			sort.Sort(queue)
+			queue := newPricedQueue(tt.baseFee, tt.unsorted)
 
 			for _, tx := range tt.sorted {
-				actual := queue.Pop()
+				actual := queue.pop()
 				assert.Equal(t, tx, actual)
 			}
 		})
@@ -269,12 +268,7 @@ func Benchmark_pricedQueue(t *testing.B) {
 	for _, tt := range testTable {
 		t.Run(tt.name, func(b *testing.B) {
 			for i := 0; i < t.N; i++ {
-				q := newPricedQueue()
-				q.queue.baseFee = uint64(i)
-
-				for _, tx := range tt.unsortedTxs {
-					q.push(tx)
-				}
+				q := newPricedQueue(uint64(100), tt.unsortedTxs)
 
 				for q.length() > 0 {
 					_ = q.pop()

--- a/txpool/queue_priced_test.go
+++ b/txpool/queue_priced_test.go
@@ -236,7 +236,7 @@ func Test_maxPriceQueue(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			queue := (&pricedQueue{}).init(tt.baseFee, tt.unsorted)
+			queue := newPricesQueue(tt.baseFee, tt.unsorted)
 
 			for _, tx := range tt.sorted {
 				actual := queue.pop()
@@ -268,7 +268,7 @@ func Benchmark_pricedQueue(t *testing.B) {
 	for _, tt := range testTable {
 		t.Run(tt.name, func(b *testing.B) {
 			for i := 0; i < t.N; i++ {
-				q := (&pricedQueue{}).init(uint64(100), tt.unsortedTxs)
+				q := newPricesQueue(uint64(100), tt.unsortedTxs)
 
 				for q.length() > 0 {
 					_ = q.pop()

--- a/txpool/queue_priced_test.go
+++ b/txpool/queue_priced_test.go
@@ -236,7 +236,7 @@ func Test_maxPriceQueue(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			queue := newPricedQueue(tt.baseFee, tt.unsorted)
+			queue := (&pricedQueue{}).initWithTxs(tt.baseFee, tt.unsorted)
 
 			for _, tx := range tt.sorted {
 				actual := queue.pop()
@@ -268,7 +268,7 @@ func Benchmark_pricedQueue(t *testing.B) {
 	for _, tt := range testTable {
 		t.Run(tt.name, func(b *testing.B) {
 			for i := 0; i < t.N; i++ {
-				q := newPricedQueue(uint64(100), tt.unsortedTxs)
+				q := (&pricedQueue{}).initWithTxs(uint64(100), tt.unsortedTxs)
 
 				for q.length() > 0 {
 					_ = q.pop()

--- a/txpool/queue_priced_test.go
+++ b/txpool/queue_priced_test.go
@@ -236,7 +236,7 @@ func Test_maxPriceQueue(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			queue := (&pricedQueue{}).initWithTxs(tt.baseFee, tt.unsorted)
+			queue := (&pricedQueue{}).init(tt.baseFee, tt.unsorted)
 
 			for _, tx := range tt.sorted {
 				actual := queue.pop()
@@ -268,7 +268,7 @@ func Benchmark_pricedQueue(t *testing.B) {
 	for _, tt := range testTable {
 		t.Run(tt.name, func(b *testing.B) {
 			for i := 0; i < t.N; i++ {
-				q := (&pricedQueue{}).initWithTxs(uint64(100), tt.unsortedTxs)
+				q := (&pricedQueue{}).init(uint64(100), tt.unsortedTxs)
 
 				for q.length() > 0 {
 					_ = q.pop()

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -202,7 +202,7 @@ func NewTxPool(
 		logger:      logger.Named("txpool"),
 		forks:       forks,
 		store:       store,
-		executables: (&pricedQueue{}).init(0, nil),
+		executables: newPricesQueue(0, nil),
 		accounts:    accountsMap{maxEnqueuedLimit: config.MaxAccountEnqueued},
 		index:       lookupMap{all: make(map[types.Hash]*types.Transaction)},
 		gauge:       slotGauge{height: 0, max: config.MaxSlots},
@@ -331,8 +331,8 @@ func (p *TxPool) Prepare(baseFee uint64) {
 	// fetch primary from each account
 	primaries := p.accounts.getPrimaries()
 
-	// re-initialize executables queue with primaries
-	p.executables.init(baseFee, primaries)
+	// create new executables queue with base fee and initial transactions (primaries)
+	p.executables = newPricesQueue(baseFee, primaries)
 }
 
 // Peek returns the best-price selected

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -2612,9 +2612,20 @@ func TestResetAccounts_Enqueued(t *testing.T) {
 func TestExecutablesOrder(t *testing.T) {
 	t.Parallel()
 
-	newPricedTx := func(addr types.Address, nonce, gasPrice uint64) *types.Transaction {
+	newPricedTx := func(
+		addr types.Address, nonce, gasPrice uint64, gasFeeCap uint64, value uint64) *types.Transaction {
 		tx := newTx(addr, nonce, 1)
-		tx.GasPrice.SetUint64(gasPrice)
+		tx.Value = new(big.Int).SetUint64(value)
+
+		if gasPrice == 0 {
+			tx.Type = types.DynamicFeeTx
+			tx.GasFeeCap = new(big.Int).SetUint64(gasFeeCap)
+			tx.GasTipCap = new(big.Int).SetUint64(2)
+			tx.GasPrice = big.NewInt(0)
+		} else {
+			tx.Type = types.LegacyTx
+			tx.GasPrice = new(big.Int).SetUint64(gasPrice)
+		}
 
 		return tx
 	}
@@ -2622,87 +2633,118 @@ func TestExecutablesOrder(t *testing.T) {
 	testCases := []struct {
 		name               string
 		allTxs             map[types.Address][]*types.Transaction
-		expectedPriceOrder []uint64
+		expectedPriceOrder [][2]uint64
 	}{
 		{
 			name: "case #1",
 			allTxs: map[types.Address][]*types.Transaction{
 				addr1: {
-					newPricedTx(addr1, 0, 1),
+					newPricedTx(addr1, 0, 1, 0, 400),
 				},
 				addr2: {
-					newPricedTx(addr2, 0, 2),
+					newPricedTx(addr2, 0, 2, 0, 500),
 				},
 				addr3: {
-					newPricedTx(addr3, 0, 3),
+					newPricedTx(addr3, 0, 3, 0, 200),
 				},
 				addr4: {
-					newPricedTx(addr4, 0, 4),
+					newPricedTx(addr4, 0, 4, 0, 300),
 				},
 				addr5: {
-					newPricedTx(addr5, 0, 5),
+					newPricedTx(addr5, 0, 5, 0, 100),
 				},
 			},
-			expectedPriceOrder: []uint64{
-				5,
-				4,
-				3,
-				2,
-				1,
+			expectedPriceOrder: [][2]uint64{
+				{5, 100},
+				{4, 300},
+				{3, 200},
+				{2, 500},
+				{1, 400},
 			},
 		},
 		{
 			name: "case #2",
 			allTxs: map[types.Address][]*types.Transaction{
 				addr1: {
-					newPricedTx(addr1, 0, 3),
-					newPricedTx(addr1, 1, 3),
-					newPricedTx(addr1, 2, 3),
+					newPricedTx(addr1, 1, 3, 0, 200),
+					newPricedTx(addr1, 2, 3, 0, 500),
+					newPricedTx(addr1, 0, 3, 0, 300),
 				},
 				addr2: {
-					newPricedTx(addr2, 0, 2),
-					newPricedTx(addr2, 1, 2),
-					newPricedTx(addr2, 2, 2),
+					newPricedTx(addr2, 0, 2, 0, 700),
+					newPricedTx(addr2, 1, 2, 0, 900),
+					newPricedTx(addr2, 2, 2, 0, 800),
 				},
 				addr3: {
-					newPricedTx(addr3, 0, 1),
-					newPricedTx(addr3, 1, 1),
-					newPricedTx(addr3, 2, 1),
+					newPricedTx(addr3, 2, 1, 0, 100),
+					newPricedTx(addr3, 1, 1, 0, 50),
+					newPricedTx(addr3, 0, 1, 0, 75),
 				},
 			},
-			expectedPriceOrder: []uint64{
-				3,
-				3,
-				3,
-				2,
-				2,
-				2,
-				1,
-				1,
-				1,
+			expectedPriceOrder: [][2]uint64{
+				{3, 300},
+				{3, 200},
+				{3, 500},
+				{2, 700},
+				{2, 900},
+				{2, 800},
+				{1, 75},
+				{1, 50},
+				{1, 100},
 			},
 		},
 		{
 			name: "case #3",
 			allTxs: map[types.Address][]*types.Transaction{
 				addr1: {
-					newPricedTx(addr1, 0, 9),
-					newPricedTx(addr1, 1, 5),
-					newPricedTx(addr1, 2, 3),
+					newPricedTx(addr1, 1, 5, 0, 100),
+					newPricedTx(addr1, 0, 9, 0, 100),
+					newPricedTx(addr1, 2, 3, 0, 100),
 				},
 				addr2: {
-					newPricedTx(addr2, 0, 9),
-					newPricedTx(addr2, 1, 3),
-					newPricedTx(addr2, 2, 1),
+					newPricedTx(addr2, 0, 9, 0, 100),
+					newPricedTx(addr2, 1, 3, 0, 100),
+					newPricedTx(addr2, 2, 1, 0, 100),
 				},
 			},
-			expectedPriceOrder: []uint64{
-				9,
-				9,
-				5,
-				3,
-				3,
-				1,
+			expectedPriceOrder: [][2]uint64{
+				{9, 100},
+				{9, 100},
+				{5, 100},
+				{3, 100},
+				{3, 100},
+				{1, 100},
+			},
+		},
+		{
+			name: "case #4",
+			allTxs: map[types.Address][]*types.Transaction{
+				addr1: {
+					newPricedTx(addr1, 0, 0, 70, 1),
+					newPricedTx(addr1, 1, 0, 50, 2),
+					newPricedTx(addr1, 2, 0, 20, 3),
+				},
+				addr2: {
+					newPricedTx(addr2, 0, 0, 90, 4),
+					newPricedTx(addr2, 1, 0, 80, 5),
+					newPricedTx(addr2, 2, 0, 10, 6),
+				},
+				addr3: {
+					newPricedTx(addr3, 0, 0, 100, 7),
+					newPricedTx(addr3, 1, 0, 60, 8),
+					newPricedTx(addr3, 2, 0, 40, 9),
+				},
+			},
+			expectedPriceOrder: [][2]uint64{
+				{0, 7},
+				{0, 4},
+				{0, 5},
+				{0, 1},
+				{0, 8},
+				{0, 2},
+				{0, 9},
+				{0, 3},
+				{0, 6},
 			},
 		},
 	}
@@ -2736,8 +2778,10 @@ func TestExecutablesOrder(t *testing.T) {
 			defer cancelFn()
 
 			// All txns should get added
-			assert.Len(t, waitForEvents(ctx, subscription, expectedPromotedTx), expectedPromotedTx)
-			assert.Equal(t, uint64(len(test.expectedPriceOrder)), pool.accounts.promoted())
+			require.Len(t, waitForEvents(ctx, subscription, expectedPromotedTx), expectedPromotedTx)
+			require.Equal(t, uint64(len(test.expectedPriceOrder)), pool.accounts.promoted())
+
+			pool.Prepare(1000)
 
 			var successful []*types.Transaction
 			for {
@@ -2750,10 +2794,13 @@ func TestExecutablesOrder(t *testing.T) {
 				successful = append(successful, tx)
 			}
 
+			require.Len(t, successful, expectedPromotedTx)
+
 			// verify the highest priced transactions
 			// were processed first
 			for i, tx := range successful {
-				assert.Equal(t, test.expectedPriceOrder[i], tx.GasPrice.Uint64())
+				require.Equal(t, test.expectedPriceOrder[i][0], tx.GasPrice.Uint64())
+				require.Equal(t, test.expectedPriceOrder[i][1], tx.Value.Uint64())
 			}
 		})
 	}

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -153,7 +153,7 @@ func (t *Transaction) GetGasPrice(baseFee uint64) *big.Int {
 	if t.GasPrice != nil && t.GasPrice.BitLen() > 0 {
 		return new(big.Int).Set(t.GasPrice)
 	} else if baseFee == 0 {
-		return new(big.Int)
+		return big.NewInt(0)
 	}
 
 	gasFeeCap := new(big.Int)
@@ -166,18 +166,17 @@ func (t *Transaction) GetGasPrice(baseFee uint64) *big.Int {
 		gasTipCap = gasTipCap.Set(t.GasTipCap)
 	}
 
-	gasPrice := new(big.Int)
 	if gasFeeCap.BitLen() > 0 || gasTipCap.BitLen() > 0 {
-		gasPrice = common.BigMin(
-			new(big.Int).Add(
+		return common.BigMin(
+			gasTipCap.Add(
 				gasTipCap,
 				new(big.Int).SetUint64(baseFee),
 			),
-			new(big.Int).Set(gasFeeCap),
+			gasFeeCap,
 		)
 	}
 
-	return gasPrice
+	return big.NewInt(0)
 }
 
 func (t *Transaction) Size() uint64 {
@@ -191,17 +190,38 @@ func (t *Transaction) Size() uint64 {
 	return size
 }
 
-// EffectiveTip defines effective tip based on tx type.
+// EffectiveGasTip defines effective tip based on tx type.
 // Spec: https://eips.ethereum.org/EIPS/eip-1559#specification
 // We use EIP-1559 fields of the tx if the london hardfork is enabled.
 // Effective tip be came to be either gas tip cap or (gas fee cap - current base fee)
-func (t *Transaction) EffectiveTip(baseFee uint64) *big.Int {
-	if t.GasFeeCap != nil && t.GasTipCap != nil {
-		return common.BigMin(
-			new(big.Int).Sub(t.GasFeeCap, new(big.Int).SetUint64(baseFee)),
-			new(big.Int).Set(t.GasTipCap),
-		)
+func (t *Transaction) EffectiveGasTip(baseFee *big.Int) *big.Int {
+	if baseFee == nil || baseFee.BitLen() == 0 {
+		return t.GetGasTipCap()
 	}
 
-	return t.GetGasPrice(baseFee)
+	return common.BigMin(
+		new(big.Int).Set(t.GetGasTipCap()),
+		new(big.Int).Sub(t.GetGasFeeCap(), baseFee))
+}
+
+// GetGasTipCap gets gas tip cap depending on tx type
+// Spec: https://eips.ethereum.org/EIPS/eip-1559#specification
+func (t *Transaction) GetGasTipCap() *big.Int {
+	switch t.Type {
+	case DynamicFeeTx:
+		return t.GasTipCap
+	default:
+		return t.GasPrice
+	}
+}
+
+// GetGasFeeCap gets gas fee cap depending on tx type
+// Spec: https://eips.ethereum.org/EIPS/eip-1559#specification
+func (t *Transaction) GetGasFeeCap() *big.Int {
+	switch t.Type {
+	case DynamicFeeTx:
+		return t.GasFeeCap
+	default:
+		return t.GasPrice
+	}
 }


### PR DESCRIPTION
# Description

Gas price comparison (for executable transactions in `pricedQueue`) does not take `GasPrice` for legacy transactions. Consequence is that those are not pulled in order when block builder builds block

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
