### PR TITLE
EVM-746 Fix txpool_content and txpool_inspect for dynamic fee txs

### DIFF
--- a/jsonrpc/txpool_endpoint_test.go
+++ b/jsonrpc/txpool_endpoint_test.go
@@ -28,14 +28,14 @@ func TestContentEndpoint(t *testing.T) {
 		assert.Equal(t, 0, len(response.Queued))
 	})
 
-	//nolint:dupl
 	t.Run("returns correct data for pending transaction", func(t *testing.T) {
 		t.Parallel()
 
 		mockStore := newMockTxPoolStore()
 		address1 := types.Address{0x1}
-		testTx := newTestTransaction(2, address1)
-		mockStore.pending[address1] = []*types.Transaction{testTx}
+		testTx1 := newTestTransaction(2, address1)
+		testTx2 := newTestDynamicFeeTransaction(3, address1)
+		mockStore.pending[address1] = []*types.Transaction{testTx1, testTx2}
 		txPoolEndpoint := &TxPool{mockStore}
 
 		result, _ := txPoolEndpoint.Content()
@@ -44,28 +44,46 @@ func TestContentEndpoint(t *testing.T) {
 
 		assert.Equal(t, 1, len(response.Pending))
 		assert.Equal(t, 0, len(response.Queued))
-		assert.Equal(t, 1, len(response.Pending[address1]))
+		assert.Equal(t, 2, len(response.Pending[address1]))
 
-		txData := response.Pending[address1][testTx.Nonce]
+		txData := response.Pending[address1][testTx1.Nonce]
 		assert.NotNil(t, txData)
-		assert.Equal(t, testTx.Gas, uint64(txData.Gas))
-		assert.Equal(t, *testTx.GasPrice, big.Int(txData.GasPrice))
-		assert.Equal(t, testTx.To, txData.To)
-		assert.Equal(t, testTx.From, txData.From)
-		assert.Equal(t, *testTx.Value, big.Int(txData.Value))
-		assert.Equal(t, testTx.Input, []byte(txData.Input))
-		assert.Equal(t, nil, txData.BlockNumber)
-		assert.Equal(t, nil, txData.TxIndex)
+		assert.Equal(t, testTx1.Gas, uint64(txData.Gas))
+		assert.Equal(t, *testTx1.GasPrice, big.Int(*txData.GasPrice))
+		assert.Equal(t, (*argBig)(nil), txData.GasFeeCap)
+		assert.Equal(t, (*argBig)(nil), txData.GasTipCap)
+		assert.Equal(t, testTx1.To, txData.To)
+		assert.Equal(t, testTx1.From, txData.From)
+		assert.Equal(t, *testTx1.Value, big.Int(txData.Value))
+		assert.Equal(t, testTx1.Input, []byte(txData.Input))
+		assert.Equal(t, (*argUint64)(nil), txData.BlockNumber)
+		assert.Equal(t, (*argUint64)(nil), txData.TxIndex)
+
+		txData = response.Pending[address1][testTx2.Nonce]
+		assert.NotNil(t, txData)
+		assert.Equal(t, (argUint64)(types.DynamicFeeTx), txData.Type)
+		assert.Equal(t, testTx2.Gas, uint64(txData.Gas))
+		assert.Equal(t, (*argBig)(nil), txData.GasPrice)
+		assert.Equal(t, *testTx2.GasFeeCap, big.Int(*txData.GasFeeCap))
+		assert.Equal(t, *testTx2.GasTipCap, big.Int(*txData.GasTipCap))
+		assert.Equal(t, testTx2.To, txData.To)
+		assert.Equal(t, testTx2.From, txData.From)
+		assert.Equal(t, *testTx2.ChainID, big.Int(*txData.ChainID))
+		assert.Equal(t, *testTx2.Value, big.Int(txData.Value))
+		assert.Equal(t, testTx2.Input, []byte(txData.Input))
+		assert.Equal(t, (*argUint64)(nil), txData.BlockNumber)
+		assert.Equal(t, (*argUint64)(nil), txData.TxIndex)
 	})
 
-	//nolint:dupl
 	t.Run("returns correct data for queued transaction", func(t *testing.T) {
 		t.Parallel()
 
 		mockStore := newMockTxPoolStore()
-		address1 := types.Address{0x1}
-		testTx := newTestTransaction(2, address1)
-		mockStore.queued[address1] = []*types.Transaction{testTx}
+		address1, address2 := types.Address{0x1}, types.Address{0x2}
+		testTx1 := newTestTransaction(2, address1)
+		testTx2 := newTestDynamicFeeTransaction(1, address2)
+		mockStore.queued[address1] = []*types.Transaction{testTx1}
+		mockStore.queued[address2] = []*types.Transaction{testTx2}
 		txPoolEndpoint := &TxPool{mockStore}
 
 		result, _ := txPoolEndpoint.Content()
@@ -73,19 +91,37 @@ func TestContentEndpoint(t *testing.T) {
 		response := result.(ContentResponse)
 
 		assert.Equal(t, 0, len(response.Pending))
-		assert.Equal(t, 1, len(response.Queued))
+		assert.Equal(t, 2, len(response.Queued))
 		assert.Equal(t, 1, len(response.Queued[address1]))
+		assert.Equal(t, 1, len(response.Queued[address2]))
 
-		txData := response.Queued[address1][testTx.Nonce]
+		txData := response.Queued[address1][testTx1.Nonce]
 		assert.NotNil(t, txData)
-		assert.Equal(t, testTx.Gas, uint64(txData.Gas))
-		assert.Equal(t, *testTx.GasPrice, big.Int(txData.GasPrice))
-		assert.Equal(t, testTx.To, txData.To)
-		assert.Equal(t, testTx.From, txData.From)
-		assert.Equal(t, *testTx.Value, big.Int(txData.Value))
-		assert.Equal(t, testTx.Input, []byte(txData.Input))
-		assert.Equal(t, nil, txData.BlockNumber)
-		assert.Equal(t, nil, txData.TxIndex)
+		assert.Equal(t, testTx1.Gas, uint64(txData.Gas))
+		assert.Equal(t, *testTx1.GasPrice, big.Int(*txData.GasPrice))
+		assert.Equal(t, (*argBig)(nil), txData.GasFeeCap)
+		assert.Equal(t, (*argBig)(nil), txData.GasTipCap)
+		assert.Equal(t, testTx1.To, txData.To)
+		assert.Equal(t, testTx1.From, txData.From)
+		assert.Equal(t, *testTx1.Value, big.Int(txData.Value))
+		assert.Equal(t, testTx1.Input, []byte(txData.Input))
+		assert.Equal(t, (*argUint64)(nil), txData.BlockNumber)
+		assert.Equal(t, (*argUint64)(nil), txData.TxIndex)
+
+		txData = response.Queued[address2][testTx2.Nonce]
+		assert.NotNil(t, txData)
+		assert.Equal(t, (argUint64)(types.DynamicFeeTx), txData.Type)
+		assert.Equal(t, testTx2.Gas, uint64(txData.Gas))
+		assert.Equal(t, (*argBig)(nil), txData.GasPrice)
+		assert.Equal(t, *testTx2.GasFeeCap, big.Int(*txData.GasFeeCap))
+		assert.Equal(t, *testTx2.GasTipCap, big.Int(*txData.GasTipCap))
+		assert.Equal(t, testTx2.To, txData.To)
+		assert.Equal(t, testTx2.From, txData.From)
+		assert.Equal(t, *testTx2.ChainID, big.Int(*txData.ChainID))
+		assert.Equal(t, *testTx2.Value, big.Int(txData.Value))
+		assert.Equal(t, testTx2.Input, []byte(txData.Input))
+		assert.Equal(t, (*argUint64)(nil), txData.BlockNumber)
+		assert.Equal(t, (*argUint64)(nil), txData.TxIndex)
 	})
 
 	t.Run("returns correct ContentResponse data for multiple transactions", func(t *testing.T) {
@@ -233,6 +269,7 @@ type mockTxPoolStore struct {
 	queued        map[types.Address][]*types.Transaction
 	capacity      uint64
 	maxSlots      uint64
+	baseFee       uint64
 	includeQueued bool
 }
 
@@ -253,6 +290,10 @@ func (s *mockTxPoolStore) GetCapacity() (uint64, uint64) {
 	return s.capacity, s.maxSlots
 }
 
+func (s *mockTxPoolStore) GetBaseFee() uint64 {
+	return s.baseFee
+}
+
 func newTestTransaction(nonce uint64, from types.Address) *types.Transaction {
 	txn := &types.Transaction{
 		Nonce:    nonce,
@@ -265,6 +306,28 @@ func newTestTransaction(nonce uint64, from types.Address) *types.Transaction {
 		V:        big.NewInt(1),
 		R:        big.NewInt(1),
 		S:        big.NewInt(1),
+	}
+
+	txn.ComputeHash(1)
+
+	return txn
+}
+
+func newTestDynamicFeeTransaction(nonce uint64, from types.Address) *types.Transaction {
+	txn := &types.Transaction{
+		Type:      types.DynamicFeeTx,
+		Nonce:     nonce,
+		GasTipCap: big.NewInt(2),
+		GasFeeCap: big.NewInt(4),
+		ChainID:   big.NewInt(100),
+		Gas:       nonce * 100,
+		Value:     big.NewInt(200),
+		Input:     []byte{0xff},
+		From:      from,
+		To:        &addr1,
+		V:         big.NewInt(1),
+		R:         big.NewInt(1),
+		S:         big.NewInt(1),
 	}
 
 	txn.ComputeHash(1)

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -755,7 +755,10 @@ func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 		return err
 	}
 
-	tx.ChainID = p.chainID // add chainID to the tx
+	// add chainID to the tx - only dynamic fee tx
+	if tx.Type == types.DynamicFeeTx {
+		tx.ChainID = p.chainID
+	}
 
 	// calculate tx hash
 	tx.ComputeHash(p.store.Header().Number)


### PR DESCRIPTION
# Description

`txpoolTransaction` structure has been deleted. `txpool_content` endpoint should use `transaction` from same package.
txpool_inspect should work for dynamic fee txs also

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually


