### PR TITLE
Use `curl` instead of `netcat` in local deployment script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,7 +6,7 @@ When deploying with `polybft` consensus, there are some additional dependencies:
 
 * [go 1.20.x](https://go.dev/dl/)
 * [jq](https://jqlang.github.io/jq)
-* Netcat (nc)
+* [curl](https://everything.curl.dev/get)
 
 ## Local development
 

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -10,8 +10,8 @@ if [[ "$1" == "polybft" ]] && ! command -v jq >/dev/null 2>&1; then
 fi
 
 # Check if nc is installed
-if [[ "$1" == "polybft" ]] && ! command -v nc >/dev/null 2>&1; then
-  echo "Netcat (nc) is not installed."
+if [[ "$1" == "polybft" ]] && ! command -v curl >/dev/null 2>&1; then
+  echo "curl is not installed."
   dp_error_flag=1
 fi
 
@@ -90,10 +90,10 @@ function initRootchain() {
   fi
 
   set +e
-  t=1
-  while [ $t -gt 0 ]; do
-    nc -z 127.0.0.1 8545 </dev/null
-    t=$?
+  while true; do
+    if curl -sSf -o /dev/null http://127.0.0.1:8545; then
+      break
+    fi
     sleep 1
   done
   set -e


### PR DESCRIPTION
# Description

This PR uses curl instead of Netcat for pinging rootchain server, because it is more widely used tool and chances are it is pre-installed with the OS.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
