### PR TITLE
[RFC-191]: EVM-759 - Don't use hardcoded addresses for governance contracts

### DIFF
--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -196,6 +196,11 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 			ProposalThreshold:        proposalThreshold,
 			ProposalQuorumPercentage: proposalQuorum,
 			GovernorAdmin:            governorAdminAddr,
+			// on genesis we deploy governance contracts on predefined addresses
+			ChildGovernorAddr: contracts.ChildGovernorContract,
+			ChildTimelockAddr: contracts.ChildTimelockContract,
+			NetworkParamsAddr: contracts.NetworkParamsContract,
+			ForkParamsAddr:    contracts.ForkParamsContract,
 		},
 	}
 

--- a/consensus/polybft/governance_manager.go
+++ b/consensus/polybft/governance_manager.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
-	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/forkmanager"
 	"github.com/0xPolygon/polygon-edge/helper/common"
@@ -89,8 +88,8 @@ func newGovernanceManager(genesisConfig *PolyBFTConfig,
 	eventsGetter := &eventsGetter[contractsapi.EventAbi]{
 		blockchain: blockhain,
 		isValidLogFn: func(l *types.Log) bool {
-			return l.Address == contracts.NetworkParamsContract ||
-				l.Address == contracts.ForkParamsContract
+			return l.Address == genesisConfig.GovernanceConfig.NetworkParamsAddr ||
+				l.Address == genesisConfig.GovernanceConfig.ForkParamsAddr
 		},
 		parseEventFn: parseGovernanceEvent,
 	}

--- a/consensus/polybft/polybft_config.go
+++ b/consensus/polybft/polybft_config.go
@@ -251,6 +251,14 @@ type GovernanceConfig struct {
 	// ProposalQuorumPercentage is the percentage of total validator stake needed for a
 	// governance proposal to be accepted
 	ProposalQuorumPercentage uint64
+	// ChildGovernorAddr is the address of ChildGovernor contract
+	ChildGovernorAddr types.Address
+	// ChildTimelockAddr is the address of ChildTimelock contract
+	ChildTimelockAddr types.Address
+	// NetworkParamsAddr is the address of NetworkParams contract
+	NetworkParamsAddr types.Address
+	// ForkParamsAddr is the address of ForkParams contract
+	ForkParamsAddr types.Address
 }
 
 func (g *GovernanceConfig) MarshalJSON() ([]byte, error) {
@@ -260,6 +268,10 @@ func (g *GovernanceConfig) MarshalJSON() ([]byte, error) {
 		ProposalThreshold:        types.EncodeBigInt(g.ProposalThreshold),
 		GovernorAdmin:            g.GovernorAdmin,
 		ProposalQuorumPercentage: g.ProposalQuorumPercentage,
+		ChildGovernorAddr:        g.ChildGovernorAddr,
+		ChildTimelockAddr:        g.ChildTimelockAddr,
+		NetworkParamsAddr:        g.NetworkParamsAddr,
+		ForkParamsAddr:           g.ForkParamsAddr,
 	}
 
 	return json.Marshal(raw)
@@ -292,6 +304,10 @@ func (g *GovernanceConfig) UnmarshalJSON(data []byte) error {
 
 	g.GovernorAdmin = raw.GovernorAdmin
 	g.ProposalQuorumPercentage = raw.ProposalQuorumPercentage
+	g.ChildGovernorAddr = raw.ChildGovernorAddr
+	g.ChildTimelockAddr = raw.ChildTimelockAddr
+	g.NetworkParamsAddr = raw.NetworkParamsAddr
+	g.ForkParamsAddr = raw.ForkParamsAddr
 
 	return nil
 }
@@ -302,4 +318,8 @@ type governanceConfigRaw struct {
 	ProposalThreshold        *string       `json:"proposalThreshold"`
 	GovernorAdmin            types.Address `json:"governorAdmin"`
 	ProposalQuorumPercentage uint64        `json:"proposalQuorumPercentage"`
+	ChildGovernorAddr        types.Address `json:"childGovernorAddr"`
+	ChildTimelockAddr        types.Address `json:"childTimelockAddr"`
+	NetworkParamsAddr        types.Address `json:"networkParamsAddr"`
+	ForkParamsAddr           types.Address `json:"forkParamsAddr"`
 }

--- a/consensus/polybft/sc_integration_test.go
+++ b/consensus/polybft/sc_integration_test.go
@@ -348,6 +348,10 @@ func TestIntegration_CommitEpoch(t *testing.T) {
 				ProposalThreshold:        big.NewInt(25),
 				GovernorAdmin:            types.BytesToAddress([]byte{0, 1, 2, 3}),
 				ProposalQuorumPercentage: 67,
+				ChildGovernorAddr:        contracts.ChildGovernorContract,
+				ChildTimelockAddr:        contracts.ChildTimelockContract,
+				NetworkParamsAddr:        contracts.NetworkParamsContract,
+				ForkParamsAddr:           contracts.ForkParamsContract,
 			},
 			Bridge: &BridgeConfig{
 				CustomSupernetManagerAddr: types.StringToAddress("0x12312451"),

--- a/consensus/polybft/state_store_governance_test.go
+++ b/consensus/polybft/state_store_governance_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
+	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/require"
@@ -202,6 +203,10 @@ func createTestPolybftConfig() *PolyBFTConfig {
 			ProposalThreshold:        big.NewInt(1000),
 			GovernorAdmin:            types.StringToAddress("0xGovernorAdmin"),
 			ProposalQuorumPercentage: 67,
+			ChildGovernorAddr:        contracts.ChildGovernorContract,
+			ChildTimelockAddr:        contracts.ChildTimelockContract,
+			NetworkParamsAddr:        contracts.NetworkParamsContract,
+			ForkParamsAddr:           contracts.ForkParamsContract,
 		},
 	}
 }


### PR DESCRIPTION
# Description

This PR introduces new fields to `governanceConfig` part of `genesis.json`:
- `childGovernorAddr` - address of `ChildGovernor` contract on supernet.
- `childTimelockAddr` - address of `ChildTimelock` contract on supernet.
- `networkParamsAddr` - address of `NetworkParams` contract on supernet.
- `forkParamsAddr` - address of `ForkParams` contract on supernet.

We need to add them to `genesis.json` because, on live chains, these contracts will be deployed on random addresses, so the user needs to manually change the `genesis.json` file to keep those addresses as well, so that edge client knows how to handle governance events.

If the chain is started a new on the release that introduces governance, these fields will be automatically updated in `genesis.json` since on genesis we deploy these contracts automatically on predefined addresses.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually