### PR TITLE
EVM-543 Enable concurrent run of multiple dial tasks

### DIFF
--- a/network/dial/dial_queue.go
+++ b/network/dial/dial_queue.go
@@ -87,8 +87,8 @@ func (d *DialQueue) DeleteTask(peer peer.ID) {
 func (d *DialQueue) AddTask(addrInfo *peer.AddrInfo, priority common.DialPriority) {
 	if d.addTaskImpl(addrInfo, priority) {
 		select {
-		case <-d.closeCh:
 		case d.updateCh <- struct{}{}:
+		default:
 		}
 	}
 }
@@ -104,6 +104,8 @@ func (d *DialQueue) addTaskImpl(addrInfo *peer.AddrInfo, priority common.DialPri
 			item.addrInfo = addrInfo
 			item.priority = uint64(priority)
 			heap.Fix(&d.heap, item.index)
+
+			return true
 		}
 
 		return false

--- a/network/dial/dial_queue.go
+++ b/network/dial/dial_queue.go
@@ -2,14 +2,13 @@ package dial
 
 import (
 	"container/heap"
+	"context"
 	"sync"
 
 	"github.com/0xPolygon/polygon-edge/network/common"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 )
-
-const updateChBufferSize = 20
 
 // DialQueue is a queue that holds dials tasks for potential peers, implemented as a min-heap
 type DialQueue struct {
@@ -27,7 +26,7 @@ func NewDialQueue() *DialQueue {
 	return &DialQueue{
 		heap:     dialQueueImpl{},
 		tasks:    map[peer.ID]*DialTask{},
-		updateCh: make(chan struct{}, updateChBufferSize),
+		updateCh: make(chan struct{}, 1),
 		closeCh:  make(chan struct{}),
 	}
 }
@@ -37,22 +36,21 @@ func (d *DialQueue) Close() {
 	close(d.closeCh)
 }
 
-// PopTask is a loop that handles update and close events [BLOCKING]
-func (d *DialQueue) PopTask() *DialTask {
-	for {
-		select {
-		case <-d.updateCh: // blocks until AddTask is called...
-			if task := d.popTaskImpl(); task != nil {
-				return task
-			}
-		case <-d.closeCh: // ... or dial queue is closed
-			return nil
-		}
+// Wait waits for closing or updating event or end of context.
+// Returns true for closing event or end of the context [BLOCKING].
+func (d *DialQueue) Wait(ctx context.Context) bool {
+	select {
+	case <-ctx.Done(): // blocks until context is done ...
+		return true
+	case <-d.updateCh: // ... or AddTask is called ...
+		return false
+	case <-d.closeCh: // ... or dial queue is closed
+		return true
 	}
 }
 
-// popTaskImpl is the implementation for task popping from the min-heap
-func (d *DialQueue) popTaskImpl() *DialTask {
+// PopTask is the implementation for task popping from the min-heap
+func (d *DialQueue) PopTask() *DialTask {
 	d.Lock()
 	defer d.Unlock()
 

--- a/network/server.go
+++ b/network/server.go
@@ -366,7 +366,7 @@ func (s *Server) runDial() {
 			peerEvent.PeerFailedToConnect,
 			peerEvent.PeerDisconnected:
 			slots.Release()
-			s.logger.Debug("slot released", "event", event.Type)
+			s.logger.Debug("slot released", "event", event.Type, "peerID", event.PeerID)
 		}
 	}); err != nil {
 		s.logger.Error(


### PR DESCRIPTION
# Description

Right now the dial task in runDial function are done sequentially because Connect is a blocking request. Change code to make up to connections concurrently. This will resolve related TODO comment in runDial function (network/server.go)

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
