### PR TITLE
Slashing double signing tracker

### DIFF
--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/blockchain"
 	"github.com/0xPolygon/polygon-edge/consensus"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/common"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/state"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -53,7 +54,7 @@ type blockchainBackend interface {
 	GetHeaderByHash(hash types.Hash) (*types.Header, bool)
 
 	// GetSystemState creates a new instance of SystemState interface
-	GetSystemState(provider contract.Provider) SystemState
+	GetSystemState(provider contract.Provider) common.SystemState
 
 	SubscribeEvents() blockchain.Subscription
 
@@ -174,7 +175,7 @@ func (p *blockchainWrapper) NewBlockBuilder(
 }
 
 // GetSystemState is an implementation of blockchainBackend interface
-func (p *blockchainWrapper) GetSystemState(provider contract.Provider) SystemState {
+func (p *blockchainWrapper) GetSystemState(provider contract.Provider) common.SystemState {
 	return NewSystemState(contracts.ValidatorSetContract, contracts.StateReceiverContract, provider)
 }
 

--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/common"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
@@ -29,7 +30,7 @@ var (
 )
 
 type CheckpointManager interface {
-	PostBlock(req *PostBlockRequest) error
+	PostBlock(req *common.PostBlockRequest) error
 	BuildEventRoot(epoch uint64) (types.Hash, error)
 	GenerateExitProof(exitID uint64) (types.Proof, error)
 }
@@ -38,7 +39,7 @@ var _ CheckpointManager = (*dummyCheckpointManager)(nil)
 
 type dummyCheckpointManager struct{}
 
-func (d *dummyCheckpointManager) PostBlock(req *PostBlockRequest) error { return nil }
+func (d *dummyCheckpointManager) PostBlock(req *common.PostBlockRequest) error { return nil }
 func (d *dummyCheckpointManager) BuildEventRoot(epoch uint64) (types.Hash, error) {
 	return types.ZeroHash, nil
 }
@@ -288,7 +289,7 @@ func (c *checkpointManager) isCheckpointBlock(blockNumber uint64, isEpochEndingB
 
 // PostBlock is called on every insert of finalized block (either from consensus or syncer)
 // It will read any exit event that happened in block and insert it to state boltDb
-func (c *checkpointManager) PostBlock(req *PostBlockRequest) error {
+func (c *checkpointManager) PostBlock(req *common.PostBlockRequest) error {
 	block := req.FullBlock.Block.Number()
 
 	lastBlock, err := c.state.CheckpointStore.getLastSaved()

--- a/consensus/polybft/checkpoint_manager_test.go
+++ b/consensus/polybft/checkpoint_manager_test.go
@@ -10,19 +10,20 @@ import (
 	"github.com/umbracle/ethgo/abi"
 	"github.com/umbracle/ethgo/jsonrpc"
 
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
-	"github.com/0xPolygon/polygon-edge/contracts"
-	"github.com/0xPolygon/polygon-edge/helper/common"
-	"github.com/0xPolygon/polygon-edge/merkle-tree"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/umbracle/ethgo"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
+	polyCommon "github.com/0xPolygon/polygon-edge/consensus/polybft/common"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
+	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/helper/common"
+	"github.com/0xPolygon/polygon-edge/merkle-tree"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 )
@@ -314,7 +315,7 @@ func TestCheckpointManager_PostBlock(t *testing.T) {
 		},
 	}
 
-	req := &PostBlockRequest{FullBlock: &types.FullBlock{Block: &types.Block{Header: &types.Header{Number: block}}},
+	req := &polyCommon.PostBlockRequest{FullBlock: &types.FullBlock{Block: &types.Block{Header: &types.Header{Number: block}}},
 		Epoch: epoch}
 
 	req.FullBlock.Block.Header.ExtraData = extra.MarshalRLPTo(nil)

--- a/consensus/polybft/common/hooks_parameters.go
+++ b/consensus/polybft/common/hooks_parameters.go
@@ -1,15 +1,26 @@
-package polybft
+package common
 
 import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
+// SystemState is an interface to interact with the consensus system contracts in the chain
+type SystemState interface {
+	// GetEpoch retrieves current epoch number from the smart contract
+	GetEpoch() (uint64, error)
+
+	// GetNextCommittedIndex retrieves next committed bridge state sync index
+	GetNextCommittedIndex() (uint64, error)
+}
+
 type PostBlockRequest struct {
 	// FullBlock is a reference of the executed block
 	FullBlock *types.FullBlock
+
 	// Epoch is the epoch number of the executed block
 	Epoch uint64
+
 	// IsEpochEndingBlock indicates if this was the last block of given epoch
 	IsEpochEndingBlock bool
 }

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -391,24 +391,19 @@ func (f *fsm) Validate(proposal []byte) error {
 
 // ValidateSender validates sender address and signature
 func (f *fsm) ValidateSender(msg *proto.Message) error {
-	msgNoSig, err := msg.PayloadNoSig()
+	signerAddress, err := wallet.RecoverSignerFromIBFTMessage(msg)
 	if err != nil {
 		return err
 	}
 
-	signerAddress, err := wallet.RecoverAddressFromSignature(msg.Signature, msgNoSig)
-	if err != nil {
-		return fmt.Errorf("failed to recover address from signature: %w", err)
-	}
-
 	// verify the signature came from the sender
 	if !bytes.Equal(msg.From, signerAddress.Bytes()) {
-		return fmt.Errorf("signer address %s doesn't match From field", signerAddress.String())
+		return fmt.Errorf("signer address %s doesn't match From field", signerAddress)
 	}
 
 	// verify the sender is in the active validator set
 	if !f.validators.Includes(signerAddress) {
-		return fmt.Errorf("signer address %s is not included in validator set", signerAddress.String())
+		return fmt.Errorf("signer address %s is not included in validator set", signerAddress)
 	}
 
 	return nil

--- a/consensus/polybft/ibft_consensus.go
+++ b/consensus/polybft/ibft_consensus.go
@@ -4,7 +4,13 @@ import (
 	"context"
 
 	"github.com/0xPolygon/go-ibft/core"
+	ibftProto "github.com/0xPolygon/go-ibft/messages/proto"
 )
+
+// IBFTMessageHandler is handling IBFT consensus messages
+type IBFTMessageHandler interface {
+	Handle(msg *ibftProto.Message)
+}
 
 // IBFTConsensusWrapper is a convenience wrapper for the go-ibft package
 type IBFTConsensusWrapper struct {
@@ -40,4 +46,8 @@ func (c *IBFTConsensusWrapper) runSequence(height uint64) (<-chan struct{}, func
 		cancelSequence()
 		<-sequenceDone // waits until c.IBFT.RunSequenc routine finishes
 	}
+}
+
+func (c *IBFTConsensusWrapper) Handle(msg *ibftProto.Message) {
+	c.AddMessage(msg)
 }

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/blockchain"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/common"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
 	"github.com/0xPolygon/polygon-edge/helper/progress"
 	"github.com/0xPolygon/polygon-edge/state"
@@ -101,10 +102,10 @@ func (m *blockchainMock) GetHeaderByHash(hash types.Hash) (*types.Header, bool) 
 	panic("Unsupported mock for GetHeaderByHash") //nolint:gocritic
 }
 
-func (m *blockchainMock) GetSystemState(provider contract.Provider) SystemState {
+func (m *blockchainMock) GetSystemState(provider contract.Provider) common.SystemState {
 	args := m.Called(provider)
 
-	return args.Get(0).(SystemState) //nolint:forcetypeassert
+	return args.Get(0).(common.SystemState) //nolint:forcetypeassert
 }
 
 func (m *blockchainMock) SubscribeEvents() blockchain.Subscription {
@@ -197,7 +198,7 @@ func (m *blockBuilderMock) GetState() *state.Transition {
 	return args.Get(0).(*state.Transition) //nolint:forcetypeassert
 }
 
-var _ SystemState = (*systemStateMock)(nil)
+var _ common.SystemState = (*systemStateMock)(nil)
 
 type systemStateMock struct {
 	mock.Mock
@@ -378,4 +379,12 @@ func (tp *syncerMock) Sync(func(*types.FullBlock) bool) error {
 func init() {
 	// setup custom hash header func
 	setupHeaderHashFunc()
+}
+
+type dummyValidatorsProvider struct {
+}
+
+// GetValidators returns AccountSet ([]*ValidatorMetadata)
+func (d dummyValidatorsProvider) GetValidators() (validator.AccountSet, error) {
+	return nil, nil
 }

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -381,10 +381,12 @@ func init() {
 	setupHeaderHashFunc()
 }
 
+var _ validator.ValidatorsProvider = (*dummyValidatorsProvider)(nil)
+
 type dummyValidatorsProvider struct {
 }
 
 // GetValidators returns AccountSet ([]*ValidatorMetadata)
-func (d dummyValidatorsProvider) GetValidators() (validator.AccountSet, error) {
+func (d dummyValidatorsProvider) GetAllValidators() (validator.AccountSet, error) {
 	return nil, nil
 }

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -50,11 +50,11 @@ func Factory(params *consensus.Params) (consensus.Consensus, error) {
 	setupHeaderHashFunc()
 
 	polybft := &Polybft{
-		config:      params,
-		closeCh:     make(chan struct{}),
-		logger:      logger,
-		txPool:      params.TxPool,
-		msgHandlers: []IBFTMessageHandler{},
+		config:          params,
+		closeCh:         make(chan struct{}),
+		logger:          logger,
+		txPool:          params.TxPool,
+		ibftMsgHandlers: []IBFTMessageHandler{},
 	}
 
 	// initialize polybft consensus config
@@ -120,8 +120,8 @@ type Polybft struct {
 	// tx pool as interface
 	txPool txPoolInterface
 
-	// msgHandlers contains IBFT consensus messages handlers
-	msgHandlers []IBFTMessageHandler
+	// ibftMsgHandlers contains IBFT consensus messages handlers
+	ibftMsgHandlers []IBFTMessageHandler
 }
 
 func GenesisPostHookFactory(config *chain.Chain, engineName string) func(txn *state.Transition) error {
@@ -471,7 +471,7 @@ func (p *Polybft) Initialize() error {
 
 	p.ibft = newIBFTConsensusWrapper(p.logger, p.runtime, p)
 	// register IBFTConsensusWrapper as IBFT message handler
-	p.msgHandlers = append(p.msgHandlers, p.ibft)
+	p.ibftMsgHandlers = append(p.ibftMsgHandlers, p.ibft)
 
 	if err = p.subscribeToIbftTopic(); err != nil {
 		return fmt.Errorf("IBFT topic subscription failed: %w", err)
@@ -552,7 +552,7 @@ func (p *Polybft) initRuntime() error {
 
 	p.runtime = runtime
 	// register double signing tracker as IBFT messages handler
-	p.msgHandlers = append(p.msgHandlers, runtime.doubleSigningTracker)
+	p.ibftMsgHandlers = append(p.ibftMsgHandlers, runtime.doubleSigningTracker)
 
 	return nil
 }

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -14,7 +14,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/slashing"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
@@ -55,7 +54,7 @@ func Factory(params *consensus.Params) (consensus.Consensus, error) {
 		closeCh:     make(chan struct{}),
 		logger:      logger,
 		txPool:      params.TxPool,
-		msgHandlers: []IBFTMessageHandler{slashing.NewDoubleSigningTracker()},
+		msgHandlers: []IBFTMessageHandler{},
 	}
 
 	// initialize polybft consensus config
@@ -552,6 +551,8 @@ func (p *Polybft) initRuntime() error {
 	}
 
 	p.runtime = runtime
+	// register double signing tracker as IBFT messages handler
+	p.msgHandlers = append(p.msgHandlers, runtime.doubleSigningTracker)
 
 	return nil
 }

--- a/consensus/polybft/proposer_calculator.go
+++ b/consensus/polybft/proposer_calculator.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/hashicorp/go-hclog"
+
+	polyCommon "github.com/0xPolygon/polygon-edge/consensus/polybft/common"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/hashicorp/go-hclog"
 )
 
 var (
@@ -197,7 +199,7 @@ func (pc *ProposerCalculator) GetSnapshot() (*ProposerSnapshot, bool) {
 
 // PostBlock is called on every insert of finalized block (either from consensus or syncer)
 // It will update priorities and save the updated snapshot to db
-func (pc *ProposerCalculator) PostBlock(req *PostBlockRequest) error {
+func (pc *ProposerCalculator) PostBlock(req *polyCommon.PostBlockRequest) error {
 	blockNumber := req.FullBlock.Block.Number()
 	pc.logger.Debug("Update proposers snapshot started", "target block", blockNumber)
 

--- a/consensus/polybft/slashing/double_signing_tracker.go
+++ b/consensus/polybft/slashing/double_signing_tracker.go
@@ -1,0 +1,130 @@
+package slashing
+
+import (
+	ibftProto "github.com/0xPolygon/go-ibft/messages/proto"
+
+	"github.com/0xPolygon/polygon-edge/types"
+)
+
+type SenderMessagesMap map[types.Address][]*ibftProto.CommitMessage
+
+type DoubleSignEvidence struct {
+	signer   types.Address
+	round    uint64
+	messages []*ibftProto.CommitMessage
+}
+
+func newDoubleSignEvidence(signer types.Address, round uint64,
+	messages []*ibftProto.CommitMessage) *DoubleSignEvidence {
+	return &DoubleSignEvidence{signer: signer, round: round, messages: messages}
+}
+
+type MessagesMap map[uint64]map[uint64]SenderMessagesMap
+
+// getSenderMsgs returns commit messages for given height, round and sender
+func (m MessagesMap) getSenderMsgs(view *ibftProto.View, sender types.Address) []*ibftProto.CommitMessage {
+	if roundMsgs, ok := m[view.Height]; ok {
+		if senderMsgsMap, ok := roundMsgs[view.Round]; ok {
+			return senderMsgsMap[sender]
+		}
+	}
+
+	return nil
+}
+
+// registerSenderMsgs registers messages for the given height, round and sender
+func (m MessagesMap) registerSenderMsgs(view *ibftProto.View, sender types.Address, msgs []*ibftProto.CommitMessage) {
+	var senderMsgs SenderMessagesMap
+
+	if roundMsgs, ok := m[view.Height]; !ok {
+		roundMsgs = make(map[uint64]SenderMessagesMap)
+		m[view.Height] = roundMsgs
+		senderMsgs = createSenderMsgsMap(view.Round, roundMsgs)
+	} else if senderMsgs, ok = roundMsgs[view.Round]; !ok {
+		senderMsgs = createSenderMsgsMap(view.Round, roundMsgs)
+	}
+
+	senderMsgs[sender] = msgs
+}
+
+// createSenderMsgsMap initializes senders message map for the given round
+func createSenderMsgsMap(round uint64, roundMsgs map[uint64]SenderMessagesMap) SenderMessagesMap {
+	sendersMsgs := make(SenderMessagesMap)
+	roundMsgs[round] = sendersMsgs
+
+	return sendersMsgs
+}
+
+type doubleSigningTracker struct {
+	commit MessagesMap
+}
+
+func NewDoubleSigningTracker() *doubleSigningTracker {
+	return &doubleSigningTracker{
+		commit: make(MessagesMap),
+	}
+}
+
+// Handle is implementation of IBFTMessageHandler interface, which handles IBFT consensus messages
+func (t *doubleSigningTracker) Handle(msg *ibftProto.Message) {
+	// track only commit messages
+	commitMsg := msg.GetCommitData()
+	if commitMsg == nil {
+		return
+	}
+
+	sender := types.BytesToAddress(msg.From)
+
+	senderMsgs := t.commit.getSenderMsgs(msg.View, sender)
+	if senderMsgs == nil {
+		senderMsgs = []*ibftProto.CommitMessage{commitMsg}
+	} else {
+		senderMsgs = append(senderMsgs, commitMsg)
+	}
+
+	t.commit.registerSenderMsgs(msg.View, sender, senderMsgs)
+}
+
+func (t *doubleSigningTracker) PruneByHeight(height uint64) {
+	// Delete all height maps up until the specified
+	for msgHeight := range t.commit {
+		if msgHeight < height {
+			delete(t.commit, height)
+		}
+	}
+}
+
+// GetEvidences returns double signing evidences for the given height
+func (t *doubleSigningTracker) GetEvidences(height uint64) []*DoubleSignEvidence {
+	roundMsgs, ok := t.commit[height]
+	if !ok {
+		return nil
+	}
+
+	var (
+		evidences = []*DoubleSignEvidence{}
+		evidence  *DoubleSignEvidence
+	)
+
+	for round, senderMsgs := range roundMsgs {
+		for address, msgs := range senderMsgs {
+			if len(msgs) <= 1 {
+				continue
+			}
+
+			firstProposalHash := types.BytesToHash(msgs[0].ProposalHash)
+			for _, msg := range msgs[1:] {
+				if firstProposalHash != types.BytesToHash(msg.ProposalHash) {
+					if evidence == nil {
+						evidence = newDoubleSignEvidence(address, round, []*ibftProto.CommitMessage{})
+						evidences = append(evidences, evidence)
+					}
+
+					evidence.messages = append(evidence.messages, msg)
+				}
+			}
+		}
+	}
+
+	return evidences
+}

--- a/consensus/polybft/slashing/double_signing_tracker.go
+++ b/consensus/polybft/slashing/double_signing_tracker.go
@@ -169,11 +169,11 @@ func (t *DoubleSigningTrackerImpl) GetEvidences(height uint64) []*DoubleSignEvid
 							evidences = append(evidences, evidence)
 						}
 
-						evidence.messages = append([]*ibftProto.Message{firstMsg}, evidence.messages...)
+						evidence.messages = append(evidence.messages, msg)
 					}
 				}
 
-				evidence.messages = append(evidence.messages, firstMsg)
+				evidence.messages = append([]*ibftProto.Message{firstMsg}, evidence.messages...)
 			}
 		}
 	}

--- a/consensus/polybft/slashing/double_signing_tracker.go
+++ b/consensus/polybft/slashing/double_signing_tracker.go
@@ -110,7 +110,7 @@ type DoubleSigningTrackerImpl struct {
 
 func NewDoubleSigningTracker(logger hclog.Logger,
 	validatorsProvider validator.ValidatorsProvider) (*DoubleSigningTrackerImpl, error) {
-	initialValidators, err := validatorsProvider.GetValidators()
+	initialValidators, err := validatorsProvider.GetAllValidators()
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +208,7 @@ func (t *DoubleSigningTrackerImpl) GetEvidences(height uint64) []*DoubleSignEvid
 
 // PostBlock is used to populate all known validators
 func (t *DoubleSigningTrackerImpl) PostBlock(_ *common.PostBlockRequest) error {
-	validators, err := t.validatorsProvider.GetValidators()
+	validators, err := t.validatorsProvider.GetAllValidators()
 	if err != nil {
 		return err
 	}

--- a/consensus/polybft/slashing/double_signing_tracker.go
+++ b/consensus/polybft/slashing/double_signing_tracker.go
@@ -37,7 +37,7 @@ type Messages struct {
 	mux     sync.RWMutex
 }
 
-// getSenderMsgsLocked returns commit messages for given height, round and sender
+// getSenderMsgsLocked returns messages for given height, round and sender
 func (m *Messages) getSenderMsgsLocked(view *ibftProto.View, sender types.Address) []*ibftProto.Message {
 	if roundMsgs, ok := m.content[view.Height]; ok {
 		if senderMsgsMap, ok := roundMsgs[view.Round]; ok {
@@ -172,6 +172,7 @@ func (t *DoubleSigningTrackerImpl) GetEvidences(height uint64) []*DoubleSignEvid
 						evidence.messages = append([]*ibftProto.Message{firstMsg}, evidence.messages...)
 					}
 				}
+
 				evidence.messages = append(evidence.messages, firstMsg)
 			}
 		}

--- a/consensus/polybft/slashing/double_signing_tracker.go
+++ b/consensus/polybft/slashing/double_signing_tracker.go
@@ -88,7 +88,7 @@ func NewDoubleSigningTracker(logger hclog.Logger) *DoubleSigningTrackerImpl {
 func (t *DoubleSigningTrackerImpl) Handle(msg *ibftProto.Message) {
 	signer, err := wallet.RecoverSignerFromIBFTMessage(msg)
 	if err != nil {
-		t.logger.Warn("failed to recover signer upon message receive",
+		t.logger.Debug("[ERROR] failed to recover signer upon message receive",
 			"message", msg)
 
 		return
@@ -97,7 +97,7 @@ func (t *DoubleSigningTrackerImpl) Handle(msg *ibftProto.Message) {
 	sender := types.BytesToAddress(msg.From)
 	// ignore messages where signer and sender are not the same
 	if signer != sender {
-		t.logger.Warn("signer and sender of IBFT message are not the same, ignoring it...",
+		t.logger.Debug("[ERROR] signer and sender of IBFT message are not the same, ignoring it...",
 			"message", msg)
 
 		return

--- a/consensus/polybft/slashing/double_signing_tracker.go
+++ b/consensus/polybft/slashing/double_signing_tracker.go
@@ -114,10 +114,8 @@ func (t *DoubleSigningTrackerImpl) Handle(msg *ibftProto.Message) {
 		return
 	}
 
-	sender := types.BytesToAddress(msg.From)
-
 	msgMap := t.resolveMessagesStorage(msg.GetType())
-	msgMap.addMessage(msg.View, sender, msg)
+	msgMap.addMessage(msg.View, types.BytesToAddress(msg.From), msg)
 }
 
 // PruneMsgsUntil deletes all messages maps until the specified height

--- a/consensus/polybft/slashing/double_signing_tracker_test.go
+++ b/consensus/polybft/slashing/double_signing_tracker_test.go
@@ -1,0 +1,262 @@
+package slashing
+
+import (
+	"testing"
+
+	ibftProto "github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
+	"github.com/0xPolygon/polygon-edge/types"
+)
+
+func TestDoubleSigningTracker_Handle(t *testing.T) {
+	t.Parallel()
+
+	acc, err := wallet.GenerateAccount()
+	require.NoError(t, err)
+
+	key := wallet.NewKey(acc)
+
+	proposalHash := types.StringToHash("Hello World.")
+	prePrepareView := &ibftProto.View{Height: 6, Round: 1}
+	view := &ibftProto.View{Height: 8, Round: 1}
+
+	prePrepareMsg := buildPrePrepareMessage(t, prePrepareView, key, proposalHash)
+	prepareMsg := buildPrepareMessage(t, view, key, proposalHash)
+
+	tracker := NewDoubleSigningTracker(hclog.NewNullLogger())
+	tracker.Handle(prePrepareMsg)
+	tracker.Handle(prepareMsg)
+
+	prePrepareMsgs := tracker.preprepare.getSenderMsgsLocked(prePrepareView, types.Address(key.Address()))
+	require.Len(t, prePrepareMsgs, 1)
+	require.Equal(t, prePrepareMsg, prePrepareMsgs[0])
+	require.Empty(t, tracker.prepare.getSenderMsgsLocked(prePrepareView, types.Address(key.Address())))
+	require.Empty(t, tracker.commit.getSenderMsgsLocked(prePrepareView, types.Address(key.Address())))
+	require.Empty(t, tracker.roundChange.getSenderMsgsLocked(prePrepareView, types.Address(key.Address())))
+
+	prepareMsgs := tracker.prepare.getSenderMsgsLocked(view, types.Address(key.Address()))
+	require.Len(t, prepareMsgs, 1)
+	require.Equal(t, prepareMsg, prepareMsgs[0])
+	require.Empty(t, tracker.preprepare.getSenderMsgsLocked(view, types.Address(key.Address())))
+	require.Empty(t, tracker.commit.getSenderMsgsLocked(view, types.Address(key.Address())))
+	require.Empty(t, tracker.roundChange.getSenderMsgsLocked(view, types.Address(key.Address())))
+
+	view.Round++
+	prepareMsg = buildPrepareMessage(t, view, key, proposalHash)
+	commitMsg := buildCommitMessage(t, view, key, proposalHash)
+	roundChangeMsg := buildRoundChangeMessage(t, view, key)
+
+	tracker.Handle(prepareMsg)
+	tracker.Handle(prepareMsg)
+	tracker.Handle(commitMsg)
+	tracker.Handle(roundChangeMsg)
+
+	prepareMsgs = tracker.prepare.getSenderMsgsLocked(view, types.Address(key.Address()))
+	commitMsgs := tracker.commit.getSenderMsgsLocked(view, types.Address(key.Address()))
+	roundChangeMsgs := tracker.roundChange.getSenderMsgsLocked(view, types.Address(key.Address()))
+
+	require.Len(t, prepareMsgs, 2)
+	require.Equal(t, prepareMsg, prepareMsgs[0])
+	require.Equal(t, prepareMsg, prepareMsgs[1])
+	require.Len(t, commitMsgs, 1)
+	require.Equal(t, commitMsg, commitMsgs[0])
+	require.Len(t, roundChangeMsgs, 1)
+	require.Equal(t, roundChangeMsg, roundChangeMsgs[0])
+	require.Empty(t, tracker.preprepare.getSenderMsgsLocked(view, types.Address(key.Address())))
+}
+
+func TestDoubleSigningTracker_validateMessage(t *testing.T) {
+	t.Parallel()
+
+	acc, err := wallet.GenerateAccount()
+	require.NoError(t, err)
+
+	key := wallet.NewKey(acc)
+
+	cases := []struct {
+		name       string
+		msgBuilder func() *ibftProto.Message
+		errMsg     string
+	}{
+		{
+			name: "invalid message view undefined",
+			msgBuilder: func() *ibftProto.Message {
+				return &ibftProto.Message{}
+			},
+			errMsg: errViewUndefined.Error(),
+		},
+		{
+			name: "invalid message invalid message type",
+			msgBuilder: func() *ibftProto.Message {
+				return &ibftProto.Message{View: &ibftProto.View{Height: 1, Round: 4}, Type: 6}
+			},
+			errMsg: errInvalidMsgType.Error(),
+		},
+		{
+			name: "invalid message invalid signature",
+			msgBuilder: func() *ibftProto.Message {
+				return &ibftProto.Message{
+					View: &ibftProto.View{Height: 1, Round: 4},
+					Type: ibftProto.MessageType_COMMIT,
+				}
+			},
+			errMsg: "failed to recover address from signature",
+		},
+		{
+			name: "invalid message invalid signature",
+			msgBuilder: func() *ibftProto.Message {
+				msg := &ibftProto.Message{
+					View: &ibftProto.View{Height: 1, Round: 4},
+					Type: ibftProto.MessageType_COMMIT,
+					From: types.ZeroAddress.Bytes(),
+				}
+
+				msg, err := key.SignIBFTMessage(msg)
+				require.NoError(t, err)
+
+				return msg
+			},
+			errMsg: errSignerAndSenderMismatch.Error(),
+		},
+		{
+			name: "valid message",
+			msgBuilder: func() *ibftProto.Message {
+				proposalHash := types.StringToHash("Lorem Ipsum")
+				committedSeal, err := key.Sign(proposalHash.Bytes())
+				require.NoError(t, err)
+
+				msg := &ibftProto.Message{
+					View: &ibftProto.View{Height: 1, Round: 4},
+					Type: ibftProto.MessageType_COMMIT,
+					From: key.Address().Bytes(),
+					Payload: &ibftProto.Message_CommitData{
+						CommitData: &ibftProto.CommitMessage{
+							ProposalHash:  proposalHash.Bytes(),
+							CommittedSeal: committedSeal,
+						},
+					},
+				}
+
+				msg, err = key.SignIBFTMessage(msg)
+				require.NoError(t, err)
+
+				return msg
+			},
+			errMsg: "",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := NewDoubleSigningTracker(hclog.NewNullLogger())
+			msg := c.msgBuilder()
+
+			err := tracker.validateMsg(msg)
+			if c.errMsg != "" {
+				require.ErrorContains(t, err, c.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func buildPrePrepareMessage(t *testing.T, view *ibftProto.View,
+	key *wallet.Key, proposalHash types.Hash) *ibftProto.Message {
+	t.Helper()
+
+	prePrepareMsg := &ibftProto.Message{
+		View: view,
+		From: key.Address().Bytes(),
+		Type: ibftProto.MessageType_PREPREPARE,
+		Payload: &ibftProto.Message_PreprepareData{
+			PreprepareData: &ibftProto.PrePrepareMessage{
+				Proposal: &ibftProto.Proposal{
+					RawProposal: proposalHash.Bytes(),
+					Round:       1,
+				},
+				ProposalHash: proposalHash.Bytes(),
+				Certificate:  &ibftProto.RoundChangeCertificate{},
+			},
+		},
+	}
+
+	prePrepareMsg, err := key.SignIBFTMessage(prePrepareMsg)
+	require.NoError(t, err)
+
+	return prePrepareMsg
+}
+
+func buildPrepareMessage(t *testing.T, view *ibftProto.View,
+	key *wallet.Key, proposalHash types.Hash) *ibftProto.Message {
+	t.Helper()
+
+	prepareMsg := &ibftProto.Message{
+		View: view,
+		From: key.Address().Bytes(),
+		Type: ibftProto.MessageType_PREPARE,
+		Payload: &ibftProto.Message_PrepareData{
+			PrepareData: &ibftProto.PrepareMessage{
+				ProposalHash: proposalHash.Bytes(),
+			},
+		},
+	}
+
+	prepareMsg, err := key.SignIBFTMessage(prepareMsg)
+	require.NoError(t, err)
+
+	return prepareMsg
+}
+
+func buildCommitMessage(t *testing.T, view *ibftProto.View,
+	key *wallet.Key, proposalHash types.Hash) *ibftProto.Message {
+	t.Helper()
+
+	seal, err := key.Sign(proposalHash.Bytes())
+	require.NoError(t, err)
+
+	commitMsg := &ibftProto.Message{
+		View: view,
+		From: key.Address().Bytes(),
+		Type: ibftProto.MessageType_COMMIT,
+		Payload: &ibftProto.Message_CommitData{
+			CommitData: &ibftProto.CommitMessage{
+				ProposalHash:  proposalHash.Bytes(),
+				CommittedSeal: seal,
+			},
+		},
+	}
+
+	commitMsg, err = key.SignIBFTMessage(commitMsg)
+	require.NoError(t, err)
+
+	return commitMsg
+}
+
+func buildRoundChangeMessage(t *testing.T, view *ibftProto.View, key *wallet.Key) *ibftProto.Message {
+	t.Helper()
+
+	roundChangeMsg := &ibftProto.Message{
+		View: view,
+		From: key.Address().Bytes(),
+		Type: ibftProto.MessageType_ROUND_CHANGE,
+		Payload: &ibftProto.Message_RoundChangeData{
+			RoundChangeData: &ibftProto.RoundChangeMessage{
+				LastPreparedProposal:      &ibftProto.Proposal{},
+				LatestPreparedCertificate: &ibftProto.PreparedCertificate{},
+			},
+		},
+	}
+
+	roundChangeMsg, err := key.SignIBFTMessage(roundChangeMsg)
+	require.NoError(t, err)
+
+	return roundChangeMsg
+}

--- a/consensus/polybft/slashing/double_signing_tracker_test.go
+++ b/consensus/polybft/slashing/double_signing_tracker_test.go
@@ -396,7 +396,7 @@ func TestDoubleSigningTracker_PostBlock(t *testing.T) {
 
 	require.NoError(t, tracker.PostBlock(nil))
 
-	validators, err := provider.GetValidators()
+	validators, err := provider.GetAllValidators()
 	require.NoError(t, err)
 
 	require.Equal(t, tracker.validators, validators)

--- a/consensus/polybft/slashing/helpers_test.go
+++ b/consensus/polybft/slashing/helpers_test.go
@@ -1,0 +1,120 @@
+package slashing
+
+import (
+	"testing"
+
+	ibftProto "github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
+	"github.com/0xPolygon/polygon-edge/types"
+)
+
+func buildPrePrepareMessage(t *testing.T, view *ibftProto.View,
+	key *wallet.Key, proposalHash types.Hash) *ibftProto.Message {
+	t.Helper()
+
+	prePrepareMsg := &ibftProto.Message{
+		View: view,
+		From: key.Address().Bytes(),
+		Type: ibftProto.MessageType_PREPREPARE,
+		Payload: &ibftProto.Message_PreprepareData{
+			PreprepareData: &ibftProto.PrePrepareMessage{
+				Proposal: &ibftProto.Proposal{
+					RawProposal: proposalHash.Bytes(),
+					Round:       1,
+				},
+				ProposalHash: proposalHash.Bytes(),
+				Certificate:  &ibftProto.RoundChangeCertificate{},
+			},
+		},
+	}
+
+	prePrepareMsg, err := key.SignIBFTMessage(prePrepareMsg)
+	require.NoError(t, err)
+
+	return prePrepareMsg
+}
+
+func buildPrepareMessage(t *testing.T, view *ibftProto.View,
+	key *wallet.Key, proposalHash types.Hash) *ibftProto.Message {
+	t.Helper()
+
+	prepareMsg := &ibftProto.Message{
+		View: view,
+		From: key.Address().Bytes(),
+		Type: ibftProto.MessageType_PREPARE,
+		Payload: &ibftProto.Message_PrepareData{
+			PrepareData: &ibftProto.PrepareMessage{
+				ProposalHash: proposalHash.Bytes(),
+			},
+		},
+	}
+
+	prepareMsg, err := key.SignIBFTMessage(prepareMsg)
+	require.NoError(t, err)
+
+	return prepareMsg
+}
+
+func buildCommitMessage(t *testing.T, view *ibftProto.View,
+	key *wallet.Key, proposalHash types.Hash) *ibftProto.Message {
+	t.Helper()
+
+	seal, err := key.Sign(proposalHash.Bytes())
+	require.NoError(t, err)
+
+	commitMsg := &ibftProto.Message{
+		View: view,
+		From: key.Address().Bytes(),
+		Type: ibftProto.MessageType_COMMIT,
+		Payload: &ibftProto.Message_CommitData{
+			CommitData: &ibftProto.CommitMessage{
+				ProposalHash:  proposalHash.Bytes(),
+				CommittedSeal: seal,
+			},
+		},
+	}
+
+	commitMsg, err = key.SignIBFTMessage(commitMsg)
+	require.NoError(t, err)
+
+	return commitMsg
+}
+
+func buildRoundChangeMessage(t *testing.T, view *ibftProto.View, key *wallet.Key) *ibftProto.Message {
+	t.Helper()
+
+	roundChangeMsg := &ibftProto.Message{
+		View: view,
+		From: key.Address().Bytes(),
+		Type: ibftProto.MessageType_ROUND_CHANGE,
+		Payload: &ibftProto.Message_RoundChangeData{
+			RoundChangeData: &ibftProto.RoundChangeMessage{
+				LastPreparedProposal:      &ibftProto.Proposal{},
+				LatestPreparedCertificate: &ibftProto.PreparedCertificate{},
+			},
+		},
+	}
+
+	roundChangeMsg, err := key.SignIBFTMessage(roundChangeMsg)
+	require.NoError(t, err)
+
+	return roundChangeMsg
+}
+
+func assertSenderMessageMapsSize(t *testing.T, tracker *DoubleSigningTrackerImpl,
+	prePrepareCount, prepareCount, commitCount, roundChangeCount int,
+	view *ibftProto.View, sender types.Address) {
+	t.Helper()
+
+	prePrepareMsgs := tracker.preprepare.getSenderMsgsLocked(view, sender)
+	prepareMsgs := tracker.prepare.getSenderMsgsLocked(view, sender)
+	commitMsgs := tracker.commit.getSenderMsgsLocked(view, sender)
+	roundChangeMsgs := tracker.roundChange.getSenderMsgsLocked(view, sender)
+
+	require.Len(t, prePrepareMsgs, prePrepareCount)
+	require.Len(t, prepareMsgs, prepareCount)
+	require.Len(t, commitMsgs, commitCount)
+	require.Len(t, roundChangeMsgs, roundChangeCount)
+}

--- a/consensus/polybft/slashing/helpers_test.go
+++ b/consensus/polybft/slashing/helpers_test.go
@@ -136,7 +136,7 @@ type dummyValidatorsProvider struct {
 	accounts []*wallet.Account
 }
 
-func (d *dummyValidatorsProvider) GetValidators() (validator.AccountSet, error) {
+func (d *dummyValidatorsProvider) GetAllValidators() (validator.AccountSet, error) {
 	validators := make(validator.AccountSet, len(d.accounts))
 	for i, a := range d.accounts {
 		validators[i] = &validator.ValidatorMetadata{

--- a/consensus/polybft/slashing/helpers_test.go
+++ b/consensus/polybft/slashing/helpers_test.go
@@ -1,6 +1,7 @@
 package slashing
 
 import (
+	"crypto/rand"
 	"testing"
 
 	ibftProto "github.com/0xPolygon/go-ibft/messages/proto"
@@ -117,4 +118,14 @@ func assertSenderMessageMapsSize(t *testing.T, tracker *DoubleSigningTrackerImpl
 	require.Len(t, prepareMsgs, prepareCount)
 	require.Len(t, commitMsgs, commitCount)
 	require.Len(t, roundChangeMsgs, roundChangeCount)
+}
+
+func generateRandomProposalHash(t *testing.T) types.Hash {
+	t.Helper()
+
+	result := make([]byte, types.HashLength)
+	_, err := rand.Reader.Read(result)
+	require.NoError(t, err, "failed to generate random hash")
+
+	return types.BytesToHash(result)
 }

--- a/consensus/polybft/stake_manager.go
+++ b/consensus/polybft/stake_manager.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/common"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
@@ -28,8 +29,8 @@ var (
 // StakeManager interface provides functions for handling stake change of validators
 // and updating validator set based on changed stake
 type StakeManager interface {
-	PostBlock(req *PostBlockRequest) error
-	PostEpoch(req *PostEpochRequest) error
+	PostBlock(req *common.PostBlockRequest) error
+	PostEpoch(req *common.PostEpochRequest) error
 	UpdateValidatorSet(epoch uint64, currentValidatorSet validator.AccountSet) (*validator.ValidatorSetDelta, error)
 }
 
@@ -37,8 +38,8 @@ type StakeManager interface {
 // used only for unit testing
 type dummyStakeManager struct{}
 
-func (d *dummyStakeManager) PostBlock(req *PostBlockRequest) error { return nil }
-func (d *dummyStakeManager) PostEpoch(req *PostEpochRequest) error { return nil }
+func (d *dummyStakeManager) PostBlock(req *common.PostBlockRequest) error { return nil }
+func (d *dummyStakeManager) PostEpoch(req *common.PostEpochRequest) error { return nil }
 func (d *dummyStakeManager) UpdateValidatorSet(epoch uint64,
 	currentValidatorSet validator.AccountSet) (*validator.ValidatorSetDelta, error) {
 	return &validator.ValidatorSetDelta{}, nil
@@ -93,7 +94,7 @@ func newStakeManager(
 }
 
 // PostEpoch saves the initial validator set to db
-func (s *stakeManager) PostEpoch(req *PostEpochRequest) error {
+func (s *stakeManager) PostEpoch(req *common.PostEpochRequest) error {
 	if req.NewEpochID != 1 {
 		return nil
 	}
@@ -109,7 +110,7 @@ func (s *stakeManager) PostEpoch(req *PostEpochRequest) error {
 
 // PostBlock is called on every insert of finalized block (either from consensus or syncer)
 // It will read any transfer event that happened in block and update full validator set in db
-func (s *stakeManager) PostBlock(req *PostBlockRequest) error {
+func (s *stakeManager) PostBlock(req *common.PostBlockRequest) error {
 	fullValidatorSet, err := s.state.StakeStore.getFullValidatorSet()
 	if err != nil {
 		return err
@@ -354,7 +355,7 @@ func (sc *validatorStakeMap) removeStake(address types.Address, amount *big.Int)
 	stakeData.IsActive = stakeData.VotingPower.Cmp(bigZero) > 0
 }
 
-// getSorted returns validators (*ValidatorMetadata) in sorted order
+// getSorted returns validators ([]*ValidatorMetadata) in sorted order
 func (sc validatorStakeMap) getSorted(maxValidatorSetSize int) validator.AccountSet {
 	activeValidators := make(validator.AccountSet, 0, len(sc))
 

--- a/consensus/polybft/stake_manager_fuzz_test.go
+++ b/consensus/polybft/stake_manager_fuzz_test.go
@@ -8,11 +8,13 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/common"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/hashicorp/go-hclog"
-	"github.com/stretchr/testify/require"
 )
 
 type epochIDValidatorsF struct {
@@ -82,7 +84,7 @@ func FuzzTestStakeManagerPostEpoch(f *testing.F) {
 			t.Skip()
 		}
 
-		err := stakeManager.PostEpoch(&PostEpochRequest{
+		err := stakeManager.PostEpoch(&common.PostEpochRequest{
 			NewEpochID: data.EpochID,
 			ValidatorSet: validator.NewValidatorSet(
 				data.Validators,
@@ -177,7 +179,7 @@ func FuzzTestStakeManagerPostBlock(f *testing.F) {
 			},
 		}
 
-		req := &PostBlockRequest{
+		req := &common.PostBlockRequest{
 			FullBlock: &types.FullBlock{Block: &types.Block{Header: &types.Header{Number: data.BlockID}},
 				Receipts: []*types.Receipt{receipt},
 			},

--- a/consensus/polybft/stake_manager_test.go
+++ b/consensus/polybft/stake_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/common"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
@@ -29,7 +30,7 @@ func TestStakeManager_PostEpoch(t *testing.T) {
 	}
 
 	t.Run("Not first epoch", func(t *testing.T) {
-		require.NoError(t, stakeManager.PostEpoch(&PostEpochRequest{
+		require.NoError(t, stakeManager.PostEpoch(&common.PostEpochRequest{
 			NewEpochID:   2,
 			ValidatorSet: validator.NewValidatorSet(validators, stakeManager.logger),
 		}))
@@ -39,7 +40,7 @@ func TestStakeManager_PostEpoch(t *testing.T) {
 	})
 
 	t.Run("First epoch", func(t *testing.T) {
-		require.NoError(t, stakeManager.PostEpoch(&PostEpochRequest{
+		require.NoError(t, stakeManager.PostEpoch(&common.PostEpochRequest{
 			NewEpochID:   1,
 			ValidatorSet: validator.NewValidatorSet(validators, stakeManager.logger),
 		}))
@@ -101,7 +102,7 @@ func TestStakeManager_PostBlock(t *testing.T) {
 
 		receipt.SetStatus(types.ReceiptSuccess)
 
-		req := &PostBlockRequest{
+		req := &common.PostBlockRequest{
 			FullBlock: &types.FullBlock{Block: &types.Block{Header: &types.Header{Number: block}},
 				Receipts: []*types.Receipt{receipt},
 			},
@@ -157,7 +158,7 @@ func TestStakeManager_PostBlock(t *testing.T) {
 
 		receipt.SetStatus(types.ReceiptSuccess)
 
-		req := &PostBlockRequest{
+		req := &common.PostBlockRequest{
 			FullBlock: &types.FullBlock{Block: &types.Block{Header: &types.Header{Number: block}},
 				Receipts: []*types.Receipt{receipt},
 			},
@@ -223,7 +224,7 @@ func TestStakeManager_PostBlock(t *testing.T) {
 			receipts[i].SetStatus(types.ReceiptSuccess)
 		}
 
-		req := &PostBlockRequest{
+		req := &common.PostBlockRequest{
 			FullBlock: &types.FullBlock{Block: &types.Block{Header: &types.Header{Number: block}},
 				Receipts: receipts},
 			Epoch: epoch,
@@ -281,7 +282,7 @@ func TestStakeManager_PostBlock(t *testing.T) {
 		}
 		receipt.SetStatus(types.ReceiptSuccess)
 
-		req := &PostBlockRequest{
+		req := &common.PostBlockRequest{
 			FullBlock: &types.FullBlock{Block: &types.Block{Header: &types.Header{Number: block}},
 				Receipts: []*types.Receipt{receipt},
 			},

--- a/consensus/polybft/state_store_stake.go
+++ b/consensus/polybft/state_store_stake.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -55,4 +56,13 @@ func (s *StakeStore) getFullValidatorSet() (validatorSetState, error) {
 	})
 
 	return fullValidatorSet, err
+}
+
+func (s *StakeStore) GetValidators() (validator.AccountSet, error) {
+	fullValidatorSet, err := s.getFullValidatorSet()
+	if err != nil {
+		return nil, err
+	}
+
+	return fullValidatorSet.Validators.getSorted(len(fullValidatorSet.Validators)), nil
 }

--- a/consensus/polybft/state_store_stake.go
+++ b/consensus/polybft/state_store_stake.go
@@ -58,7 +58,8 @@ func (s *StakeStore) getFullValidatorSet() (validatorSetState, error) {
 	return fullValidatorSet, err
 }
 
-func (s *StakeStore) GetValidators() (validator.AccountSet, error) {
+// GetValidators returns all validators regardless if they are active or not
+func (s *StakeStore) GetAllValidators() (validator.AccountSet, error) {
 	fullValidatorSet, err := s.getFullValidatorSet()
 	if err != nil {
 		return nil, err

--- a/consensus/polybft/state_sync_manager.go
+++ b/consensus/polybft/state_sync_manager.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/common"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	polybftProto "github.com/0xPolygon/polygon-edge/consensus/polybft/proto"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
@@ -38,8 +39,8 @@ type StateSyncManager interface {
 	Close()
 	Commitment(blockNumber uint64) (*CommitmentMessageSigned, error)
 	GetStateSyncProof(stateSyncID uint64) (types.Proof, error)
-	PostBlock(req *PostBlockRequest) error
-	PostEpoch(req *PostEpochRequest) error
+	PostBlock(req *common.PostBlockRequest) error
+	PostEpoch(req *common.PostEpochRequest) error
 }
 
 var _ StateSyncManager = (*dummyStateSyncManager)(nil)
@@ -52,8 +53,8 @@ func (n *dummyStateSyncManager) Close()      {}
 func (n *dummyStateSyncManager) Commitment(blockNumber uint64) (*CommitmentMessageSigned, error) {
 	return nil, nil
 }
-func (n *dummyStateSyncManager) PostBlock(req *PostBlockRequest) error { return nil }
-func (n *dummyStateSyncManager) PostEpoch(req *PostEpochRequest) error { return nil }
+func (n *dummyStateSyncManager) PostBlock(req *common.PostBlockRequest) error { return nil }
+func (n *dummyStateSyncManager) PostEpoch(req *common.PostEpochRequest) error { return nil }
 func (n *dummyStateSyncManager) GetStateSyncProof(stateSyncID uint64) (types.Proof, error) {
 	return types.Proof{}, nil
 }
@@ -373,7 +374,7 @@ func (s *stateSyncManager) getAggSignatureForCommitmentMessage(blockNumber uint6
 
 // PostEpoch notifies the state sync manager that an epoch has changed,
 // so that it can discard any previous epoch commitments, and build a new one (since validator set changed)
-func (s *stateSyncManager) PostEpoch(req *PostEpochRequest) error {
+func (s *stateSyncManager) PostEpoch(req *common.PostEpochRequest) error {
 	s.lock.Lock()
 
 	s.pendingCommitments = nil
@@ -397,7 +398,7 @@ func (s *stateSyncManager) PostEpoch(req *PostEpochRequest) error {
 
 // PostBlock notifies state sync manager that a block was finalized,
 // so that it can build state sync proofs if a block has a commitment submission transaction
-func (s *stateSyncManager) PostBlock(req *PostBlockRequest) error {
+func (s *stateSyncManager) PostBlock(req *common.PostBlockRequest) error {
 	commitment, err := getCommitmentMessageSignedTx(req.FullBlock.Block.Transactions)
 	if err != nil {
 		return err

--- a/consensus/polybft/state_sync_manager_test.go
+++ b/consensus/polybft/state_sync_manager_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/umbracle/ethgo/testutil"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/common"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
@@ -306,7 +307,7 @@ func TestStateSyncerManager_BuildProofs(t *testing.T) {
 
 	tx := createStateTransactionWithData(1, types.Address{}, txData)
 
-	req := &PostBlockRequest{
+	req := &common.PostBlockRequest{
 		FullBlock: &types.FullBlock{
 			Block: &types.Block{
 				Transactions: []*types.Transaction{tx},

--- a/consensus/polybft/system_state.go
+++ b/consensus/polybft/system_state.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/common"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/umbracle/ethgo"
@@ -20,15 +21,7 @@ type ValidatorInfo struct {
 	IsWhitelisted       bool          `json:"isWhitelisted"`
 }
 
-// SystemState is an interface to interact with the consensus system contracts in the chain
-type SystemState interface {
-	// GetEpoch retrieves current epoch number from the smart contract
-	GetEpoch() (uint64, error)
-	// GetNextCommittedIndex retrieves next committed bridge state sync index
-	GetNextCommittedIndex() (uint64, error)
-}
-
-var _ SystemState = &SystemStateImpl{}
+var _ common.SystemState = &SystemStateImpl{}
 
 // SystemStateImpl is implementation of SystemState interface
 type SystemStateImpl struct {

--- a/consensus/polybft/transport.go
+++ b/consensus/polybft/transport.go
@@ -28,7 +28,7 @@ func (p *Polybft) subscribeToIbftTopic() error {
 			return
 		}
 
-		for _, handler := range p.msgHandlers {
+		for _, handler := range p.ibftMsgHandlers {
 			handler.Handle(msg)
 		}
 

--- a/consensus/polybft/transport.go
+++ b/consensus/polybft/transport.go
@@ -29,7 +29,16 @@ func (p *Polybft) subscribeToIbftTopic() error {
 		}
 
 		for _, handler := range p.ibftMsgHandlers {
-			handler.Handle(msg)
+			handler := handler
+
+			go func() {
+				select {
+				case <-p.closeCh:
+					return
+				default:
+					handler.Handle(msg)
+				}
+			}()
 		}
 
 		p.logger.Debug(

--- a/consensus/polybft/validator/validator_metadata.go
+++ b/consensus/polybft/validator/validator_metadata.go
@@ -19,6 +19,11 @@ import (
 	"github.com/umbracle/fastrlp"
 )
 
+type ValidatorsProvider interface {
+	// GetValidators returns AccountSet ([]*ValidatorMetadata)
+	GetValidators() (AccountSet, error)
+}
+
 var accountSetABIType = abi.MustNewType(`tuple(tuple(address _address, uint256[4] blsKey, uint256 votingPower)[])`)
 
 // ValidatorMetadata represents a validator metadata (its public identity)

--- a/consensus/polybft/validator/validator_metadata.go
+++ b/consensus/polybft/validator/validator_metadata.go
@@ -20,8 +20,8 @@ import (
 )
 
 type ValidatorsProvider interface {
-	// GetValidators returns AccountSet ([]*ValidatorMetadata)
-	GetValidators() (AccountSet, error)
+	// GetAllValidators returns all validators ([]*ValidatorMetadata) regardless if they are active or not
+	GetAllValidators() (AccountSet, error)
 }
 
 var accountSetABIType = abi.MustNewType(`tuple(tuple(address _address, uint256[4] blsKey, uint256 votingPower)[])`)

--- a/consensus/polybft/wallet/key.go
+++ b/consensus/polybft/wallet/key.go
@@ -3,12 +3,13 @@ package wallet
 import (
 	"fmt"
 
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	ibftProto "github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/umbracle/ethgo"
+	protobuf "google.golang.org/protobuf/proto"
+
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/umbracle/ethgo"
-	protobuf "google.golang.org/protobuf/proto"
 )
 
 type Key struct {
@@ -48,7 +49,7 @@ func (k *Key) SignWithDomain(digest, domain []byte) ([]byte, error) {
 }
 
 // SignIBFTMessage signs the IBFT consensus message with ECDSA key
-func (k *Key) SignIBFTMessage(msg *proto.Message) (*proto.Message, error) {
+func (k *Key) SignIBFTMessage(msg *ibftProto.Message) (*ibftProto.Message, error) {
 	msgRaw, err := protobuf.Marshal(msg)
 	if err != nil {
 		return nil, fmt.Errorf("cannot marshal message: %w", err)
@@ -59,6 +60,22 @@ func (k *Key) SignIBFTMessage(msg *proto.Message) (*proto.Message, error) {
 	}
 
 	return msg, nil
+}
+
+// RecoverSignerFromIBFTMessage recovers signer address from provided IBFT message based
+// on signed message and its signature
+func RecoverSignerFromIBFTMessage(msg *ibftProto.Message) (types.Address, error) {
+	msgNoSig, err := msg.PayloadNoSig()
+	if err != nil {
+		return types.ZeroAddress, err
+	}
+
+	signerAddress, err := RecoverAddressFromSignature(msg.Signature, msgNoSig)
+	if err != nil {
+		return types.ZeroAddress, fmt.Errorf("failed to recover address from signature: %w", err)
+	}
+
+	return signerAddress, nil
 }
 
 // RecoverAddressFromSignature calculates keccak256 hash of provided rawContent


### PR DESCRIPTION
# Description

This PR implements a slashing double signing tracker. It contains an in-memory mapping of relayed IBFT messages for specific heights, rounds, and senders. Based on tracked messages it is able to build evidences for specific heights.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
