### PR TITLE
[RFC-191]: EVM-740 - Move distribute rewards to first block in epoch

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -516,7 +516,7 @@ func (c *consensusRuntime) calculateDistributeRewardsInput(
 	lastFinalizedBlock *types.Header,
 	epochID uint64,
 ) (*contractsapi.DistributeRewardForRewardPoolFn, error) {
-	if !shouldAddOrValidateRewardDistribution(isFirstBlockOfEpoch, isEndOfEpoch, pendingBlockNumber) {
+	if !isRewardDistributionBlock(isFirstBlockOfEpoch, isEndOfEpoch, pendingBlockNumber) {
 		// we don't have to distribute rewards at this block
 		return nil, nil
 	}

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -392,7 +392,7 @@ func (c *consensusRuntime) FSM() error {
 	}
 
 	if isEndOfEpoch {
-		ff.commitEpochInput = c.calculateCommitEpochInput(parent, epoch)
+		ff.commitEpochInput = createCommitEpochInput(parent, epoch)
 
 		ff.newValidatorsDelta, err = c.stakeManager.UpdateValidatorSet(epoch.Number, epoch.Validators.Copy())
 		if err != nil {
@@ -496,8 +496,8 @@ func (c *consensusRuntime) restartEpoch(header *types.Header) (*epochMetadata, e
 	}, nil
 }
 
-// calculateCommitEpochInput calculates commit epoch input data
-func (c *consensusRuntime) calculateCommitEpochInput(
+// createCommitEpochInput creates commit epoch input data
+func createCommitEpochInput(
 	currentBlock *types.Header, epoch *epochMetadata) *contractsapi.CommitEpochValidatorSetFn {
 	return &contractsapi.CommitEpochValidatorSetFn{
 		ID: new(big.Int).SetUint64(epoch.Number),

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -397,8 +397,6 @@ func TestConsensusRuntime_FSM_EndOfEpoch_BuildCommitEpoch(t *testing.T) {
 	validatorAccounts := validator.NewTestValidatorsWithAliases(t, []string{"A", "B", "C", "D", "E", "F"})
 	validators := validatorAccounts.GetPublicIdentities()
 
-	lastBuiltBlock := &types.Header{Number: 9}
-
 	blockchainMock := new(blockchainMock)
 	blockchainMock.On("NewBlockBuilder", mock.Anything).Return(&BlockBuilder{}, nil).Once()
 
@@ -427,7 +425,7 @@ func TestConsensusRuntime_FSM_EndOfEpoch_BuildCommitEpoch(t *testing.T) {
 		state:              state,
 		epoch:              metadata,
 		config:             config,
-		lastBuiltBlock:     lastBuiltBlock,
+		lastBuiltBlock:     &types.Header{Number: 9},
 		stateSyncManager:   &dummyStateSyncManager{},
 		checkpointManager:  &dummyCheckpointManager{},
 		stakeManager:       &dummyStakeManager{},

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/consensus"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
@@ -16,6 +17,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/forkmanager"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
@@ -23,6 +25,12 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func init() {
+	// for tests
+	forkmanager.GetInstance().RegisterFork(chain.Governance, nil)
+	forkmanager.GetInstance().ActivateFork(chain.Governance, 0) //nolint:errcheck
+}
 
 func TestConsensusRuntime_isFixedSizeOfEpochMet_NotReachedEnd(t *testing.T) {
 	t.Parallel()
@@ -581,8 +589,10 @@ func TestConsensusRuntime_calculateCommitEpochInput_SecondEpoch(t *testing.T) {
 		lastBuiltBlock: lastBuiltBlock,
 	}
 
-	distributeRewardsInput, err := consensusRuntime.calculateDistributeRewardsInput(lastBuiltBlock,
-		consensusRuntime.epoch.Number-1)
+	distributeRewardsInput, err := consensusRuntime.calculateDistributeRewardsInput(
+		true, false,
+		lastBuiltBlock.Number+1,
+		lastBuiltBlock, consensusRuntime.epoch.Number)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(currentEpoch-1), distributeRewardsInput.EpochID.Uint64())
 

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -36,11 +36,11 @@ var (
 	errCommitEpochTxSingleExpected = errors.New("only one commit epoch transaction is allowed " +
 		"in an epoch ending block")
 	errDistributeRewardsTxDoesNotExist = errors.New("distribute rewards transaction is " +
-		"not found in the given block, but should be added")
+		"not found in the given block, though it is expected to be present")
 	errDistributeRewardsTxNotExpected = errors.New("distribute rewards transaction " +
 		"is not expected at this block")
 	errDistributeRewardsTxSingleExpected = errors.New("only one distribute rewards transaction is " +
-		"allowed at the expected block")
+		"allowed in the given block")
 	errProposalDontMatch = errors.New("failed to insert proposal, because the validated proposal " +
 		"is either nil or it does not match the received one")
 	errValidatorSetDeltaMismatch           = errors.New("validator set delta mismatch")
@@ -139,7 +139,7 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 		}
 	}
 
-	if shouldAddOrValidateRewardDistribution(f.isFirstBlockOfEpoch, f.isEndOfEpoch, f.Height()) {
+	if isRewardDistributionBlock(f.isFirstBlockOfEpoch, f.isEndOfEpoch, f.Height()) {
 		tx, err := f.createDistributeRewardsTx()
 		if err != nil {
 			return nil, err
@@ -490,7 +490,7 @@ func (f *fsm) VerifyStateTransactions(transactions []*types.Transaction) error {
 		}
 	}
 
-	if shouldAddOrValidateRewardDistribution(f.isFirstBlockOfEpoch, f.isEndOfEpoch, f.Height()) {
+	if isRewardDistributionBlock(f.isFirstBlockOfEpoch, f.isEndOfEpoch, f.Height()) {
 		if !distributeRewardsTxExists {
 			// this is a check if distribute rewards transaction is not in the list of transactions at all
 			// but it should be
@@ -610,7 +610,7 @@ func (f *fsm) verifyCommitEpochTx(commitEpochTx *types.Transaction) error {
 // and compares its hash with the one extracted from the block.
 func (f *fsm) verifyDistributeRewardsTx(distributeRewardsTx *types.Transaction) error {
 	// we don't have distribute rewards tx if we just started the chain
-	if shouldAddOrValidateRewardDistribution(f.isFirstBlockOfEpoch, f.isEndOfEpoch, f.Height()) {
+	if isRewardDistributionBlock(f.isFirstBlockOfEpoch, f.isEndOfEpoch, f.Height()) {
 		localDistributeRewardsTx, err := f.createDistributeRewardsTx()
 		if err != nil {
 			return err

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -36,11 +36,11 @@ var (
 	errCommitEpochTxSingleExpected = errors.New("only one commit epoch transaction is allowed " +
 		"in an epoch ending block")
 	errDistributeRewardsTxDoesNotExist = errors.New("distribute rewards transaction is " +
-		"not found in the epoch ending block")
-	errDistributeRewardsTxNotExpected = errors.New("didn't expect distribute rewards transaction " +
-		"in a non epoch ending block")
+		"not found in the first block of an epoch")
+	errDistributeRewardsTxNotExpected = errors.New("distribute rewards transaction " +
+		"is only expected in the first block of epoch")
 	errDistributeRewardsTxSingleExpected = errors.New("only one distribute rewards transaction is " +
-		"allowed in an epoch ending block")
+		"allowed in the first block of an epoch")
 	errProposalDontMatch = errors.New("failed to insert proposal, because the validated proposal " +
 		"is either nil or it does not match the received one")
 	errValidatorSetDeltaMismatch           = errors.New("validator set delta mismatch")
@@ -88,6 +88,9 @@ type fsm struct {
 	// isEndOfSprint indicates if sprint reached its end
 	isEndOfSprint bool
 
+	// isFirstBlockOfEpoch indicates if this is the start of new epoch
+	isFirstBlockOfEpoch bool
+
 	// proposerCommitmentToRegister is a commitment that is registered via state transaction by proposer
 	proposerCommitmentToRegister *CommitmentMessageSigned
 
@@ -134,8 +137,11 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 		if err := f.blockBuilder.WriteTx(tx); err != nil {
 			return nil, fmt.Errorf("failed to apply commit epoch transaction: %w", err)
 		}
+	}
 
-		tx, err = f.createDistributeRewardsTx()
+	// only create distribute rewards tx if this is not start of the chain
+	if f.isFirstBlockOfEpoch && f.Height() > 1 {
+		tx, err := f.createDistributeRewardsTx()
 		if err != nil {
 			return nil, err
 		}
@@ -483,7 +489,10 @@ func (f *fsm) VerifyStateTransactions(transactions []*types.Transaction) error {
 			// but it should be
 			return errCommitEpochTxDoesNotExist
 		}
+	}
 
+	// distribute rewards tx is only present if this is not start of chain
+	if f.isFirstBlockOfEpoch && f.Height() > 1 {
 		if !distributeRewardsTxExists {
 			// this is a check if distribute rewards transaction is not in the list of transactions at all
 			// but it should be
@@ -602,7 +611,8 @@ func (f *fsm) verifyCommitEpochTx(commitEpochTx *types.Transaction) error {
 // verifyDistributeRewardsTx creates distribute rewards transaction
 // and compares its hash with the one extracted from the block.
 func (f *fsm) verifyDistributeRewardsTx(distributeRewardsTx *types.Transaction) error {
-	if f.isEndOfEpoch {
+	// we don't have distribute rewards tx if we just started the chain
+	if f.isFirstBlockOfEpoch && f.Height() > 1 {
 		localDistributeRewardsTx, err := f.createDistributeRewardsTx()
 		if err != nil {
 			return err

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -36,11 +36,11 @@ var (
 	errCommitEpochTxSingleExpected = errors.New("only one commit epoch transaction is allowed " +
 		"in an epoch ending block")
 	errDistributeRewardsTxDoesNotExist = errors.New("distribute rewards transaction is " +
-		"not found in the first block of an epoch")
+		"not found in the given block, but should be added")
 	errDistributeRewardsTxNotExpected = errors.New("distribute rewards transaction " +
-		"is only expected in the first block of epoch")
+		"is not expected at this block")
 	errDistributeRewardsTxSingleExpected = errors.New("only one distribute rewards transaction is " +
-		"allowed in the first block of an epoch")
+		"allowed at the expected block")
 	errProposalDontMatch = errors.New("failed to insert proposal, because the validated proposal " +
 		"is either nil or it does not match the received one")
 	errValidatorSetDeltaMismatch           = errors.New("validator set delta mismatch")
@@ -139,8 +139,7 @@ func (f *fsm) BuildProposal(currentRound uint64) ([]byte, error) {
 		}
 	}
 
-	// only create distribute rewards tx if this is not start of the chain
-	if f.isFirstBlockOfEpoch && f.Height() > 1 {
+	if shouldAddOrValidateRewardDistribution(f.isFirstBlockOfEpoch, f.isEndOfEpoch, f.Height()) {
 		tx, err := f.createDistributeRewardsTx()
 		if err != nil {
 			return nil, err
@@ -491,8 +490,7 @@ func (f *fsm) VerifyStateTransactions(transactions []*types.Transaction) error {
 		}
 	}
 
-	// distribute rewards tx is only present if this is not start of chain
-	if f.isFirstBlockOfEpoch && f.Height() > 1 {
+	if shouldAddOrValidateRewardDistribution(f.isFirstBlockOfEpoch, f.isEndOfEpoch, f.Height()) {
 		if !distributeRewardsTxExists {
 			// this is a check if distribute rewards transaction is not in the list of transactions at all
 			// but it should be
@@ -612,7 +610,7 @@ func (f *fsm) verifyCommitEpochTx(commitEpochTx *types.Transaction) error {
 // and compares its hash with the one extracted from the block.
 func (f *fsm) verifyDistributeRewardsTx(distributeRewardsTx *types.Transaction) error {
 	// we don't have distribute rewards tx if we just started the chain
-	if f.isFirstBlockOfEpoch && f.Height() > 1 {
+	if shouldAddOrValidateRewardDistribution(f.isFirstBlockOfEpoch, f.isEndOfEpoch, f.Height()) {
 		localDistributeRewardsTx, err := f.createDistributeRewardsTx()
 		if err != nil {
 			return err

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -453,6 +453,7 @@ func TestFSM_VerifyStateTransactions_CommitEpoch(t *testing.T) {
 		validatorSet := validator.NewValidatorSet(validators.GetPublicIdentities(), hclog.NewNullLogger())
 
 		fsm := &fsm{
+			parent:                 &types.Header{Number: 9},
 			isEndOfEpoch:           true,
 			isEndOfSprint:          true,
 			validators:             validatorSet,
@@ -472,7 +473,10 @@ func TestFSM_VerifyStateTransactions_CommitEpoch(t *testing.T) {
 	t.Run("Middle of epoch with transactions", func(t *testing.T) {
 		t.Parallel()
 
-		fsm := &fsm{commitEpochInput: createTestCommitEpochInput(t, 0, 10)}
+		fsm := &fsm{
+			parent:           &types.Header{Number: 5},
+			commitEpochInput: createTestCommitEpochInput(t, 0, 10),
+		}
 		tx, err := fsm.createCommitEpochTx()
 		require.NoError(t, err)
 		err = fsm.VerifyStateTransactions([]*types.Transaction{tx})
@@ -482,7 +486,10 @@ func TestFSM_VerifyStateTransactions_CommitEpoch(t *testing.T) {
 	t.Run("Middle of epoch without transaction", func(t *testing.T) {
 		t.Parallel()
 
-		fsm := &fsm{commitEpochInput: createTestCommitEpochInput(t, 0, 10)}
+		fsm := &fsm{
+			parent:           &types.Header{Number: 5},
+			commitEpochInput: createTestCommitEpochInput(t, 0, 10),
+		}
 		err := fsm.VerifyStateTransactions([]*types.Transaction{})
 		require.NoError(t, err)
 	})
@@ -490,7 +497,11 @@ func TestFSM_VerifyStateTransactions_CommitEpoch(t *testing.T) {
 	t.Run("End of epoch without transaction", func(t *testing.T) {
 		t.Parallel()
 
-		fsm := &fsm{isEndOfEpoch: true, commitEpochInput: createTestCommitEpochInput(t, 0, 10)}
+		fsm := &fsm{
+			parent:           &types.Header{Number: 9},
+			isEndOfEpoch:     true,
+			commitEpochInput: createTestCommitEpochInput(t, 0, 10),
+		}
 		err := fsm.VerifyStateTransactions([]*types.Transaction{})
 		require.ErrorContains(t, err, errCommitEpochTxDoesNotExist.Error())
 	})
@@ -498,7 +509,11 @@ func TestFSM_VerifyStateTransactions_CommitEpoch(t *testing.T) {
 	t.Run("End of epoch wrong commit transaction", func(t *testing.T) {
 		t.Parallel()
 
-		fsm := &fsm{isEndOfEpoch: true, commitEpochInput: createTestCommitEpochInput(t, 0, 10)}
+		fsm := &fsm{
+			isEndOfEpoch:     true,
+			parent:           &types.Header{Number: 9},
+			commitEpochInput: createTestCommitEpochInput(t, 0, 10),
+		}
 		commitEpochInput, err := createTestCommitEpochInput(t, 1, 5).EncodeAbi()
 		require.NoError(t, err)
 
@@ -511,7 +526,11 @@ func TestFSM_VerifyStateTransactions_CommitEpoch(t *testing.T) {
 		t.Parallel()
 
 		txs := make([]*types.Transaction, 2)
-		fsm := &fsm{isEndOfEpoch: true, commitEpochInput: createTestCommitEpochInput(t, 0, 10)}
+		fsm := &fsm{
+			isEndOfEpoch:     true,
+			parent:           &types.Header{Number: 9},
+			commitEpochInput: createTestCommitEpochInput(t, 0, 10),
+		}
 
 		commitEpochTxOne, err := fsm.createCommitEpochTx()
 		require.NoError(t, err)
@@ -633,6 +652,7 @@ func TestFSM_VerifyStateTransaction_Commitments(t *testing.T) {
 
 			f := &fsm{
 				isEndOfSprint: true,
+				parent:        &types.Header{Number: 9},
 				validators:    validators.ToValidatorSet(),
 			}
 

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -200,7 +200,7 @@ func TestFSM_BuildProposal_WithCommitEpochTxGood(t *testing.T) {
 	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, extra)
 
 	mBlockBuilder := newBlockBuilderMock(stateBlock)
-	mBlockBuilder.On("WriteTx", mock.Anything).Return(error(nil)).Twice()
+	mBlockBuilder.On("WriteTx", mock.Anything).Return(error(nil)).Once()
 
 	blockChainMock := new(blockchainMock)
 
@@ -213,12 +213,11 @@ func TestFSM_BuildProposal_WithCommitEpochTxGood(t *testing.T) {
 	}
 
 	fsm := &fsm{parent: parent, blockBuilder: mBlockBuilder, config: &PolyBFTConfig{}, backend: blockChainMock,
-		isEndOfEpoch:           true,
-		validators:             validators.ToValidatorSet(),
-		commitEpochInput:       createTestCommitEpochInput(t, 0, 10),
-		distributeRewardsInput: createTestDistributeRewardsInput(t, 0, nil, 10),
-		exitEventRootHash:      eventRoot,
-		logger:                 hclog.NewNullLogger(),
+		isEndOfEpoch:      true,
+		validators:        validators.ToValidatorSet(),
+		commitEpochInput:  createTestCommitEpochInput(t, 0, 10),
+		exitEventRootHash: eventRoot,
+		logger:            hclog.NewNullLogger(),
 	}
 
 	proposal, err := fsm.BuildProposal(currentRound)
@@ -306,7 +305,7 @@ func TestFSM_BuildProposal_EpochEndingBlock_ValidatorsDeltaExists(t *testing.T) 
 	stateBlock := createDummyStateBlock(parentBlockNumber+1, parent.Hash, extraData)
 
 	blockBuilderMock := newBlockBuilderMock(stateBlock)
-	blockBuilderMock.On("WriteTx", mock.Anything).Return(error(nil)).Twice()
+	blockBuilderMock.On("WriteTx", mock.Anything).Return(error(nil)).Once()
 
 	addedValidators := validator.NewTestValidators(t, 2).GetPublicIdentities()
 	removedValidators := [3]uint64{3, 4, 5}
@@ -327,17 +326,16 @@ func TestFSM_BuildProposal_EpochEndingBlock_ValidatorsDeltaExists(t *testing.T) 
 	validatorSet := validator.NewValidatorSet(validators, hclog.NewNullLogger())
 
 	fsm := &fsm{
-		parent:                 parent,
-		blockBuilder:           blockBuilderMock,
-		config:                 &PolyBFTConfig{},
-		backend:                blockChainMock,
-		isEndOfEpoch:           true,
-		validators:             validatorSet,
-		commitEpochInput:       createTestCommitEpochInput(t, 0, 10),
-		distributeRewardsInput: createTestDistributeRewardsInput(t, 0, validators, 10),
-		exitEventRootHash:      types.ZeroHash,
-		logger:                 hclog.NewNullLogger(),
-		newValidatorsDelta:     newDelta,
+		parent:             parent,
+		blockBuilder:       blockBuilderMock,
+		config:             &PolyBFTConfig{},
+		backend:            blockChainMock,
+		isEndOfEpoch:       true,
+		validators:         validatorSet,
+		commitEpochInput:   createTestCommitEpochInput(t, 0, 10),
+		exitEventRootHash:  types.ZeroHash,
+		logger:             hclog.NewNullLogger(),
+		newValidatorsDelta: newDelta,
 	}
 
 	proposal, err := fsm.BuildProposal(0)
@@ -423,19 +421,18 @@ func TestFSM_BuildProposal_EpochEndingBlock_FailToGetNextValidatorsHash(t *testi
 	parent := &types.Header{Number: parentBlockNumber, ExtraData: extra.MarshalRLPTo(nil)}
 
 	blockBuilderMock := new(blockBuilderMock)
-	blockBuilderMock.On("WriteTx", mock.Anything).Return(error(nil)).Twice()
+	blockBuilderMock.On("WriteTx", mock.Anything).Return(error(nil)).Once()
 	blockBuilderMock.On("Reset").Return(error(nil)).Once()
 	blockBuilderMock.On("Fill").Once()
 
 	fsm := &fsm{parent: parent,
-		blockBuilder:           blockBuilderMock,
-		config:                 &PolyBFTConfig{},
-		isEndOfEpoch:           true,
-		validators:             testValidators.ToValidatorSet(),
-		commitEpochInput:       createTestCommitEpochInput(t, 0, 10),
-		distributeRewardsInput: createTestDistributeRewardsInput(t, 0, allAccounts, 10),
-		exitEventRootHash:      types.ZeroHash,
-		newValidatorsDelta:     newValidatorDelta,
+		blockBuilder:       blockBuilderMock,
+		config:             &PolyBFTConfig{},
+		isEndOfEpoch:       true,
+		validators:         testValidators.ToValidatorSet(),
+		commitEpochInput:   createTestCommitEpochInput(t, 0, 10),
+		exitEventRootHash:  types.ZeroHash,
+		newValidatorsDelta: newValidatorDelta,
 	}
 
 	proposal, err := fsm.BuildProposal(0)
@@ -446,176 +443,333 @@ func TestFSM_BuildProposal_EpochEndingBlock_FailToGetNextValidatorsHash(t *testi
 	blockBuilderMock.AssertExpectations(t)
 }
 
-func TestFSM_VerifyStateTransactions_MiddleOfEpochWithTransaction(t *testing.T) {
+func TestFSM_VerifyStateTransactions_CommitEpoch(t *testing.T) {
 	t.Parallel()
 
-	fsm := &fsm{commitEpochInput: createTestCommitEpochInput(t, 0, 10)}
-	tx, err := fsm.createCommitEpochTx()
-	assert.NoError(t, err)
-	err = fsm.VerifyStateTransactions([]*types.Transaction{tx})
-	assert.ErrorContains(t, err, err.Error())
-}
+	t.Run("commit epoch at end of epoch", func(t *testing.T) {
+		t.Parallel()
 
-func TestFSM_VerifyStateTransactions_MiddleOfEpochWithoutTransaction(t *testing.T) {
-	t.Parallel()
+		validators := validator.NewTestValidators(t, 5)
+		validatorSet := validator.NewValidatorSet(validators.GetPublicIdentities(), hclog.NewNullLogger())
 
-	fsm := &fsm{commitEpochInput: createTestCommitEpochInput(t, 0, 10)}
-	err := fsm.VerifyStateTransactions([]*types.Transaction{})
-	assert.NoError(t, err)
-}
+		fsm := &fsm{
+			isEndOfEpoch:           true,
+			isEndOfSprint:          true,
+			validators:             validatorSet,
+			commitEpochInput:       createTestCommitEpochInput(t, 0, 10),
+			distributeRewardsInput: createTestDistributeRewardsInput(t, 0, validators.GetPublicIdentities(), 10),
+			logger:                 hclog.NewNullLogger(),
+		}
 
-func TestFSM_VerifyStateTransactions_EndOfEpochWithoutTransaction(t *testing.T) {
-	t.Parallel()
+		// add commit epoch commitEpochTx to the end of transactions list
+		commitEpochTx, err := fsm.createCommitEpochTx()
+		require.NoError(t, err)
 
-	fsm := &fsm{isEndOfEpoch: true, commitEpochInput: createTestCommitEpochInput(t, 0, 10)}
-	assert.EqualError(t, fsm.VerifyStateTransactions([]*types.Transaction{}),
-		"commit epoch transaction is not found in the epoch ending block")
-}
-
-func TestFSM_VerifyStateTransactions_EndOfEpochWrongCommitEpochTx(t *testing.T) {
-	t.Parallel()
-
-	fsm := &fsm{isEndOfEpoch: true, commitEpochInput: createTestCommitEpochInput(t, 0, 10)}
-	commitEpochInput, err := createTestCommitEpochInput(t, 1, 5).EncodeAbi()
-	require.NoError(t, err)
-
-	commitEpochTx := createStateTransactionWithData(contracts.ValidatorSetContract, commitEpochInput)
-	assert.ErrorContains(t, fsm.VerifyStateTransactions([]*types.Transaction{commitEpochTx}), "invalid commit epoch transaction")
-}
-
-func TestFSM_VerifyStateTransactions_CommitmentTransactionAndSprintIsFalse(t *testing.T) {
-	t.Parallel()
-
-	fsm := &fsm{}
-
-	encodedCommitment, err := createTestCommitmentMessage(t, 1).EncodeAbi()
-	require.NoError(t, err)
-
-	tx := createStateTransactionWithData(contracts.StateReceiverContract, encodedCommitment)
-	assert.ErrorContains(t, fsm.VerifyStateTransactions([]*types.Transaction{tx}),
-		"found commitment tx in block which should not contain it")
-}
-
-func TestFSM_VerifyStateTransactions_EndOfEpochMoreThanOneCommitEpochTx(t *testing.T) {
-	t.Parallel()
-
-	txs := make([]*types.Transaction, 2)
-	fsm := &fsm{isEndOfEpoch: true, commitEpochInput: createTestCommitEpochInput(t, 0, 10)}
-
-	commitEpochTxOne, err := fsm.createCommitEpochTx()
-	require.NoError(t, err)
-
-	txs[0] = commitEpochTxOne
-
-	commitEpochTxTwo := createTestCommitEpochInput(t, 0, 100)
-	input, err := commitEpochTxTwo.EncodeAbi()
-	require.NoError(t, err)
-
-	txs[1] = createStateTransactionWithData(types.ZeroAddress, input)
-
-	assert.ErrorIs(t, fsm.VerifyStateTransactions(txs), errCommitEpochTxSingleExpected)
-}
-
-func TestFSM_VerifyStateTransactions_StateTransactionPass(t *testing.T) {
-	t.Parallel()
-
-	validators := validator.NewTestValidators(t, 5)
-
-	validatorSet := validator.NewValidatorSet(validators.GetPublicIdentities(), hclog.NewNullLogger())
-
-	fsm := &fsm{
-		isEndOfEpoch:           true,
-		isEndOfSprint:          true,
-		validators:             validatorSet,
-		commitEpochInput:       createTestCommitEpochInput(t, 0, 10),
-		distributeRewardsInput: createTestDistributeRewardsInput(t, 0, validators.GetPublicIdentities(), 10),
-		logger:                 hclog.NewNullLogger(),
-	}
-
-	// add commit epoch commitEpochTx to the end of transactions list
-	commitEpochTx, err := fsm.createCommitEpochTx()
-	require.NoError(t, err)
-
-	distributeRewardsTx, err := fsm.createDistributeRewardsTx()
-	require.NoError(t, err)
-
-	err = fsm.VerifyStateTransactions([]*types.Transaction{commitEpochTx, distributeRewardsTx})
-	require.NoError(t, err)
-}
-
-func TestFSM_VerifyStateTransactions_StateTransactionQuorumNotReached(t *testing.T) {
-	t.Parallel()
-
-	validators := validator.NewTestValidators(t, 5)
-	commitment := createTestCommitment(t, validators.GetPrivateIdentities())
-	commitment.AggSignature = Signature{
-		AggregatedSignature: []byte{1, 2},
-		Bitmap:              []byte{},
-	}
-
-	validatorSet := validator.NewValidatorSet(validators.GetPublicIdentities(), hclog.NewNullLogger())
-
-	fsm := &fsm{
-		isEndOfEpoch:                 true,
-		isEndOfSprint:                true,
-		validators:                   validatorSet,
-		proposerCommitmentToRegister: commitment,
-		commitEpochInput:             createTestCommitEpochInput(t, 0, 10),
-		distributeRewardsInput:       createTestDistributeRewardsInput(t, 0, nil, 10),
-		logger:                       hclog.NewNullLogger(),
-	}
-
-	bridgeCommitmentTx, err := fsm.createBridgeCommitmentTx()
-	require.NoError(t, err)
-
-	// add commit epoch commitEpochTx to the end of transactions list
-	commitEpochTx, err := fsm.createCommitEpochTx()
-	require.NoError(t, err)
-
-	stateTxs := []*types.Transaction{commitEpochTx, bridgeCommitmentTx}
-
-	err = fsm.VerifyStateTransactions(stateTxs)
-	require.ErrorContains(t, err, "quorum size not reached")
-}
-
-func TestFSM_VerifyStateTransactions_StateTransactionInvalidSignature(t *testing.T) {
-	t.Parallel()
-
-	validators := validator.NewTestValidators(t, 5)
-	commitment := createTestCommitment(t, validators.GetPrivateIdentities())
-	nonValidators := validator.NewTestValidators(t, 3)
-	aggregatedSigs := bls.Signatures{}
-
-	nonValidators.IterAcct(nil, func(t *validator.TestValidator) {
-		aggregatedSigs = append(aggregatedSigs, t.MustSign([]byte("dummyHash"), bls.DomainStateReceiver))
+		err = fsm.VerifyStateTransactions([]*types.Transaction{commitEpochTx})
+		require.NoError(t, err)
 	})
 
-	sig, err := aggregatedSigs.Aggregate().Marshal()
-	require.NoError(t, err)
+	t.Run("Middle of epoch with transactions", func(t *testing.T) {
+		t.Parallel()
 
-	commitment.AggSignature.AggregatedSignature = sig
+		fsm := &fsm{commitEpochInput: createTestCommitEpochInput(t, 0, 10)}
+		tx, err := fsm.createCommitEpochTx()
+		require.NoError(t, err)
+		err = fsm.VerifyStateTransactions([]*types.Transaction{tx})
+		require.ErrorContains(t, err, errCommitEpochTxNotExpected.Error())
+	})
 
+	t.Run("Middle of epoch without transaction", func(t *testing.T) {
+		t.Parallel()
+
+		fsm := &fsm{commitEpochInput: createTestCommitEpochInput(t, 0, 10)}
+		err := fsm.VerifyStateTransactions([]*types.Transaction{})
+		require.NoError(t, err)
+	})
+
+	t.Run("End of epoch without transaction", func(t *testing.T) {
+		t.Parallel()
+
+		fsm := &fsm{isEndOfEpoch: true, commitEpochInput: createTestCommitEpochInput(t, 0, 10)}
+		err := fsm.VerifyStateTransactions([]*types.Transaction{})
+		require.ErrorContains(t, err, errCommitEpochTxDoesNotExist.Error())
+	})
+
+	t.Run("End of epoch wrong commit transaction", func(t *testing.T) {
+		t.Parallel()
+
+		fsm := &fsm{isEndOfEpoch: true, commitEpochInput: createTestCommitEpochInput(t, 0, 10)}
+		commitEpochInput, err := createTestCommitEpochInput(t, 1, 5).EncodeAbi()
+		require.NoError(t, err)
+
+		commitEpochTx := createStateTransactionWithData(contracts.ValidatorSetContract, commitEpochInput)
+		err = fsm.VerifyStateTransactions([]*types.Transaction{commitEpochTx})
+		require.ErrorContains(t, err, "invalid commit epoch transaction")
+	})
+
+	t.Run("end of epoch, more than one commit epoch transaction", func(t *testing.T) {
+		t.Parallel()
+
+		txs := make([]*types.Transaction, 2)
+		fsm := &fsm{isEndOfEpoch: true, commitEpochInput: createTestCommitEpochInput(t, 0, 10)}
+
+		commitEpochTxOne, err := fsm.createCommitEpochTx()
+		require.NoError(t, err)
+
+		txs[0] = commitEpochTxOne
+
+		commitEpochTxTwo := createTestCommitEpochInput(t, 0, 100)
+		input, err := commitEpochTxTwo.EncodeAbi()
+		require.NoError(t, err)
+
+		txs[1] = createStateTransactionWithData(types.ZeroAddress, input)
+
+		assert.ErrorIs(t, fsm.VerifyStateTransactions(txs), errCommitEpochTxSingleExpected)
+	})
+}
+
+func TestBre(t *testing.T) {
+	fmt.Println(types.StringToAddress("0x105"))
+}
+
+func TestFSM_VerifyStateTransactions_DistributeRewards(t *testing.T) {
+	t.Parallel()
+
+	validators := validator.NewTestValidators(t, 5)
 	validatorSet := validator.NewValidatorSet(validators.GetPublicIdentities(), hclog.NewNullLogger())
 
-	fsm := &fsm{
-		isEndOfEpoch:                 true,
-		isEndOfSprint:                true,
-		validators:                   validatorSet,
-		proposerCommitmentToRegister: commitment,
-		commitEpochInput:             createTestCommitEpochInput(t, 0, 10),
-		distributeRewardsInput:       createTestDistributeRewardsInput(t, 0, nil, 10),
-		logger:                       hclog.NewNullLogger(),
-	}
+	t.Run("distribute rewards on first block of epoch", func(t *testing.T) {
+		t.Parallel()
 
-	bridgeCommitmentTx, err := fsm.createBridgeCommitmentTx()
-	require.NoError(t, err)
+		fsm := &fsm{
+			parent:                 &types.Header{Number: 10},
+			isFirstBlockOfEpoch:    true,
+			validators:             validatorSet,
+			distributeRewardsInput: createTestDistributeRewardsInput(t, 0, validators.GetPublicIdentities(), 10),
+			logger:                 hclog.NewNullLogger(),
+		}
 
-	// add commit epoch commitEpochTx to the end of transactions list
-	commitEpochTx, err := fsm.createCommitEpochTx()
-	require.NoError(t, err)
+		distributeRewardsTx, err := fsm.createDistributeRewardsTx()
+		require.NoError(t, err)
 
-	err = fsm.VerifyStateTransactions([]*types.Transaction{commitEpochTx, bridgeCommitmentTx})
-	require.ErrorContains(t, err, "invalid signature")
+		err = fsm.VerifyStateTransactions([]*types.Transaction{distributeRewardsTx})
+		require.NoError(t, err)
+	})
+
+	t.Run("not a first block of epoch", func(t *testing.T) {
+		t.Parallel()
+
+		fsm := &fsm{
+			parent:                 &types.Header{Number: 9},
+			validators:             validatorSet,
+			distributeRewardsInput: createTestDistributeRewardsInput(t, 0, validators.GetPublicIdentities(), 10),
+			logger:                 hclog.NewNullLogger(),
+		}
+
+		distributeRewardsTx, err := fsm.createDistributeRewardsTx()
+		require.NoError(t, err)
+
+		err = fsm.VerifyStateTransactions([]*types.Transaction{distributeRewardsTx})
+		require.ErrorContains(t, err, errDistributeRewardsTxNotExpected.Error())
+	})
+
+	t.Run("two distribute rewards txs", func(t *testing.T) {
+		t.Parallel()
+
+		fsm := &fsm{
+			isFirstBlockOfEpoch:    true,
+			parent:                 &types.Header{Number: 9},
+			validators:             validatorSet,
+			distributeRewardsInput: createTestDistributeRewardsInput(t, 0, validators.GetPublicIdentities(), 10),
+			logger:                 hclog.NewNullLogger(),
+		}
+
+		distributeRewardsTx, err := fsm.createDistributeRewardsTx()
+		require.NoError(t, err)
+
+		err = fsm.VerifyStateTransactions([]*types.Transaction{distributeRewardsTx, distributeRewardsTx})
+		require.ErrorContains(t, err, errDistributeRewardsTxSingleExpected.Error())
+	})
+
+	t.Run("no distribute rewards tx", func(t *testing.T) {
+		t.Parallel()
+
+		fsm := &fsm{
+			isFirstBlockOfEpoch: true,
+			parent:              &types.Header{Number: 9},
+			validators:          validatorSet,
+			logger:              hclog.NewNullLogger(),
+		}
+
+		err := fsm.VerifyStateTransactions([]*types.Transaction{})
+		require.ErrorContains(t, err, errDistributeRewardsTxDoesNotExist.Error())
+	})
+}
+
+func TestFSM_VerifyStateTransaction_Commitments(t *testing.T) {
+	t.Parallel()
+
+	t.Run("submit commitments at end of sprint", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			commitments       [2]*PendingCommitment
+			stateSyncs        [2][]*contractsapi.StateSyncedEvent
+			signedCommitments [2]*CommitmentMessageSigned
+		)
+
+		validators := validator.NewTestValidatorsWithAliases(t, []string{"A", "B", "C", "D", "E"})
+		commitments[0], signedCommitments[0], stateSyncs[0] = buildCommitmentAndStateSyncs(t, 10, uint64(3), 2)
+		commitments[1], signedCommitments[1], stateSyncs[1] = buildCommitmentAndStateSyncs(t, 10, uint64(3), 12)
+
+		executeForValidators := func(aliases ...string) error {
+			for _, sc := range signedCommitments {
+				// add register commitment state transaction
+				hash, err := sc.Hash()
+				require.NoError(t, err)
+				signature := createSignature(t, validators.GetPrivateIdentities(aliases...), hash, bls.DomainStateReceiver)
+				sc.AggSignature = *signature
+			}
+
+			f := &fsm{
+				isEndOfSprint: true,
+				validators:    validators.ToValidatorSet(),
+			}
+
+			var txns []*types.Transaction
+
+			for i, sc := range signedCommitments {
+				inputData, err := sc.EncodeAbi()
+				require.NoError(t, err)
+
+				if i == 0 {
+					tx := createStateTransactionWithData(contracts.StateReceiverContract, inputData)
+					txns = append(txns, tx)
+				}
+			}
+
+			return f.VerifyStateTransactions(txns)
+		}
+
+		assert.NoError(t, executeForValidators("A", "B", "C", "D"))
+		assert.ErrorContains(t, executeForValidators("A", "B", "C"), "quorum size not reached for state tx")
+	})
+
+	t.Run("invalid signature", func(t *testing.T) {
+		t.Parallel()
+
+		validators := validator.NewTestValidators(t, 5)
+		commitment := createTestCommitment(t, validators.GetPrivateIdentities())
+		nonValidators := validator.NewTestValidators(t, 3)
+		aggregatedSigs := bls.Signatures{}
+
+		nonValidators.IterAcct(nil, func(t *validator.TestValidator) {
+			aggregatedSigs = append(aggregatedSigs, t.MustSign([]byte("dummyHash"), bls.DomainStateReceiver))
+		})
+
+		sig, err := aggregatedSigs.Aggregate().Marshal()
+		require.NoError(t, err)
+
+		commitment.AggSignature.AggregatedSignature = sig
+
+		validatorSet := validator.NewValidatorSet(validators.GetPublicIdentities(), hclog.NewNullLogger())
+
+		fsm := &fsm{
+			isEndOfSprint:                true,
+			validators:                   validatorSet,
+			proposerCommitmentToRegister: commitment,
+			logger:                       hclog.NewNullLogger(),
+		}
+
+		bridgeCommitmentTx, err := fsm.createBridgeCommitmentTx()
+		require.NoError(t, err)
+
+		err = fsm.VerifyStateTransactions([]*types.Transaction{bridgeCommitmentTx})
+		require.ErrorContains(t, err, "invalid signature")
+	})
+
+	t.Run("quorum size not reached", func(t *testing.T) {
+		t.Parallel()
+
+		validators := validator.NewTestValidators(t, 5)
+		commitment := createTestCommitment(t, validators.GetPrivateIdentities())
+		commitment.AggSignature = Signature{
+			AggregatedSignature: []byte{1, 2},
+			Bitmap:              []byte{},
+		}
+
+		validatorSet := validator.NewValidatorSet(validators.GetPublicIdentities(), hclog.NewNullLogger())
+
+		fsm := &fsm{
+			isEndOfEpoch:                 true,
+			isEndOfSprint:                true,
+			validators:                   validatorSet,
+			proposerCommitmentToRegister: commitment,
+			commitEpochInput:             createTestCommitEpochInput(t, 0, 10),
+			distributeRewardsInput:       createTestDistributeRewardsInput(t, 0, nil, 10),
+			logger:                       hclog.NewNullLogger(),
+		}
+
+		bridgeCommitmentTx, err := fsm.createBridgeCommitmentTx()
+		require.NoError(t, err)
+
+		// add commit epoch commitEpochTx to the end of transactions list
+		commitEpochTx, err := fsm.createCommitEpochTx()
+		require.NoError(t, err)
+
+		stateTxs := []*types.Transaction{commitEpochTx, bridgeCommitmentTx}
+
+		err = fsm.VerifyStateTransactions(stateTxs)
+		require.ErrorContains(t, err, "quorum size not reached")
+	})
+
+	t.Run("commitment in unexpected block", func(t *testing.T) {
+		t.Parallel()
+
+		fsm := &fsm{}
+
+		encodedCommitment, err := createTestCommitmentMessage(t, 1).EncodeAbi()
+		require.NoError(t, err)
+
+		tx := createStateTransactionWithData(contracts.StateReceiverContract, encodedCommitment)
+		assert.ErrorContains(t, fsm.VerifyStateTransactions([]*types.Transaction{tx}),
+			"found commitment tx in block which should not contain it")
+	})
+
+	t.Run("two commitment transactions", func(t *testing.T) {
+		t.Parallel()
+
+		validators := validator.NewTestValidatorsWithAliases(t, []string{"A", "B", "C", "D", "E", "F"})
+		_, commitmentMessageSigned, _ := buildCommitmentAndStateSyncs(t, 10, uint64(3), 2)
+
+		validatorSet := validator.NewValidatorSet(validators.GetPublicIdentities(), hclog.NewNullLogger())
+
+		f := &fsm{
+			isEndOfSprint: true,
+			validators:    validatorSet,
+		}
+
+		hash, err := commitmentMessageSigned.Hash()
+		require.NoError(t, err)
+
+		var txns []*types.Transaction
+
+		signature := createSignature(t, validators.GetPrivateIdentities("A", "B", "C", "D"), hash, bls.DomainStateReceiver)
+		commitmentMessageSigned.AggSignature = *signature
+
+		inputData, err := commitmentMessageSigned.EncodeAbi()
+		require.NoError(t, err)
+
+		txns = append(txns,
+			createStateTransactionWithData(contracts.StateReceiverContract, inputData))
+		inputData, err = commitmentMessageSigned.EncodeAbi()
+		require.NoError(t, err)
+
+		txns = append(txns,
+			createStateTransactionWithData(contracts.StateReceiverContract, inputData))
+		err = f.VerifyStateTransactions(txns)
+		require.ErrorContains(t, err, "only one commitment tx is allowed per block")
+	})
 }
 
 func TestFSM_ValidateCommit_WrongValidator(t *testing.T) {
@@ -811,16 +965,11 @@ func TestFSM_Validate_EpochEndingBlock_MismatchInDeltas(t *testing.T) {
 	commitEpochTxInput, err := commitEpoch.EncodeAbi()
 	require.NoError(t, err)
 
-	distributeRewards := createTestDistributeRewardsInput(t, 1, validators.GetPublicIdentities(), 10)
-	distributeRewardsTxInput, err := distributeRewards.EncodeAbi()
-	require.NoError(t, err)
-
 	stateBlock.Block.Header.Hash = proposalHash
 	stateBlock.Block.Header.ParentHash = parent.Hash
 	stateBlock.Block.Header.Timestamp = uint64(time.Now().UTC().Unix())
 	stateBlock.Block.Transactions = []*types.Transaction{
 		createStateTransactionWithData(contracts.ValidatorSetContract, commitEpochTxInput),
-		createStateTransactionWithData(contracts.RewardPoolContract, distributeRewardsTxInput),
 	}
 
 	proposal := stateBlock.Block.MarshalRLP()
@@ -844,16 +993,15 @@ func TestFSM_Validate_EpochEndingBlock_MismatchInDeltas(t *testing.T) {
 	}
 
 	fsm := &fsm{
-		parent:                 parent,
-		backend:                blockchainMock,
-		validators:             validators.ToValidatorSet(),
-		logger:                 hclog.NewNullLogger(),
-		isEndOfEpoch:           true,
-		commitEpochInput:       commitEpoch,
-		distributeRewardsInput: distributeRewards,
-		polybftBackend:         polybftBackendMock,
-		newValidatorsDelta:     newValidatorDelta,
-		config:                 &PolyBFTConfig{BlockTimeDrift: 1},
+		parent:             parent,
+		backend:            blockchainMock,
+		validators:         validators.ToValidatorSet(),
+		logger:             hclog.NewNullLogger(),
+		isEndOfEpoch:       true,
+		commitEpochInput:   commitEpoch,
+		polybftBackend:     polybftBackendMock,
+		newValidatorsDelta: newValidatorDelta,
+		config:             &PolyBFTConfig{BlockTimeDrift: 1},
 	}
 
 	err = fsm.Validate(proposal)
@@ -1306,52 +1454,6 @@ func TestFSM_DecodeCommitEpochStateTx(t *testing.T) {
 	require.True(t, commitEpoch.Epoch.EndBlock.Cmp(decodedCommitEpoch.Epoch.EndBlock) == 0)
 }
 
-func TestFSM_VerifyStateTransaction_ValidBothTypesOfStateTransactions(t *testing.T) {
-	t.Parallel()
-
-	var (
-		commitments       [2]*PendingCommitment
-		stateSyncs        [2][]*contractsapi.StateSyncedEvent
-		signedCommitments [2]*CommitmentMessageSigned
-	)
-
-	validators := validator.NewTestValidatorsWithAliases(t, []string{"A", "B", "C", "D", "E"})
-	commitments[0], signedCommitments[0], stateSyncs[0] = buildCommitmentAndStateSyncs(t, 10, uint64(3), 2)
-	commitments[1], signedCommitments[1], stateSyncs[1] = buildCommitmentAndStateSyncs(t, 10, uint64(3), 12)
-
-	executeForValidators := func(aliases ...string) error {
-		for _, sc := range signedCommitments {
-			// add register commitment state transaction
-			hash, err := sc.Hash()
-			require.NoError(t, err)
-			signature := createSignature(t, validators.GetPrivateIdentities(aliases...), hash, bls.DomainStateReceiver)
-			sc.AggSignature = *signature
-		}
-
-		f := &fsm{
-			isEndOfSprint: true,
-			validators:    validators.ToValidatorSet(),
-		}
-
-		var txns []*types.Transaction
-
-		for i, sc := range signedCommitments {
-			inputData, err := sc.EncodeAbi()
-			require.NoError(t, err)
-
-			if i == 0 {
-				tx := createStateTransactionWithData(contracts.StateReceiverContract, inputData)
-				txns = append(txns, tx)
-			}
-		}
-
-		return f.VerifyStateTransactions(txns)
-	}
-
-	assert.NoError(t, executeForValidators("A", "B", "C", "D"))
-	assert.ErrorContains(t, executeForValidators("A", "B", "C"), "quorum size not reached for state tx")
-}
-
 func TestFSM_VerifyStateTransaction_InvalidTypeOfStateTransactions(t *testing.T) {
 	t.Parallel()
 
@@ -1364,103 +1466,6 @@ func TestFSM_VerifyStateTransaction_InvalidTypeOfStateTransactions(t *testing.T)
 		createStateTransactionWithData(contracts.StateReceiverContract, []byte{9, 3, 1, 1}))
 
 	require.ErrorContains(t, f.VerifyStateTransactions(txns), "unknown state transaction")
-}
-
-func TestFSM_VerifyStateTransaction_QuorumNotReached(t *testing.T) {
-	t.Parallel()
-
-	validators := validator.NewTestValidatorsWithAliases(t, []string{"A", "B", "C", "D", "E", "F"})
-	_, commitmentMessageSigned, _ := buildCommitmentAndStateSyncs(t, 10, uint64(3), 2)
-	f := &fsm{
-		isEndOfSprint: true,
-		validators:    validators.ToValidatorSet(),
-	}
-
-	hash, err := commitmentMessageSigned.Hash()
-	require.NoError(t, err)
-
-	var txns []*types.Transaction
-
-	signature := createSignature(t, validators.GetPrivateIdentities("A", "B"), hash, bls.DomainStateReceiver)
-	commitmentMessageSigned.AggSignature = *signature
-
-	inputData, err := commitmentMessageSigned.EncodeAbi()
-	require.NoError(t, err)
-
-	txns = append(txns,
-		createStateTransactionWithData(contracts.StateReceiverContract, inputData))
-
-	err = f.VerifyStateTransactions(txns)
-	require.ErrorContains(t, err, "quorum size not reached for state tx")
-}
-
-func TestFSM_VerifyStateTransaction_InvalidSignature(t *testing.T) {
-	t.Parallel()
-
-	validators := validator.NewTestValidatorsWithAliases(t, []string{"A", "B", "C", "D", "E", "F"})
-	_, commitmentMessageSigned, _ := buildCommitmentAndStateSyncs(t, 10, uint64(3), 2)
-	f := &fsm{
-		isEndOfSprint: true,
-		validators:    validators.ToValidatorSet(),
-	}
-
-	hash, err := commitmentMessageSigned.Hash()
-	require.NoError(t, err)
-
-	var txns []*types.Transaction
-
-	signature := createSignature(t, validators.GetPrivateIdentities("A", "B", "C", "D"), hash, bls.DomainStateReceiver)
-	invalidValidator := validator.NewTestValidator(t, "G", 1)
-	invalidSignature, err := invalidValidator.MustSign([]byte("malicious message"), bls.DomainStateReceiver).Marshal()
-	require.NoError(t, err)
-
-	commitmentMessageSigned.AggSignature = Signature{
-		Bitmap:              signature.Bitmap,
-		AggregatedSignature: invalidSignature,
-	}
-
-	inputData, err := commitmentMessageSigned.EncodeAbi()
-	require.NoError(t, err)
-
-	txns = append(txns,
-		createStateTransactionWithData(contracts.StateReceiverContract, inputData))
-
-	require.ErrorContains(t, f.VerifyStateTransactions(txns), "invalid signature for state tx")
-}
-
-func TestFSM_VerifyStateTransaction_TwoCommitmentMessages(t *testing.T) {
-	t.Parallel()
-
-	validators := validator.NewTestValidatorsWithAliases(t, []string{"A", "B", "C", "D", "E", "F"})
-	_, commitmentMessageSigned, _ := buildCommitmentAndStateSyncs(t, 10, uint64(3), 2)
-
-	validatorSet := validator.NewValidatorSet(validators.GetPublicIdentities(), hclog.NewNullLogger())
-
-	f := &fsm{
-		isEndOfSprint: true,
-		validators:    validatorSet,
-	}
-
-	hash, err := commitmentMessageSigned.Hash()
-	require.NoError(t, err)
-
-	var txns []*types.Transaction
-
-	signature := createSignature(t, validators.GetPrivateIdentities("A", "B", "C", "D"), hash, bls.DomainStateReceiver)
-	commitmentMessageSigned.AggSignature = *signature
-
-	inputData, err := commitmentMessageSigned.EncodeAbi()
-	require.NoError(t, err)
-
-	txns = append(txns,
-		createStateTransactionWithData(contracts.StateReceiverContract, inputData))
-	inputData, err = commitmentMessageSigned.EncodeAbi()
-	require.NoError(t, err)
-
-	txns = append(txns,
-		createStateTransactionWithData(contracts.StateReceiverContract, inputData))
-	err = f.VerifyStateTransactions(txns)
-	require.ErrorContains(t, err, "only one commitment tx is allowed per block")
 }
 
 func TestFSM_Validate_FailToVerifySignatures(t *testing.T) {

--- a/consensus/polybft/governance_fork.go
+++ b/consensus/polybft/governance_fork.go
@@ -1,0 +1,35 @@
+package polybft
+
+import (
+	"github.com/0xPolygon/polygon-edge/chain"
+	"github.com/0xPolygon/polygon-edge/forkmanager"
+)
+
+const (
+	oldRewardLookbackSize = uint64(2) // number of blocks to calculate commit epoch info from the previous epoch
+	newRewardLookbackSize = uint64(1)
+)
+
+// shouldAddOrValidateRewardDistribution indicates if reward distribution transaction
+// should be validated or added at given block
+// if governance fork is enabled, reward distribution is only present on the first block of epoch
+// and if we are not at the start of chain
+// if governance fork is not enabled, reward distribution is only present at the epoch ending block
+func shouldAddOrValidateRewardDistribution(isFirstBlockOfEpoch, isEndOfEpoch bool,
+	pendingBlockNumber uint64) bool {
+	if forkmanager.GetInstance().IsForkEnabled(chain.Governance, pendingBlockNumber) {
+		return isFirstBlockOfEpoch && pendingBlockNumber > 1
+	}
+
+	return isEndOfEpoch
+}
+
+// getLookbackSizeForRewardDistribution returns lookback size for reward distribution
+// based on if governance fork is enabled or not
+func getLookbackSizeForRewardDistribution(blockNumber uint64) uint64 {
+	if forkmanager.GetInstance().IsForkEnabled(chain.Governance, blockNumber) {
+		return newRewardLookbackSize
+	}
+
+	return oldRewardLookbackSize
+}

--- a/consensus/polybft/governance_fork.go
+++ b/consensus/polybft/governance_fork.go
@@ -10,12 +10,12 @@ const (
 	newRewardLookbackSize = uint64(1)
 )
 
-// shouldAddOrValidateRewardDistribution indicates if reward distribution transaction
-// should be validated or added at given block
+// isRewardDistributionBlock indicates if reward distribution transaction
+// should happen in given block
 // if governance fork is enabled, reward distribution is only present on the first block of epoch
 // and if we are not at the start of chain
 // if governance fork is not enabled, reward distribution is only present at the epoch ending block
-func shouldAddOrValidateRewardDistribution(isFirstBlockOfEpoch, isEndOfEpoch bool,
+func isRewardDistributionBlock(isFirstBlockOfEpoch, isEndOfEpoch bool,
 	pendingBlockNumber uint64) bool {
 	if forkmanager.GetInstance().IsForkEnabled(chain.Governance, pendingBlockNumber) {
 		return isFirstBlockOfEpoch && pendingBlockNumber > 1

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -51,7 +51,8 @@ function createGenesis() {
     --epoch-size 10 \
     --reward-wallet 0xDEADBEEF:1000000 \
     --native-token-config "Polygon:MATIC:18:true:$address1" \
-    --burn-contract 0:0x0000000000000000000000000000000000000000
+    --burn-contract 0:0x0000000000000000000000000000000000000000 \
+    --governor-admin $address1
 }
 
 function initRootchain() {


### PR DESCRIPTION
# Description

`ValidatorSet` contract on supernet is used as a wrapper around staked tokens by validators on `L2`. For governance, it is used as a voting token as well, which makes sense, since we are only allowing validators to propose and vote for governance proposals.

But, to be able to use `ValidatorSet` as vote token in governance, we needed to change it to implement `ERC20VotesUpgradable` implementation, which changed how the contract checkpoints its total supply at a certain point in time, and how it returns `totalSupplyAt`, which is used by `RewardPool` contract to accurately distribute rewards.
Now `totalSupplyAt` has a check which prevents calling it for the last checkpointed total supply, if they happen in the same block, and because of that, reward distribution failed.

This PR moves reward distribution to the first block of epoch. So when an epoch completes, and gets committed (which will checkpoint total supply at `ValidatorSet` contract), the new epoch will start, and in the first block of new epoch, proposer will add the distribute rewards transaction for the previously completed epoch.

This has three benefits:
1. It lowers gas consumption on epoch ending blocks.
2. It enables more accurate reward distribution.
3. We can use `ValidatorSet` as voting token for governance.

**IMPORTANT NOTE**:
Rewards will only be distributed in the first block of an epoch if `governance` fork is enabled. If it is not enabled, rewards will be distributed old way, at epoch ending block. 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually