### PR TITLE
Stop retrying event tracker on context cancellation and timeout

### DIFF
--- a/helper/common/common_test.go
+++ b/helper/common/common_test.go
@@ -116,19 +116,11 @@ func TestRetryForever_AlwaysReturnError_ShouldNeverEnd(t *testing.T) {
 	require.False(t, ended)
 }
 
-func TestRetryForever_ReturnNilAfterFirstRun_ShouldEnd(t *testing.T) {
+func TestRetryForever_CancelContext_ShouldEnd(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	cancel()
 	RetryForever(ctx, time.Millisecond*100, func(ctx context.Context) error {
-		select {
-		case <-ctx.Done():
-
-			return nil
-		default:
-			cancel()
-
-			return errors.New("")
-		}
+		return errors.New("")
 	})
-	<-ctx.Done()
 	require.True(t, errors.Is(ctx.Err(), context.Canceled))
 }

--- a/tracker/event_tracker.go
+++ b/tracker/event_tracker.go
@@ -80,17 +80,21 @@ func (e *EventTracker) Start(ctx context.Context) error {
 
 	// Init and start block tracker concurrently, retrying indefinitely
 	go common.RetryForever(ctx, time.Second, func(context.Context) error {
+		// Init
 		start := time.Now().UTC()
-
 		if err := blockTracker.Init(); err != nil {
 			e.logger.Error("failed to init blocktracker", "error", err)
 
 			return err
 		}
+		elapsed := time.Now().UTC().Sub(start)
 
-		elapsed := time.Now().UTC().Sub(start) // Calculate the elapsed time
-
+		// Start
 		if err := blockTracker.Start(); err != nil {
+			if common.IsContextDone(err) {
+				return nil
+			}
+
 			e.logger.Error("failed to start blocktracker", "error", err)
 
 			return err
@@ -117,8 +121,12 @@ func (e *EventTracker) Start(ctx context.Context) error {
 		return err
 	}
 	// Sync concurrently, retrying indefinitely
-	go common.RetryForever(ctx, time.Second, func(context.Context) error {
+	go common.RetryForever(ctx, time.Second, func(ctx context.Context) error {
 		if err := tt.Sync(ctx); err != nil {
+			if common.IsContextDone(err) {
+				return nil
+			}
+
 			e.logger.Error("failed to sync", "error", err)
 
 			return err

--- a/tracker/event_tracker.go
+++ b/tracker/event_tracker.go
@@ -122,6 +122,12 @@ func (e *EventTracker) Start(ctx context.Context) error {
 	}
 	// Sync concurrently, retrying indefinitely
 	go common.RetryForever(ctx, time.Second, func(ctx context.Context) error {
+		// Some errors from sync can cause this channel to be closed.
+		// We need to ensure that it is not closed before we retry,
+		// otherwise we will get a panic.
+		tt.ReadyCh = make(chan struct{})
+
+		// Run the sync
 		if err := tt.Sync(ctx); err != nil {
 			if common.IsContextDone(err) {
 				return nil


### PR DESCRIPTION
# Changes

* Check for context completion in retry forever loops (in case anonymous func doesn't stop on context done)
* Check for context completion in anonymous funcs passed into retry forever loops where we want to avoid printing an error log in such cases

# Background 

When we shutdown, the loops that retry forever treat context cancellation as a retryable error. Instead, these loops should exit.

We also log these as ERRORs when they should not be logged at all.

These are the relevant log lines:
```
message:2023-07-05T23:40:04.443Z [ERROR] polygon.server.polybft.state-sync-manager.event_tracker: failed to sync: error="context canceled"
```
and
```
message:2023-07-05T23:39:49.465Z [ERROR] polygon.server.polybft.state-sync-manager.event_tracker: failed to start blocktracker: error="context canceled"
```

# Local Tests

Running with fix, shutdown looks like:
```
[SIGNAL] Caught signal: terminated
Gracefully shutting down client...
...
```

Without fix (v1.0.1):
```
[SIGNAL] Caught signal: terminated
Gracefully shutting down client...
...
2023-07-06T21:34:05.747+1200 [ERROR] polygon.server.polybft.state-sync-manager.event_tracker: failed to start blocktracker: error="context canceled"
2023-07-06T21:34:05.747+1200 [ERROR] polygon.server.polybft.state-sync-manager.event_tracker: failed to sync: error="context canceled"

```