### PR TITLE
NOTICKET: parse pending block correctly for BlockNumberOrHash

### DIFF
--- a/jsonrpc/codec.go
+++ b/jsonrpc/codec.go
@@ -176,7 +176,9 @@ func stringToBlockNumber(str string) (BlockNumber, error) {
 
 	str = strings.Trim(str, "\"")
 	switch str {
-	case pending, latest:
+	case pending:
+		return PendingBlockNumber, nil
+	case latest:
 		return LatestBlockNumber, nil
 	case earliest:
 		return EarliestBlockNumber, nil

--- a/jsonrpc/codec_test.go
+++ b/jsonrpc/codec_test.go
@@ -16,6 +16,7 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 
 	blockNumberZero := BlockNumber(0x0)
 	blockNumberLatest := LatestBlockNumber
+	blockNumberPending := PendingBlockNumber
 
 	tests := []struct {
 		name        string
@@ -56,6 +57,14 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 			false,
 			BlockNumberOrHash{
 				BlockNumber: &blockNumberLatest,
+			},
+		},
+		{
+			"should unmarshal pending block number properly",
+			`"pending"`,
+			false,
+			BlockNumberOrHash{
+				BlockNumber: &blockNumberPending,
 			},
 		},
 		{

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -304,7 +304,7 @@ func TestDispatcherFuncDecode(t *testing.T) {
 		{
 			"filter",
 			`[{"fromBlock": "pending", "toBlock": "earliest"}]`,
-			LogQuery{fromBlock: LatestBlockNumber, toBlock: EarliestBlockNumber}, // pending = latest
+			LogQuery{fromBlock: PendingBlockNumber, toBlock: EarliestBlockNumber}, // pending = latest
 		},
 	}
 

--- a/jsonrpc/query_test.go
+++ b/jsonrpc/query_test.go
@@ -105,7 +105,7 @@ func TestFilterDecode(t *testing.T) {
 				"toBlock": "earliest"
 			}`,
 			&LogQuery{
-				fromBlock: LatestBlockNumber, // pending = latest
+				fromBlock: PendingBlockNumber,
 				toBlock:   EarliestBlockNumber,
 			},
 		},


### PR DESCRIPTION
# Description

It looks like this bug was intentionally introduced, so a bit more follow up might be required: https://github.com/0xPolygon/polygon-edge/pull/974

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Technically it can be considered a breaking change as it changes the semantics of public endpoints that relly on unmarshalling `BlockNumberOrHash`.

# Checklist

- [ ] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
