### PR TITLE
TestDiscovery_ConnectedPopulatesRoutingTable fix

### DIFF
--- a/network/discovery_e2e_test.go
+++ b/network/discovery_e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func discoveryConfig(c *Config) {
@@ -35,13 +36,11 @@ func TestDiscovery_ConnectedPopulatesRoutingTable(t *testing.T) {
 	}
 
 	// make sure each routing table has peer
-	if _, err := WaitUntilRoutingTableToBeFilled(ctx, servers[0], 1); err != nil {
-		t.Fatalf("server 0 should add a peer to routing table but didn't, peer=%s", servers[1].host.ID())
-	}
+	_, err := WaitUntilRoutingTableIsFilled(ctx, servers[0], 1)
+	require.NoError(t, err, "server 0 should add a peer to routing table but didn't, peer=%s", servers[1].host.ID())
 
-	if _, err := WaitUntilRoutingTableToBeFilled(ctx, servers[1], 1); err != nil {
-		t.Fatalf("server 1 should add a peer to routing table but didn't, peer=%s", servers[0].host.ID())
-	}
+	_, err = WaitUntilRoutingTableIsFilled(ctx, servers[1], 1)
+	require.NoError(t, err, "server 1 should add a peer to routing table but didn't, peer=%s", servers[0].host.ID())
 }
 
 func TestRoutingTable_Connected(t *testing.T) {
@@ -76,13 +75,11 @@ func TestRoutingTable_Connected(t *testing.T) {
 		cancel()
 	})
 
-	if _, err := WaitUntilRoutingTableToBeFilled(ctx, servers[0], 1); err != nil {
-		t.Fatalf("server 0 should add a peer to routing table but didn't, peer=%s", servers[1].host.ID())
-	}
+	_, err := WaitUntilRoutingTableIsFilled(ctx, servers[0], 1)
+	require.NoError(t, err, "server 0 should add a peer to routing table but didn't, peer=%s", servers[1].host.ID())
 
-	if _, err := WaitUntilRoutingTableToBeFilled(ctx, servers[1], 1); err != nil {
-		t.Fatalf("server 1 should add a peer to routing table but didn't, peer=%s", servers[0].host.ID())
-	}
+	_, err = WaitUntilRoutingTableIsFilled(ctx, servers[1], 1)
+	require.NoError(t, err, "server 1 should add a peer to routing table but didn't, peer=%s", servers[0].host.ID())
 
 	assert.Contains(t, servers[0].discovery.RoutingTablePeers(), servers[1].AddrInfo().ID)
 	assert.Contains(t, servers[1].discovery.RoutingTablePeers(), servers[0].AddrInfo().ID)
@@ -121,18 +118,14 @@ func TestRoutingTable_Disconnected(t *testing.T) {
 		cancel()
 	})
 
-	if _, err := WaitUntilRoutingTableToBeFilled(ctx, servers[0], 1); err != nil {
-		t.Fatalf("server 0 should add a peer to routing table but didn't, peer=%s", servers[1].host.ID())
-	}
+	_, err := WaitUntilRoutingTableIsFilled(ctx, servers[0], 1)
+	require.NoError(t, err, "server 0 should add a peer to routing table but didn't, peer=%s", servers[1].host.ID())
 
-	if _, err := WaitUntilRoutingTableToBeFilled(ctx, servers[1], 1); err != nil {
-		t.Fatalf("server 1 should add a peer to routing table but didn't, peer=%s", servers[0].host.ID())
-	}
+	_, err = WaitUntilRoutingTableIsFilled(ctx, servers[1], 1)
+	require.NoError(t, err, "server 1 should add a peer to routing table but didn't, peer=%s", servers[0].host.ID())
 
 	// disconnect the servers by closing server 0 to stop auto-reconnection
-	if closeErr := servers[0].Close(); closeErr != nil {
-		t.Fatalf("Unable to close server 0, %v", closeErr)
-	}
+	require.NoError(t, servers[0].Close())
 
 	// make sure each routing table remove a peer
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 15*time.Second)
@@ -141,9 +134,9 @@ func TestRoutingTable_Disconnected(t *testing.T) {
 		cancel2()
 	})
 
-	if _, err := WaitUntilRoutingTableToBeFilled(ctx2, servers[1], 0); err != nil {
-		t.Fatalf("server 1 should remove a peer from routing table but didn't, peer=%s", servers[0].host.ID())
-	}
+	_, err = WaitUntilRoutingTableIsFilled(ctx2, servers[1], 0)
+	require.NoError(t, err, "server 1 should remove a peer from routing table but didn't, peer=%s",
+		servers[0].host.ID())
 }
 
 func TestRoutingTable_ConnectionFailure(t *testing.T) {

--- a/network/e2e_testing.go
+++ b/network/e2e_testing.go
@@ -174,8 +174,8 @@ func WaitUntilPeerDisconnectsFrom(ctx context.Context, srv *Server, ids ...peer.
 	return resVal, nil
 }
 
-// WaitUntilRoutingTableToBeAdded check routing table has given ids and retry by timeout
-func WaitUntilRoutingTableToBeFilled(ctx context.Context, srv *Server, size int) (bool, error) {
+// WaitUntilRoutingTableIsFilled check routing table has given ids and retry by timeout
+func WaitUntilRoutingTableIsFilled(ctx context.Context, srv *Server, size int) (bool, error) {
 	res, err := tests.RetryUntilTimeout(ctx, func() (interface{}, bool) {
 		if size == srv.discovery.RoutingTableSize() {
 			return true, false


### PR DESCRIPTION
# Description

Just a fix for one unit test: The routing table is filled after peers connect to each other (and therefore populate their peers map). So, it is not enough to wait for the peers map to be populated.

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually
