### PR TITLE
[EVM-739]: Fix `eth_feeHistory` parsing of hex arguments

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -803,9 +803,15 @@ func (e *Eth) MaxPriorityFeePerGas() (interface{}, error) {
 	return argBigPtr(priorityFee), nil
 }
 
-func (e *Eth) FeeHistory(blockCount uint64, newestBlock uint64, rewardPercentiles []float64) (interface{}, error) {
+func (e *Eth) FeeHistory(blockCount argUint64, newestBlock BlockNumber,
+	rewardPercentiles []float64) (interface{}, error) {
+	block, err := GetNumericBlockNumber(newestBlock, e.store)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse newest block argument. Error: %w", err)
+	}
+
 	// Retrieve oldestBlock, baseFeePerGas, gasUsedRatio, and reward synchronously
-	history, err := e.store.FeeHistory(blockCount, newestBlock, rewardPercentiles)
+	history, err := e.store.FeeHistory(uint64(blockCount), block, rewardPercentiles)
 	if err != nil {
 		return nil, err
 	}

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -818,7 +818,7 @@ func (e *Eth) FeeHistory(blockCount argUint64, newestBlock BlockNumber,
 
 	// Create channels to receive the processed slices asynchronously
 	baseFeePerGasCh := make(chan []argUint64)
-	gasUsedRatioCh := make(chan []argUint64)
+	gasUsedRatioCh := make(chan []float64)
 	rewardCh := make(chan [][]argUint64)
 
 	// Process baseFeePerGas asynchronously
@@ -828,7 +828,7 @@ func (e *Eth) FeeHistory(blockCount argUint64, newestBlock BlockNumber,
 
 	// Process gasUsedRatio asynchronously
 	go func() {
-		gasUsedRatioCh <- convertFloat64SliceToArgUint64Slice(history.GasUsedRatio)
+		gasUsedRatioCh <- history.GasUsedRatio
 	}()
 
 	// Process reward asynchronously

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -350,10 +350,10 @@ type progression struct {
 }
 
 type feeHistoryResult struct {
-	OldestBlock   argUint64
-	BaseFeePerGas []argUint64
-	GasUsedRatio  []float64
-	Reward        [][]argUint64
+	OldestBlock   argUint64     `json:"oldestBlock"`
+	BaseFeePerGas []argUint64   `json:"baseFeePerGas,omitempty"`
+	GasUsedRatio  []float64     `json:"gasUsedRatio"`
+	Reward        [][]argUint64 `json:"reward,omitempty"`
 }
 
 func convertToArgUint64Slice(slice []uint64) []argUint64 {

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -352,7 +352,7 @@ type progression struct {
 type feeHistoryResult struct {
 	OldestBlock   argUint64
 	BaseFeePerGas []argUint64
-	GasUsedRatio  []argUint64
+	GasUsedRatio  []float64
 	Reward        [][]argUint64
 }
 
@@ -369,15 +369,6 @@ func convertToArgUint64SliceSlice(slice [][]uint64) [][]argUint64 {
 	argSlice := make([][]argUint64, len(slice))
 	for i, value := range slice {
 		argSlice[i] = convertToArgUint64Slice(value)
-	}
-
-	return argSlice
-}
-
-func convertFloat64SliceToArgUint64Slice(slice []float64) []argUint64 {
-	argSlice := make([]argUint64, len(slice))
-	for i, value := range slice {
-		argSlice[i] = argUint64(value)
 	}
 
 	return argSlice


### PR DESCRIPTION
# Description

`eth_feeHistory` rpc endpoint did not parse hex values for arguments `blockCount` and `newestBlock`.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually