### PR TITLE
EVM-778 Debug Transaction endpoint - use one structure for logs

### DIFF
--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -236,7 +236,7 @@ func (c *state) Run() ([]byte, error) {
 		inst := dispatchTable[op]
 		if inst.inst == nil {
 			c.exit(errOpCodeNotFound)
-			c.captureExecutionError(op.String(), c.ip, gasCopy, 0)
+			c.captureExecution(op.String(), uint64(c.ip), gasCopy, 0)
 
 			break
 		}
@@ -244,7 +244,7 @@ func (c *state) Run() ([]byte, error) {
 		// check if the depth of the stack is enough for the instruction
 		if c.sp < inst.stack {
 			c.exit(&runtime.StackUnderflowError{StackLen: c.sp, Required: inst.stack})
-			c.captureExecutionError(op.String(), c.ip, gasCopy, inst.gas)
+			c.captureExecution(op.String(), uint64(c.ip), gasCopy, inst.gas)
 
 			break
 		}
@@ -252,7 +252,7 @@ func (c *state) Run() ([]byte, error) {
 		// consume the gas of the instruction
 		if !c.consumeGas(inst.gas) {
 			c.exit(errOutOfGas)
-			c.captureExecutionError(op.String(), c.ip, gasCopy, inst.gas)
+			c.captureExecution(op.String(), uint64(c.ip), gasCopy, inst.gas)
 
 			break
 		}
@@ -260,7 +260,7 @@ func (c *state) Run() ([]byte, error) {
 		// execute the instruction
 		inst.inst(c)
 
-		c.captureSuccessfulExecution(op.String(), ipCopy, gasCopy, gasCopy-c.gas)
+		c.captureExecution(op.String(), ipCopy, gasCopy, gasCopy-c.gas)
 
 		// check if stack size exceeds the max size
 		if c.sp > stackSize {
@@ -390,14 +390,13 @@ func (c *state) captureState(opCode int) {
 	)
 }
 
-func (c *state) captureSuccessfulExecution(
+func (c *state) captureExecution(
 	opCode string,
 	ip uint64,
 	gas uint64,
 	consumedGas uint64,
 ) {
 	tracer := c.host.GetTracer()
-
 	if tracer == nil {
 		return
 	}
@@ -405,31 +404,6 @@ func (c *state) captureSuccessfulExecution(
 	tracer.ExecuteState(
 		c.msg.Address,
 		ip,
-		opCode,
-		gas,
-		consumedGas,
-		c.returnData,
-		c.msg.Depth,
-		c.err,
-		c.host,
-	)
-}
-
-func (c *state) captureExecutionError(
-	opCode string,
-	ip int,
-	gas uint64,
-	consumedGas uint64,
-) {
-	tracer := c.host.GetTracer()
-
-	if tracer == nil {
-		return
-	}
-
-	tracer.ExecuteState(
-		c.msg.Address,
-		uint64(ip),
 		opCode,
 		gas,
 		consumedGas,


### PR DESCRIPTION
# Description

Use only one structure for logs to reduce memory consumption. 

Prior to these changes, there was an additional slice of objects that stored information about each step's execution. That slice was later on converted into json response slice of different objects. That caused additional memory consumption without any special reason.

Additionally, `omitempty` is added for fields
```
Stack           []string          `json:"stack,omitempty"`
Memory       []string          `json:"memory,omitempty"`
Storage       map[string]string `json:"storage,omitempty"`
```
and that will reduce json output in case when those fields are empty or disabled by json request input parameters (`disableStack, disableStorage, enableMemory`).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [X] I have tested this code manually

### Manual tests

Start cluster, deploy smart contract(s) and transaction that calls some of those sc. `0x09e60436fc2344c03ef2c721dcb179d2e9cb4cecf535f1217f25abe24ea37dc6` is hash of that transaction and that is the tx you want to debug.
Try to execute following endpoint request. You should get the same json response as with old code (minus that in newest version empty fields will be omitted)
```
[{
	"jsonrpc":"2.0",
	"method":"debug_traceTransaction",
	"params":[
        "0x09e60436fc2344c03ef2c721dcb179d2e9cb4cecf535f1217f25abe24ea37dc6",
        {
            "timeout": "30s",
            "disableStack": false,
            "disableStorage": false,
            "enableMemory": true,
            "enableReturnData": true
        }
	],
	"id":1
}]
```
