### PR TITLE
EVM-735: Gas limit estimation is not precise

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -196,7 +196,9 @@ func (c *consensusRuntime) initStateSyncManager(logger hcf.Logger) error {
 func (c *consensusRuntime) initCheckpointManager(logger hcf.Logger) error {
 	if c.IsBridgeEnabled() {
 		// enable checkpoint manager
-		txRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithIPAddress(c.config.PolyBFTConfig.Bridge.JSONRPCEndpoint))
+		txRelayer, err := txrelayer.NewTxRelayer(
+			txrelayer.WithIPAddress(c.config.PolyBFTConfig.Bridge.JSONRPCEndpoint),
+			txrelayer.WithWriter(logger.StandardWriter(&hcf.StandardLoggerOptions{})))
 		if err != nil {
 			return err
 		}

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -125,7 +125,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 			return ethgo.ZeroHash, err
 		}
 
-		txn.Gas = gasLimit
+		txn.Gas = gasLimit * 2
 	}
 
 	chainID, err := t.client.Eth().ChainID()

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -14,10 +14,11 @@ import (
 )
 
 const (
-	defaultGasPrice   = 1879048192 // 0x70000000
-	DefaultGasLimit   = 5242880    // 0x500000
-	DefaultRPCAddress = "http://127.0.0.1:8545"
-	numRetries        = 1000
+	defaultGasPrice    = 1879048192 // 0x70000000
+	DefaultGasLimit    = 5242880    // 0x500000
+	DefaultRPCAddress  = "http://127.0.0.1:8545"
+	numRetries         = 1000
+	gasLimitMultiplier = 2
 )
 
 var (
@@ -125,7 +126,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 			return ethgo.ZeroHash, err
 		}
 
-		txn.Gas = gasLimit * 2
+		txn.Gas = gasLimit * gasLimitMultiplier
 	}
 
 	chainID, err := t.client.Eth().ChainID()

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -14,11 +14,12 @@ import (
 )
 
 const (
-	defaultGasPrice    = 1879048192 // 0x70000000
-	DefaultGasLimit    = 5242880    // 0x500000
-	DefaultRPCAddress  = "http://127.0.0.1:8545"
-	numRetries         = 1000
-	gasLimitMultiplier = 2
+	defaultGasPrice   = 1879048192 // 0x70000000
+	DefaultGasLimit   = 5242880    // 0x500000
+	DefaultRPCAddress = "http://127.0.0.1:8545"
+	numRetries        = 1000
+	gasLimitPercent   = 100
+	gasPricePercent   = 20
 )
 
 var (
@@ -117,7 +118,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 			return ethgo.ZeroHash, err
 		}
 
-		txn.GasPrice = gasPrice
+		txn.GasPrice = gasPrice + (gasPrice * gasPricePercent / 100)
 	}
 
 	if txn.Gas == 0 {
@@ -126,7 +127,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 			return ethgo.ZeroHash, err
 		}
 
-		txn.Gas = gasLimit * gasLimitMultiplier
+		txn.Gas = gasLimit + (gasLimit * gasLimitPercent / 100)
 	}
 
 	chainID, err := t.client.Eth().ChainID()


### PR DESCRIPTION
# Description

`txRelayer` in Edge codebase, calls `eth_estimateGas` rpc endpoint to get gas estimation for the given transaction (either on `supernet` or if transaction is sent to `rootchain`, it will call the rpc endpoint on `rootchain`).

That estimation on some networks is just not precise every time (we saw that both on Mumbai and on Sepolia network), and transaction fails, because the gas used by transaction is higher than the estimated gas limit provided in the transaction itself. This leads to spending tokens on a failed automated transaction that should always pass, and that is not something the users want, especially for heavy and frequent transactions like checkpoints.

Through this PR we add more to gas limit estimation we receive. Since fee is paid only for the gas used (not for the gas limit), then this should be more than enough to not perceive this error again.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually