### PR TITLE
[EVM-736]: Quorum calculation discrepancy between SC and Edge

### DIFF
--- a/chain/params.go
+++ b/chain/params.go
@@ -78,16 +78,16 @@ func (p *Params) GetEngine() string {
 
 // predefined forks
 const (
-	Homestead      = "homestead"
-	Byzantium      = "byzantium"
-	Constantinople = "constantinople"
-	Petersburg     = "petersburg"
-	Istanbul       = "istanbul"
-	London         = "london"
-	EIP150         = "EIP150"
-	EIP158         = "EIP158"
-	EIP155         = "EIP155"
-	NoviSad        = "novisad"
+	Homestead           = "homestead"
+	Byzantium           = "byzantium"
+	Constantinople      = "constantinople"
+	Petersburg          = "petersburg"
+	Istanbul            = "istanbul"
+	London              = "london"
+	EIP150              = "EIP150"
+	EIP158              = "EIP158"
+	EIP155              = "EIP155"
+	QuorumCalcAlignment = "quorumcalcalignment"
 )
 
 // Forks is map which contains all forks and their starting blocks from genesis
@@ -112,16 +112,16 @@ func (f *Forks) RemoveFork(name string) {
 // At returns ForksInTime instance that shows which supported forks are enabled for the block
 func (f *Forks) At(block uint64) ForksInTime {
 	return ForksInTime{
-		Homestead:      f.IsActive(Homestead, block),
-		Byzantium:      f.IsActive(Byzantium, block),
-		Constantinople: f.IsActive(Constantinople, block),
-		Petersburg:     f.IsActive(Petersburg, block),
-		Istanbul:       f.IsActive(Istanbul, block),
-		London:         f.IsActive(London, block),
-		EIP150:         f.IsActive(EIP150, block),
-		EIP158:         f.IsActive(EIP158, block),
-		EIP155:         f.IsActive(EIP155, block),
-		NoviSad:        f.IsActive(NoviSad, block),
+		Homestead:           f.IsActive(Homestead, block),
+		Byzantium:           f.IsActive(Byzantium, block),
+		Constantinople:      f.IsActive(Constantinople, block),
+		Petersburg:          f.IsActive(Petersburg, block),
+		Istanbul:            f.IsActive(Istanbul, block),
+		London:              f.IsActive(London, block),
+		EIP150:              f.IsActive(EIP150, block),
+		EIP158:              f.IsActive(EIP158, block),
+		EIP155:              f.IsActive(EIP155, block),
+		QuorumCalcAlignment: f.IsActive(QuorumCalcAlignment, block),
 	}
 }
 
@@ -167,19 +167,19 @@ type ForksInTime struct {
 	EIP150,
 	EIP158,
 	EIP155,
-	NoviSad bool
+	QuorumCalcAlignment bool
 }
 
 // AllForksEnabled should contain all supported forks by current edge version
 var AllForksEnabled = &Forks{
-	Homestead:      NewFork(0),
-	EIP150:         NewFork(0),
-	EIP155:         NewFork(0),
-	EIP158:         NewFork(0),
-	Byzantium:      NewFork(0),
-	Constantinople: NewFork(0),
-	Petersburg:     NewFork(0),
-	Istanbul:       NewFork(0),
-	London:         NewFork(0),
-	NoviSad:        NewFork(0),
+	Homestead:           NewFork(0),
+	EIP150:              NewFork(0),
+	EIP155:              NewFork(0),
+	EIP158:              NewFork(0),
+	Byzantium:           NewFork(0),
+	Constantinople:      NewFork(0),
+	Petersburg:          NewFork(0),
+	Istanbul:            NewFork(0),
+	London:              NewFork(0),
+	QuorumCalcAlignment: NewFork(0),
 }

--- a/chain/params.go
+++ b/chain/params.go
@@ -87,6 +87,7 @@ const (
 	EIP150         = "EIP150"
 	EIP158         = "EIP158"
 	EIP155         = "EIP155"
+	NoviSad        = "novisad"
 )
 
 // Forks is map which contains all forks and their starting blocks from genesis
@@ -120,6 +121,7 @@ func (f *Forks) At(block uint64) ForksInTime {
 		EIP150:         f.IsActive(EIP150, block),
 		EIP158:         f.IsActive(EIP158, block),
 		EIP155:         f.IsActive(EIP155, block),
+		NoviSad:        f.IsActive(NoviSad, block),
 	}
 }
 
@@ -164,7 +166,8 @@ type ForksInTime struct {
 	London,
 	EIP150,
 	EIP158,
-	EIP155 bool
+	EIP155,
+	NoviSad bool
 }
 
 // AllForksEnabled should contain all supported forks by current edge version
@@ -178,4 +181,5 @@ var AllForksEnabled = &Forks{
 	Petersburg:     NewFork(0),
 	Istanbul:       NewFork(0),
 	London:         NewFork(0),
+	NoviSad:        NewFork(0),
 }

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -380,7 +380,7 @@ func (c *consensusRuntime) FSM() error {
 	}
 
 	if isEndOfSprint {
-		commitment, err := c.stateSyncManager.Commitment()
+		commitment, err := c.stateSyncManager.Commitment(pendingBlockNumber)
 		if err != nil {
 			return err
 		}

--- a/consensus/polybft/extra_test.go
+++ b/consensus/polybft/extra_test.go
@@ -394,10 +394,10 @@ func TestSignature_Verify(t *testing.T) {
 				Bitmap:              bitmap,
 			}
 
-			err = s.Verify(validatorsMetadata, msgHash, bls.DomainCheckpointManager, hclog.NewNullLogger())
+			err = s.Verify(10, validatorsMetadata, msgHash, bls.DomainCheckpointManager, hclog.NewNullLogger())
 			signers[val.Address()] = struct{}{}
 
-			if !validatorSet.HasQuorum(signers) {
+			if !validatorSet.HasQuorum(10, signers) {
 				assert.ErrorContains(t, err, "quorum not reached", "failed for %d", i)
 			} else {
 				assert.NoError(t, err)
@@ -415,7 +415,7 @@ func TestSignature_Verify(t *testing.T) {
 		bmp.Set(uint64(validatorSet.Len() + 1))
 		s := &Signature{Bitmap: bmp}
 
-		err := s.Verify(validatorSet, types.Hash{0x1}, bls.DomainCheckpointManager, hclog.NewNullLogger())
+		err := s.Verify(0, validatorSet, types.Hash{0x1}, bls.DomainCheckpointManager, hclog.NewNullLogger())
 		require.Error(t, err)
 	})
 }
@@ -483,7 +483,7 @@ func TestSignature_VerifyRandom(t *testing.T) {
 		Bitmap:              bitmap,
 	}
 
-	err = s.Verify(vals.GetPublicIdentities(), msgHash, bls.DomainCheckpointManager, hclog.NewNullLogger())
+	err = s.Verify(1, vals.GetPublicIdentities(), msgHash, bls.DomainCheckpointManager, hclog.NewNullLogger())
 	assert.NoError(t, err)
 }
 

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -443,7 +443,7 @@ func (f *fsm) VerifyStateTransactions(transactions []*types.Transaction) error {
 
 			commitmentTxExists = true
 
-			if err = verifyBridgeCommitmentTx(tx.Hash, stateTxData, f.validators); err != nil {
+			if err = verifyBridgeCommitmentTx(f.Height(), tx.Hash, stateTxData, f.validators); err != nil {
 				return err
 			}
 		case *contractsapi.CommitEpochValidatorSetFn:
@@ -623,7 +623,7 @@ func (f *fsm) verifyDistributeRewardsTx(distributeRewardsTx *types.Transaction) 
 }
 
 // verifyBridgeCommitmentTx validates bridge commitment transaction
-func verifyBridgeCommitmentTx(txHash types.Hash,
+func verifyBridgeCommitmentTx(blockNumber uint64, txHash types.Hash,
 	commitment *CommitmentMessageSigned,
 	validators validator.ValidatorSet) error {
 	signers, err := validators.Accounts().GetFilteredValidators(commitment.AggSignature.Bitmap)
@@ -631,7 +631,7 @@ func verifyBridgeCommitmentTx(txHash types.Hash,
 		return fmt.Errorf("failed to retrieve signers for state tx (%s): %w", txHash, err)
 	}
 
-	if !validators.HasQuorum(signers.GetAddressesAsSet()) {
+	if !validators.HasQuorum(blockNumber, signers.GetAddressesAsSet()) {
 		return fmt.Errorf("quorum size not reached for state tx (%s)", txHash)
 	}
 

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -556,6 +556,7 @@ func TestFSM_VerifyStateTransactions_StateTransactionQuorumNotReached(t *testing
 	validatorSet := validator.NewValidatorSet(validators.GetPublicIdentities(), hclog.NewNullLogger())
 
 	fsm := &fsm{
+		parent:                       &types.Header{Number: 2},
 		isEndOfEpoch:                 true,
 		isEndOfSprint:                true,
 		validators:                   validatorSet,
@@ -598,6 +599,7 @@ func TestFSM_VerifyStateTransactions_StateTransactionInvalidSignature(t *testing
 	validatorSet := validator.NewValidatorSet(validators.GetPublicIdentities(), hclog.NewNullLogger())
 
 	fsm := &fsm{
+		parent:                       &types.Header{Number: 1},
 		isEndOfEpoch:                 true,
 		isEndOfSprint:                true,
 		validators:                   validatorSet,
@@ -1329,6 +1331,7 @@ func TestFSM_VerifyStateTransaction_ValidBothTypesOfStateTransactions(t *testing
 		}
 
 		f := &fsm{
+			parent:        &types.Header{Number: 9},
 			isEndOfSprint: true,
 			validators:    validators.ToValidatorSet(),
 		}
@@ -1372,6 +1375,7 @@ func TestFSM_VerifyStateTransaction_QuorumNotReached(t *testing.T) {
 	validators := validator.NewTestValidatorsWithAliases(t, []string{"A", "B", "C", "D", "E", "F"})
 	_, commitmentMessageSigned, _ := buildCommitmentAndStateSyncs(t, 10, uint64(3), 2)
 	f := &fsm{
+		parent:        &types.Header{Number: 9},
 		isEndOfSprint: true,
 		validators:    validators.ToValidatorSet(),
 	}
@@ -1400,6 +1404,7 @@ func TestFSM_VerifyStateTransaction_InvalidSignature(t *testing.T) {
 	validators := validator.NewTestValidatorsWithAliases(t, []string{"A", "B", "C", "D", "E", "F"})
 	_, commitmentMessageSigned, _ := buildCommitmentAndStateSyncs(t, 10, uint64(3), 2)
 	f := &fsm{
+		parent:        &types.Header{Number: 9},
 		isEndOfSprint: true,
 		validators:    validators.ToValidatorSet(),
 	}
@@ -1437,6 +1442,7 @@ func TestFSM_VerifyStateTransaction_TwoCommitmentMessages(t *testing.T) {
 	validatorSet := validator.NewValidatorSet(validators.GetPublicIdentities(), hclog.NewNullLogger())
 
 	f := &fsm{
+		parent:        &types.Header{Number: 9},
 		isEndOfSprint: true,
 		validators:    validatorSet,
 	}

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -743,6 +743,7 @@ func (p *Polybft) PreCommitState(block *types.Block, _ *state.Transition) error 
 			commitmentTxExists = true
 
 			if err := verifyBridgeCommitmentTx(
+				block.Number(),
 				tx.Hash,
 				signedCommitment,
 				validator.NewValidatorSet(validators, p.logger)); err != nil {

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -36,7 +36,7 @@ type StateSyncProof struct {
 type StateSyncManager interface {
 	Init() error
 	Close()
-	Commitment() (*CommitmentMessageSigned, error)
+	Commitment(blockNumber uint64) (*CommitmentMessageSigned, error)
 	GetStateSyncProof(stateSyncID uint64) (types.Proof, error)
 	PostBlock(req *PostBlockRequest) error
 	PostEpoch(req *PostEpochRequest) error
@@ -47,11 +47,13 @@ var _ StateSyncManager = (*dummyStateSyncManager)(nil)
 // dummyStateSyncManager is used when bridge is not enabled
 type dummyStateSyncManager struct{}
 
-func (n *dummyStateSyncManager) Init() error                                   { return nil }
-func (n *dummyStateSyncManager) Close()                                        {}
-func (n *dummyStateSyncManager) Commitment() (*CommitmentMessageSigned, error) { return nil, nil }
-func (n *dummyStateSyncManager) PostBlock(req *PostBlockRequest) error         { return nil }
-func (n *dummyStateSyncManager) PostEpoch(req *PostEpochRequest) error         { return nil }
+func (n *dummyStateSyncManager) Init() error { return nil }
+func (n *dummyStateSyncManager) Close()      {}
+func (n *dummyStateSyncManager) Commitment(blockNumber uint64) (*CommitmentMessageSigned, error) {
+	return nil, nil
+}
+func (n *dummyStateSyncManager) PostBlock(req *PostBlockRequest) error { return nil }
+func (n *dummyStateSyncManager) PostEpoch(req *PostEpochRequest) error { return nil }
 func (n *dummyStateSyncManager) GetStateSyncProof(stateSyncID uint64) (types.Proof, error) {
 	return types.Proof{}, nil
 }
@@ -268,7 +270,7 @@ func (s *stateSyncManager) AddLog(eventLog *ethgo.Log) error {
 }
 
 // Commitment returns a commitment to be submitted if there is a pending commitment with quorum
-func (s *stateSyncManager) Commitment() (*CommitmentMessageSigned, error) {
+func (s *stateSyncManager) Commitment(blockNumber uint64) (*CommitmentMessageSigned, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
@@ -277,7 +279,7 @@ func (s *stateSyncManager) Commitment() (*CommitmentMessageSigned, error) {
 	// we start from the end, since last pending commitment is the largest one
 	for i := len(s.pendingCommitments) - 1; i >= 0; i-- {
 		commitment := s.pendingCommitments[i]
-		aggregatedSignature, publicKeys, err := s.getAggSignatureForCommitmentMessage(commitment)
+		aggregatedSignature, publicKeys, err := s.getAggSignatureForCommitmentMessage(blockNumber, commitment)
 
 		if err != nil {
 			if errors.Is(err, errQuorumNotReached) {
@@ -306,7 +308,7 @@ func (s *stateSyncManager) Commitment() (*CommitmentMessageSigned, error) {
 
 // getAggSignatureForCommitmentMessage checks if pending commitment has quorum,
 // and if it does, aggregates the signatures
-func (s *stateSyncManager) getAggSignatureForCommitmentMessage(
+func (s *stateSyncManager) getAggSignatureForCommitmentMessage(blockNumber uint64,
 	commitment *PendingCommitment) (Signature, [][]byte, error) {
 	validatorSet := s.validatorSet
 
@@ -352,7 +354,7 @@ func (s *stateSyncManager) getAggSignatureForCommitmentMessage(
 		signers[types.StringToAddress(vote.From)] = struct{}{}
 	}
 
-	if !validatorSet.HasQuorum(signers) {
+	if !validatorSet.HasQuorum(blockNumber, signers) {
 		return Signature{}, nil, errQuorumNotReached
 	}
 

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -228,7 +228,7 @@ func TestStateSyncManager_BuildCommitment(t *testing.T) {
 	s.validatorSet = vals.ToValidatorSet()
 
 	// commitment is empty
-	commitment, err := s.Commitment()
+	commitment, err := s.Commitment(1)
 	require.NoError(t, err)
 	require.Nil(t, commitment)
 
@@ -262,7 +262,7 @@ func TestStateSyncManager_BuildCommitment(t *testing.T) {
 	require.NoError(t, s.saveVote(signedMsg1))
 	require.NoError(t, s.saveVote(signedMsg2))
 
-	commitment, err = s.Commitment()
+	commitment, err = s.Commitment(1)
 	require.NoError(t, err) // there is no error if quorum is not met, since its a valid case
 	require.Nil(t, commitment)
 
@@ -277,7 +277,7 @@ func TestStateSyncManager_BuildCommitment(t *testing.T) {
 	require.NoError(t, s.saveVote(signedMsg1))
 	require.NoError(t, s.saveVote(signedMsg2))
 
-	commitment, err = s.Commitment()
+	commitment, err = s.Commitment(1)
 	require.NoError(t, err)
 	require.NotNil(t, commitment)
 }

--- a/consensus/polybft/validator/validator_set.go
+++ b/consensus/polybft/validator/validator_set.go
@@ -112,7 +112,7 @@ func getQuorumSize(blockNumber uint64, totalVotingPower *big.Int) *big.Int {
 	quorum := new(big.Int)
 	quorum.Mul(totalVotingPower, big.NewInt(2))
 
-	if forkmanager.GetInstance().IsForkEnabled(chain.NoviSad, blockNumber) {
+	if forkmanager.GetInstance().IsForkEnabled(chain.QuorumCalcAlignment, blockNumber) {
 		// this will floor the 2 * totalVotingPower / 3 and add one to it
 		return quorum.Div(quorum, big.NewInt(3)).Add(quorum, big.NewInt(1))
 	}

--- a/consensus/polybft/validator/validator_set.go
+++ b/consensus/polybft/validator/validator_set.go
@@ -3,6 +3,8 @@ package validator
 import (
 	"math/big"
 
+	"github.com/0xPolygon/polygon-edge/chain"
+	"github.com/0xPolygon/polygon-edge/forkmanager"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
@@ -20,11 +22,13 @@ type ValidatorSet interface {
 	Accounts() AccountSet
 
 	// HasQuorum checks if submitted signers have reached quorum
-	HasQuorum(signers map[types.Address]struct{}) bool
+	HasQuorum(blockNumber uint64, signers map[types.Address]struct{}) bool
 
 	// GetVotingPowers retrieves map: string(address) -> vp
 	GetVotingPowers() map[string]*big.Int
 }
+
+var _ ValidatorSet = (*validatorSet)(nil)
 
 type validatorSet struct {
 	// validators represents current list of validators
@@ -36,18 +40,12 @@ type validatorSet struct {
 	// totalVotingPower is sum of active validator set
 	totalVotingPower *big.Int
 
-	// quorumSize is 2/3 super-majority of totalVotingPower
-	quorumSize *big.Int
-
 	// logger instance
 	logger hclog.Logger
 }
 
 // NewValidatorSet creates a new validator set.
 func NewValidatorSet(valz AccountSet, logger hclog.Logger) *validatorSet {
-	totalVotingPower := valz.GetTotalVotingPower()
-	quorumSize := getQuorumSize(totalVotingPower)
-
 	votingPowerMap := make(map[types.Address]*big.Int, len(valz))
 	for _, val := range valz {
 		votingPowerMap[val.Address] = val.VotingPower
@@ -56,15 +54,14 @@ func NewValidatorSet(valz AccountSet, logger hclog.Logger) *validatorSet {
 	return &validatorSet{
 		validators:       valz,
 		votingPowerMap:   votingPowerMap,
-		totalVotingPower: totalVotingPower,
-		quorumSize:       quorumSize,
+		totalVotingPower: valz.GetTotalVotingPower(),
 		logger:           logger.Named("validator_set"),
 	}
 }
 
 // HasQuorum determines if there is quorum of enough signers reached,
 // based on its voting power and quorum size
-func (vs validatorSet) HasQuorum(signers map[types.Address]struct{}) bool {
+func (vs validatorSet) HasQuorum(blockNumber uint64, signers map[types.Address]struct{}) bool {
 	aggregateVotingPower := big.NewInt(0)
 
 	for address := range signers {
@@ -73,7 +70,8 @@ func (vs validatorSet) HasQuorum(signers map[types.Address]struct{}) bool {
 		}
 	}
 
-	hasQuorum := aggregateVotingPower.Cmp(vs.quorumSize) >= 0
+	quorumSize := getQuorumSize(blockNumber, vs.totalVotingPower)
+	hasQuorum := aggregateVotingPower.Cmp(quorumSize) >= 0
 
 	vs.logger.Debug("HasQuorum",
 		"signers", len(signers),
@@ -110,9 +108,14 @@ func (vs validatorSet) TotalVotingPower() big.Int {
 }
 
 // getQuorumSize calculates quorum size as 2/3 super-majority of provided total voting power
-func getQuorumSize(totalVotingPower *big.Int) *big.Int {
+func getQuorumSize(blockNumber uint64, totalVotingPower *big.Int) *big.Int {
 	quorum := new(big.Int)
 	quorum.Mul(totalVotingPower, big.NewInt(2))
+
+	if forkmanager.GetInstance().IsForkEnabled(chain.NoviSad, blockNumber) {
+		// this will floor the 2 * totalVotingPower / 3 and add one to it
+		return quorum.Div(quorum, big.NewInt(3)).Add(quorum, big.NewInt(1))
+	}
 
 	return common.BigIntDivCeil(quorum, big.NewInt(3))
 }

--- a/consensus/polybft/validator/validator_set_test.go
+++ b/consensus/polybft/validator/validator_set_test.go
@@ -21,7 +21,7 @@ func TestValidatorSet_HasQuorum(t *testing.T) {
 		signers[v.Address()] = struct{}{}
 	})
 
-	require.True(t, vs.HasQuorum(signers))
+	require.True(t, vs.HasQuorum(1, signers))
 
 	// not enough signers for quorum (less than 2/3 super-majority of validators are signers)
 	signers = make(map[types.Address]struct{})
@@ -29,7 +29,7 @@ func TestValidatorSet_HasQuorum(t *testing.T) {
 	validators.IterAcct([]string{"A", "B", "C", "D"}, func(v *TestValidator) {
 		signers[v.Address()] = struct{}{}
 	})
-	require.False(t, vs.HasQuorum(signers))
+	require.False(t, vs.HasQuorum(1, signers))
 }
 
 func TestValidatorSet_getQuorumSize(t *testing.T) {
@@ -47,7 +47,7 @@ func TestValidatorSet_getQuorumSize(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		quorumSize := getQuorumSize(big.NewInt(c.totalVotingPower))
+		quorumSize := getQuorumSize(1, big.NewInt(c.totalVotingPower))
 		require.Equal(t, c.expectedQuorumSize, quorumSize.Int64())
 	}
 }

--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -3,8 +3,6 @@ package e2e
 import (
 	"fmt"
 	"math/big"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
@@ -20,20 +18,6 @@ import (
 var (
 	one = big.NewInt(1)
 )
-
-func init() {
-	wd, err := os.Getwd()
-	if err != nil {
-		return
-	}
-
-	parent := filepath.Dir(wd)
-	wd = filepath.Join(parent, "../artifacts/polygon-edge")
-	os.Setenv("EDGE_BINARY", wd)
-	os.Setenv("E2E_TESTS", "true")
-	os.Setenv("E2E_LOGS", "true")
-	os.Setenv("E2E_LOG_LEVEL", "debug")
-}
 
 func TestE2E_JsonRPC(t *testing.T) {
 	acct, err := wallet.GenerateKey()

--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -3,6 +3,8 @@ package e2e
 import (
 	"fmt"
 	"math/big"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
@@ -19,11 +21,25 @@ var (
 	one = big.NewInt(1)
 )
 
+func init() {
+	wd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+
+	parent := filepath.Dir(wd)
+	wd = filepath.Join(parent, "../artifacts/polygon-edge")
+	os.Setenv("EDGE_BINARY", wd)
+	os.Setenv("E2E_TESTS", "true")
+	os.Setenv("E2E_LOGS", "true")
+	os.Setenv("E2E_LOG_LEVEL", "debug")
+}
+
 func TestE2E_JsonRPC(t *testing.T) {
 	acct, err := wallet.GenerateKey()
 	require.NoError(t, err)
 
-	cluster := framework.NewTestCluster(t, 3,
+	cluster := framework.NewTestCluster(t, 4,
 		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, acct.Address())),
 		framework.WithPremine(types.Address(acct.Address())),
 	)

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 )
 
 require (
-	github.com/0xPolygon/go-ibft v0.4.1-0.20230612114712-fa4235351cbc
+	github.com/0xPolygon/go-ibft v0.4.1-0.20230717081138-628065cf23b6
 	github.com/docker/docker v20.10.18+incompatible
 	github.com/docker/go-connections v0.4.0
 	go.etcd.io/bbolt v1.3.7

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D
 filippo.io/edwards25519 v1.0.0-rc.1 h1:m0VOOB23frXZvAOK44usCgLWvtsxIoMCTBGJZlpmGfU=
 filippo.io/edwards25519 v1.0.0-rc.1/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
-github.com/0xPolygon/go-ibft v0.4.1-0.20230612114712-fa4235351cbc h1:LSrOswaGy5kmLZTr8B1t5WnSpm8plYGAmdrUd6lGhRw=
-github.com/0xPolygon/go-ibft v0.4.1-0.20230612114712-fa4235351cbc/go.mod h1:mJGwdcGvLdg9obtnzBqx1aAzuhzvGeWav5AiUWN7F3Q=
+github.com/0xPolygon/go-ibft v0.4.1-0.20230717081138-628065cf23b6 h1:EL/37sEjeLmQ2RTd9xMLLOuMXY6fMV/zB8a5X0BJUMM=
+github.com/0xPolygon/go-ibft v0.4.1-0.20230717081138-628065cf23b6/go.mod h1:0W1BnkhtXa2K59PzTPoQvbKOnI+G6QliXIHpQWNeiAM=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=


### PR DESCRIPTION
# Description

Quorum was not calculated correctly according to the IBFT paper. It was calculated by ceiling the 2*totalVotingPower/3. For example, if we have total voting power of 6, where each validator has one token staked, than:

```
CEILING(2*6/3) = 4 -> 2 faulty -> WRONG
FLOOR(2*6/3) + 1 = 5 -> 1 faulty -> CORRECT
```

Since Edge Supernets is in release, this is added through a hard fork, called `quorumcalcalignment`. If chain is deployed from scratch, this fork is enabled by default from 0 block. If supernet is already running on an older version, users need to add `quorumcalcalignment` fork to `genesis.json` file, specify a block from which it is active, and restart the nodes.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually