### PR TITLE
polygon-edge.sh now checks if jq is installed

### DIFF
--- a/docker/local/polygon-edge.sh
+++ b/docker/local/polygon-edge.sh
@@ -2,6 +2,13 @@
 
 set -e
 
+# Check if jq is installed. If not exit and inform user.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "The jq utility is not installed or is not in the PATH. Please install it and run the script again."
+  exit 1
+fi
+
+
 POLYGON_EDGE_BIN=./polygon-edge
 CHAIN_CUSTOM_OPTIONS=$(tr "\n" " " << EOL
 --block-gas-limit 10000000


### PR DESCRIPTION
# Description

Scripted polygon-edge.sh assumed `jq` is installed.
It now checks if it is. If it is, its proceeds. If it isn't it exits the script and informs the user.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
