### PR TITLE
Invoke `PruneMsgsUntil` when block is written into blockchain

### DIFF
--- a/consensus/polybft/slashing/double_signing_tracker.go
+++ b/consensus/polybft/slashing/double_signing_tracker.go
@@ -340,7 +340,9 @@ func (t *DoubleSigningTrackerImpl) GetDoubleSigners(height uint64) DoubleSigners
 }
 
 // PostBlock is used to populate all known validators
-func (t *DoubleSigningTrackerImpl) PostBlock(_ *common.PostBlockRequest) error {
+func (t *DoubleSigningTrackerImpl) PostBlock(req *common.PostBlockRequest) error {
+	t.PruneMsgsUntil(req.FullBlock.Block.Number())
+
 	validators, err := t.validatorsProvider.GetAllValidators()
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description

Clean up past collected messages in the double signing tracker when a certain block gets written into the blockchain. So when a block N gets written, collected relayed consensus messages up to block N-1 (inclusive) get deleted.
