### PR TITLE
Byzantine node testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test-e2e:
 test-e2e-polybft:
     # We can not build with race because of a bug in boltdb dependency
 	go build -o artifacts/polygon-edge .
-	env EDGE_BINARY=${PWD}/artifacts/polygon-edge E2E_TESTS=true E2E_LOGS=true \
+	env EDGE_BINARY=${PWD}/artifacts/polygon-edge E2E_TESTS=true E2E_LOGS=true BYZANTINE_BINARY=${PWD}/e2e-polybft/e2e/polygon-edge-byzantine \
 	go test -v -timeout=1h10m ./e2e-polybft/e2e/...
 
 .PHONY: test-property-polybft

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -221,10 +221,10 @@ func TestE2E_Consensus_RegisterValidator(t *testing.T) {
 
 	// start the first and the second validator
 	cluster.InitTestServer(t, cluster.Config.ValidatorPrefix+strconv.Itoa(validatorSetSize+1),
-		cluster.Bridge.JSONRPCAddr(), true, false)
+		cluster.Bridge.JSONRPCAddr(), true, false, false)
 
 	cluster.InitTestServer(t, cluster.Config.ValidatorPrefix+strconv.Itoa(validatorSetSize+2),
-		cluster.Bridge.JSONRPCAddr(), true, false)
+		cluster.Bridge.JSONRPCAddr(), true, false, false)
 
 	// collect the first and the second validator from the cluster
 	firstValidator := cluster.Servers[validatorSetSize]
@@ -617,4 +617,24 @@ func TestE2E_Consensus_CustomRewardToken(t *testing.T) {
 
 	require.NoError(t, err)
 	require.True(t, validatorInfo.WithdrawableRewards.Cmp(big.NewInt(0)) > 0)
+}
+
+func TestE2E_Consensus_WithByzantineNode(t *testing.T) {
+	const (
+		epochSize      = 4
+		validatorCount = 4
+		byzantineCount = 2
+	)
+
+	cluster := framework.NewTestCluster(t, validatorCount,
+		framework.WithEpochSize(epochSize),
+		framework.WithByzantineNodes(byzantineCount),
+	)
+	defer cluster.Stop()
+
+	cluster.WaitForReady(t)
+
+	t.Run("consensus protocol", func(t *testing.T) {
+		require.NoError(t, cluster.WaitForBlock(2*epochSize+1, 1*time.Minute))
+	})
 }

--- a/e2e-polybft/e2e/migration_test.go
+++ b/e2e-polybft/e2e/migration_test.go
@@ -202,6 +202,6 @@ func TestE2E_Migration(t *testing.T) {
 	_, err = cluster.InitSecrets("test-chain-8", 1)
 	require.NoError(t, err)
 
-	cluster.InitTestServer(t, "test-chain-8", cluster.Bridge.JSONRPCAddr(), false, false)
+	cluster.InitTestServer(t, "test-chain-8", cluster.Bridge.JSONRPCAddr(), false, false, false)
 	require.NoError(t, cluster.WaitForBlock(33, time.Minute))
 }

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -651,7 +651,7 @@ func (c *TestCluster) InitTestServer(t *testing.T,
 		}
 	}
 
-	srv := NewTestServer(t, c.Config, bridgeJSONRPC, byzantine, func(config *TestServerConfig) {
+	srv := NewTestServer(t, c.Config, bridgeJSONRPC, func(config *TestServerConfig) {
 		config.DataDir = dataDir
 		config.Seal = isValidator
 		config.Chain = c.Config.Dir("genesis.json")
@@ -660,6 +660,7 @@ func (c *TestCluster) InitTestServer(t *testing.T,
 		config.Relayer = relayer
 		config.NumBlockConfirmations = c.Config.NumBlockConfirmations
 		config.BridgeJSONRPC = bridgeJSONRPC
+		config.Byzantine = byzantine
 	})
 
 	// watch the server for stop signals. It is important to fix the specific

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -72,7 +72,7 @@ func resolveBinary() string {
 	return "polygon-edge"
 }
 
-func resolveByzantineBynary() string {
+func resolveByzantineBinary() string {
 	bin := os.Getenv("BYZANTINE_BINARY")
 	if bin != "" {
 		return bin
@@ -398,7 +398,7 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 		WithLogs:        isTrueEnv(envLogsEnabled),
 		WithStdout:      isTrueEnv(envStdoutEnabled),
 		Binary:          resolveBinary(),
-		ByzantineBinary: resolveByzantineBynary(),
+		ByzantineBinary: resolveByzantineBinary(),
 		EpochSize:       10,
 		EpochReward:     1,
 		BlockGasLimit:   1e7, // 10M

--- a/e2e-polybft/framework/test-server.go
+++ b/e2e-polybft/framework/test-server.go
@@ -38,6 +38,7 @@ type TestServerConfig struct {
 	Relayer               bool
 	NumBlockConfirmations uint64
 	BridgeJSONRPC         string
+	Byzantine             bool
 }
 
 type TestServerConfigCallback func(*TestServerConfig)
@@ -57,7 +58,6 @@ type TestServer struct {
 	clusterConfig *TestClusterConfig
 	config        *TestServerConfig
 	node          *node
-	byzantine     bool
 }
 
 func (t *TestServer) GrpcAddr() string {
@@ -113,6 +113,7 @@ func NewTestServer(t *testing.T, clusterConfig *TestClusterConfig,
 		GRPCPort:      getOpenPortForServer(),
 		P2PPort:       getOpenPortForServer(),
 		BridgeJSONRPC: bridgeJSONRPC,
+		Byzantine:     byzantine,
 	}
 
 	if callback != nil {
@@ -137,7 +138,6 @@ func NewTestServer(t *testing.T, clusterConfig *TestClusterConfig,
 		clusterConfig: clusterConfig,
 		address:       types.Address(key.Address()),
 		config:        config,
-		byzantine:     byzantine,
 	}
 	srv.Start()
 
@@ -186,7 +186,9 @@ func (t *TestServer) Start() {
 	stdout := t.clusterConfig.GetStdout(t.config.Name)
 
 	binary := t.clusterConfig.Binary
-	if t.byzantine && t.clusterConfig.ByzantineBinary != "" {
+	if config.Byzantine && t.clusterConfig.ByzantineBinary == "" {
+		t.t.Fatal("no byzantine binary")
+	} else if config.Byzantine {
 		binary = t.clusterConfig.ByzantineBinary
 	}
 

--- a/e2e-polybft/framework/test-server.go
+++ b/e2e-polybft/framework/test-server.go
@@ -104,7 +104,7 @@ func (t *TestServer) TxnPoolOperator() txpoolProto.TxnPoolOperatorClient {
 }
 
 func NewTestServer(t *testing.T, clusterConfig *TestClusterConfig,
-	bridgeJSONRPC string, byzantine bool, callback TestServerConfigCallback) *TestServer {
+	bridgeJSONRPC string, callback TestServerConfigCallback) *TestServer {
 	t.Helper()
 
 	config := &TestServerConfig{
@@ -113,7 +113,6 @@ func NewTestServer(t *testing.T, clusterConfig *TestClusterConfig,
 		GRPCPort:      getOpenPortForServer(),
 		P2PPort:       getOpenPortForServer(),
 		BridgeJSONRPC: bridgeJSONRPC,
-		Byzantine:     byzantine,
 	}
 
 	if callback != nil {

--- a/e2e-polybft/framework/test-server.go
+++ b/e2e-polybft/framework/test-server.go
@@ -184,8 +184,8 @@ func (t *TestServer) Start() {
 
 	// Start the server
 	stdout := t.clusterConfig.GetStdout(t.config.Name)
-
 	binary := t.clusterConfig.Binary
+
 	if config.Byzantine && t.clusterConfig.ByzantineBinary == "" {
 		t.t.Fatal("no byzantine binary")
 	} else if config.Byzantine {

--- a/e2e-polybft/framework/test-server.go
+++ b/e2e-polybft/framework/test-server.go
@@ -57,6 +57,7 @@ type TestServer struct {
 	clusterConfig *TestClusterConfig
 	config        *TestServerConfig
 	node          *node
+	byzantine     bool
 }
 
 func (t *TestServer) GrpcAddr() string {
@@ -103,7 +104,7 @@ func (t *TestServer) TxnPoolOperator() txpoolProto.TxnPoolOperatorClient {
 }
 
 func NewTestServer(t *testing.T, clusterConfig *TestClusterConfig,
-	bridgeJSONRPC string, callback TestServerConfigCallback) *TestServer {
+	bridgeJSONRPC string, byzantine bool, callback TestServerConfigCallback) *TestServer {
 	t.Helper()
 
 	config := &TestServerConfig{
@@ -136,6 +137,7 @@ func NewTestServer(t *testing.T, clusterConfig *TestClusterConfig,
 		clusterConfig: clusterConfig,
 		address:       types.Address(key.Address()),
 		config:        config,
+		byzantine:     byzantine,
 	}
 	srv.Start()
 
@@ -183,7 +185,12 @@ func (t *TestServer) Start() {
 	// Start the server
 	stdout := t.clusterConfig.GetStdout(t.config.Name)
 
-	node, err := newNode(t.clusterConfig.Binary, args, stdout)
+	binary := t.clusterConfig.Binary
+	if t.byzantine && t.clusterConfig.ByzantineBinary != "" {
+		binary = t.clusterConfig.ByzantineBinary
+	}
+
+	node, err := newNode(binary, args, stdout)
 	if err != nil {
 		t.t.Fatal(err)
 	}


### PR DESCRIPTION
# Description

With the `WithByzantineNodes` we can set the number of byzantine nodes in the cluster. 
Byzantine node binary is currently located in "e2e-polybft/e2e/polygon-edge-byzantine". Makefile command `test-e2e-polybft` is changed to create a new env variable BYZANTINE_BINARY for resolving binary location for the byzantine node. 


# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
