### PR TITLE
Correctly initialize use allow list and use block list parameters on the access list predicates

### DIFF
--- a/consensus/polybft/contracts_initializer.go
+++ b/consensus/polybft/contracts_initializer.go
@@ -85,7 +85,7 @@ func getInitERC20PredicateInput(config *BridgeConfig, childChainMintable bool) (
 
 // getInitERC20PredicateACLInput builds initialization input parameters for child chain ERC20PredicateAccessList SC
 func getInitERC20PredicateACLInput(config *BridgeConfig, owner types.Address,
-	childChainMintable bool) ([]byte, error) {
+	useAllowList, useBlockList, childChainMintable bool) ([]byte, error) {
 	var params contractsapi.StateTransactionInput
 	if childChainMintable {
 		params = &contractsapi.InitializeRootMintableERC20PredicateACLFn{
@@ -93,8 +93,8 @@ func getInitERC20PredicateACLInput(config *BridgeConfig, owner types.Address,
 			NewStateReceiver:       contracts.StateReceiverContract,
 			NewChildERC20Predicate: config.ChildMintableERC20PredicateAddr,
 			NewChildTokenTemplate:  config.ChildERC20Addr,
-			NewUseAllowList:        owner != contracts.SystemCaller,
-			NewUseBlockList:        owner != contracts.SystemCaller,
+			NewUseAllowList:        useAllowList,
+			NewUseBlockList:        useBlockList,
 			NewOwner:               owner,
 		}
 	} else {
@@ -104,8 +104,8 @@ func getInitERC20PredicateACLInput(config *BridgeConfig, owner types.Address,
 			NewRootERC20Predicate:     config.RootERC20PredicateAddr,
 			NewChildTokenTemplate:     contracts.ChildERC20Contract,
 			NewNativeTokenRootAddress: config.RootNativeERC20Addr,
-			NewUseAllowList:           owner != contracts.SystemCaller,
-			NewUseBlockList:           owner != contracts.SystemCaller,
+			NewUseAllowList:           useAllowList,
+			NewUseBlockList:           useBlockList,
 			NewOwner:                  owner,
 		}
 	}
@@ -138,7 +138,7 @@ func getInitERC721PredicateInput(config *BridgeConfig, childOriginatedTokens boo
 // getInitERC721PredicateACLInput builds initialization input parameters
 // for child chain ERC721PredicateAccessList SC
 func getInitERC721PredicateACLInput(config *BridgeConfig, owner types.Address,
-	childChainMintable bool) ([]byte, error) {
+	useAllowList, useBlockList, childChainMintable bool) ([]byte, error) {
 	var params contractsapi.StateTransactionInput
 	if childChainMintable {
 		params = &contractsapi.InitializeRootMintableERC721PredicateACLFn{
@@ -146,8 +146,8 @@ func getInitERC721PredicateACLInput(config *BridgeConfig, owner types.Address,
 			NewStateReceiver:        contracts.StateReceiverContract,
 			NewChildERC721Predicate: config.ChildMintableERC721PredicateAddr,
 			NewChildTokenTemplate:   config.ChildERC721Addr,
-			NewUseAllowList:         owner != contracts.SystemCaller,
-			NewUseBlockList:         owner != contracts.SystemCaller,
+			NewUseAllowList:         useAllowList,
+			NewUseBlockList:         useBlockList,
 			NewOwner:                owner,
 		}
 	} else {
@@ -156,8 +156,8 @@ func getInitERC721PredicateACLInput(config *BridgeConfig, owner types.Address,
 			NewStateReceiver:       contracts.StateReceiverContract,
 			NewRootERC721Predicate: config.RootERC721PredicateAddr,
 			NewChildTokenTemplate:  contracts.ChildERC721Contract,
-			NewUseAllowList:        owner != contracts.SystemCaller,
-			NewUseBlockList:        owner != contracts.SystemCaller,
+			NewUseAllowList:        useAllowList,
+			NewUseBlockList:        useBlockList,
 			NewOwner:               owner,
 		}
 	}
@@ -190,7 +190,7 @@ func getInitERC1155PredicateInput(config *BridgeConfig, childChainMintable bool)
 // getInitERC1155PredicateACLInput builds initialization input parameters
 // for child chain ERC1155PredicateAccessList SC
 func getInitERC1155PredicateACLInput(config *BridgeConfig, owner types.Address,
-	childChainMintable bool) ([]byte, error) {
+	useAllowList, useBlockList, childChainMintable bool) ([]byte, error) {
 	var params contractsapi.StateTransactionInput
 	if childChainMintable {
 		params = &contractsapi.InitializeRootMintableERC1155PredicateACLFn{
@@ -198,8 +198,8 @@ func getInitERC1155PredicateACLInput(config *BridgeConfig, owner types.Address,
 			NewStateReceiver:         contracts.StateReceiverContract,
 			NewChildERC1155Predicate: config.ChildMintableERC1155PredicateAddr,
 			NewChildTokenTemplate:    config.ChildERC1155Addr,
-			NewUseAllowList:          owner != contracts.SystemCaller,
-			NewUseBlockList:          owner != contracts.SystemCaller,
+			NewUseAllowList:          useAllowList,
+			NewUseBlockList:          useBlockList,
 			NewOwner:                 owner,
 		}
 	} else {
@@ -208,8 +208,8 @@ func getInitERC1155PredicateACLInput(config *BridgeConfig, owner types.Address,
 			NewStateReceiver:        contracts.StateReceiverContract,
 			NewRootERC1155Predicate: config.RootERC1155PredicateAddr,
 			NewChildTokenTemplate:   contracts.ChildERC1155Contract,
-			NewUseAllowList:         owner != contracts.SystemCaller,
-			NewUseBlockList:         owner != contracts.SystemCaller,
+			NewUseAllowList:         useAllowList,
+			NewUseBlockList:         useBlockList,
 			NewOwner:                owner,
 		}
 	}

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -167,7 +167,7 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 
 		// check if there are Bridge Allow List Admins and Bridge Block List Admins
 		// and if there are, get the first address as the Admin
-		var bridgeAllowListAdmin types.Address
+		bridgeAllowListAdmin := types.ZeroAddress
 		if config.Params.BridgeAllowList != nil && len(config.Params.BridgeAllowList.AdminAddresses) > 0 {
 			bridgeAllowListAdmin = config.Params.BridgeAllowList.AdminAddresses[0]
 		}
@@ -181,6 +181,9 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 		if bridgeAllowListAdmin != types.ZeroAddress || bridgeBlockListAdmin != types.ZeroAddress {
 			// The owner of the contract will be the allow list admin or the block list admin, if any of them is set.
 			owner := contracts.SystemCaller
+			useBridgeAllowList := bridgeAllowListAdmin != types.ZeroAddress
+			useBridgeBlockList := bridgeBlockListAdmin != types.ZeroAddress
+
 			if bridgeAllowListAdmin != types.ZeroAddress {
 				owner = bridgeAllowListAdmin
 			} else if bridgeBlockListAdmin != types.ZeroAddress {
@@ -188,7 +191,8 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 			}
 
 			// initialize ChildERC20PredicateAccessList SC
-			input, err := getInitERC20PredicateACLInput(polyBFTConfig.Bridge, owner, false)
+			input, err := getInitERC20PredicateACLInput(polyBFTConfig.Bridge, owner,
+				useBridgeAllowList, useBridgeBlockList, false)
 			if err != nil {
 				return err
 			}
@@ -199,7 +203,8 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 			}
 
 			// initialize ChildERC721PredicateAccessList SC
-			input, err = getInitERC721PredicateACLInput(polyBFTConfig.Bridge, owner, false)
+			input, err = getInitERC721PredicateACLInput(polyBFTConfig.Bridge, owner,
+				useBridgeAllowList, useBridgeBlockList, false)
 			if err != nil {
 				return err
 			}
@@ -210,7 +215,8 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 			}
 
 			// initialize ChildERC1155PredicateAccessList SC
-			input, err = getInitERC1155PredicateACLInput(polyBFTConfig.Bridge, owner, false)
+			input, err = getInitERC1155PredicateACLInput(polyBFTConfig.Bridge, owner,
+				useBridgeAllowList, useBridgeBlockList, false)
 			if err != nil {
 				return err
 			}
@@ -221,7 +227,8 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 			}
 
 			// initialize RootMintableERC20PredicateAccessList SC
-			input, err = getInitERC20PredicateACLInput(polyBFTConfig.Bridge, owner, true)
+			input, err = getInitERC20PredicateACLInput(polyBFTConfig.Bridge, owner,
+				useBridgeAllowList, useBridgeBlockList, true)
 			if err != nil {
 				return err
 			}
@@ -232,7 +239,8 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 			}
 
 			// initialize RootMintableERC721PredicateAccessList SC
-			input, err = getInitERC721PredicateACLInput(polyBFTConfig.Bridge, owner, true)
+			input, err = getInitERC721PredicateACLInput(polyBFTConfig.Bridge, owner,
+				useBridgeAllowList, useBridgeBlockList, true)
 			if err != nil {
 				return err
 			}
@@ -243,7 +251,8 @@ func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *st
 			}
 
 			// initialize RootMintableERC1155PredicateAccessList SC
-			input, err = getInitERC1155PredicateACLInput(polyBFTConfig.Bridge, owner, true)
+			input, err = getInitERC1155PredicateACLInput(polyBFTConfig.Bridge, owner,
+				useBridgeAllowList, useBridgeBlockList, true)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
# Description

In case either bridge allow list admin or bridge block list admin is provided, predicate contracts are initialized with flags that indicate that both bridge transactions allow list and block list should be checked. 

This was wrong because if someone configures Supernets to rely only on the bridge block list (by specifying the bridge block list admin address), SC will also check the allow list. Since the bridge allow list is empty it would result in the account not being able to execute bridge transactions, even though it is not block-listed.

Therefore, the fix includes using separate boolean parameters to initialize SCs whether allow list or block list should be used.

## Existing data fix
If bridge transactions are not executed successfully (either deposit for child chain mintable tokens or withdraw for root chain mintable tokens), and access lists are in use, chances are the issue is related to this bug.
In order to fix it the following Foundry commands need to be run (https://book.getfoundry.sh/reference/cast/cast-send).

### Use only block lists for bridge transactions
In case only bridge block lists should be used, an account that was specified as bridge block lists admin during deployment should send the following transactions, which would disable usage of allow lists on the predicate contracts:
```bash
$ cast send --private-key <owner private key> --rpc-url <Supernets JSON RPC URL> --legacy --gas-limit 100000 0x0000000000000000000000000000000000001004 "function setAllowList(bool)" false
$ cast send --private-key <owner private key> --rpc-url <Supernets JSON RPC URL> --legacy --gas-limit 100000 0x0000000000000000000000000000000000001006 "function setAllowList(bool)" false
$ cast send --private-key <owner private key> --rpc-url <Supernets JSON RPC URL> --legacy --gas-limit 100000 0x0000000000000000000000000000000000001008 "function setAllowList(bool)" false
$ cast send --private-key <owner private key> --rpc-url <Supernets JSON RPC URL> --legacy --gas-limit 100000 0x0000000000000000000000000000000000001009 "function setAllowList(bool)" false
$ cast send --private-key <owner private key> --rpc-url <Supernets JSON RPC URL> --legacy --gas-limit 100000 0x000000000000000000000000000000000000100a "function setAllowList(bool)" false
$ cast send --private-key <owner private key> --rpc-url <Supernets JSON RPC URL> --legacy --gas-limit 100000 0x000000000000000000000000000000000000100b "function setAllowList(bool)" false
```
### Use only allow lists for bridge transactions
In case only bridge block lists should be used, an account that was specified as bridge block lists admin during deployment should send the following transactions, which would disable usage of block lists on the predicate contracts:
```bash
$ cast send --private-key <owner private key> --rpc-url <Supernets JSON RPC URL> --legacy --gas-limit 100000 0x0000000000000000000000000000000000001004 "function setBlockList(bool)" false
$ cast send --private-key <owner private key> --rpc-url <Supernets JSON RPC URL> --legacy --gas-limit 100000 0x0000000000000000000000000000000000001006 "function setBlockList(bool)" false
$ cast send --private-key <owner private key> --rpc-url <Supernets JSON RPC URL> --legacy --gas-limit 100000 0x0000000000000000000000000000000000001008 "function setBlockList(bool)" false
$ cast send --private-key <owner private key> --rpc-url <Supernets JSON RPC URL> --legacy --gas-limit 100000 0x0000000000000000000000000000000000001009 "function setBlockList(bool)" false
$ cast send --private-key <owner private key> --rpc-url <Supernets JSON RPC URL> --legacy --gas-limit 100000 0x000000000000000000000000000000000000100a "function setBlockList(bool)" false
$ cast send --private-key <owner private key> --rpc-url <Supernets JSON RPC URL> --legacy --gas-limit 100000 0x000000000000000000000000000000000000100b "function setBlockList(bool)" false
```

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually