### PR TITLE
EstimateGas endpoint - nonce should be automatically set the current nonce for the account

### DIFF
--- a/jsonrpc/debug_endpoint.go
+++ b/jsonrpc/debug_endpoint.go
@@ -155,7 +155,7 @@ func (d *Debug) TraceCall(
 		return nil, ErrHeaderNotFound
 	}
 
-	tx, err := DecodeTxn(arg, header.Number, d.store)
+	tx, err := DecodeTxn(arg, d.store, true)
 	if err != nil {
 		return nil, err
 	}

--- a/jsonrpc/debug_endpoint.go
+++ b/jsonrpc/debug_endpoint.go
@@ -155,7 +155,7 @@ func (d *Debug) TraceCall(
 		return nil, ErrHeaderNotFound
 	}
 
-	tx, err := DecodeTxn(arg, d.store, true)
+	tx, err := DecodeTxn(arg, header.Number, d.store, true)
 	if err != nil {
 		return nil, err
 	}

--- a/jsonrpc/debug_endpoint_test.go
+++ b/jsonrpc/debug_endpoint_test.go
@@ -600,8 +600,6 @@ func TestTraceCall(t *testing.T) {
 		}
 	)
 
-	decodedTx.ComputeHash(1)
-
 	tests := []struct {
 		name   string
 		arg    *txnArgs
@@ -630,6 +628,12 @@ func TestTraceCall(t *testing.T) {
 
 					return testTraceResult, nil
 				},
+				headerFn: func() *types.Header {
+					return testLatestHeader
+				},
+				getAccountFn: func(h types.Hash, a types.Address) (*Account, error) {
+					return &Account{Nonce: 1}, nil
+				},
 			},
 			result: testTraceResult,
 			err:    false,
@@ -647,6 +651,12 @@ func TestTraceCall(t *testing.T) {
 					assert.False(t, full)
 
 					return nil, false
+				},
+				headerFn: func() *types.Header {
+					return testLatestHeader
+				},
+				getAccountFn: func(h types.Hash, a types.Address) (*Account, error) {
+					return &Account{Nonce: 1}, nil
 				},
 			},
 			result: nil,
@@ -666,6 +676,9 @@ func TestTraceCall(t *testing.T) {
 			store: &debugEndpointMockStore{
 				headerFn: func() *types.Header {
 					return testLatestHeader
+				},
+				getAccountFn: func(h types.Hash, a types.Address) (*Account, error) {
+					return &Account{Nonce: 1}, nil
 				},
 			},
 			result: nil,

--- a/jsonrpc/debug_endpoint_test.go
+++ b/jsonrpc/debug_endpoint_test.go
@@ -600,6 +600,8 @@ func TestTraceCall(t *testing.T) {
 		}
 	)
 
+	decodedTx.ComputeHash(1)
+
 	tests := []struct {
 		name   string
 		arg    *txnArgs

--- a/jsonrpc/eth_blockchain_test.go
+++ b/jsonrpc/eth_blockchain_test.go
@@ -594,6 +594,10 @@ func (m *mockBlockStore) TxPoolSubscribe(request *proto.SubscribeRequest) (<-cha
 	return nil, nil, nil
 }
 
+func (m *mockBlockStore) GetAccount(root types.Hash, addr types.Address) (*Account, error) {
+	return &Account{Nonce: 0}, nil
+}
+
 func newTestBlock(number uint64, hash types.Hash) *types.Block {
 	return &types.Block{
 		Header: &types.Header{

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -444,7 +444,7 @@ func (e *Eth) Call(arg *txnArgs, filter BlockNumberOrHash, apiOverride *stateOve
 		return nil, err
 	}
 
-	transaction, err := DecodeTxn(arg, header.Number, e.store)
+	transaction, err := DecodeTxn(arg, e.store, true)
 	if err != nil {
 		return nil, err
 	}
@@ -492,7 +492,8 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 		return nil, err
 	}
 
-	transaction, err := DecodeTxn(arg, header.Number, e.store)
+	// testTransaction should execute tx with nonce always set to the current expected nonce for the account
+	transaction, err := DecodeTxn(arg, e.store, true)
 	if err != nil {
 		return nil, err
 	}
@@ -589,8 +590,7 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 
 	// Checks if EVM level valid gas errors occurred
 	isGasEVMError := func(err error) bool {
-		return errors.Is(err, runtime.ErrOutOfGas) ||
-			errors.Is(err, runtime.ErrCodeStoreOutOfGas)
+		return errors.Is(err, runtime.ErrOutOfGas) || errors.Is(err, runtime.ErrCodeStoreOutOfGas)
 	}
 
 	// Checks if the EVM reverted during execution
@@ -601,11 +601,9 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 	// Run the transaction with the specified gas value.
 	// Returns a status indicating if the transaction failed and the accompanying error
 	testTransaction := func(gas uint64, shouldOmitErr bool) (bool, error) {
-		// Create a dummy transaction with the new gas
-		txn := transaction.Copy()
-		txn.Gas = gas
+		transaction.Gas = gas
 
-		result, applyErr := e.store.ApplyTxn(header, txn, nil)
+		result, applyErr := e.store.ApplyTxn(header, transaction, nil)
 
 		if applyErr != nil {
 			// Check the application error.
@@ -643,11 +641,10 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 
 	// Start the binary search for the lowest possible gas price
 	for lowEnd < highEnd {
-		mid := (lowEnd + highEnd) / 2
+		mid := lowEnd + ((highEnd - lowEnd) >> 1) // (lowEnd + highEnd) / 2 can overflow
 
 		failed, testErr := testTransaction(mid, true)
-		if testErr != nil &&
-			!isEVMRevertError(testErr) {
+		if testErr != nil && !isEVMRevertError(testErr) {
 			// Reverts are ignored in the binary search, but are checked later on
 			// during the execution for the optimal gas limit found
 			return 0, testErr

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -444,7 +444,7 @@ func (e *Eth) Call(arg *txnArgs, filter BlockNumberOrHash, apiOverride *stateOve
 		return nil, err
 	}
 
-	transaction, err := DecodeTxn(arg, e.store, true)
+	transaction, err := DecodeTxn(arg, header.Number, e.store, true)
 	if err != nil {
 		return nil, err
 	}
@@ -493,7 +493,7 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 	}
 
 	// testTransaction should execute tx with nonce always set to the current expected nonce for the account
-	transaction, err := DecodeTxn(arg, e.store, true)
+	transaction, err := DecodeTxn(arg, header.Number, e.store, true)
 	if err != nil {
 		return nil, err
 	}

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -160,15 +160,12 @@ func TestEth_DecodeTxn(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if tt.res != nil {
-				tt.res.ComputeHash(1)
-			}
 			store := newMockStore()
 			for addr, acc := range tt.accounts {
 				store.SetAccount(addr, acc)
 			}
 
-			res, err := DecodeTxn(tt.arg, 1, store)
+			res, err := DecodeTxn(tt.arg, store, false)
 			assert.Equal(t, tt.res, res)
 			assert.Equal(t, tt.err, err)
 		})
@@ -288,9 +285,8 @@ func TestEth_TxnType(t *testing.T) {
 		Nonce:     0,
 		Type:      types.DynamicFeeTx,
 	}
-	res, err := DecodeTxn(args, 1, store)
+	res, err := DecodeTxn(args, store, false)
 
-	expectedRes.ComputeHash(1)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedRes, res)
 }

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -160,12 +160,16 @@ func TestEth_DecodeTxn(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			if tt.res != nil {
+				tt.res.ComputeHash(1)
+			}
+
 			store := newMockStore()
 			for addr, acc := range tt.accounts {
 				store.SetAccount(addr, acc)
 			}
 
-			res, err := DecodeTxn(tt.arg, store, false)
+			res, err := DecodeTxn(tt.arg, 1, store, false)
 			assert.Equal(t, tt.res, res)
 			assert.Equal(t, tt.err, err)
 		})
@@ -285,8 +289,9 @@ func TestEth_TxnType(t *testing.T) {
 		Nonce:     0,
 		Type:      types.DynamicFeeTx,
 	}
-	res, err := DecodeTxn(args, store, false)
+	res, err := DecodeTxn(args, 1, store, false)
 
+	expectedRes.ComputeHash(1)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedRes, res)
 }

--- a/jsonrpc/helper.go
+++ b/jsonrpc/helper.go
@@ -165,7 +165,7 @@ func GetNextNonce(address types.Address, number BlockNumber, store nonceGetter) 
 	return acc.Nonce, nil
 }
 
