### PR TITLE
Jp/hotfix optional gas price in rpc transaction type

### DIFF
--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -18,7 +18,7 @@ type transactionOrHash interface {
 
 type transaction struct {
 	Nonce       argUint64      `json:"nonce"`
-	GasPrice    *argBig        `json:"gasPrice"`
+	GasPrice    *argBig        `json:"gasPrice,omitempty"`
 	GasTipCap   *argBig        `json:"gasTipCap,omitempty"`
 	GasFeeCap   *argBig        `json:"gasFeeCap,omitempty"`
 	Gas         argUint64      `json:"gas"`

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -18,7 +18,7 @@ type transactionOrHash interface {
 
 type transaction struct {
 	Nonce       argUint64      `json:"nonce"`
-	GasPrice    *argBig         `json:"gasPrice"`
+	GasPrice    *argBig        `json:"gasPrice"`
 	GasTipCap   *argBig        `json:"gasTipCap,omitempty"`
 	GasFeeCap   *argBig        `json:"gasFeeCap,omitempty"`
 	Gas         argUint64      `json:"gas"`
@@ -58,20 +58,20 @@ func toTransaction(
 	txIndex *int,
 ) *transaction {
 	res := &transaction{
-		Nonce:    argUint64(t.Nonce),
-		Gas:      argUint64(t.Gas),
-		To:       t.To,
-		Value:    argBig(*t.Value),
-		Input:    t.Input,
-		V:        argBig(*t.V),
-		R:        argBig(*t.R),
-		S:        argBig(*t.S),
-		Hash:     t.Hash,
-		From:     t.From,
-		Type:     argUint64(t.Type),
+		Nonce: argUint64(t.Nonce),
+		Gas:   argUint64(t.Gas),
+		To:    t.To,
+		Value: argBig(*t.Value),
+		Input: t.Input,
+		V:     argBig(*t.V),
+		R:     argBig(*t.R),
+		S:     argBig(*t.S),
+		Hash:  t.Hash,
+		From:  t.From,
+		Type:  argUint64(t.Type),
 	}
 
-	if (t.GasPrice != nil) {
+	if t.GasPrice != nil {
 		gasPrice := argBig(*t.GasPrice)
 		res.GasPrice = &gasPrice
 	}

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -18,7 +18,7 @@ type transactionOrHash interface {
 
 type transaction struct {
 	Nonce       argUint64      `json:"nonce"`
-	GasPrice    argBig         `json:"gasPrice"`
+	GasPrice    *argBig         `json:"gasPrice"`
 	GasTipCap   *argBig        `json:"gasTipCap,omitempty"`
 	GasFeeCap   *argBig        `json:"gasFeeCap,omitempty"`
 	Gas         argUint64      `json:"gas"`
@@ -59,7 +59,6 @@ func toTransaction(
 ) *transaction {
 	res := &transaction{
 		Nonce:    argUint64(t.Nonce),
-		GasPrice: argBig(*t.GasPrice),
 		Gas:      argUint64(t.Gas),
 		To:       t.To,
 		Value:    argBig(*t.Value),
@@ -70,6 +69,11 @@ func toTransaction(
 		Hash:     t.Hash,
 		From:     t.From,
 		Type:     argUint64(t.Type),
+	}
+
+	if (t.GasPrice != nil) {
+		gasPrice := argBig(*t.GasPrice)
+		res.GasPrice = &gasPrice
 	}
 
 	if t.GasTipCap != nil {

--- a/jsonrpc/types_test.go
+++ b/jsonrpc/types_test.go
@@ -135,19 +135,19 @@ func TestToTransaction_EIP1559(t *testing.T) {
 	r, _ := hex.DecodeHex(hexWithLeading0)
 	s, _ := hex.DecodeHex(hexWithLeading0)
 	txn := types.Transaction{
-		Nonce:    0,
-		GasPrice: nil,
+		Nonce:     0,
+		GasPrice:  nil,
 		GasTipCap: big.NewInt(10),
 		GasFeeCap: big.NewInt(10),
-		Gas:      0,
-		To:       nil,
-		Value:    big.NewInt(0),
-		Input:    nil,
-		V:        new(big.Int).SetBytes(v),
-		R:        new(big.Int).SetBytes(r),
-		S:        new(big.Int).SetBytes(s),
-		Hash:     types.Hash{},
-		From:     types.Address{},
+		Gas:       0,
+		To:        nil,
+		Value:     big.NewInt(0),
+		Input:     nil,
+		V:         new(big.Int).SetBytes(v),
+		R:         new(big.Int).SetBytes(r),
+		S:         new(big.Int).SetBytes(s),
+		Hash:      types.Hash{},
+		From:      types.Address{},
 	}
 
 	jsonTx := toTransaction(&txn, nil, nil, nil)

--- a/jsonrpc/types_test.go
+++ b/jsonrpc/types_test.go
@@ -128,6 +128,39 @@ func TestToTransaction_Returns_V_R_S_ValuesWithoutLeading0(t *testing.T) {
 	assert.Equal(t, hexWithoutLeading0, string(jsonS))
 }
 
+func TestToTransaction_EIP1559(t *testing.T) {
+	hexWithLeading0 := "0x0ba93811466694b3b3cb8853cb8227b7c9f49db10bf6e7db59d20ac904961565"
+	hexWithoutLeading0 := "0xba93811466694b3b3cb8853cb8227b7c9f49db10bf6e7db59d20ac904961565"
+	v, _ := hex.DecodeHex(hexWithLeading0)
+	r, _ := hex.DecodeHex(hexWithLeading0)
+	s, _ := hex.DecodeHex(hexWithLeading0)
+	txn := types.Transaction{
+		Nonce:    0,
+		GasPrice: nil,
+		GasTipCap: big.NewInt(10),
+		GasFeeCap: big.NewInt(10),
+		Gas:      0,
+		To:       nil,
+		Value:    big.NewInt(0),
+		Input:    nil,
+		V:        new(big.Int).SetBytes(v),
+		R:        new(big.Int).SetBytes(r),
+		S:        new(big.Int).SetBytes(s),
+		Hash:     types.Hash{},
+		From:     types.Address{},
+	}
+
+	jsonTx := toTransaction(&txn, nil, nil, nil)
+
+	jsonV, _ := jsonTx.V.MarshalText()
+	jsonR, _ := jsonTx.R.MarshalText()
+	jsonS, _ := jsonTx.S.MarshalText()
+
+	assert.Equal(t, hexWithoutLeading0, string(jsonV))
+	assert.Equal(t, hexWithoutLeading0, string(jsonR))
+	assert.Equal(t, hexWithoutLeading0, string(jsonS))
+}
+
 func TestBlock_Copy(t *testing.T) {
 	b := &block{
 		ExtraData: []byte{0x1},
@@ -206,7 +239,7 @@ func mockTxn() *transaction {
 
 	tt := &transaction{
 		Nonce:       1,
-		GasPrice:    argBig(*big.NewInt(10)),
+		GasPrice:    argBigPtr(big.NewInt(10)),
 		Gas:         100,
 		To:          &to,
 		Value:       argBig(*big.NewInt(1000)),


### PR DESCRIPTION
# Description

I've made `GasPrice` optional in the `transaction` struct in `jsonrpc/types.go`. The previous implementation made it impossible to call `eth_getTransactionByHash` for EIP-1559 transactions or `eth_getBlockByNumber` with the transaction details flag. on, if the block contained EIP-1559 transactions. 

# Changes include

Marking this as a HOTFIX as Immutable needs this issue solved before we can release our public testnet.

- [x] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

N/A

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

I had a local polygon-edge chain with 4 nodes. Three of them running `v1.0.0`. One of them running a version with this fix. A call to `eth_getBlockByNumber` with the transaction details flag on would fail on v1.0.0 with `nil` dereference error, but it would work on the node with the fix.

# Documentation update

N/A

# Additional comments

N/A
