### PR TITLE
EVM-707 Remove `balance` field from initial validators in `genesis.json`

### DIFF
--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -112,7 +112,7 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 		rewardTokenAddr = contracts.RewardTokenContract
 	}
 
-	initialValidators, err := p.getValidatorAccounts(premineBalances)
+	initialValidators, err := p.getValidatorAccounts()
 	if err != nil {
 		return fmt.Errorf("failed to retrieve genesis validators: %w", err)
 	}
@@ -484,8 +484,7 @@ func (p *genesisParams) deployContracts(
 }
 
 // getValidatorAccounts gathers validator accounts info either from CLI or from provided local storage
-func (p *genesisParams) getValidatorAccounts(
-	premineBalances map[types.Address]*premineInfo) ([]*validator.GenesisValidator, error) {
+func (p *genesisParams) getValidatorAccounts() ([]*validator.GenesisValidator, error) {
 	// populate validators premine info
 	if len(p.validators) > 0 {
 		validators := make([]*validator.GenesisValidator, len(p.validators))
@@ -516,7 +515,6 @@ func (p *genesisParams) getValidatorAccounts(
 				MultiAddr: parts[0],
 				Address:   addr,
 				BlsKey:    trimmedBLSKey,
-				Balance:   getPremineAmount(addr, premineBalances, big.NewInt(0)),
 				Stake:     big.NewInt(0),
 			}
 		}
@@ -534,22 +532,7 @@ func (p *genesisParams) getValidatorAccounts(
 		return nil, err
 	}
 
-	for _, v := range validators {
-		v.Balance = getPremineAmount(v.Address, premineBalances, big.NewInt(0))
-		v.Stake = big.NewInt(0)
-	}
-
 	return validators, nil
-}
-
-// getPremineAmount retrieves amount from the premine map or if not provided, returns default amount
-func getPremineAmount(addr types.Address, premineMap map[types.Address]*premineInfo,
-	defaultAmount *big.Int) *big.Int {
-	if premine, exists := premineMap[addr]; exists {
-		return premine.amount
-	}
-
-	return defaultAmount
 }
 
 func stringSliceToAddressSlice(addrs []string) []types.Address {

--- a/command/genesis/utils.go
+++ b/command/genesis/utils.go
@@ -217,10 +217,10 @@ func ReadValidatorsByPrefix(dir, prefix string) ([]*validator.GenesisValidator, 
 		}
 
 		validators[i] = &validator.GenesisValidator{
-			Address:       types.Address(account.Ecdsa.Address()),
-			BlsPrivateKey: account.Bls,
-			BlsKey:        hex.EncodeToString(account.Bls.PublicKey().Marshal()),
-			MultiAddr:     fmt.Sprintf("/ip4/%s/tcp/%d/p2p/%s", "127.0.0.1", bootnodePortStart+int64(i), nodeID),
+			Address:   types.Address(account.Ecdsa.Address()),
+			BlsKey:    hex.EncodeToString(account.Bls.PublicKey().Marshal()),
+			MultiAddr: fmt.Sprintf("/ip4/%s/tcp/%d/p2p/%s", "127.0.0.1", bootnodePortStart+int64(i), nodeID),
+			Stake:     big.NewInt(0),
 		}
 	}
 

--- a/command/rootchain/supernet/stakemanager/stake_manager_deploy.go
+++ b/command/rootchain/supernet/stakemanager/stake_manager_deploy.go
@@ -21,16 +21,16 @@ import (
 var params stakeManagerDeployParams
 
 func GetCommand() *cobra.Command {
-	registerCmd := &cobra.Command{
+	stakeMgrDeployCmd := &cobra.Command{
 		Use:     "stake-manager-deploy",
 		Short:   "Command for deploying stake manager contract on rootchain",
 		PreRunE: runPreRun,
 		RunE:    runCommand,
 	}
 
-	setFlags(registerCmd)
+	setFlags(stakeMgrDeployCmd)
 
-	return registerCmd
+	return stakeMgrDeployCmd
 }
 
 func runPreRun(cmd *cobra.Command, _ []string) error {

--- a/consensus/polybft/sc_integration_test.go
+++ b/consensus/polybft/sc_integration_test.go
@@ -314,7 +314,6 @@ func TestIntegration_CommitEpoch(t *testing.T) {
 			// create validator data for polybft config
 			initValidators[i] = &validator.GenesisValidator{
 				Address: val.Address,
-				Balance: val.VotingPower,
 				Stake:   val.VotingPower,
 				BlsKey:  hex.EncodeToString(val.BlsKey.Marshal()),
 			}

--- a/consensus/polybft/validator/genesis_validator.go
+++ b/consensus/polybft/validator/genesis_validator.go
@@ -12,35 +12,28 @@ import (
 
 // GenesisValidator represents public information about validator accounts which are the part of genesis
 type GenesisValidator struct {
-	Address       types.Address
-	BlsPrivateKey *bls.PrivateKey
-	BlsKey        string
-	Balance       *big.Int
-	Stake         *big.Int
-	MultiAddr     string
+	Address   types.Address
+	BlsKey    string
+	Stake     *big.Int
+	MultiAddr string
 }
 
 type genesisValidatorRaw struct {
 	Address   types.Address `json:"address"`
 	BlsKey    string        `json:"blsKey"`
-	Balance   *string       `json:"balance"`
 	Stake     *string       `json:"stake"`
 	MultiAddr string        `json:"multiAddr"`
 }
 
 func (v *GenesisValidator) MarshalJSON() ([]byte, error) {
 	raw := &genesisValidatorRaw{Address: v.Address, BlsKey: v.BlsKey, MultiAddr: v.MultiAddr}
-	raw.Balance = types.EncodeBigInt(v.Balance)
 	raw.Stake = types.EncodeBigInt(v.Stake)
 
 	return json.Marshal(raw)
 }
 
-func (v *GenesisValidator) UnmarshalJSON(data []byte) error {
-	var (
-		raw genesisValidatorRaw
-		err error
-	)
+func (v *GenesisValidator) UnmarshalJSON(data []byte) (err error) {
+	var raw genesisValidatorRaw
 
 	if err = json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -50,17 +43,9 @@ func (v *GenesisValidator) UnmarshalJSON(data []byte) error {
 	v.BlsKey = raw.BlsKey
 	v.MultiAddr = raw.MultiAddr
 
-	v.Balance, err = types.ParseUint256orHex(raw.Balance)
-	if err != nil {
-		return err
-	}
-
 	v.Stake, err = types.ParseUint256orHex(raw.Stake)
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }
 
 // UnmarshalBLSPublicKey unmarshals the hex encoded BLS public key
@@ -92,6 +77,6 @@ func (v *GenesisValidator) ToValidatorMetadata() (*ValidatorMetadata, error) {
 
 // String implements fmt.Stringer interface
 func (v *GenesisValidator) String() string {
-	return fmt.Sprintf("Address=%s; Balance=%d; Stake=%d; P2P Multi addr=%s; BLS Key=%s;",
-		v.Address, v.Balance, v.Stake, v.MultiAddr, v.BlsKey)
+	return fmt.Sprintf("Address=%s; Stake=%d; P2P Multi addr=%s; BLS Key=%s;",
+		v.Address, v.Stake, v.MultiAddr, v.BlsKey)
 }

--- a/consensus/polybft/validator/test_helpers.go
+++ b/consensus/polybft/validator/test_helpers.go
@@ -163,7 +163,6 @@ func (v *TestValidator) ParamsValidator() *GenesisValidator {
 	return &GenesisValidator{
 		Address: v.Address(),
 		BlsKey:  hex.EncodeToString(bls),
-		Balance: big.NewInt(1000),
 		Stake:   big.NewInt(1000),
 	}
 }


### PR DESCRIPTION
# Description
We should remove Balance field from initial validators list in genesis.json since its not used anywhere anymore.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually

