### PR TITLE
EVM-779 Throttling with concurrency

### DIFF
--- a/command/server/config/config.go
+++ b/command/server/config/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	Relayer               bool   `json:"relayer" yaml:"relayer"`
 	NumBlockConfirmations uint64 `json:"num_block_confirmations" yaml:"num_block_confirmations"`
 
-	RequestsPerSecondDebug uint64 `json:"requests_per_second_debug" yaml:"requests_per_second_debug"`
+	ConcurrentRequestsDebug uint64 `json:"requests_per_second_debug" yaml:"requests_per_second_debug"`
 }
 
 // Telemetry holds the config details for metric services.
@@ -82,8 +82,8 @@ const (
 	// on ethereum epoch lasts for 32 blocks. more details: https://www.alchemy.com/overviews/ethereum-commitment-levels
 	DefaultNumBlockConfirmations uint64 = 64
 
-	// Maximum number of allowed requests per second for debug endpoints
-	DefaultRequestsPerSecondDebug uint64 = 5
+	// Maximum number of allowed concurrent requests for debug endpoints
+	DefaultConcurrentRequestsDebug uint64 = 32
 )
 
 // DefaultConfig returns the default server configuration
@@ -121,7 +121,7 @@ func DefaultConfig() *Config {
 		JSONRPCBlockRangeLimit:   DefaultJSONRPCBlockRangeLimit,
 		Relayer:                  false,
 		NumBlockConfirmations:    DefaultNumBlockConfirmations,
-		RequestsPerSecondDebug:   DefaultRequestsPerSecondDebug,
+		ConcurrentRequestsDebug:  DefaultConcurrentRequestsDebug,
 	}
 }
 

--- a/command/server/config/config.go
+++ b/command/server/config/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	Relayer               bool   `json:"relayer" yaml:"relayer"`
 	NumBlockConfirmations uint64 `json:"num_block_confirmations" yaml:"num_block_confirmations"`
 
-	ConcurrentRequestsDebug uint64 `json:"requests_per_second_debug" yaml:"requests_per_second_debug"`
+	ConcurrentRequestsDebug uint64 `json:"concurrent_requests_debug" yaml:"concurrent_requests_debug"`
 }
 
 // Telemetry holds the config details for metric services.

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -41,7 +41,7 @@ const (
 	relayerFlag               = "relayer"
 	numBlockConfirmationsFlag = "num-block-confirmations"
 
-	requestsPerSecondDebugFlag = "requests-per-second-debug"
+	concurrentRequestsDebugFlag = "concurrent-requests-debug"
 )
 
 // Flags that are deprecated, but need to be preserved for
@@ -154,7 +154,7 @@ func (p *serverParams) generateConfig() *server.Config {
 			AccessControlAllowOrigin: p.rawConfig.CorsAllowedOrigins,
 			BatchLengthLimit:         p.rawConfig.JSONRPCBatchRequestLimit,
 			BlockRangeLimit:          p.rawConfig.JSONRPCBlockRangeLimit,
-			RequestsPerSecondDebug:   p.rawConfig.RequestsPerSecondDebug,
+			ConcurrentRequestsDebug:  p.rawConfig.ConcurrentRequestsDebug,
 		},
 		GRPCAddr:   p.grpcAddress,
 		LibP2PAddr: p.libp2pAddress,

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -229,10 +229,10 @@ func setFlags(cmd *cobra.Command) {
 	)
 
 	cmd.Flags().Uint64Var(
-		&params.rawConfig.RequestsPerSecondDebug,
-		requestsPerSecondDebugFlag,
-		defaultConfig.RequestsPerSecondDebug,
-		"maximal number of requests per second for debug endpoints",
+		&params.rawConfig.ConcurrentRequestsDebug,
+		concurrentRequestsDebugFlag,
+		defaultConfig.ConcurrentRequestsDebug,
+		"maximal number of concurrent requests for debug endpoints",
 	)
 
 	setLegacyFlags(cmd)

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -60,7 +60,7 @@ type dispatcherParams struct {
 	jsonRPCBatchLengthLimit uint64
 	blockRangeLimit         uint64
 
-	requestsPerSecondDebug uint64
+	concurrentRequestsDebug uint64
 }
 
 func (dp dispatcherParams) isExceedingBatchLengthLimit(value uint64) bool {
@@ -111,7 +111,7 @@ func (d *Dispatcher) registerEndpoints(store JSONRPCStore) error {
 	d.endpoints.Bridge = &Bridge{
 		store,
 	}
-	d.endpoints.Debug = NewDebug(store, int(d.params.requestsPerSecondDebug))
+	d.endpoints.Debug = NewDebug(store, d.params.concurrentRequestsDebug)
 
 	var err error
 

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -69,7 +69,7 @@ type Config struct {
 	BatchLengthLimit         uint64
 	BlockRangeLimit          uint64
 
-	RequestsPerSecondDebug uint64
+	ConcurrentRequestsDebug uint64
 }
 
 // NewJSONRPC returns the JSONRPC http server
@@ -83,7 +83,7 @@ func NewJSONRPC(logger hclog.Logger, config *Config) (*JSONRPC, error) {
 			priceLimit:              config.PriceLimit,
 			jsonRPCBatchLengthLimit: config.BatchLengthLimit,
 			blockRangeLimit:         config.BlockRangeLimit,
-			requestsPerSecondDebug:  config.RequestsPerSecondDebug,
+			concurrentRequestsDebug: config.ConcurrentRequestsDebug,
 		},
 	)
 

--- a/jsonrpc/throttling.go
+++ b/jsonrpc/throttling.go
@@ -24,7 +24,7 @@ func NewThrottling(maximumConcurrentRequests uint64, timeout time.Duration) *Thr
 	}
 }
 