-func DecodeTxn(arg *txnArgs, blockNumber uint64, store nonceGetter) (*types.Transaction, error) {
+func DecodeTxn(arg *txnArgs, store nonceGetter, forceSetNonce bool) (*types.Transaction, error) {
 	if arg == nil {
 		return nil, errors.New("missing value for required argument 0")
 	}
@@ -173,7 +173,7 @@ func DecodeTxn(arg *txnArgs, blockNumber uint64, store nonceGetter) (*types.Tran
 	if arg.From == nil {
 		arg.From = &types.ZeroAddress
 		arg.Nonce = argUintPtr(0)
-	} else if arg.Nonce == nil {
+	} else if arg.Nonce == nil || forceSetNonce {
 		// get nonce from the pool
 		nonce, err := GetNextNonce(*arg.From, LatestBlockNumber, store)
 		if err != nil {
@@ -237,8 +237,6 @@ func DecodeTxn(arg *txnArgs, blockNumber uint64, store nonceGetter) (*types.Tran
 	if arg.To != nil {
 		txn.To = arg.To
 	}
-
-	txn.ComputeHash(blockNumber)
 
 	return txn, nil
 }

--- a/jsonrpc/helper.go
+++ b/jsonrpc/helper.go
@@ -165,7 +165,7 @@ func GetNextNonce(address types.Address, number BlockNumber, store nonceGetter) 
 	return acc.Nonce, nil
 }
 
-func DecodeTxn(arg *txnArgs, store nonceGetter, forceSetNonce bool) (*types.Transaction, error) {
+func DecodeTxn(arg *txnArgs, blockNumber uint64, store nonceGetter, forceSetNonce bool) (*types.Transaction, error) {
 	if arg == nil {
 		return nil, errors.New("missing value for required argument 0")
 	}
@@ -237,6 +237,8 @@ func DecodeTxn(arg *txnArgs, store nonceGetter, forceSetNonce bool) (*types.Tran
 	if arg.To != nil {
 		txn.To = arg.To
 	}
+
+	txn.ComputeHash(blockNumber)
 
 	return txn, nil
 }

--- a/jsonrpc/helper_test.go
+++ b/jsonrpc/helper_test.go
@@ -825,7 +825,12 @@ func TestDecodeTxn(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			tx, err := DecodeTxn(test.arg, test.store, false)
+			tx, err := DecodeTxn(test.arg, 1, test.store, false)
+
+			// DecodeTxn computes hash of tx
+			if !test.err {
+				test.expected.ComputeHash(1)
+			}
 
 			assert.Equal(t, test.expected, tx)
 

--- a/jsonrpc/helper_test.go
+++ b/jsonrpc/helper_test.go
@@ -825,12 +825,7 @@ func TestDecodeTxn(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			tx, err := DecodeTxn(test.arg, 1, test.store)
-
-			// DecodeTxn computes hash of tx
-			if !test.err {
-				test.expected.ComputeHash(1)
-			}
+			tx, err := DecodeTxn(test.arg, test.store, false)
 
 			assert.Equal(t, test.expected, tx)
 


### PR DESCRIPTION
# Description

- The DebugTransaction, EstimateGas, and Call endpoints should not depend on the nonce provided by the user. Instead, the nonce should be automatically set to the current value for the account.

- I have left the optional parameter forceNonce in DecodeTxn because, in the future, certain endpoints might rely on the nonce provided by the user.

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [X] I have tested this code manually

### Manual tests

- Start cluster
- Execute from the terminal:
```
cur_nonce=$(cast nonce --block pending --rpc-url http://127.0.0.1:10002/ 0x85da99c8a7c2c95964c8efd687e95e632fc533d6)
gap_nonce=$((cur_nonce + 1))
cast send --legacy --private-key 0x42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa --rpc-url http://127.0.0.1:10002/ --async --nonce $gap_nonce 0x03893a7c7463AE47D46bc7f091665f1893656003
```
- There should be no error
- Try sending tx with `cur_nonce` also and then both of those transactions should be included in some block