### PR TITLE
Allow 0 premined reward wallet

### DIFF
--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -466,13 +466,13 @@ func (p *genesisParams) validateRewardWallet() error {
 		return errors.New("reward wallet address must be defined")
 	}
 
-	if p.rewardWallet == types.AddressToString(types.ZeroAddress) {
-		return errors.New("reward wallet address must not be zero address")
-	}
-
 	premineInfo, err := parsePremineInfo(p.rewardWallet)
 	if err != nil {
 		return err
+	}
+
+	if premineInfo.address == types.ZeroAddress {
+		return errors.New("reward wallet address must not be zero address")
 	}
 
 	// If epoch rewards are enabled, reward wallet must have some amount of premine

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -475,7 +475,8 @@ func (p *genesisParams) validateRewardWallet() error {
 		return err
 	}
 
-	if premineInfo.amount.Cmp(big.NewInt(0)) < 1 {
+	// If epoch rewards are enabled, reward wallet must have some amount of premine
+	if p.epochReward > 0 && premineInfo.amount.Cmp(big.NewInt(0)) < 1 {
 		return errRewardWalletAmountZero
 	}
 

--- a/command/genesis/params_test.go
+++ b/command/genesis/params_test.go
@@ -185,3 +185,40 @@ func Test_validatePremineInfo(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateRewardWallet(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name              string
+		rewardWallet      string
+		epochReward       uint64
+		expectValidateErr error
+	}{
+		{
+			name:              "invalid reward wallet: no premine + reward",
+			rewardWallet:      types.StringToAddress("1").String() + ":0",
+			epochReward:       10,
+			expectValidateErr: errRewardWalletAmountZero,
+		},
+		{
+			name:              "valid reward wallet: no premine + no reward",
+			rewardWallet:      types.StringToAddress("1").String() + ":0",
+			epochReward:       0,
+			expectValidateErr: nil,
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &genesisParams{
+				rewardWallet: c.rewardWallet,
+				epochReward:  c.epochReward,
+			}
+			err := p.validateRewardWallet()
+			require.ErrorIs(t, err, c.expectValidateErr)
+		})
+	}
+}

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -98,7 +98,7 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 		rewardTokenAddr     = contracts.NativeERC20TokenContract
 	)
 
-	if p.rewardTokenCode == "" {
+	if p.rewardTokenCode == "" && p.epochReward > 0 {
 		// native token is used as a reward token, and reward wallet is not a zero address
 		// so we need to add that address to premine map
 		premineBalances[walletPremineInfo.address] = walletPremineInfo

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -98,10 +98,12 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 		rewardTokenAddr     = contracts.NativeERC20TokenContract
 	)
 
-	if p.rewardTokenCode == "" && p.epochReward > 0 {
+	if p.rewardTokenCode == "" {
 		// native token is used as a reward token, and reward wallet is not a zero address
-		// so we need to add that address to premine map
-		premineBalances[walletPremineInfo.address] = walletPremineInfo
+		if p.epochReward > 0 {
+			// epoch reward is non zero so premine reward wallet
+			premineBalances[walletPremineInfo.address] = walletPremineInfo
+		}
 	} else {
 		bytes, err := hex.DecodeString(p.rewardTokenCode)
 		if err != nil {


### PR DESCRIPTION
# Description

Update logic that prevents 0 premine for reward wallet. Allow 0 premine if epoch rewards are also 0.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Ran local cluster against Sepolia rootchain. Verified that bridging works. Verified that legacy and EIP1559 L2 functionality works.
