### PR TITLE
Initialize ABI type only once

### DIFF
--- a/consensus/polybft/governance_manager.go
+++ b/consensus/polybft/governance_manager.go
@@ -106,9 +106,10 @@ func newGovernanceManager(genesisConfig *PolyBFTConfig,
 
 	// cache all fork name hashes that we have in code
 	allForkNameHashes := map[types.Hash]string{}
+	stringABIType := abi.MustNewType("tuple(string)")
 
 	for name := range *chain.AllForksEnabled {
-		encoded, err := abi.Encode([]interface{}{name}, abi.MustNewType("tuple(string)"))
+		encoded, err := stringABIType.Encode([]interface{}{name})
 		if err != nil {
 			return nil, fmt.Errorf("could not encode fork name: %s. Error: %w", name, err)
 		}


### PR DESCRIPTION
# Description

This PR introduces minor optimization in a way that abi type is instantiated only once and reused in the for loop.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
