### PR TITLE
Query Block Number before deploying contracts.

### DIFF
--- a/command/rootchain/deploy/deploy.go
+++ b/command/rootchain/deploy/deploy.go
@@ -343,6 +343,16 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		}
 	}
 
+	// set event tracker start blocks for rootchain contract(s) of interest
+	// the block number should be queried before deploying contracts so that no events during deployment
+	// and initialization are missed
+	blockNum, err := client.Eth().BlockNumber()
+	if err != nil {
+		outputter.SetError(fmt.Errorf("failed to query rootchain latest block number: %w", err))
+
+		return
+	}
+
 	deploymentResultInfo, err := deployContracts(outputter, client,
 		chainConfig.Params.ChainID, consensusCfg.InitialValidatorSet, cmd.Context())
 	if err != nil {
@@ -362,14 +372,6 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	consensusCfg.Bridge = bridgeConfig
-
-	// set event tracker start blocks for rootchain contract(s) of interest
-	blockNum, err := client.Eth().BlockNumber()
-	if err != nil {
-		outputter.SetError(fmt.Errorf("failed to query rootchain latest block number: %w", err))
-
-		return
-	}
 
 	consensusCfg.Bridge.EventTrackerStartBlocks = map[types.Address]uint64{
 		deploymentResultInfo.RootchainCfg.StateSenderAddress: blockNum,


### PR DESCRIPTION
# Description

Please provide a detailed description of what was done in this PR

This  PR modifies the setup of the genesis file so that the value set for the block tracker is before the deployment and initialization of the genesis contracts. This has two major benefits:
1. If someone deposits in the gap between initialization and querying, their statesync event will not be missed
2. If any state sync messages are sent during initialization of the bridge contracts, they will not be missed. 

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