-// AttemptRequest returns an error if there is more thab
+// AttemptRequest returns an error if more than the maximum concurrent requests are currently being executed
 func (t *Throttling) AttemptRequest(
 	parentCtx context.Context,
 	requestHandler func() (interface{}, error)) (interface{}, error) {

--- a/jsonrpc/throttling.go
+++ b/jsonrpc/throttling.go
@@ -1,70 +1,41 @@
 package jsonrpc
 
 import (
-	"container/heap"
+	"context"
 	"errors"
-	"sync"
 	"time"
+
+	"golang.org/x/sync/semaphore"
 )
 
 var errRequestLimitExceeded = errors.New("request limit exceeded")
 
+// Throttling provides functionality which limits number of concurrent requests
 type Throttling struct {
-	requestsPerSeconds int
-	requests           timeQueue
-	lock               sync.Mutex
+	sem     *semaphore.Weighted
+	timeout time.Duration
 }
 
-func NewThrottling(requestsPerSeconds int) *Throttling {
+// NewThrottling creates new throttling and limits number of concurrent requests to maximumConcurrentRequests
+func NewThrottling(maximumConcurrentRequests uint64, timeout time.Duration) *Throttling {
 	return &Throttling{
-		requestsPerSeconds: requestsPerSeconds,
+		sem:     semaphore.NewWeighted(int64(maximumConcurrentRequests)),
+		timeout: timeout,
 	}
 }
 
-func (t *Throttling) AttemptRequest() error {
-	t.lock.Lock()
-	defer t.lock.Unlock()
+// AttemptRequest returns an error if there is more thab
+func (t *Throttling) AttemptRequest(
+	parentCtx context.Context,
+	requestHandler func() (interface{}, error)) (interface{}, error) {
+	ctx, cancel := context.WithTimeout(parentCtx, t.timeout)
+	defer cancel()
 
-	currTime := time.Now().UTC()
-
-	// remove all old requests
-	for t.requests.Len() > 0 && currTime.Sub(t.requests[0]) > time.Second {
-		heap.Pop(&t.requests)
+	if err := t.sem.Acquire(ctx, 1); err != nil {
+		return nil, errRequestLimitExceeded
 	}
 
-	// if too many requests in one second return error
-	if t.requests.Len() == t.requestsPerSeconds {
-		return errRequestLimitExceeded
-	}
+	defer t.sem.Release(1)
 
-	heap.Push(&t.requests, currTime)
-
-	return nil
-}
-
-type timeQueue []time.Time
-
-func (t *timeQueue) Len() int {
-	return len(*t)
-}
-
-func (t *timeQueue) Swap(i, j int) {
-	(*t)[i], (*t)[j] = (*t)[j], (*t)[i]
-}
-
-func (t *timeQueue) Push(x interface{}) {
-	if time, ok := x.(time.Time); ok {
-		*t = append(*t, time)
-	}
-}
-
-func (t *timeQueue) Pop() interface{} {
-	x := (*t)[len(*t)-1]
-	*t = (*t)[0 : len(*t)-1]
-
-	return x
-}
-
-func (t *timeQueue) Less(i, j int) bool {
-	return (*t)[i].Compare((*t)[j]) < 0
+	return requestHandler()
 }

--- a/jsonrpc/throttling_test.go
+++ b/jsonrpc/throttling_test.go
@@ -38,7 +38,7 @@ func TestThrottling(t *testing.T) {
 
 	for i := 2; i <= 5; i++ {
 		go func() {
-			wg.Done()
+			defer wg.Done()
 
 			res, err := th.AttemptRequest(context.Background(), sfn(100, time.Millisecond*1000))
 
@@ -46,6 +46,8 @@ func TestThrottling(t *testing.T) {
 			assert.Equal(t, 100, res.(int)) // nolint
 		}()
 	}
+
+	time.Sleep(time.Millisecond * 200)
 
 	go func() {
 		defer wg.Done()
@@ -56,10 +58,10 @@ func TestThrottling(t *testing.T) {
 		assert.Nil(t, res)
 	}()
 
-	time.Sleep(time.Millisecond * 200)
+	time.Sleep(time.Millisecond * 1000)
 
 	go func() {
-		wg.Done()
+		defer wg.Done()
 
 		res, err := th.AttemptRequest(context.Background(), sfn(10, time.Millisecond))
 

--- a/jsonrpc/throttling_test.go
+++ b/jsonrpc/throttling_test.go
@@ -13,7 +13,7 @@ import (
 func TestThrottling(t *testing.T) {
 	t.Parallel()
 
-	th := NewThrottling(5, time.Millisecond*100)
+	th := NewThrottling(5, time.Millisecond*50)
 	sfn := func(value int, sleep time.Duration) func() (interface{}, error) {
 		return func() (interface{}, error) {
 			time.Sleep(sleep)
@@ -23,18 +23,18 @@ func TestThrottling(t *testing.T) {
 	}
 
 	wg := sync.WaitGroup{}
-	wg.Add(7)
+	wg.Add(9)
 
 	go func() {
 		defer wg.Done()
 
-		res, err := th.AttemptRequest(context.Background(), sfn(100, time.Millisecond*1200))
+		res, err := th.AttemptRequest(context.Background(), sfn(100, time.Millisecond*500))
 
 		require.NoError(t, err)
 		assert.Equal(t, 100, res.(int)) //nolint
 	}()
 
-	time.Sleep(time.Millisecond * 200)
+	time.Sleep(time.Millisecond * 100)
 
 	for i := 2; i <= 5; i++ {
 		go func() {
@@ -47,26 +47,48 @@ func TestThrottling(t *testing.T) {
 		}()
 	}
 
-	time.Sleep(time.Millisecond * 200)
-
 	go func() {
+		time.Sleep(time.Millisecond * 100)
+
 		defer wg.Done()
 
-		res, err := th.AttemptRequest(context.Background(), sfn(100, time.Millisecond))
+		res, err := th.AttemptRequest(context.Background(), sfn(100, time.Millisecond*100))
 
 		require.ErrorIs(t, err, errRequestLimitExceeded)
 		assert.Nil(t, res)
 	}()
 
-	time.Sleep(time.Millisecond * 1000)
-
 	go func() {
+		time.Sleep(time.Millisecond * 600)
+
 		defer wg.Done()
 
-		res, err := th.AttemptRequest(context.Background(), sfn(10, time.Millisecond))
+		res, err := th.AttemptRequest(context.Background(), sfn(10, time.Millisecond*100))
 
 		require.NoError(t, err)
 		assert.Equal(t, 10, res.(int)) //nolint
+	}()
+
+	go func() {
+		time.Sleep(time.Millisecond * 610)
+
+		defer wg.Done()
+
+		res, err := th.AttemptRequest(context.Background(), sfn(100, time.Millisecond*100))
+
+		require.ErrorIs(t, err, errRequestLimitExceeded)
+		assert.Nil(t, res)
+	}()
+
+	go func() {
+		time.Sleep(time.Millisecond * 950)
+
+		defer wg.Done()
+
+		res, err := th.AttemptRequest(context.Background(), sfn(1, time.Millisecond*100))
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, res.(int)) //nolint
 	}()
 
 	wg.Wait()

--- a/jsonrpc/throttling_test.go
+++ b/jsonrpc/throttling_test.go
@@ -31,7 +31,7 @@ func TestThrottling(t *testing.T) {
 		res, err := th.AttemptRequest(context.Background(), sfn(100, time.Millisecond*1200))
 
 		require.NoError(t, err)
-		assert.Equal(t, 100, res.(int)) // nolint
+		assert.Equal(t, 100, res.(int)) //nolint
 	}()
 
 	time.Sleep(time.Millisecond * 200)
@@ -43,7 +43,7 @@ func TestThrottling(t *testing.T) {
 			res, err := th.AttemptRequest(context.Background(), sfn(100, time.Millisecond*1000))
 
 			require.NoError(t, err)
-			assert.Equal(t, 100, res.(int)) // nolint
+			assert.Equal(t, 100, res.(int)) //nolint
 		}()
 	}
 
@@ -66,7 +66,7 @@ func TestThrottling(t *testing.T) {
 		res, err := th.AttemptRequest(context.Background(), sfn(10, time.Millisecond))
 
 		require.NoError(t, err)
-		assert.Equal(t, 10, res.(int)) // nolint
+		assert.Equal(t, 10, res.(int)) //nolint
 	}()
 
 	wg.Wait()

--- a/server/config.go
+++ b/server/config.go
@@ -57,5 +57,5 @@ type JSONRPC struct {
 	AccessControlAllowOrigin []string
 	BatchLengthLimit         uint64
 	BlockRangeLimit          uint64
-	RequestsPerSecondDebug   uint64
+	ConcurrentRequestsDebug  uint64
 }

--- a/server/server.go
+++ b/server/server.go
@@ -908,7 +908,7 @@ func (s *Server) setupJSONRPC() error {
 		PriceLimit:               s.config.PriceLimit,
 		BatchLengthLimit:         s.config.JSONRPC.BatchLengthLimit,
 		BlockRangeLimit:          s.config.JSONRPC.BlockRangeLimit,
-		RequestsPerSecondDebug:   s.config.JSONRPC.RequestsPerSecondDebug,
+		ConcurrentRequestsDebug:  s.config.JSONRPC.ConcurrentRequestsDebug,
 	}
 
 	srv, err := jsonrpc.NewJSONRPC(s.logger, conf)


### PR DESCRIPTION
# Description

Instead of using requests per second measure to refuse request, use different approach:
Only `--concurrent-requests-debug` (default `32`) requests are allowed to be executed concurrently for all the debug endpoints 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

