### PR TITLE
Fix TestE2E_Migration

### DIFF
--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -145,6 +145,10 @@ func (p *genesisParams) validateFlags() error {
 		return errValidatorsNotSpecified
 	}
 
+	if err := p.parsePremineInfo(); err != nil {
+		return err
+	}
+
 	if p.isPolyBFTConsensus() {
 		if err := p.extractNativeTokenMetadata(); err != nil {
 			return err
@@ -478,10 +482,9 @@ func (p *genesisParams) validateRewardWallet() error {
 	return nil
 }
 
-// validatePremineInfo validates whether reserve account (0x0 address) is premined
-func (p *genesisParams) validatePremineInfo() error {
+// parsePremineInfo parses premine flag
+func (p *genesisParams) parsePremineInfo() error {
 	p.premineInfos = make([]*premineInfo, 0, len(p.premine))
-	isReserveAccPremined := false
 
 	for _, premine := range p.premine {
 		premineInfo, err := parsePremineInfo(premine)
@@ -490,7 +493,16 @@ func (p *genesisParams) validatePremineInfo() error {
 		}
 
 		p.premineInfos = append(p.premineInfos, premineInfo)
+	}
 
+	return nil
+}
+
+// validatePremineInfo validates whether reserve account (0x0 address) is premined
+func (p *genesisParams) validatePremineInfo() error {
+	isReserveAccPremined := false
+
+	for _, premineInfo := range p.premineInfos {
 		if premineInfo.address == types.ZeroAddress {
 			isReserveAccPremined = true
 		}

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -504,7 +504,8 @@ func (p *genesisParams) validatePremineInfo() error {
 
 	for _, premineInfo := range p.premineInfos {
 		if premineInfo.address == types.ZeroAddress {
-			isReserveAccPremined = true
+			// we have premine of zero address, just return
+			return nil
 		}
 	}
 

--- a/e2e-polybft/e2e/migration_test.go
+++ b/e2e-polybft/e2e/migration_test.go
@@ -14,7 +14,6 @@ import (
 	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/umbracle/ethgo"
@@ -41,14 +40,14 @@ func TestE2E_Migration(t *testing.T) {
 		userAddr,
 		ethgo.Latest,
 	)
-	assert.NoError(t, err)
-	assert.Equal(t, balanceSender.Cmp(initialBalance), 0)
+	require.NoError(t, err)
+	require.Equal(t, balanceSender.Cmp(initialBalance), 0)
 
 	balanceReceiver, err := rpcClient.Eth().GetBalance(
 		userAddr2,
 		ethgo.Latest,
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	if balanceReceiver.Uint64() != 0 {
 		t.Fatal("balanceReceiver is not 0")
@@ -65,8 +64,8 @@ func TestE2E_Migration(t *testing.T) {
 		Gas:   1000000,
 		Value: sendAmount,
 	}, userKey)
-	assert.NoError(t, err)
-	assert.NotNil(t, receipt)
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
 
 	receipt, err = relayer.SendTransaction(&ethgo.Transaction{
 		From:  userAddr,
@@ -91,14 +90,14 @@ func TestE2E_Migration(t *testing.T) {
 		userAddr,
 		ethgo.Latest,
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	balanceReceiver, err = rpcClient.Eth().GetBalance(
 		userAddr2,
 		ethgo.Latest,
 	)
-	assert.NoError(t, err)
-	assert.Equal(t, sendAmount, balanceReceiver)
+	require.NoError(t, err)
+	require.Equal(t, sendAmount, balanceReceiver)
 
 	block, err := rpcClient.Eth().GetBlockByNumber(ethgo.Latest, true)
 	if err != nil {
@@ -163,8 +162,8 @@ func TestE2E_Migration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, balanceSender, senderBalanceAfterMigration)
-	assert.Equal(t, balanceReceiver, receiverBalanceAfterMigration)
+	require.Equal(t, balanceSender, senderBalanceAfterMigration)
+	require.Equal(t, balanceReceiver, receiverBalanceAfterMigration)
 
 	deployedCode, err := cluster.Servers[0].JSONRPC().Eth().GetCode(deployedContractBalance, ethgo.Latest)
 	if err != nil {


### PR DESCRIPTION
# Description

E2E test `TestE2E_Migration` was failing because of a bug introduced in https://github.com/0xPolygon/polygon-edge/pull/1685. Through given PR we moved parsing of `premine` flag in `genesis` command to `validatePremineInfos` function, but that function was only called if consensus is `polybft`.

Since given E2E test, tests the migration from an older consensus (in this case `dev` consensus) to `polybft`, premine flag was not parsed when starting cluster in `dev` consensus, so the test's checks failed.

This PR fixes the issue, by first parsing `premine` flag (without checking which consensus is selected), and then calling validate if `polybft` consensus is in place.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually