### PR TITLE
Calculate EIP1559 gas price in JSON-RPC

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -237,6 +237,7 @@ func (e *Eth) GetTransactionByHash(hash types.Hash) (interface{}, error) {
 		// Find the transaction within the block
 		if txn, idx := types.FindTxByHash(block.Transactions, hash); txn != nil {
 			txn.GasPrice = txn.GetGasPrice(block.Header.BaseFee)
+
 			return toTransaction(
 				txn,
 				argUintPtr(block.Number()),

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -236,6 +236,7 @@ func (e *Eth) GetTransactionByHash(hash types.Hash) (interface{}, error) {
 
 		// Find the transaction within the block
 		if txn, idx := types.FindTxByHash(block.Transactions, hash); txn != nil {
+			txn.GasPrice = txn.GetGasPrice(block.Header.BaseFee)
 			return toTransaction(
 				txn,
 				argUintPtr(block.Number()),

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -166,6 +166,7 @@ func toBlock(b *types.Block, fullTx bool) *block {
 
 	for idx, txn := range b.Transactions {
 		if fullTx {
+			txn.GasPrice = txn.GetGasPrice(b.Header.BaseFee)
 			res.Transactions = append(
 				res.Transactions,
 				toTransaction(


### PR DESCRIPTION
# Description

Tools like https://github.com/blockscout/blockscout operate under the premise that field "gasPrice" will be present even if the TX is an EIP 1559 type, and thus don't work correctly when connected to Polygon-Edge's RPC. 
This PR calculates the gas price on the fly for requests done to the RPC, through the existing function GetGasPrice.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Additional comments

This fixes issues https://github.com/blockscout/blockscout/issues/8128 and https://github.com/blockscout/blockscout/issues/8130. All other RPCs I have tested (Llama RPC, Alchemy, Ankr) include the gasPrice field for EIP1559 transactions.