### PR TITLE
fixed txpool maxEnqueued issue

### DIFF
--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -814,7 +814,7 @@ func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 
 		slotsFree += slotsRequired(oldTxWithSameNonce) // add old tx slots
 	} else {
-		if account.enqueued.length() == account.maxEnqueued {
+		if account.enqueued.length() == account.maxEnqueued && tx.Nonce != accountNonce {
 			return ErrMaxEnqueuedLimitReached
 		}
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -778,7 +778,7 @@ func TestEnqueueHandler(t *testing.T) {
 			assert.NoError(t, err)
 			pool.SetSigner(&mockSigner{})
 
-			//	mock full enqueued
+			// mock full enqueued
 			pool.accounts.maxEnqueuedLimit = 10
 
 			// add 10 transaction in txpool i.e. max enqueued transactions

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -768,6 +768,43 @@ func TestEnqueueHandler(t *testing.T) {
 			acc.nonceToTx.unlock()
 		},
 	)
+
+	t.Run(
+		"accept new tx with nextNonce when enqueued is full",
+		func(t *testing.T) {
+			t.Parallel()
+
+			pool, err := newTestPool()
+			assert.NoError(t, err)
+			pool.SetSigner(&mockSigner{})
+
+			//	mock full enqueued
+			pool.accounts.maxEnqueuedLimit = 10
+
+			// add 10 transaction in txpool i.e. max enqueued transactions
+			for i := uint64(1); i <= 10; i++ {
+				err := pool.addTx(local, newTx(addr1, i, 1))
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, uint64(10), pool.accounts.get(addr1).enqueued.length())
+			assert.Equal(t, uint64(0), pool.accounts.get(addr1).promoted.length())
+			assert.Equal(t, uint64(0), pool.accounts.get(addr1).getNonce())
+
+			err = pool.addTx(local, newTx(addr1, 11, 1))
+			assert.True(t, errors.Is(err, ErrMaxEnqueuedLimitReached))
+
+			// add the transaction with nextNonce i.e. nonce=0
+			err = pool.addTx(local, newTx(addr1, uint64(0), 1))
+			assert.NoError(t, err)
+
+			pool.handlePromoteRequest(<-pool.promoteReqCh)
+
+			assert.Equal(t, uint64(0), pool.accounts.get(addr1).enqueued.length())
+			assert.Equal(t, uint64(11), pool.accounts.get(addr1).promoted.length())
+			assert.Equal(t, uint64(11), pool.accounts.get(addr1).getNonce())
+		},
+	)
 }
 
 func TestAddTx(t *testing.T) {


### PR DESCRIPTION
# Description

Currently, the Txpool refuses to process transactions for a specific address once the `maxEnqueued` limit for that address is reached. This situation results in a stagnant state for the address, preventing it from accommodating any further transactions, including those with the `nextNonce`. With the introduction of this PR, addresses will have the capability to accept transactions with the `nextNonce`,  even when the `maxEnqueued` limit for an account has been reached.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

