### PR TITLE
fix eth_estimateGas panic

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -490,10 +490,6 @@ func (e *Eth) Call(arg *txnArgs, filter BlockNumberOrHash, apiOverride *stateOve
 
 // EstimateGas estimates the gas needed to execute a transaction
 func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error) {
-	if arg == nil {
-		return nil, errors.New("missing value for required argument 0")
-	}
-
 	transaction, err := DecodeTxn(arg, e.store)
 	if err != nil {
 		return nil, err

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -490,6 +490,10 @@ func (e *Eth) Call(arg *txnArgs, filter BlockNumberOrHash, apiOverride *stateOve
 
 // EstimateGas estimates the gas needed to execute a transaction
 func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error) {
+	if arg == nil {
+		return nil, errors.New("missing value for required argument 0")
+	}
+
 	transaction, err := DecodeTxn(arg, e.store)
 	if err != nil {
 		return nil, err

--- a/jsonrpc/helper.go
+++ b/jsonrpc/helper.go
@@ -168,6 +168,9 @@ func GetNextNonce(address types.Address, number BlockNumber, store nonceGetter) 
 }
 
 func DecodeTxn(arg *txnArgs, store nonceGetter) (*types.Transaction, error) {
+	if arg == nil {
+		return nil, errors.New("missing value for required argument 0")
+	}
 	// set default values
 	if arg.From == nil {
 		arg.From = &types.ZeroAddress


### PR DESCRIPTION
# Description

eth_estimateGas panics with nil reference if arg param is nil ie
`{
	"jsonrpc":"2.0",
	"method":"eth_estimateGas",
	"params":[],
	"id":1
}`
this change catches nil arg and throws appropriate error
# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ x] I have tested this code with the official test suite
- [ x] I have tested this code manually

### Manual tests
`curl -X POST --data '{"jsonrpc":"2.0","method":"eth_estimateGas","params":[],"id":1}' http://localhost:10002`
now returns
`"message": "missing value for required argument 0"`

