### PR TITLE
Renamed gasTipCap and gasFeeCap in JSON serialization configuration

### DIFF
--- a/jsonrpc/testsuite/transaction-eip1559.json
+++ b/jsonrpc/testsuite/transaction-eip1559.json
@@ -1,8 +1,8 @@
 {
     "nonce": "0x1",
     "gasPrice": "0xa",
-    "gasTipCap": "0xa",
-    "gasFeeCap": "0xa",
+    "maxPriorityFeePerGas": "0xa",
+    "maxFeePerGas": "0xa",
     "gas": "0x64",
     "to": "0x0000000000000000000000000000000000000000",
     "value": "0x3e8",

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -18,9 +18,9 @@ type transactionOrHash interface {
 
 type transaction struct {
 	Nonce       argUint64      `json:"nonce"`
-	GasPrice    argBig         `json:"gasPrice"`
-	GasTipCap   *argBig        `json:"gasTipCap,omitempty"`
-	GasFeeCap   *argBig        `json:"gasFeeCap,omitempty"`
+	GasPrice    *argBig        `json:"gasPrice"`
+	GasTipCap   *argBig        `json:"maxPriorityFeePerGas,omitempty"`
+	GasFeeCap   *argBig        `json:"maxFeePerGas,omitempty"`
 	Gas         argUint64      `json:"gas"`
 	To          *types.Address `json:"to"`
 	Value       argBig         `json:"value"`


### PR DESCRIPTION
# Description

Changed JSON serialization configuration in `jsonrpc/types.go`  for `gasTipCap` and `gasFeeCap` to match EIP-1559.

Polygon might want to treat this as a breaking change. If so, I'm unclear on what the next steps are.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
