### PR TITLE
fixed copy method

### DIFF
--- a/types/transaction.go
+++ b/types/transaction.go
@@ -106,18 +106,15 @@ func (t *Transaction) Copy() *Transaction {
 	}
 
 	if t.V != nil {
-		tt.V = new(big.Int)
-		tt.V = big.NewInt(0).SetBits(t.V.Bits())
+		tt.V = new(big.Int).Set(t.V)
 	}
 
 	if t.R != nil {
-		tt.R = new(big.Int)
-		tt.R = big.NewInt(0).SetBits(t.R.Bits())
+		tt.R = new(big.Int).Set(t.R)
 	}
 
 	if t.S != nil {
-		tt.S = new(big.Int)
-		tt.S = big.NewInt(0).SetBits(t.S.Bits())
+		tt.S = new(big.Int).Set(t.S)
 	}
 
 	tt.Input = make([]byte, len(t.Input))

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -105,6 +105,11 @@ func (t *Transaction) Copy() *Transaction {
 		tt.Value.Set(t.Value)
 	}
 
+	if t.V != nil {
+		tt.V = new(big.Int)
+		tt.V = big.NewInt(0).SetBits(t.V.Bits())
+	}
+
 	if t.R != nil {
 		tt.R = new(big.Int)
 		tt.R = big.NewInt(0).SetBits(t.R.Bits())


### PR DESCRIPTION
# Description

While copying a Transaction as of now edge client doesn’t create a deep copy of V field of ECDSA signature, this PR is to fix that.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually


