### PR TITLE
fix: renaming EIP 1559 fields to match spec

### DIFF
--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -304,5 +304,8 @@ func TestE2E_JsonRPC(t *testing.T) {
 
 		// Test. The dynamic 'from' field is populated
 		require.NotEqual(t, ethTxn.From, ethgo.ZeroAddress)
+		// Test. chainId is included
+		require.NotZero(t, ethTxn.MaxFeePerGas)
+		require.NotZero(t, ethTxn.MaxPriorityFeePerGas)
 	})
 }

--- a/jsonrpc/testsuite/transaction-eip1559.json
+++ b/jsonrpc/testsuite/transaction-eip1559.json
@@ -1,8 +1,8 @@
 {
     "nonce": "0x1",
     "gasPrice": "0xa",
-    "gasTipCap": "0xa",
-    "gasFeeCap": "0xa",
+    "maxPriorityFeePerGas": "0xa",
+    "maxFeePerGas": "0xa",
     "gas": "0x64",
     "to": "0x0000000000000000000000000000000000000000",
     "value": "0x3e8",

--- a/jsonrpc/txpool_endpoint.go
+++ b/jsonrpc/txpool_endpoint.go
@@ -41,8 +41,8 @@ type StatusResponse struct {
 type txpoolTransaction struct {
 	Nonce       argUint64      `json:"nonce"`
 	GasPrice    argBig         `json:"gasPrice"`
-	GasFeeCap   *argBig        `json:"gasFeeCap,omitempty"`
-	GasTipCap   *argBig        `json:"gasTipCap,omitempty"`
+	GasFeeCap   *argBig        `json:"maxFeePerGas,omitempty"`
+	GasTipCap   *argBig        `json:"maxPriorityFeePerGas,omitempty"`
 	Gas         argUint64      `json:"gas"`
 	To          *types.Address `json:"to"`
 	Value       argBig         `json:"value"`

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -19,8 +19,8 @@ type transactionOrHash interface {
 type transaction struct {
 	Nonce       argUint64      `json:"nonce"`
 	GasPrice    *argBig        `json:"gasPrice,omitempty"`
-	GasTipCap   *argBig        `json:"gasTipCap,omitempty"`
-	GasFeeCap   *argBig        `json:"gasFeeCap,omitempty"`
+	GasTipCap   *argBig        `json:"maxPriorityFeePerGas,omitempty"`
+	GasFeeCap   *argBig        `json:"maxFeePerGas,omitempty"`
 	Gas         argUint64      `json:"gas"`
 	To          *types.Address `json:"to"`
 	Value       argBig         `json:"value"`

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -61,6 +61,7 @@ type Transaction struct {
 	V, R, S   *big.Int
 	Hash      Hash
 	From      Address
+	ChainId   *big.Int
 
 	Type TxType
 


### PR DESCRIPTION
# Description

Renames EIP1559 txn fields to match spec:

`gasFeeCap` --> `maxFeePerGas`
`gasTipCap` --> `maxPriorityFeePerGas`

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)



# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [] I have tested this code manually
