### PR TITLE
[RFC-191] Add `governorAdmin` flag

### DIFF
--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -278,8 +278,8 @@ func setFlags(cmd *cobra.Command) {
 			&params.governorAdmin,
 			governorAdminFlag,
 			"",
-			"address of a governance admin (governance admin can add new proposers of governance proposals "+
-				"and add new executors of accepted proposals)",
+			"address of a governance admin (governance admin can add new or remove old proposers "+
+				"of governance proposals, and add new and remove old executors of accepted proposals)",
 		)
 	}
 

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -273,6 +273,14 @@ func setFlags(cmd *cobra.Command) {
 			defaultVoteProposalThreshold,
 			"number of vote tokens required in order for a voter to become a proposer",
 		)
+
+		cmd.Flags().StringVar(
+			&params.governorAdmin,
+			governorAdminFlag,
+			"",
+			"address of a governance admin (governance admin can add new proposers of governance proposals "+
+				"and add new executors of accepted proposals)",
+		)
 	}
 
 	// Access Control Lists

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -44,6 +44,7 @@ const (
 	voteDelayFlag             = "vote-delay"
 	votePeriodFlag            = "vote-period"
 	voteProposalThresholdFlag = "vote-proposal-threshold"
+	governorAdminFlag         = "governor-admin"
 
 	defaultNativeTokenName     = "Polygon"
 	defaultNativeTokenSymbol   = "MATIC"
@@ -145,6 +146,7 @@ type genesisParams struct {
 	voteDelay         string
 	votingPeriod      string
 	proposalThreshold string
+	governorAdmin     string
 }
 
 func (p *genesisParams) validateFlags() error {

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -156,10 +156,10 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 	}
 
 	governorAdminAddr := types.ZeroAddress
+	// if no admin is defined, zero address will be the owner,
+	// meaning no new proposers and executors besides genesis validator
+	// set can be added/removed later
 	if p.governorAdmin != "" {
-		// if no admin is defined, zero address will be the owner,
-		// meaning no new proposers and executors besides genesis validator
-		// set can be added later
 		governorAdminAddr = types.StringToAddress(p.governorAdmin)
 	}
 

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -155,6 +155,14 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 		return err
 	}
 
+	governorAdminAddr := types.ZeroAddress
+	if p.governorAdmin != "" {
+		// if no admin is defined, zero address will be the owner,
+		// meaning no new proposers and executors besides genesis validator
+		// set can be added later
+		governorAdminAddr = types.StringToAddress(p.governorAdmin)
+	}
+
 	polyBftConfig := &polybft.PolyBFTConfig{
 		InitialValidatorSet: initialValidators,
 		BlockTime:           common.Duration{Duration: p.blockTime},
@@ -179,6 +187,7 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 			VotingDelay:       voteDelay,
 			VotingPeriod:      votingPeriod,
 			ProposalThreshold: proposalThreshold,
+			GovernorAdmin:     governorAdminAddr,
 		},
 	}
 

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -245,6 +245,9 @@ type GovernanceConfig struct {
 	VotingPeriod *big.Int
 	// ProposalThreshold indicates number of vote tokens required in order for a voter to become a proposer
 	ProposalThreshold *big.Int
+	// GovernorAdmin is the address of governance contract admin
+	// (he is the only one able to add new executors and proposers)
+	GovernorAdmin types.Address
 }
 
 func (g *GovernanceConfig) MarshalJSON() ([]byte, error) {
@@ -252,6 +255,7 @@ func (g *GovernanceConfig) MarshalJSON() ([]byte, error) {
 		VotingDelay:       types.EncodeBigInt(g.VotingDelay),
 		VotingPeriod:      types.EncodeBigInt(g.VotingPeriod),
 		ProposalThreshold: types.EncodeBigInt(g.ProposalThreshold),
+		GovernorAdmin:     g.GovernorAdmin,
 	}
 
 	return json.Marshal(raw)
@@ -282,11 +286,14 @@ func (g *GovernanceConfig) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	g.GovernorAdmin = raw.GovernorAdmin
+
 	return nil
 }
 
 type governanceConfigRaw struct {
-	VotingDelay       *string `json:"votingDelay"`
-	VotingPeriod      *string `json:"votingPeriod"`
-	ProposalThreshold *string `json:"proposalThreshold"`
+	VotingDelay       *string       `json:"votingDelay"`
+	VotingPeriod      *string       `json:"votingPeriod"`
+	ProposalThreshold *string       `json:"proposalThreshold"`
+	GovernorAdmin     types.Address `json:"governorAdmin"`
 }

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -246,7 +246,7 @@ type GovernanceConfig struct {
 	// ProposalThreshold indicates number of vote tokens required in order for a voter to become a proposer
 	ProposalThreshold *big.Int
 	// GovernorAdmin is the address of governance contract admin
-	// (he is the only one able to add new executors and proposers)
+	// (he is the only one able to add new and remove old executors and proposers)
 	GovernorAdmin types.Address
 }
 


### PR DESCRIPTION
# Description

Added a new flag to `genesis` command, called `--governor-admin`. 

It specifies the address of an admin for governance contracts. Given admin can add new addresses to the list of proposers of new governance proposals, and can add new addresses to the list of executors of accepted proposals.

On genesis, and contract deployment, we will set the initial list of proposers and executors of governance proposals to the genesis validator set. Later, when the chain is live, specified governor admin, can add new addresses and remove old ones.

If governor admin address was not specified, zero address will be set as admin, and no new proposer and executor or governance proposals can be added later when chain is live (the genesis validator set will remain forever as possible proposers and executors).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually