### PR TITLE
Move `Encode*` and `Parse*` functions from `types` to `common` package

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -132,13 +132,13 @@ func (g *Genesis) MarshalJSON() ([]byte, error) {
 	var enc Genesis
 	enc.Nonce = hex.EncodeToHex(g.Nonce[:])
 
-	enc.Timestamp = types.EncodeUint64(g.Timestamp)
-	enc.ExtraData = types.EncodeBytes(g.ExtraData)
+	enc.Timestamp = common.EncodeUint64(g.Timestamp)
+	enc.ExtraData = common.EncodeBytes(g.ExtraData)
 
-	enc.GasLimit = types.EncodeUint64(g.GasLimit)
-	enc.Difficulty = types.EncodeUint64(g.Difficulty)
-	enc.BaseFee = types.EncodeUint64(g.BaseFee)
-	enc.BaseFeeEM = types.EncodeUint64(g.BaseFeeEM)
+	enc.GasLimit = common.EncodeUint64(g.GasLimit)
+	enc.Difficulty = common.EncodeUint64(g.Difficulty)
+	enc.BaseFee = common.EncodeUint64(g.BaseFee)
+	enc.BaseFeeEM = common.EncodeUint64(g.BaseFeeEM)
 
 	enc.Mixhash = g.Mixhash
 	enc.Coinbase = g.Coinbase
@@ -152,8 +152,8 @@ func (g *Genesis) MarshalJSON() ([]byte, error) {
 		enc.Alloc = &alloc
 	}
 
-	enc.Number = types.EncodeUint64(g.Number)
-	enc.GasUsed = types.EncodeUint64(g.GasUsed)
+	enc.Number = common.EncodeUint64(g.Number)
+	enc.GasUsed = common.EncodeUint64(g.GasUsed)
 	enc.ParentHash = g.ParentHash
 
 	return json.Marshal(&enc)
@@ -201,7 +201,7 @@ func (g *Genesis) UnmarshalJSON(data []byte) error {
 	}
 
 	if dec.ExtraData != nil {
-		g.ExtraData, subErr = types.ParseBytes(dec.ExtraData)
+		g.ExtraData, subErr = common.ParseBytes(dec.ExtraData)
 		if subErr != nil {
 			parseError("extradata", subErr)
 		}
@@ -288,7 +288,7 @@ func (g *GenesisAccount) MarshalJSON() ([]byte, error) {
 	obj := &genesisAccountEncoder{}
 
 	if g.Code != nil {
-		obj.Code = types.EncodeBytes(g.Code)
+		obj.Code = common.EncodeBytes(g.Code)
 	}
 
 	if len(g.Storage) != 0 {
@@ -296,15 +296,15 @@ func (g *GenesisAccount) MarshalJSON() ([]byte, error) {
 	}
 
 	if g.Balance != nil {
-		obj.Balance = types.EncodeBigInt(g.Balance)
+		obj.Balance = common.EncodeBigInt(g.Balance)
 	}
 
 	if g.Nonce != 0 {
-		obj.Nonce = types.EncodeUint64(g.Nonce)
+		obj.Nonce = common.EncodeUint64(g.Nonce)
 	}
 
 	if g.PrivateKey != nil {
-		obj.PrivateKey = types.EncodeBytes(g.PrivateKey)
+		obj.PrivateKey = common.EncodeBytes(g.PrivateKey)
 	}
 
 	return json.Marshal(obj)
@@ -335,7 +335,7 @@ func (g *GenesisAccount) UnmarshalJSON(data []byte) error {
 	}
 
 	if dec.Code != nil {
-		g.Code, subErr = types.ParseBytes(dec.Code)
+		g.Code, subErr = common.ParseBytes(dec.Code)
 		if subErr != nil {
 			parseError("code", subErr)
 		}
@@ -345,7 +345,7 @@ func (g *GenesisAccount) UnmarshalJSON(data []byte) error {
 		g.Storage = dec.Storage
 	}
 
-	g.Balance, subErr = types.ParseUint256orHex(dec.Balance)
+	g.Balance, subErr = common.ParseUint256orHex(dec.Balance)
 	if subErr != nil {
 		parseError("balance", subErr)
 	}
@@ -357,7 +357,7 @@ func (g *GenesisAccount) UnmarshalJSON(data []byte) error {
 	}
 
 	if dec.PrivateKey != nil {
-		g.PrivateKey, subErr = types.ParseBytes(dec.PrivateKey)
+		g.PrivateKey, subErr = common.ParseBytes(dec.PrivateKey)
 		if subErr != nil {
 			parseError("privatekey", subErr)
 		}

--- a/command/backup/params.go
+++ b/command/backup/params.go
@@ -6,7 +6,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/archive"
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/helper"
-	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/hashicorp/go-hclog"
 )
 
@@ -41,14 +41,14 @@ type backupParams struct {
 func (p *backupParams) validateFlags() error {
 	var parseErr error
 
-	if p.from, parseErr = types.ParseUint64orHex(&p.fromRaw); parseErr != nil {
+	if p.from, parseErr = common.ParseUint64orHex(&p.fromRaw); parseErr != nil {
 		return errDecodeRange
 	}
 
 	if p.toRaw != "" {
 		var parsedTo uint64
 
-		if parsedTo, parseErr = types.ParseUint64orHex(&p.toRaw); parseErr != nil {
+		if parsedTo, parseErr = common.ParseUint64orHex(&p.toRaw); parseErr != nil {
 			return errDecodeRange
 		}
 

--- a/command/bridge/deposit/erc1155/deposit_erc1155.go
+++ b/command/bridge/deposit/erc1155/deposit_erc1155.go
@@ -12,6 +12,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/bridge/common"
 	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	helperCommon "github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 )
@@ -110,7 +111,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		amountRaw := dp.Amounts[i]
 		tokenIDRaw := dp.TokenIDs[i]
 
-		amount, err := types.ParseUint256orHex(&amountRaw)
+		amount, err := helperCommon.ParseUint256orHex(&amountRaw)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("failed to decode provided amount %s: %w", amountRaw, err))
 
@@ -119,7 +120,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 		amounts[i] = amount
 
-		tokenID, err := types.ParseUint256orHex(&tokenIDRaw)
+		tokenID, err := helperCommon.ParseUint256orHex(&tokenIDRaw)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("failed to decode provided token id %s: %w", tokenIDRaw, err))
 

--- a/command/bridge/deposit/erc20/deposit_erc20.go
+++ b/command/bridge/deposit/erc20/deposit_erc20.go
@@ -12,6 +12,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/bridge/common"
 	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	helperCommon "github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 )
@@ -101,7 +102,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	for i, amountRaw := range dp.Amounts {
 		amountRaw := amountRaw
 
-		amount, err := types.ParseUint256orHex(&amountRaw)
+		amount, err := helperCommon.ParseUint256orHex(&amountRaw)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("failed to decode provided amount %s: %w", amountRaw, err))
 

--- a/command/bridge/deposit/erc721/deposit_erc721.go
+++ b/command/bridge/deposit/erc721/deposit_erc721.go
@@ -9,6 +9,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/bridge/common"
 	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	helperCommon "github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/spf13/cobra"
@@ -98,7 +99,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	for i, tokenIDRaw := range dp.TokenIDs {
 		tokenIDRaw := tokenIDRaw
 
-		tokenID, err := types.ParseUint256orHex(&tokenIDRaw)
+		tokenID, err := helperCommon.ParseUint256orHex(&tokenIDRaw)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("failed to decode provided token id %s: %w", tokenIDRaw, err))
 

--- a/command/bridge/withdraw/erc1155/withdraw_erc1155.go
+++ b/command/bridge/withdraw/erc1155/withdraw_erc1155.go
@@ -14,6 +14,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/bridge/common"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	helperCommon "github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 )
@@ -106,14 +107,14 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		amountRaw := wp.Amounts[i]
 		tokenIDRaw := wp.TokenIDs[i]
 
-		amount, err := types.ParseUint256orHex(&amountRaw)
+		amount, err := helperCommon.ParseUint256orHex(&amountRaw)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("failed to decode provided amount %s: %w", amountRaw, err))
 
 			return
 		}
 
-		tokenID, err := types.ParseUint256orHex(&tokenIDRaw)
+		tokenID, err := helperCommon.ParseUint256orHex(&tokenIDRaw)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("failed to decode provided token id %s: %w", amountRaw, err))
 

--- a/command/bridge/withdraw/erc20/withdraw_erc20.go
+++ b/command/bridge/withdraw/erc20/withdraw_erc20.go
@@ -13,6 +13,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/bridge/common"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	helperCommon "github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 )
@@ -95,7 +96,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		receiver := wp.Receivers[i]
 		amount := wp.Amounts[i]
 
-		amountBig, err := types.ParseUint256orHex(&amount)
+		amountBig, err := helperCommon.ParseUint256orHex(&amount)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("failed to decode provided amount %s: %w", amount, err))
 

--- a/command/bridge/withdraw/erc721/withdraw_erc721.go
+++ b/command/bridge/withdraw/erc721/withdraw_erc721.go
@@ -10,6 +10,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/bridge/common"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	helperCommon "github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/spf13/cobra"
@@ -94,7 +95,7 @@ func run(cmd *cobra.Command, _ []string) {
 	for i, tokenIDRaw := range wp.TokenIDs {
 		tokenIDRaw := tokenIDRaw
 
-		tokenID, err := types.ParseUint256orHex(&tokenIDRaw)
+		tokenID, err := helperCommon.ParseUint256orHex(&tokenIDRaw)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("failed to decode provided token id %s: %w", tokenIDRaw, err))
 

--- a/command/genesis/utils.go
+++ b/command/genesis/utils.go
@@ -16,6 +16,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/secrets"
 	"github.com/0xPolygon/polygon-edge/secrets/helper"
 	"github.com/0xPolygon/polygon-edge/secrets/local"
@@ -132,7 +133,7 @@ func parseBurnContractInfo(burnContractInfoRaw string) (*polybft.BurnContractInf
 
 	blockRaw := burnContractParts[0]
 
-	blockNum, err := types.ParseUint64orHex(&blockRaw)
+	blockNum, err := common.ParseUint64orHex(&blockRaw)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse block number %s: %w", blockRaw, err)
 	}

--- a/command/genesis/utils.go
+++ b/command/genesis/utils.go
@@ -82,7 +82,7 @@ func parsePremineInfo(premineInfoRaw string) (*premineInfo, error) {
 		// <addr>:<balance>
 		valueRaw := premineInfoRaw[delimiterIdx+1:]
 
-		amount, err = types.ParseUint256orHex(&valueRaw)
+		amount, err = common.ParseUint256orHex(&valueRaw)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse amount %s: %w", valueRaw, err)
 		}

--- a/command/ibft/switch/params.go
+++ b/command/ibft/switch/params.go
@@ -10,7 +10,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/consensus/ibft/fork"
 	"github.com/0xPolygon/polygon-edge/helper/common"
-	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/0xPolygon/polygon-edge/validators"
 )
 
@@ -136,7 +135,7 @@ func (p *switchParams) initDeployment() error {
 			)
 		}
 
-		d, err := types.ParseUint64orHex(&p.deploymentRaw)
+		d, err := common.ParseUint64orHex(&p.deploymentRaw)
 		if err != nil {
 			return fmt.Errorf(
 				"unable to parse deployment value, %w",
@@ -224,7 +223,7 @@ func (p *switchParams) initPoSConfig() error {
 	}
 
 	if p.minValidatorCountRaw != "" {
-		value, err := types.ParseUint64orHex(&p.minValidatorCountRaw)
+		value, err := common.ParseUint64orHex(&p.minValidatorCountRaw)
 		if err != nil {
 			return fmt.Errorf(
 				"unable to parse min validator count value, %w",
@@ -236,7 +235,7 @@ func (p *switchParams) initPoSConfig() error {
 	}
 
 	if p.maxValidatorCountRaw != "" {
-		value, err := types.ParseUint64orHex(&p.maxValidatorCountRaw)
+		value, err := common.ParseUint64orHex(&p.maxValidatorCountRaw)
 		if err != nil {
 			return fmt.Errorf(
 				"unable to parse max validator count value, %w",
@@ -273,7 +272,7 @@ func (p *switchParams) validateMinMaxValidatorNumber() error {
 }
 
 func (p *switchParams) initFrom() error {
-	from, err := types.ParseUint64orHex(&p.fromRaw)
+	from, err := common.ParseUint64orHex(&p.fromRaw)
 	if err != nil {
 		return fmt.Errorf("unable to parse from value, %w", err)
 	}

--- a/command/rootchain/helper/metadata.go
+++ b/command/rootchain/helper/metadata.go
@@ -12,6 +12,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	polybftWallet "github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -203,7 +204,7 @@ func GetValidatorInfo(validatorAddr ethgo.Address, supernetManagerAddr, stakeMan
 		return nil, err
 	}
 
-	stake, err := types.ParseUint256orHex(&response)
+	stake, err := common.ParseUint256orHex(&response)
 	if err != nil {
 		return nil, err
 	}

--- a/command/rootchain/supernet/supernet.go
+++ b/command/rootchain/supernet/supernet.go
@@ -14,6 +14,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/spf13/cobra"
@@ -252,7 +253,7 @@ func getFinalizedStake(owner, validator, stakeManager types.Address, chainID int
 		return nil, err
 	}
 
-	return types.ParseUint256orHex(&response)
+	return common.ParseUint256orHex(&response)
 }
 
 // validatorSetToABISlice converts given validators to generic map

--- a/command/server/init.go
+++ b/command/server/init.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/command/server/config"
 
+	helperCommon "github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/network/common"
 
 	"github.com/0xPolygon/polygon-edge/chain"
@@ -15,7 +16,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/network"
 	"github.com/0xPolygon/polygon-edge/secrets"
 	"github.com/0xPolygon/polygon-edge/server"
-	"github.com/0xPolygon/polygon-edge/types"
 )
 
 var (
@@ -78,7 +78,7 @@ func (p *serverParams) initLogFileLocation() {
 func (p *serverParams) initBlockGasTarget() error {
 	var parseErr error
 
-	if p.blockGasTarget, parseErr = types.ParseUint64orHex(
+	if p.blockGasTarget, parseErr = helperCommon.ParseUint64orHex(
 		&p.rawConfig.BlockGasTarget,
 	); parseErr != nil {
 		return parseErr

--- a/command/sidechain/helper.go
+++ b/command/sidechain/helper.go
@@ -11,6 +11,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/umbracle/ethgo"
@@ -78,7 +79,7 @@ func GetValidatorInfo(validatorAddr ethgo.Address, supernetManager, stakeManager
 		return nil, err
 	}
 
-	withdrawableRewards, err := types.ParseUint256orHex(&response)
+	withdrawableRewards, err := common.ParseUint256orHex(&response)
 	if err != nil {
 		return nil, err
 	}

--- a/command/sidechain/rewards/rewards.go
+++ b/command/sidechain/rewards/rewards.go
@@ -10,6 +10,7 @@ import (
 	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/spf13/cobra"
@@ -84,7 +85,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	amount, err := types.ParseUint256orHex(&response)
+	amount, err := common.ParseUint256orHex(&response)
 	if err != nil {
 		return err
 	}

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -189,7 +189,7 @@ func (r *RewardsConfig) MarshalJSON() ([]byte, error) {
 	raw := &rewardsConfigRaw{
 		TokenAddress:  r.TokenAddress,
 		WalletAddress: r.WalletAddress,
-		WalletAmount:  types.EncodeBigInt(r.WalletAmount),
+		WalletAmount:  common.EncodeBigInt(r.WalletAmount),
 	}
 
 	return json.Marshal(raw)
@@ -208,7 +208,7 @@ func (r *RewardsConfig) UnmarshalJSON(data []byte) error {
 	r.TokenAddress = raw.TokenAddress
 	r.WalletAddress = raw.WalletAddress
 
-	r.WalletAmount, err = types.ParseUint256orHex(raw.WalletAmount)
+	r.WalletAmount, err = common.ParseUint256orHex(raw.WalletAmount)
 	if err != nil {
 		return err
 	}

--- a/consensus/polybft/validator/genesis_validator.go
+++ b/consensus/polybft/validator/genesis_validator.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
@@ -27,7 +28,7 @@ type genesisValidatorRaw struct {
 
 func (v *GenesisValidator) MarshalJSON() ([]byte, error) {
 	raw := &genesisValidatorRaw{Address: v.Address, BlsKey: v.BlsKey, MultiAddr: v.MultiAddr}
-	raw.Stake = types.EncodeBigInt(v.Stake)
+	raw.Stake = common.EncodeBigInt(v.Stake)
 
 	return json.Marshal(raw)
 }
@@ -43,7 +44,7 @@ func (v *GenesisValidator) UnmarshalJSON(data []byte) (err error) {
 	v.BlsKey = raw.BlsKey
 	v.MultiAddr = raw.MultiAddr
 
-	v.Stake, err = types.ParseUint256orHex(raw.Stake)
+	v.Stake, err = common.ParseUint256orHex(raw.Stake)
 
 	return err
 }

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -693,7 +693,7 @@ func TestE2E_Bridge_ERC1155Transfer(t *testing.T) {
 		balanceRaw, err := txRelayer.Call(ethgo.ZeroAddress, ethgo.Address(l2ChildTokenAddr), balanceInput)
 		require.NoError(t, err)
 
-		balance, err := types.ParseUint256orHex(&balanceRaw)
+		balance, err := helperCommon.ParseUint256orHex(&balanceRaw)
 		require.NoError(t, err)
 		require.Equal(t, big.NewInt(int64(amount)), balance)
 	}
@@ -755,7 +755,7 @@ func TestE2E_Bridge_ERC1155Transfer(t *testing.T) {
 		balanceRaw, err := rootchainTxRelayer.Call(ethgo.ZeroAddress, rootERC1155Addr, balanceInput)
 		require.NoError(t, err)
 
-		balance, err := types.ParseUint256orHex(&balanceRaw)
+		balance, err := helperCommon.ParseUint256orHex(&balanceRaw)
 		require.NoError(t, err)
 		require.Equal(t, big.NewInt(amount), balance)
 	}

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/e2e-polybft/framework"
+	helperCommon "github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/state/runtime/addresslist"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -218,7 +219,7 @@ func TestE2E_Bridge_Transfers(t *testing.T) {
 		commitmentIDRaw, err := txRelayer.Call(ethgo.ZeroAddress, ethgo.Address(contracts.StateReceiverContract), lastCommittedIDInput)
 		require.NoError(t, err)
 
-		initialCommittedID, err := types.ParseUint64orHex(&commitmentIDRaw)
+		initialCommittedID, err := helperCommon.ParseUint64orHex(&commitmentIDRaw)
 		require.NoError(t, err)
 
 		initialBlockNum, err := childEthEndpoint.BlockNumber()
@@ -252,7 +253,7 @@ func TestE2E_Bridge_Transfers(t *testing.T) {
 			ethgo.Address(contracts.StateReceiverContract), lastCommittedIDInput)
 		require.NoError(t, err)
 
-		lastCommittedID, err := types.ParseUint64orHex(&commitmentIDRaw)
+		lastCommittedID, err := helperCommon.ParseUint64orHex(&commitmentIDRaw)
 		require.NoError(t, err)
 		require.Equal(t, initialCommittedID+depositsSubset, lastCommittedID)
 
@@ -279,7 +280,7 @@ func TestE2E_Bridge_Transfers(t *testing.T) {
 		require.NoError(t, err)
 
 		// check that the second (larger commitment) was also submitted in epoch
-		lastCommittedID, err = types.ParseUint64orHex(&commitmentIDRaw)
+		lastCommittedID, err = helperCommon.ParseUint64orHex(&commitmentIDRaw)
 		require.NoError(t, err)
 		require.Equal(t, initialCommittedID+uint64(transfersCount), lastCommittedID)
 

--- a/e2e-polybft/e2e/helpers_test.go
+++ b/e2e-polybft/e2e/helpers_test.go
@@ -274,7 +274,7 @@ func erc20BalanceOf(t *testing.T, account types.Address, tokenAddr types.Address
 
 	balanceRaw, err := relayer.Call(ethgo.ZeroAddress, ethgo.Address(tokenAddr), balanceOfInput)
 	require.NoError(t, err)
-	balance, err := types.ParseUint256orHex(&balanceRaw)
+	balance, err := common.ParseUint256orHex(&balanceRaw)
 	require.NoError(t, err)
 
 	return balance

--- a/e2e-polybft/e2e/helpers_test.go
+++ b/e2e-polybft/e2e/helpers_test.go
@@ -169,7 +169,7 @@ func getCheckpointBlockNumber(l1Relayer txrelayer.TxRelayer, checkpointManagerAd
 		return 0, err
 	}
 
-	actualCheckpointBlock, err := types.ParseUint64orHex(&checkpointBlockNumRaw)
+	actualCheckpointBlock, err := common.ParseUint64orHex(&checkpointBlockNumRaw)
 	if err != nil {
 		return 0, err
 	}

--- a/e2e-polybft/e2e/migration_test.go
+++ b/e2e-polybft/e2e/migration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	frameworkpolybft "github.com/0xPolygon/polygon-edge/e2e-polybft/framework"
 	"github.com/0xPolygon/polygon-edge/e2e/framework"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -170,7 +171,7 @@ func TestE2E_Migration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	require.Equal(t, deployedCode, *types.EncodeBytes(contractsapi.TestWriteBlockMetadata.DeployedBytecode))
+	require.Equal(t, deployedCode, *common.EncodeBytes(contractsapi.TestWriteBlockMetadata.DeployedBytecode))
 	require.NoError(t, cluster.WaitForBlock(10, 1*time.Minute))
 
 	//stop last node of validator and non-validator

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -16,6 +16,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/contracts/abis"
 	"github.com/0xPolygon/polygon-edge/contracts/staking"
 	"github.com/0xPolygon/polygon-edge/crypto"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/helper/tests"
 	"github.com/0xPolygon/polygon-edge/server/proto"
@@ -194,7 +195,7 @@ func GetStakedAmount(from types.Address, rpcClient *jsonrpc.Client) (*big.Int, e
 		return nil, fmt.Errorf("unable to call Staking contract method stakedAmount, %w", err)
 	}
 
-	bigResponse, decodeErr := types.ParseUint256orHex(&response)
+	bigResponse, decodeErr := common.ParseUint256orHex(&response)
 	if decodeErr != nil {
 		return nil, fmt.Errorf("unable to decode hex response")
 	}

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -40,6 +40,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/ibft/fork"
 	ibftOp "github.com/0xPolygon/polygon-edge/consensus/ibft/proto"
 	"github.com/0xPolygon/polygon-edge/crypto"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	stakingHelper "github.com/0xPolygon/polygon-edge/helper/staking"
 	"github.com/0xPolygon/polygon-edge/helper/tests"
 	"github.com/0xPolygon/polygon-edge/network"
@@ -348,7 +349,7 @@ func (t *TestServer) GenerateGenesis() error {
 
 	// add base fee
 	if t.Config.BaseFee != 0 {
-		args = append(args, "--base-fee", *types.EncodeUint64(t.Config.BaseFee))
+		args = append(args, "--base-fee", *common.EncodeUint64(t.Config.BaseFee))
 	}
 
 	// add burn contracts
@@ -448,7 +449,7 @@ func (t *TestServer) Start(ctx context.Context) error {
 
 	// add block gas target
 	if t.Config.BlockGasTarget != 0 {
-		args = append(args, "--block-gas-target", *types.EncodeUint64(t.Config.BlockGasTarget))
+		args = append(args, "--block-gas-target", *common.EncodeUint64(t.Config.BlockGasTarget))
 	}
 
 	if t.Config.IBFTBaseTimeout != 0 {

--- a/e2e/pos_test.go
+++ b/e2e/pos_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/contracts/staking"
 	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/e2e/framework"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	stakingHelper "github.com/0xPolygon/polygon-edge/helper/staking"
 	"github.com/0xPolygon/polygon-edge/helper/tests"
 	txpoolOp "github.com/0xPolygon/polygon-edge/txpool/proto"
@@ -44,7 +45,7 @@ func getBigDefaultStakedBalance(t *testing.T) *big.Int {
 	t.Helper()
 
 	val := stakingHelper.DefaultStakedBalance
-	bigDefaultStakedBalance, err := types.ParseUint256orHex(&val)
+	bigDefaultStakedBalance, err := common.ParseUint256orHex(&val)
 
 	if err != nil {
 		t.Fatalf("unable to parse DefaultStakedBalance, %v", err)

--- a/e2e/transaction_test.go
+++ b/e2e/transaction_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/contracts/abis"
 	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/e2e/framework"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/helper/tests"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/0xPolygon/polygon-edge/validators"
@@ -259,7 +260,7 @@ func getCount(
 		response = "0x0"
 	}
 
-	bigResponse, decodeErr := types.ParseUint256orHex(&response)
+	bigResponse, decodeErr := common.ParseUint256orHex(&response)
 
 	if decodeErr != nil {
 		return nil, fmt.Errorf("wnable to decode hex response, %w", decodeErr)

--- a/e2e/websocket_test.go
+++ b/e2e/websocket_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/0xPolygon/polygon-edge/e2e/framework"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/jsonrpc"
-	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 )
@@ -98,7 +98,7 @@ func TestWS_Response(t *testing.T) {
 			t.Fatalf("Unable to unmarshal WS result: %v", wsError)
 		}
 
-		foundBalance, parseError := types.ParseUint256orHex(&balanceHex)
+		foundBalance, parseError := common.ParseUint256orHex(&balanceHex)
 		if parseError != nil {
 			t.Fatalf("Unable to parse WS result balance: %v", parseError)
 		}
@@ -142,7 +142,7 @@ func TestWS_Response(t *testing.T) {
 			t.Fatalf("Unable to unmarshal WS result: %v", wsError)
 		}
 
-		blockNumInt, parseError := types.ParseUint256orHex(&blockNum)
+		blockNumInt, parseError := common.ParseUint256orHex(&blockNum)
 		if parseError != nil {
 			t.Fatalf("Unable to parse WS result balance: %v", parseError)
 		}

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -14,7 +14,6 @@ import (
 	"os/user"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
@@ -94,24 +93,6 @@ func ConvertUnmarshalledUint(x interface{}) (uint64, error) {
 	default:
 		return 0, errors.New("unsupported type for unmarshalled integer")
 	}
-}
-
-// ParseUint64orHex parses the given uint64 hex string into the number.
-// It can parse the string with 0x prefix as well.
-func ParseUint64orHex(val *string) (uint64, error) {
-	if val == nil {
-		return 0, nil
-	}
-
-	str := *val
-	base := 10
-
-	if strings.HasPrefix(str, "0x") {
-		str = str[2:]
-		base = 16
-	}
-
-	return strconv.ParseUint(str, base, 64)
 }
 
 func roundFloat(num float64) int64 {

--- a/helper/common/encoding.go
+++ b/helper/common/encoding.go
@@ -1,13 +1,31 @@
-package types
+package common
 
 import (
 	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 )
 
+// ParseUint64orHex parses the given uint64 hex string into the number.
+// It can parse the string with 0x prefix as well.
+func ParseUint64orHex(val *string) (uint64, error) {
+	if val == nil {
+		return 0, nil
+	}
+
+	str := *val
+	base := 10
+
+	if strings.HasPrefix(str, "0x") {
+		str = str[2:]
+		base = 16
+	}
+
+	return strconv.ParseUint(str, base, 64)
+}
 func ParseUint256orHex(val *string) (*big.Int, error) {
 	if val == nil {
 		return nil, nil

--- a/helper/staking/staking.go
+++ b/helper/staking/staking.go
@@ -177,7 +177,7 @@ func PredeployStakingSC(
 
 	// Parse the default staked balance value into *big.Int
 	val := DefaultStakedBalance
-	bigDefaultStakedBalance, err := types.ParseUint256orHex(&val)
+	bigDefaultStakedBalance, err := common.ParseUint256orHex(&val)
 
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate DefaultStatkedBalance, %w", err)

--- a/jsonrpc/codec.go
+++ b/jsonrpc/codec.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
@@ -181,7 +182,7 @@ func stringToBlockNumber(str string) (BlockNumber, error) {
 		return EarliestBlockNumber, nil
 	}
 
-	n, err := types.ParseUint64orHex(&str)
+	n, err := common.ParseUint64orHex(&str)
 	if err != nil {
 		return 0, err
 	}

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -180,7 +180,7 @@ func (e *Eth) GetBlockTransactionCountByNumber(number BlockNumber) (interface{},
 		return nil, nil
 	}
 
-	return *types.EncodeUint64(uint64(len(block.Transactions))), nil
+	return *common.EncodeUint64(uint64(len(block.Transactions))), nil
 }
 
 // BlockNumber returns current block number

--- a/tests/testing.go
+++ b/tests/testing.go
@@ -343,7 +343,7 @@ func (t *stTransaction) UnmarshalJSON(input []byte) error {
 		loopVal := i
 
 		if loopVal != "0x" {
-			v, err := types.ParseUint256orHex(&loopVal)
+			v, err := common.ParseUint256orHex(&loopVal)
 			if err != nil {
 				return err
 			}
@@ -383,7 +383,7 @@ func (t *stTransaction) UnmarshalJSON(input []byte) error {
 	t.From = types.Address{}
 
 	if len(dec.SecretKey) > 0 {
-		secretKey, err := types.ParseBytes(&dec.SecretKey)
+		secretKey, err := common.ParseBytes(&dec.SecretKey)
 		if err != nil {
 			return fmt.Errorf("failed to parse secret key: %w", err)
 		}

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -3,31 +3,10 @@ package types
 import (
 	"fmt"
 	"math/big"
-	"strconv"
 	"strings"
 
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 )
-
-// ParseUint64orHex parses the given string as uint64 in hex
-// It should go to the common package from the logical perspective
-// as well as avoiding cycle imports.
-// DEPRECATED. Use common.ParseUint64orHex.
-func ParseUint64orHex(val *string) (uint64, error) {
-	if val == nil {
-		return 0, nil
-	}
-
-	str := *val
-	base := 10
-
-	if strings.HasPrefix(str, "0x") {
-		str = str[2:]
-		base = 16
-	}
-
-	return strconv.ParseUint(str, base, 64)
-}
 
 func ParseUint256orHex(val *string) (*big.Int, error) {
 	if val == nil {


### PR DESCRIPTION
# Description

Moves `types.Parse*` (e.g. `ParseUint64OrHex` etc.) and `types.Encode*` (e.g. `EncodeUint64` etc.) to the `common` package in order to remove redundant `ParseUint64OrHex` function.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
