### PR TITLE
Error kind detection bug fix 

### DIFF
--- a/command/bridge/deposit/erc20/deposit_erc20.go
+++ b/command/bridge/deposit/erc20/deposit_erc20.go
@@ -155,7 +155,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 	receipt, err := txRelayer.SendTransaction(approveTxn, depositorKey)
 	if err != nil {
-		outputter.SetError(fmt.Errorf("failed to send root erc 20 approve transaction"))
+		outputter.SetError(fmt.Errorf("failed to send root erc 20 approve transaction: %w", err))
 
 		return
 	}

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -574,7 +574,12 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 	// Checks if executor level valid gas errors occurred
 	isGasApplyError := func(err error) bool {
 		// Not linting this as the underlying error is actually wrapped
-		return errors.Is(err, state.ErrNotEnoughIntrinsicGas)
+		if errors.Is(err, state.ErrNotEnoughIntrinsicGas) {
+			return true
+		}
+
+		transitionErr, ok := err.(*state.TransitionApplicationError)
+		return ok && errors.Is(transitionErr.Err, state.ErrNotEnoughIntrinsicGas)
 	}
 
 	// Checks if EVM level valid gas errors occurred

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -573,16 +573,16 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 
 	// Checks if executor level valid gas errors occurred
 	isGasApplyError := func(err error) bool {
-		// Not linting this as the underlying error is actually wrapped
 		if errors.Is(err, state.ErrNotEnoughIntrinsicGas) {
 			return true
 		}
 
-		if !state.IsTransitionApplicationError(err) {
-			return false
+		var expected *state.TransitionApplicationError
+		if errors.As(err, &expected) {
+			return errors.Is(expected.Err, state.ErrNotEnoughIntrinsicGas)
 		}
 
-		return errors.Is(err.(*state.TransitionApplicationError).Err, state.ErrNotEnoughIntrinsicGas)
+		return false
 	}
 
 	// Checks if EVM level valid gas errors occurred

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -578,8 +578,11 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 			return true
 		}
 
-		transitionErr, ok := err.(*state.TransitionApplicationError)
-		return ok && errors.Is(transitionErr.Err, state.ErrNotEnoughIntrinsicGas)
+		if !state.IsTransitionApplicationError(err) {
+			return false
+		}
+
+		return errors.Is(err.(*state.TransitionApplicationError).Err, state.ErrNotEnoughIntrinsicGas)
 	}
 
 	// Checks if EVM level valid gas errors occurred

--- a/state/executor.go
+++ b/state/executor.go
@@ -558,16 +558,6 @@ func NewTransitionApplicationError(err error, isRecoverable bool) *TransitionApp
 	}
 }
 
-func IsTransitionApplicationError(err error) bool {
-	var expected *TransitionApplicationError
-
-	if err == nil {
-		return false
-	}
-
-	return errors.As(err, &expected)
-}
-
 type GasLimitReachedTransitionApplicationError struct {
 	TransitionApplicationError
 }

--- a/state/executor.go
+++ b/state/executor.go
@@ -519,10 +519,10 @@ func (t *Transition) checkDynamicFees(msg *types.Transaction) error {
 // surfacing of these errors reject the transaction thus not including it in the block
 
 var (
-	ErrNonceIncorrect        = fmt.Errorf("incorrect nonce")
-	ErrNotEnoughFundsForGas  = fmt.Errorf("not enough funds to cover gas costs")
-	ErrBlockLimitReached     = fmt.Errorf("gas limit reached in the pool")
-	ErrIntrinsicGasOverflow  = fmt.Errorf("overflow in intrinsic gas calculation")
+	ErrNonceIncorrect        = errors.New("incorrect nonce")
+	ErrNotEnoughFundsForGas  = errors.New("not enough funds to cover gas costs")
+	ErrBlockLimitReached     = errors.New("gas limit reached in the pool")
+	ErrIntrinsicGasOverflow  = errors.New("overflow in intrinsic gas calculation")
 	ErrNotEnoughIntrinsicGas = errors.New("not enough gas supplied for intrinsic gas costs")
 
 	// ErrTipAboveFeeCap is a sanity error to ensure no one is able to specify a

--- a/state/executor.go
+++ b/state/executor.go
@@ -523,7 +523,7 @@ var (
 	ErrNotEnoughFundsForGas  = fmt.Errorf("not enough funds to cover gas costs")
 	ErrBlockLimitReached     = fmt.Errorf("gas limit reached in the pool")
 	ErrIntrinsicGasOverflow  = fmt.Errorf("overflow in intrinsic gas calculation")
-	ErrNotEnoughIntrinsicGas = fmt.Errorf("not enough gas supplied for intrinsic gas costs")
+	ErrNotEnoughIntrinsicGas = errors.New("not enough gas supplied for intrinsic gas costs")
 
 	// ErrTipAboveFeeCap is a sanity error to ensure no one is able to specify a
 	// transaction with a tip higher than the total fee cap.

--- a/state/executor.go
+++ b/state/executor.go
@@ -558,6 +558,16 @@ func NewTransitionApplicationError(err error, isRecoverable bool) *TransitionApp
 	}
 }
 
+func IsTransitionApplicationError(err error) bool {
+	var expected *TransitionApplicationError
+
+	if err == nil {
+		return false
+	}
+
+	return errors.As(err, &expected)
+}
+
 type GasLimitReachedTransitionApplicationError struct {
 	TransitionApplicationError
 }

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -105,7 +105,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 
 	nonce, err := t.client.Eth().GetNonce(key.Address(), ethgo.Pending)
 	if err != nil {
-		return ethgo.ZeroHash, err
+		return ethgo.ZeroHash, fmt.Errorf("failed to get nonce: %w", err)
 	}
 
 	txn.Nonce = nonce
@@ -115,7 +115,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 	if txn.GasPrice == 0 {
 		gasPrice, err := t.Client().Eth().GasPrice()
 		if err != nil {
-			return ethgo.ZeroHash, err
+			return ethgo.ZeroHash, fmt.Errorf("failed to get gas price: %w", err)
 		}
 
 		txn.GasPrice = gasPrice + (gasPrice * gasPricePercent / 100)
@@ -124,7 +124,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 	if txn.Gas == 0 {
 		gasLimit, err := t.client.Eth().EstimateGas(ConvertTxnToCallMsg(txn))
 		if err != nil {
-			return ethgo.ZeroHash, err
+			return ethgo.ZeroHash, fmt.Errorf("failed to estimate gas: %w", err)
 		}
 
 		txn.Gas = gasLimit + (gasLimit * gasLimitPercent / 100)


### PR DESCRIPTION
# Description

Addressing: https://github.com/0xPolygon/polygon-edge/issues/1753

Error `state.ErrNotEnoughIntrinsicGas` was wrapped into the high level error wrapper and was not properly detected using `errors.Is` function

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

