### PR TITLE
Sort rounds and senders in double signing tracker storage

### DIFF
--- a/consensus/polybft/slashing/double_signing_tracker.go
+++ b/consensus/polybft/slashing/double_signing_tracker.go
@@ -300,6 +300,8 @@ func (t *DoubleSigningTrackerImpl) GetDoubleSigners(height uint64) DoubleSigners
 		rounds, sortedRoundsExist := msgs.sortedRounds[height]
 
 		if !msgsMapExists || !sortedSendersExist || !sortedRoundsExist {
+			msgs.mux.Unlock()
+
 			continue
 		}
 

--- a/consensus/polybft/slashing/double_signing_tracker.go
+++ b/consensus/polybft/slashing/double_signing_tracker.go
@@ -89,15 +89,6 @@ func (s *DoubleSigners) contains(sender types.Address) bool {
 //nolint:godox
 // TODO: RLP serialize/deserialize methods, Equals method for validation, etc.
 
-type DoubleSignEvidence struct {
-	sender   types.Address
-	messages []*ibftProto.Message
-}
-
-func newDoubleSignEvidence(sender types.Address, messages []*ibftProto.Message) *DoubleSignEvidence {
-	return &DoubleSignEvidence{sender: sender, messages: messages}
-}
-
 type Messages struct {
 	content       MessagesMap
 	sortedSenders map[uint64]SortedAddresses

--- a/consensus/polybft/slashing/double_signing_tracker.go
+++ b/consensus/polybft/slashing/double_signing_tracker.go
@@ -96,6 +96,19 @@ type Messages struct {
 	mux           sync.RWMutex
 }
 
+func (m *Messages) String() string {
+	var buf bytes.Buffer
+
+	buf.WriteString("senders")
+	buf.WriteString(fmt.Sprintf("\t%v\n", m.sortedSenders))
+	buf.WriteString("rounds")
+	buf.WriteString(fmt.Sprintf("\t%v\n", m.sortedRounds))
+	buf.WriteString("messages")
+	buf.WriteString(fmt.Sprintf("\t%v\n", m.content))
+
+	return buf.String()
+}
+
 // newMessages is a constructor function for Messages struct
 func newMessages() *Messages {
 	return &Messages{

--- a/consensus/polybft/slashing/double_signing_tracker_test.go
+++ b/consensus/polybft/slashing/double_signing_tracker_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
-var r = rand.New(rand.NewSource(time.Now().Unix()))
+var r = rand.New(rand.NewSource(time.Now().UTC().Unix()))
 
 func TestDoubleSigningTracker_Handle_SingleSender(t *testing.T) {
 	t.Parallel()
@@ -426,12 +426,14 @@ func TestDoubleSigningTracker_GetEvidences_Randomized(t *testing.T) {
 
 	doubleSigners := make([]types.Address, 0, doubleSignersCount)
 	keys := make([]*wallet.Key, accountsCount)
+
 	for i := 0; i < accountsCount; i++ {
 		acc, err := wallet.GenerateAccount()
 		require.NoError(t, err)
 
 		keys[i] = wallet.NewKey(acc)
 		provider.accounts[i] = acc
+
 		if len(doubleSigners) < doubleSignersCount {
 			doubleSigners = append(doubleSigners, types.Address(keys[i].Address()))
 		}
@@ -489,12 +491,14 @@ func TestDoubleSigningTracker_GetEvidences_Randomized(t *testing.T) {
 			if len(doubleSigners) == 0 {
 				t.Log(tracker.prepare.String())
 			}
+
 			require.Len(t, doubleSigners, 1)
 			require.Equal(t, doubleSigners[0], types.Address(keys[0].Address()))
 		} else {
 			if len(doubleSigners) > 0 {
 				t.Log(tracker.prepare.String())
 			}
+
 			require.Empty(t, doubleSigners)
 		}
 	}

--- a/consensus/polybft/slashing/double_signing_tracker_test.go
+++ b/consensus/polybft/slashing/double_signing_tracker_test.go
@@ -350,7 +350,7 @@ func TestDoubleSigningTracker_PruneMsgsUntil(t *testing.T) {
 	}
 }
 
-func TestDoubleSigningTracker_GetDoubleSigners_Simple(t *testing.T) {
+func TestDoubleSigningTracker_GetDoubleSigners_SingleDoubleSigner(t *testing.T) {
 	t.Parallel()
 
 	const (

--- a/consensus/polybft/slashing/double_signing_tracker_test.go
+++ b/consensus/polybft/slashing/double_signing_tracker_test.go
@@ -411,7 +411,7 @@ func TestDoubleSigningTracker_GetDoubleSigners_Simple(t *testing.T) {
 	require.Equal(t, doubleSignerAddr, doubleSigners[0])
 }
 
-func TestDoubleSigningTracker_GetEvidences_Randomized(t *testing.T) {
+func TestDoubleSigningTracker_GetDoubleSigners_Property(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -421,173 +421,96 @@ func TestDoubleSigningTracker_GetEvidences_Randomized(t *testing.T) {
 		accountsCount = 5
 	)
 
-	doubleSignersCount := r.Intn(accountsCount + 1)
-	provider := &dummyValidatorsProvider{accounts: make([]*wallet.Account, accountsCount)}
-
-	doubleSignerAddrs := make([]types.Address, 0, doubleSignersCount)
-	keys := make([]*wallet.Key, accountsCount)
-
-	for i := 0; i < accountsCount; i++ {
-		acc, err := wallet.GenerateAccount()
-		require.NoError(t, err)
-
-		keys[i] = wallet.NewKey(acc)
-		provider.accounts[i] = acc
-
-		if len(doubleSignerAddrs) < doubleSignersCount {
-			doubleSignerAddrs = append(doubleSignerAddrs, types.Address(keys[i].Address()))
-		}
-	}
-
-	sort.Slice(doubleSignerAddrs, func(i, j int) bool {
-		return bytes.Compare(doubleSignerAddrs[i].Bytes(), doubleSignerAddrs[j].Bytes()) < 0
-	})
-
-	tracker, err := NewDoubleSigningTracker(hclog.NewNullLogger(), provider)
-	require.NoError(t, err)
-
-	heightsNum := r.Intn(4)
-	if heightsNum == 0 {
-		heightsNum++
-	}
-
-	roundsNum := r.Intn(3)
-	if roundsNum == 0 {
-		roundsNum++
-	}
-
-	views := make([]*ibftProto.View, heightsNum)
-	expectedDoubleSigning := make(map[uint64]bool, heightsNum)
-	existingRounds := make(map[uint64]struct{}, roundsNum)
-
-	for i := 0; i < heightsNum; i++ {
-		height := uint64(r.Int63n(maxHeight))
-		shouldDoubleSign := rand.Intn(2) != 0
-		expectedDoubleSigning[height] = shouldDoubleSign
-		proposalHash := generateRandomProposalHash(t)
-
-		for j := 0; j < roundsNum; j++ {
-			round := enforceUniqueRandomNumber(existingRounds, maxRound, func() uint64 {
-				return uint64(r.Int63n(int64(maxRound)))
-			})
-			existingRounds[round] = struct{}{}
-			view := &ibftProto.View{Height: height, Round: round}
-			views[i] = view
-
-			if shouldDoubleSign {
-				messagesCount := r.Intn(maxMsgs)
-				if messagesCount < 2 {
-					messagesCount = 2
-				}
-
-				for i, key := range keys {
-					if i < len(doubleSignerAddrs) {
-						for msgsCount := 0; msgsCount < messagesCount; msgsCount++ {
-							tracker.Handle(buildPrepareMessage(t, view, key, generateRandomProposalHash(t)))
-						}
-					} else {
-						tracker.Handle(buildPrepareMessage(t, view, key, generateRandomProposalHash(t)))
-					}
-				}
-			} else {
-				for _, key := range keys {
-					tracker.Handle(buildPrepareMessage(t, view, key, proposalHash))
-				}
-			}
-		}
-	}
-
-	for _, view := range views {
-		doubleSigners := tracker.GetDoubleSigners(view.Height)
-		if expectedDoubleSigning[view.Height] {
-			if len(doubleSigners) != len(doubleSignerAddrs) {
-				t.Log(tracker.prepare.String())
-			}
-
-			require.Len(t, doubleSigners, len(doubleSignerAddrs))
-			require.Equal(t, doubleSigners, DoubleSigners(doubleSignerAddrs))
-		} else {
-			if len(doubleSigners) > 0 {
-				t.Log(tracker.prepare.String())
-			}
-
-			require.Empty(t, doubleSigners)
-		}
-	}
-}
-
-func TestDoubleSigningTracker_GetEvidences_Property(t *testing.T) {
-	t.Skip("flaky")
-	t.Parallel()
-
-	const (
-		maxRound      = 10
-		maxHeight     = 1000
-		maxMsgs       = 4
-		accountsCount = 1
-	)
-
 	rapid.Check(t, func(rapidT *rapid.T) {
-		t.Log("Execute test")
-
 		doubleSignersCount := rapid.IntRange(0, accountsCount).Draw(rapidT, "double signers count")
 		provider := &dummyValidatorsProvider{accounts: make([]*wallet.Account, accountsCount)}
 
-		doubleSigners := make([]types.Address, 0, doubleSignersCount)
+		doubleSignerAddrs := make([]types.Address, 0, doubleSignersCount)
 		keys := make([]*wallet.Key, accountsCount)
+
 		for i := 0; i < accountsCount; i++ {
 			acc, err := wallet.GenerateAccount()
 			require.NoError(t, err)
 
 			keys[i] = wallet.NewKey(acc)
 			provider.accounts[i] = acc
-			if len(doubleSigners) < doubleSignersCount {
-				doubleSigners = append(doubleSigners, types.Address(keys[i].Address()))
+
+			if len(doubleSignerAddrs) < doubleSignersCount {
+				doubleSignerAddrs = append(doubleSignerAddrs, types.Address(keys[i].Address()))
 			}
 		}
+
+		sort.Slice(doubleSignerAddrs, func(i, j int) bool {
+			return bytes.Compare(doubleSignerAddrs[i].Bytes(), doubleSignerAddrs[j].Bytes()) < 0
+		})
 
 		tracker, err := NewDoubleSigningTracker(hclog.NewNullLogger(), provider)
 		require.NoError(t, err)
 
-		heightsNum := rapid.IntRange(1, 2).Draw(rapidT, "number of heights")
-		roundsNum := rapid.IntRange(1, 3).Draw(rapidT, "number of rounds")
+		heightsNum := rapid.IntRange(1, 5).Draw(rapidT, "number of heights")
+		roundsNum := rapid.IntRange(1, 4).Draw(rapidT, "number of rounds")
 
-		views := make([]*ibftProto.View, heightsNum)
+		heights := make([]uint64, heightsNum)
 		expectedDoubleSigning := make(map[uint64]bool, heightsNum)
+		existingHeights := make(map[uint64]struct{}, heightsNum)
 
 		for i := 0; i < heightsNum; i++ {
-			height := rapid.Uint64Range(1, maxHeight).Draw(rapidT, fmt.Sprintf("generate height#%d", i+1))
+			height := enforceUniqueRandomNumber(existingHeights, maxHeight, func() uint64 {
+				return rapid.Uint64Range(1, maxHeight).Draw(rapidT, fmt.Sprintf("generate height#%d", i+1))
+			})
+
+			existingHeights[height] = struct{}{}
 			shouldDoubleSign := rapid.Bool().Draw(rapidT, "double signing flag")
 			expectedDoubleSigning[height] = shouldDoubleSign
-			// proposalHash := generateRandomProposalHash(t)
+			existingRounds := make(map[uint64]struct{}, roundsNum)
+			proposalHash := generateRandomProposalHash(t)
 
 			for j := 0; j < roundsNum; j++ {
-				round := rapid.Uint64Range(0, maxRound).Draw(rapidT, fmt.Sprintf("generate round#%d", j+1))
+				round := enforceUniqueRandomNumber(existingRounds, uint64(maxRound), func() uint64 {
+					return rapid.Uint64Range(0, maxRound).Draw(rapidT, fmt.Sprintf("generate round#%d", j+1))
+				})
+
+				existingRounds[round] = struct{}{}
+				heights[i] = height
 
 				view := &ibftProto.View{Height: height, Round: round}
-				views[i] = view
 
 				if shouldDoubleSign {
 					messagesCount := rapid.IntRange(2, maxMsgs).Draw(rapidT, "messages count")
 
-					for i := 0; i < messagesCount; i++ {
-						tracker.Handle(buildPrepareMessage(t, view, keys[0], generateRandomProposalHash(t)))
+					for i, key := range keys {
+						if i < len(doubleSignerAddrs) {
+							for msgsCount := 0; msgsCount < messagesCount; msgsCount++ {
+								tracker.Handle(buildPrepareMessage(t, view, key, generateRandomProposalHash(t)))
+							}
+						} else {
+							tracker.Handle(buildPrepareMessage(t, view, key, proposalHash))
+						}
 					}
 				} else {
-					tracker.Handle(buildPrepareMessage(t, view, keys[0], generateRandomProposalHash(t)))
+					for _, key := range keys {
+						tracker.Handle(buildPrepareMessage(t, view, key, proposalHash))
+					}
 				}
 			}
 		}
 
-		for _, view := range views {
-			doubleSigners := tracker.GetDoubleSigners(view.Height)
-			if expectedDoubleSigning[view.Height] {
-				require.Len(t, doubleSigners, 1)
-				require.Equal(t, doubleSigners[0], types.Address(keys[0].Address()))
-			} else {
-				if len(doubleSigners) > 0 {
+		for _, height := range heights {
+			doubleSigners := tracker.GetDoubleSigners(height)
+			if expectedDoubleSigning[height] {
+				if len(doubleSigners) != len(doubleSignerAddrs) {
+					t.Log("failed at height", height)
 					t.Log(tracker.prepare.String())
 				}
+
+				require.Len(t, doubleSigners, len(doubleSignerAddrs))
+				require.Equal(t, doubleSigners, DoubleSigners(doubleSignerAddrs))
+			} else {
+				if len(doubleSigners) > 0 {
+					t.Log("failed at height", height)
+					t.Log(tracker.prepare.String())
+				}
+
 				require.Empty(t, doubleSigners)
 			}
 		}

--- a/consensus/polybft/slashing/double_signing_tracker_test.go
+++ b/consensus/polybft/slashing/double_signing_tracker_test.go
@@ -3,11 +3,9 @@ package slashing
 import (
 	"bytes"
 	"fmt"
-	"math/rand"
 	"sort"
 	"sync"
 	"testing"
-	"time"
 
 	ibftProto "github.com/0xPolygon/go-ibft/messages/proto"
 	"github.com/hashicorp/go-hclog"
@@ -18,8 +16,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
 	"github.com/0xPolygon/polygon-edge/types"
 )
-
-var r = rand.New(rand.NewSource(time.Now().UTC().Unix()))
 
 func TestDoubleSigningTracker_Handle_SingleSender(t *testing.T) {
 	t.Parallel()
@@ -455,10 +451,7 @@ func TestDoubleSigningTracker_GetDoubleSigners_Property(t *testing.T) {
 		existingHeights := make(map[uint64]struct{}, heightsNum)
 
 		for i := 0; i < heightsNum; i++ {
-			height := enforceUniqueRandomNumber(existingHeights, maxHeight, func() uint64 {
-				return rapid.Uint64Range(1, maxHeight).Draw(rapidT, fmt.Sprintf("generate height#%d", i+1))
-			})
-
+			height := enforceUniqueRandomNumber(rapidT, existingHeights, 1, maxHeight, fmt.Sprintf("generate height#%d", i+1))
 			existingHeights[height] = struct{}{}
 			shouldDoubleSign := rapid.Bool().Draw(rapidT, "double signing flag")
 			expectedDoubleSigning[height] = shouldDoubleSign
@@ -466,10 +459,7 @@ func TestDoubleSigningTracker_GetDoubleSigners_Property(t *testing.T) {
 			proposalHash := generateRandomProposalHash(t)
 
 			for j := 0; j < roundsNum; j++ {
-				round := enforceUniqueRandomNumber(existingRounds, uint64(maxRound), func() uint64 {
-					return rapid.Uint64Range(0, maxRound).Draw(rapidT, fmt.Sprintf("generate round#%d", j+1))
-				})
-
+				round := enforceUniqueRandomNumber(rapidT, existingRounds, 0, maxRound, fmt.Sprintf("round#%d", j+1))
 				existingRounds[round] = struct{}{}
 				heights[i] = height
 

--- a/consensus/polybft/slashing/helpers_test.go
+++ b/consensus/polybft/slashing/helpers_test.go
@@ -140,11 +140,9 @@ func enforceUniqueRandomNumber(existingNums map[uint64]struct{}, maxNum uint64, 
 	for {
 		num = numGenFn()
 		if _, ok := existingNums[num]; !ok {
-			break
+			return num
 		}
 	}
-
-	return num
 }
 
 type dummyValidatorsProvider struct {

--- a/consensus/polybft/slashing/helpers_test.go
+++ b/consensus/polybft/slashing/helpers_test.go
@@ -132,6 +132,21 @@ func generateRandomProposalHash(t *testing.T) types.Hash {
 	return types.BytesToHash(result)
 }
 
+// enforceUniqueRandomNumber enforces that generated number is a unique,
+// by checking if generated number is among provided existingNums
+func enforceUniqueRandomNumber(existingNums map[uint64]struct{}, maxNum uint64, numGenFn func() uint64) uint64 {
+	var num uint64
+
+	for {
+		num = numGenFn()
+		if _, ok := existingNums[num]; !ok {
+			break
+		}
+	}
+
+	return num
+}
+
 type dummyValidatorsProvider struct {
 	accounts []*wallet.Account
 }

--- a/consensus/polybft/slashing/helpers_test.go
+++ b/consensus/polybft/slashing/helpers_test.go
@@ -7,6 +7,7 @@ import (
 
 	ibftProto "github.com/0xPolygon/go-ibft/messages/proto"
 	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
@@ -134,11 +135,12 @@ func generateRandomProposalHash(t *testing.T) types.Hash {
 
 // enforceUniqueRandomNumber enforces that generated number is a unique,
 // by checking if generated number is among provided existingNums
-func enforceUniqueRandomNumber(existingNums map[uint64]struct{}, maxNum uint64, numGenFn func() uint64) uint64 {
+func enforceUniqueRandomNumber(rapidT *rapid.T, existingNums map[uint64]struct{},
+	minNum, maxNum uint64, label string) uint64 {
 	var num uint64
 
 	for {
-		num = numGenFn()
+		num = rapid.Uint64Range(minNum, maxNum).Draw(rapidT, label)
 		if _, ok := existingNums[num]; !ok {
 			return num
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -42,7 +42,7 @@ type Hash [HashLength]byte
 
 type Address [AddressLength]byte
 
-func Min(i, j int) int {
+func min(i, j int) int {
 	if i < j {
 		return i
 	}
@@ -54,7 +54,7 @@ func BytesToHash(b []byte) Hash {
 	var h Hash
 
 	size := len(b)
-	min := Min(size, HashLength)
+	min := min(size, HashLength)
 
 	copy(h[HashLength-min:], b[len(b)-min:])
 
@@ -122,7 +122,7 @@ func BytesToAddress(b []byte) Address {
 	var a Address
 
 	size := len(b)
-	min := Min(size, AddressLength)
+	min := min(size, AddressLength)
 
 	copy(a[AddressLength-min:], b[len(b)-min:])
 

--- a/types/types.go
+++ b/types/types.go
@@ -42,7 +42,7 @@ type Hash [HashLength]byte
 
 type Address [AddressLength]byte
 
-func min(i, j int) int {
+func Min(i, j int) int {
 	if i < j {
 		return i
 	}
@@ -54,7 +54,7 @@ func BytesToHash(b []byte) Hash {
 	var h Hash
 
 	size := len(b)
-	min := min(size, HashLength)
+	min := Min(size, HashLength)
 
 	copy(h[HashLength-min:], b[len(b)-min:])
 
@@ -122,7 +122,7 @@ func BytesToAddress(b []byte) Address {
 	var a Address
 
 	size := len(b)
-	min := min(size, AddressLength)
+	min := Min(size, AddressLength)
 
 	copy(a[AddressLength-min:], b[len(b)-min:])
 


### PR DESCRIPTION
# Description

Double signers are malicious actors who have signed more than 1 message of the same type, with different hash in the given round.

Sort messages by rounds and senders in the double signing tracker, so that all validators behave deterministically in terms of tracker storage data alignment.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
