### PR TITLE
Implementation for  newPendingTransactions (eth_subscribe)

### DIFF
--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -210,7 +210,7 @@ func (d *Dispatcher) handleSubscribe(req Request, conn wsConn) (string, Error) {
 		}
 		filterID = d.filterManager.NewLogFilter(logQuery, conn)
 	} else if subscribeMethod == "newPendingTransactions" {
-		filterID = d.filterManager.NewTxFilter(conn)
+		filterID = d.filterManager.NewPendingTxFilter(conn)
 	} else {
 		return "", NewSubscriptionNotFoundError(subscribeMethod)
 	}

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -209,6 +209,8 @@ func (d *Dispatcher) handleSubscribe(req Request, conn wsConn) (string, Error) {
 			return "", NewInternalError(err.Error())
 		}
 		filterID = d.filterManager.NewLogFilter(logQuery, conn)
+	} else if subscribeMethod == "newPendingTransactions" {
+		filterID = d.filterManager.NewTxFilter(conn)
 	} else {
 		return "", NewSubscriptionNotFoundError(subscribeMethod)
 	}

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -73,7 +73,7 @@ func TestDispatcher_HandleWebsocketConnection_EthSubscribe(t *testing.T) {
 		},
 	)
 
-	t.Run("clients should be able to receive \"newHeads\" event thru eth_subscribe", func(t *testing.T) {
+	t.Run("clients should be able to receive \"newHeads\" event through eth_subscribe", func(t *testing.T) {
 		t.Parallel()
 
 		mockConnection, msgCh := newMockWsConnWithMsgCh()
@@ -82,9 +82,8 @@ func TestDispatcher_HandleWebsocketConnection_EthSubscribe(t *testing.T) {
 		"method": "eth_subscribe",
 		"params": ["newHeads"]
 	}`)
-		if _, err := dispatcher.HandleWs(req, mockConnection); err != nil {
-			t.Fatal(err)
-		}
+		_, err := dispatcher.HandleWs(req, mockConnection)
+		require.NoError(t, err)
 
 		store.emitEvent(&mockEvent{
 			NewChain: []*mockHeader{
@@ -103,7 +102,7 @@ func TestDispatcher_HandleWebsocketConnection_EthSubscribe(t *testing.T) {
 		}
 	})
 
-	t.Run("clients should be able to receive \"newPendingTransactions\" event thru eth_subscribe", func(t *testing.T) {
+	t.Run("clients should be able to receive \"newPendingTransactions\" event through eth_subscribe", func(t *testing.T) {
 		t.Parallel()
 
 		mockConnection, msgCh := newMockWsConnWithMsgCh()
@@ -112,9 +111,8 @@ func TestDispatcher_HandleWebsocketConnection_EthSubscribe(t *testing.T) {
 		"method": "eth_subscribe",
 		"params": ["newPendingTransactions"]
 	}`)
-		if _, err := dispatcher.HandleWs(req, mockConnection); err != nil {
-			t.Fatal(err)
-		}
+		_, err := dispatcher.HandleWs(req, mockConnection)
+		require.NoError(t, err)
 
 		store.emitTxPoolEvent(proto.EventType_ADDED, "evt1")
 
@@ -313,7 +311,7 @@ func TestDispatcherFuncDecode(t *testing.T) {
 	for _, c := range cases {
 		res := handleReq(c.typ, c.msg)
 		if !reflect.DeepEqual(res, c.res) {
-			t.Fatal("bad")
+			t.Fatal("no tx pool events received in the predefined time slot")
 		}
 	}
 }

--- a/jsonrpc/eth_blockchain_test.go
+++ b/jsonrpc/eth_blockchain_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/helper/progress"
 	"github.com/0xPolygon/polygon-edge/state/runtime"
+	"github.com/0xPolygon/polygon-edge/txpool/proto"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -587,6 +588,10 @@ func (m *mockBlockStore) SubscribeEvents() blockchain.Subscription {
 
 func (m *mockBlockStore) FilterExtra(extra []byte) ([]byte, error) {
 	return extra, nil
+}
+
+func (m *mockBlockStore) TxPoolSubscribe(request *proto.SubscribeRequest) (<-chan *proto.TxPoolEvent, func(), error) {
+	return nil, nil, nil
 }
 
 func newTestBlock(number uint64, hash types.Hash) *types.Block {

--- a/jsonrpc/filter_manager.go
+++ b/jsonrpc/filter_manager.go
@@ -281,12 +281,7 @@ func (f *pendingTxFilter) sendUpdates() error {
 	pendingTxHashes := f.takePendingTxsUpdates()
 
 	for _, txHash := range pendingTxHashes {
-		res, err := json.Marshal(txHash)
-		if err != nil {
-			return err
-		}
-
-		if err := f.writeMessageToWs(string(res)); err != nil {
+		if err := f.writeMessageToWs(txHash); err != nil {
 			return err
 		}
 	}

--- a/jsonrpc/filter_manager.go
+++ b/jsonrpc/filter_manager.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/blockchain"
+	"github.com/0xPolygon/polygon-edge/txpool/proto"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -25,6 +26,7 @@ var (
 	ErrIncorrectBlockRange              = errors.New("incorrect range")
 	ErrBlockRangeTooHigh                = errors.New("block range too high")
 	ErrNoWSConnection                   = errors.New("no websocket connection")
+	ErrUnknownSubscriptionType          = errors.New("unknown subscription type")
 )
 
 // defaultTimeout is the timeout to remove the filters that don't have a web socket stream
@@ -35,6 +37,16 @@ const (
 	NoIndexInHeap = -1
 )
 
+// subscriptionType determines which event type the filter is subscribed to
+type subscriptionType byte
+
+const (
+	// Blocks represents subscription type for blockchain events
+	Blocks subscriptionType = iota
+	// PendingTransactions represents subscription type for tx pool events
+	PendingTransactions
+)
+
 // filter is an interface that BlockFilter and LogFilter implement
 type filter interface {
 	// hasWSConn returns the flag indicating the filter has web socket stream
@@ -42,6 +54,9 @@ type filter interface {
 
 	// getFilterBase returns filterBase that has common fields
 	getFilterBase() *filterBase
+
+	// getSubscriptionType returns the type of the event the filter is subscribed to
+	getSubscriptionType() subscriptionType
 
 	// getUpdates returns stored data in a JSON serializable form
 	getUpdates() (interface{}, error)
@@ -159,6 +174,11 @@ func (f *blockFilter) sendUpdates() error {
 	return nil
 }
 
+// getSubscriptionType returns the type of the event the filter is subscribed to
+func (f *blockFilter) getSubscriptionType() subscriptionType {
+	return Blocks
+}
+
 // logFilter is a filter to store logs that meet the conditions in query
 type logFilter struct {
 	filterBase
@@ -212,6 +232,68 @@ func (f *logFilter) sendUpdates() error {
 	return nil
 }
 
+// getSubscriptionType returns the type of the event the filter is subscribed to
+func (f *logFilter) getSubscriptionType() subscriptionType {
+	return Blocks
+}
+
+// pendingTxFilter is a filter to store pending tx
+type pendingTxFilter struct {
+	filterBase
+	sync.Mutex
+
+	txHashes []string
+}
+
+// appendPendingTxHashes appends new pending tx hash to tx hashes
+func (f *pendingTxFilter) appendPendingTxHashes(txHash string) {
+	f.Lock()
+	defer f.Unlock()
+
+	f.txHashes = append(f.txHashes, txHash)
+}
+
+// takePendingTxsUpdates returns all saved pending tx hashes in filter and sets a new slice
+func (f *pendingTxFilter) takePendingTxsUpdates() []string {
+	f.Lock()
+	defer f.Unlock()
+
+	txHashes := f.txHashes
+	f.txHashes = []string{}
+
+	return txHashes
+}
+
+// getSubscriptionType returns the type of the event the filter is subscribed to
+func (f *pendingTxFilter) getSubscriptionType() subscriptionType {
+	return PendingTransactions
+}
+
+// getUpdates returns stored pending tx hashes
+func (f *pendingTxFilter) getUpdates() (interface{}, error) {
+	pendingTxHashes := f.takePendingTxsUpdates()
+
+	return pendingTxHashes, nil
+}
+
+// sendUpdates write the hashes for all pending transactions to web socket stream
+func (f *pendingTxFilter) sendUpdates() error {
+	pendingTxHashes := f.takePendingTxsUpdates()
+
+	for _, txHash := range pendingTxHashes {
+		res, err := json.Marshal(txHash)
+		if err != nil {
+			return err
+		}
+
+		if err := f.writeMessageToWs(string(res)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // filterManagerStore provides methods required by FilterManager
 type filterManagerStore interface {
 	// Header returns the current header of the chain (genesis if empty)
@@ -228,6 +310,9 @@ type filterManagerStore interface {
 
 	// GetBlockByNumber returns a block using the provided number
 	GetBlockByNumber(num uint64, full bool) (*types.Block, bool)
+
+	//TxPoolSubscribe subscribes for tx pool events
+	TxPoolSubscribe(request *proto.SubscribeRequest) (<-chan *proto.TxPoolEvent, func(), error)
 }
 
 // FilterManager manages all running filters
@@ -279,7 +364,7 @@ func NewFilterManager(logger hclog.Logger, store filterManagerStore, blockRangeL
 // Run starts worker process to handle events
 func (f *FilterManager) Run() {
 	// watch for new events in the blockchain
-	watchCh := make(chan *blockchain.Event)
+	blockWatchCh := make(chan *blockchain.Event)
 
 	go func() {
 		for {
@@ -287,9 +372,23 @@ func (f *FilterManager) Run() {
 			if evnt == nil {
 				return
 			}
-			watchCh <- evnt
+			blockWatchCh <- evnt
 		}
 	}()
+
+	// watch for new events in the tx pool
+	txRequest := &proto.SubscribeRequest{
+		Types: []proto.EventType{proto.EventType_ADDED},
+	}
+
+	txWatchCh, txPoolUnsubscribe, err := f.store.TxPoolSubscribe(txRequest)
+	if err != nil {
+		f.logger.Error("Unable to subcribe to tx pool")
+
+		return
+	}
+
+	defer txPoolUnsubscribe()
 
 	var timeoutCh <-chan time.Time
 
@@ -303,10 +402,16 @@ func (f *FilterManager) Run() {
 		}
 
 		select {
-		case evnt := <-watchCh:
+		case evnt := <-blockWatchCh:
 			// new blockchain event
 			if err := f.dispatchEvent(evnt); err != nil {
-				f.logger.Error("failed to dispatch event", "err", err)
+				f.logger.Error("failed to dispatch block event", "err", err)
+			}
+
+		case evnt := <-txWatchCh:
+			// new tx pool event
+			if err := f.dispatchEvent(evnt); err != nil {
+				f.logger.Error("failed to dispatch tx pool event", "err", err)
 			}
 
 		case <-timeoutCh:
@@ -350,6 +455,20 @@ func (f *FilterManager) NewLogFilter(logQuery *LogQuery, ws wsConn) string {
 	filter := &logFilter{
 		filterBase: newFilterBase(ws),
 		query:      logQuery,
+	}
+
+	if filter.hasWSConn() {
+		ws.SetFilterID(filter.id)
+	}
+
+	return f.addFilter(filter)
+}
+
+// NewTxFilter adds new PendingTxFilter
+func (f *FilterManager) NewTxFilter(ws wsConn) string {
+	filter := &pendingTxFilter{
+		filterBase: newFilterBase(ws),
+		txHashes:   []string{},
 	}
 
 	if filter.hasWSConn() {
@@ -621,12 +740,26 @@ func (f *FilterManager) nextTimeoutFilter() (string, time.Time) {
 }
 
 // dispatchEvent is an event handler for new block event
-func (f *FilterManager) dispatchEvent(evnt *blockchain.Event) error {
+func (f *FilterManager) dispatchEvent(evnt interface{}) error {
+	var subType subscriptionType
+
 	// store new event in each filters
-	f.processEvent(evnt)
+	switch evt := evnt.(type) {
+	case *blockchain.Event:
+		f.processBlockEvent(evt)
+
+		subType = Blocks
+	case *proto.TxPoolEvent:
+		f.processTxEvent(evt)
+
+		subType = PendingTransactions
+
+	default:
+		return ErrUnknownSubscriptionType
+	}
 
 	// send data to web socket stream
-	if err := f.flushWsFilters(); err != nil {
+	if err := f.flushWsFilters(subType); err != nil {
 		return err
 	}
 
@@ -634,7 +767,7 @@ func (f *FilterManager) dispatchEvent(evnt *blockchain.Event) error {
 }
 
 // processEvent makes each filter append the new data that interests them
-func (f *FilterManager) processEvent(evnt *blockchain.Event) {
+func (f *FilterManager) processBlockEvent(evnt *blockchain.Event) {
 	f.RLock()
 	defer f.RUnlock()
 
@@ -710,15 +843,27 @@ func (f *FilterManager) appendLogsToFilters(header *block) error {
 	return nil
 }
 
+// processTxEvent makes each filter refresh the pending tx hashes
+func (f *FilterManager) processTxEvent(evnt *proto.TxPoolEvent) {
+	f.RLock()
+	defer f.RUnlock()
+
+	for _, f := range f.filters {
+		if txFilter, ok := f.(*pendingTxFilter); ok {
+			txFilter.appendPendingTxHashes(evnt.TxHash)
+		}
+	}
+}
+
 // flushWsFilters make each filters with web socket connection write the updates to web socket stream
 // flushWsFilters also removes the filters if flushWsFilters notices the connection is closed
-func (f *FilterManager) flushWsFilters() error {
+func (f *FilterManager) flushWsFilters(subType subscriptionType) error {
 	closedFilterIDs := make([]string, 0)
 
 	f.RLock()
 
 	for id, filter := range f.filters {
-		if !filter.hasWSConn() {
+		if !filter.hasWSConn() || filter.getSubscriptionType() != subType {
 			continue
 		}
 

--- a/jsonrpc/filter_manager.go
+++ b/jsonrpc/filter_manager.go
@@ -311,7 +311,7 @@ type filterManagerStore interface {
 	// GetBlockByNumber returns a block using the provided number
 	GetBlockByNumber(num uint64, full bool) (*types.Block, bool)
 
-	//TxPoolSubscribe subscribes for tx pool events
+	// TxPoolSubscribe subscribes for tx pool events
 	TxPoolSubscribe(request *proto.SubscribeRequest) (<-chan *proto.TxPoolEvent, func(), error)
 }
 
@@ -383,7 +383,7 @@ func (f *FilterManager) Run() {
 
 	txWatchCh, txPoolUnsubscribe, err := f.store.TxPoolSubscribe(txRequest)
 	if err != nil {
-		f.logger.Error("Unable to subcribe to tx pool")
+		f.logger.Error("Unable to subscribe to tx pool")
 
 		return
 	}
@@ -464,8 +464,8 @@ func (f *FilterManager) NewLogFilter(logQuery *LogQuery, ws wsConn) string {
 	return f.addFilter(filter)
 }
 
-// NewTxFilter adds new PendingTxFilter
-func (f *FilterManager) NewTxFilter(ws wsConn) string {
+// NewPendingTxFilter adds new PendingTxFilter
+func (f *FilterManager) NewPendingTxFilter(ws wsConn) string {
 	filter := &pendingTxFilter{
 		filterBase: newFilterBase(ws),
 		txHashes:   []string{},

--- a/jsonrpc/filter_manager_test.go
+++ b/jsonrpc/filter_manager_test.go
@@ -395,7 +395,7 @@ func TestFilterPendingTx(t *testing.T) {
 	go m.Run()
 
 	// add pending tx filter
-	id := m.NewTxFilter(nil)
+	id := m.NewPendingTxFilter(nil)
 
 	// emit two events
 	store.emitTxPoolEvent(proto.EventType_ADDED, "evt1")
@@ -609,7 +609,7 @@ func TestFilterPendingTxWebsocket(t *testing.T) {
 
 	go m.Run()
 
-	id := m.NewTxFilter(mock)
+	id := m.NewPendingTxFilter(mock)
 
 	// we cannot call get filter changes for a websocket filter
 	_, err := m.GetFilterChanges(id)

--- a/jsonrpc/filter_manager_test.go
+++ b/jsonrpc/filter_manager_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/blockchain"
+	"github.com/0xPolygon/polygon-edge/txpool/proto"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/gorilla/websocket"
 	"github.com/hashicorp/go-hclog"
@@ -383,6 +384,56 @@ func TestFilterBlock(t *testing.T) {
 	}
 }
 
+func TestFilterPendingTx(t *testing.T) {
+	t.Parallel()
+
+	store := newMockStore()
+
+	m := NewFilterManager(hclog.NewNullLogger(), store, 1000)
+	defer m.Close()
+
+	go m.Run()
+
+	// add pending tx filter
+	id := m.NewTxFilter(nil)
+
+	// emit two events
+	store.emitTxPoolEvent(proto.EventType_ADDED, "evt1")
+	store.emitTxPoolEvent(proto.EventType_ADDED, "evt2")
+
+	// we need to wait for the manager to process the data
+	time.Sleep(500 * time.Millisecond)
+
+	var res interface{}
+
+	var fetchErr error
+
+	if res, fetchErr = m.GetFilterChanges(id); fetchErr != nil {
+		t.Fatalf("Unable to get filter changes, %v", fetchErr)
+	}
+
+	txHashes, ok := res.([]string)
+	require.True(t, ok)
+	require.Equal(t, 2, len(txHashes))
+	require.Equal(t, "evt1", txHashes[0])
+	require.Equal(t, "evt2", txHashes[1])
+
+	// emit one more event, it should not return the
+	// first two hashes
+	store.emitTxPoolEvent(proto.EventType_ADDED, "evt3")
+	time.Sleep(500 * time.Millisecond)
+
+	if res, fetchErr = m.GetFilterChanges(id); fetchErr != nil {
+		t.Fatalf("Unable to get filter changes, %v", fetchErr)
+	}
+
+	txHashes, ok = res.([]string)
+	require.True(t, ok)
+	require.NotNil(t, txHashes)
+	require.Equal(t, 1, len(txHashes))
+	require.Equal(t, "evt3", txHashes[0])
+}
+
 func TestFilterTimeout(t *testing.T) {
 	t.Parallel()
 
@@ -528,7 +579,7 @@ func TestFilterWebsocket(t *testing.T) {
 	_, err := m.GetFilterChanges(id)
 	assert.Equal(t, err, ErrWSFilterDoesNotSupportGetChanges)
 
-	// emit two events
+	// emit event
 	store.emitEvent(&mockEvent{
 		NewChain: []*mockHeader{
 			{
@@ -538,6 +589,34 @@ func TestFilterWebsocket(t *testing.T) {
 			},
 		},
 	})
+
+	select {
+	case <-msgCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("bad")
+	}
+}
+
+func TestFilterPendingTxWebsocket(t *testing.T) {
+	t.Parallel()
+
+	store := newMockStore()
+
+	mock, msgCh := newMockWsConnWithMsgCh()
+
+	m := NewFilterManager(hclog.NewNullLogger(), store, 1000)
+	defer m.Close()
+
+	go m.Run()
+
+	id := m.NewTxFilter(mock)
+
+	// we cannot call get filter changes for a websocket filter
+	_, err := m.GetFilterChanges(id)
+	assert.Equal(t, err, ErrWSFilterDoesNotSupportGetChanges)
+
+	// emit event
+	store.emitTxPoolEvent(proto.EventType_ADDED, "evt1")
 
 	select {
 	case <-msgCh:

--- a/jsonrpc/mocks_test.go
+++ b/jsonrpc/mocks_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/0xPolygon/polygon-edge/blockchain"
+	"github.com/0xPolygon/polygon-edge/txpool/proto"
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
@@ -44,11 +45,12 @@ type mockEvent struct {
 type mockStore struct {
 	JSONRPCStore
 
-	header       *types.Header
-	subscription *blockchain.MockSubscription
-	receiptsLock sync.Mutex
-	receipts     map[types.Hash][]*types.Receipt
-	accounts     map[types.Address]*Account
+	header        *types.Header
+	subscription  *blockchain.MockSubscription
+	txPoolChannel chan *proto.TxPoolEvent
+	receiptsLock  sync.Mutex
+	receipts      map[types.Hash][]*types.Receipt
+	accounts      map[types.Address]*Account
 
 	// headers is the list of historical headers
 	historicalHeaders []*types.Header
@@ -56,9 +58,10 @@ type mockStore struct {
 
 func newMockStore() *mockStore {
 	m := &mockStore{
-		header:       &types.Header{Number: 0},
-		subscription: blockchain.NewMockSubscription(),
-		accounts:     map[types.Address]*Account{},
+		header:        &types.Header{Number: 0},
+		subscription:  blockchain.NewMockSubscription(),
+		accounts:      map[types.Address]*Account{},
+		txPoolChannel: make(chan *proto.TxPoolEvent),
 	}
 	m.addHeader(m.header)
 
@@ -108,6 +111,15 @@ func (m *mockStore) emitEvent(evnt *mockEvent) {
 	m.subscription.Push(bEvnt)
 }
 
+func (m *mockStore) emitTxPoolEvent(eventType proto.EventType, txHash string) {
+	evt := &proto.TxPoolEvent{
+		Type:   eventType,
+		TxHash: txHash,
+	}
+
+	m.txPoolChannel <- evt
+}
+
 func (m *mockStore) GetAccount(root types.Hash, addr types.Address) (*Account, error) {
 	if acc, ok := m.accounts[addr]; ok {
 		return acc, nil
@@ -135,6 +147,14 @@ func (m *mockStore) GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error)
 
 func (m *mockStore) SubscribeEvents() blockchain.Subscription {
 	return m.subscription
+}
+
+func (m *mockStore) TxPoolSubscribe(request *proto.SubscribeRequest) (<-chan *proto.TxPoolEvent, func(), error) {
+	txPoolUnsubscribe := func() {
+		close(m.txPoolChannel)
+	}
+
+	return m.txPoolChannel, txPoolUnsubscribe, nil
 }
 
 func (m *mockStore) GetHeaderByNumber(num uint64) (*types.Header, bool) {

--- a/txpool/operator.go
+++ b/txpool/operator.go
@@ -82,3 +82,18 @@ func (p *TxPool) Subscribe(
 		}
 	}
 }
+
+// TxPoolSubscribe subscribes to new events in the tx pool and returns subscription channel and unsubscribe fn
+func (p *TxPool) TxPoolSubscribe(request *proto.SubscribeRequest) (<-chan *proto.TxPoolEvent, func(), error) {
+	if err := request.ValidateAll(); err != nil {
+		return nil, nil, err
+	}
+
+	subscription := p.eventManager.subscribe(request.Types)
+
+	cancelSubscription := func() {
+		p.eventManager.cancelSubscription(subscription.subscriptionID)
+	}
+
+	return subscription.subscriptionChannel, cancelSubscription, nil
+}


### PR DESCRIPTION
# Description
This PR introduces implementation of [newPendingTransaction](https://geth.ethereum.org/docs/interacting-with-geth/rpc/pubsub#newpendingtransactions) as a parameter of eth_subscribe. User can subscribe to this parameter and receive updates when the new tx is added to the tx pool.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Custer is run using e2e test which periodically inserts transactions

```
 func TestE2E_NewTx(t *testing.T) {
	
        sender, err := wallet.GenerateKey()
	require.NoError(t, err)

	cluster := framework.NewTestCluster(t, 4,
		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, sender.Address())),
		framework.WithPremine(types.Address(sender.Address())),
	)
	defer cluster.Stop()

	cluster.WaitForReady(t)

	acct, err := wallet.GenerateKey()
	require.NoError(t, err)

	toAddr := acct.Address()

	srv := cluster.Servers[0]
	t.Log("**JSON RPC ADDR", srv.JSONRPCAddr())

	for i := 0; i < 100; i++ {
		txn := cluster.SendTxn(t, sender, &ethgo.Transaction{
			To:       &toAddr,
			Value:    big.NewInt(1),
			GasPrice: 0,
		})
		require.NoError(t, txn.Wait())
		require.True(t, txn.Succeed())
		t.Log("Tx", i, "- hash:", txn.Receipt().TransactionHash.String())
		time.Sleep(5 * time.Second)
	}
}

```
 In a separate console we subscribed to newPendingTransaction events using following command:
`wscat -c ws://localhost:12001/ws -x '{"jsonrpc":"2.0", "id": 1, "method":"eth_subscribe", "params": ["newPendingTransactions"]}' -w 120`

# Documentation update

@DannyS03 if we have documented which json rpc calls we support, then we should add newPendingTransaction as a part of eth_subscribe 

