### PR TITLE
[EVM-747]: `eth_subscribe` issue with `LogIndex`

### DIFF
--- a/jsonrpc/filter_manager.go
+++ b/jsonrpc/filter_manager.go
@@ -678,6 +678,8 @@ func (f *FilterManager) appendLogsToFilters(header *block) error {
 		return nil
 	}
 
+	logIndex := uint64(0)
+
 	for indx, receipt := range receipts {
 		if receipt.TxHash == types.ZeroHash {
 			// Extract tx Hash
@@ -696,9 +698,12 @@ func (f *FilterManager) appendLogsToFilters(header *block) error {
 						TxHash:      receipt.TxHash,
 						TxIndex:     argUint64(indx),
 						Removed:     false,
+						LogIndex:    argUint64(logIndex),
 					})
 				}
 			}
+
+			logIndex++
 		}
 	}
 


### PR DESCRIPTION
# Description

This PR fixes issue where `eth_subscribe` rpc call did not set `LogIndex` for block log at all.

This PR added a UT for this.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually