### PR TITLE
Remove executed slashing exit events from storage

### DIFF
--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -384,6 +384,7 @@ func main() {
 				"Transfer",
 				"WithdrawalRegistered",
 				"Withdrawal",
+				"Slashed",
 			},
 		},
 		{

--- a/consensus/polybft/contractsapi/contractsapi.go
+++ b/consensus/polybft/contractsapi/contractsapi.go
@@ -1602,6 +1602,28 @@ func (w *WithdrawalEvent) ParseLog(log *ethgo.Log) (bool, error) {
 	return true, decodeEvent(ValidatorSet.Abi.Events["Withdrawal"], log, w)
 }
 
+type SlashedEvent struct {
+	ExitID     *big.Int        `abi:"exitId"`
+	Validators []types.Address `abi:"validators"`
+	Amounts    []*big.Int      `abi:"amounts"`
+}
+
+func (*SlashedEvent) Sig() ethgo.Hash {
+	return ValidatorSet.Abi.Events["Slashed"].ID()
+}
+
+func (*SlashedEvent) Encode(inputs interface{}) ([]byte, error) {
+	return ValidatorSet.Abi.Events["Slashed"].Inputs.Encode(inputs)
+}
+
+func (s *SlashedEvent) ParseLog(log *ethgo.Log) (bool, error) {
+	if !ValidatorSet.Abi.Events["Slashed"].Match(log) {
+		return false, nil
+	}
+
+	return true, decodeEvent(ValidatorSet.Abi.Events["Slashed"], log, s)
+}
+
 type InitializeRewardPoolFn struct {
 	NewRewardToken    types.Address `abi:"newRewardToken"`
 	NewRewardWallet   types.Address `abi:"newRewardWallet"`


### PR DESCRIPTION
# Description

Remove processed slashing exit event ids from off chain storage. This is done after `Slashed` event is emitted on the `ValidatorSet` contract, which is final step when dealing with slashing. We are tracking `Slashed` events and when it is captured, we are removing only slashing event ids from slashing exit events bucket (where original exit events bucket remain intact).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
