### PR TITLE
[EVM-757]: Some commands did not print out errors returned by tx relayer

### DIFF
--- a/command/bridge/deposit/erc1155/deposit_erc1155.go
+++ b/command/bridge/deposit/erc1155/deposit_erc1155.go
@@ -147,7 +147,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 		receipt, err := txRelayer.SendTransaction(mintTxn, minterKey)
 		if err != nil {
-			outputter.SetError(fmt.Errorf("failed to send mint transaction to depositor %s", depositorAddr))
+			outputter.SetError(fmt.Errorf("failed to send mint transaction to depositor %s: %w", depositorAddr, err))
 
 			return
 		}
@@ -171,7 +171,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 	receipt, err := txRelayer.SendTransaction(approveTxn, depositorKey)
 	if err != nil {
-		outputter.SetError(fmt.Errorf("failed to send root erc 1155 approve transaction"))
+		outputter.SetError(fmt.Errorf("failed to send root erc 1155 approve transaction: %w", err))
 
 		return
 	}

--- a/command/bridge/deposit/erc20/deposit_erc20.go
+++ b/command/bridge/deposit/erc20/deposit_erc20.go
@@ -131,7 +131,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 		receipt, err := txRelayer.SendTransaction(mintTxn, minterKey)
 		if err != nil {
-			outputter.SetError(fmt.Errorf("failed to send mint transaction to depositor %s", depositorAddr))
+			outputter.SetError(fmt.Errorf("failed to send mint transaction to depositor %s: %w", depositorAddr, err))
 
 			return
 		}
@@ -155,7 +155,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 	receipt, err := txRelayer.SendTransaction(approveTxn, depositorKey)
 	if err != nil {
-		outputter.SetError(fmt.Errorf("failed to send root erc 20 approve transaction"))
+		outputter.SetError(fmt.Errorf("failed to send root erc 20 approve transaction: %w", err))
 
 		return
 	}

--- a/command/bridge/deposit/erc721/deposit_erc721.go
+++ b/command/bridge/deposit/erc721/deposit_erc721.go
@@ -127,7 +127,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 			receipt, err := txRelayer.SendTransaction(mintTxn, minterKey)
 			if err != nil {
-				outputter.SetError(fmt.Errorf("failed to send mint transaction to depositor %s", depositorAddr))
+				outputter.SetError(fmt.Errorf("failed to send mint transaction to depositor %s: %w",
+					depositorAddr, err))
 
 				return
 			}
@@ -150,7 +151,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 	receipt, err := txRelayer.SendTransaction(approveTxn, depositorKey)
 	if err != nil {
-		outputter.SetError(fmt.Errorf("failed to send root erc 721 approve transaction"))
+		outputter.SetError(fmt.Errorf("failed to send root erc 721 approve transaction: %w", err))
 
 		return
 	}


### PR DESCRIPTION
# Description

This PR fixes the issue where some commands did not print out errors returned by tx relayer to command output.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually