### PR TITLE
Improved genesis predeploy, allowing initializing immutables and accessing chainID from constructor.

### DIFF
--- a/command/genesis/predeploy/params.go
+++ b/command/genesis/predeploy/params.go
@@ -142,6 +142,7 @@ func (p *predeployParams) updateGenesisConfig() error {
 		p.artifactsPath,
 		p.constructorArgs,
 		p.address,
+		p.genesisConfig.Params.ChainID,
 	)
 	if err != nil {
 		return err

--- a/helper/predeployment/predeployment.go
+++ b/helper/predeployment/predeployment.go
@@ -8,6 +8,8 @@ import (
 	"math/big"
 	"os"
 
+	"github.com/umbracle/ethgo/abi"
+
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/state"
@@ -15,7 +17,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/state/runtime"
 	"github.com/0xPolygon/polygon-edge/state/runtime/evm"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/umbracle/ethgo/abi"
 )
 
 var (
@@ -116,7 +117,7 @@ func getModifiedStorageMap(radix *state.Txn, address types.Address) map[types.Ha
 	return storageMap
 }
 
-func getPredeployAccount(address types.Address, input, deployedBytecode []byte) (*chain.GenesisAccount, error) {
+func getPredeployAccount(address types.Address, input []byte, chainID int64) (*chain.GenesisAccount, error) {
 	// Create an instance of the state
 	st := itrie.NewState(itrie.NewMemoryStorage())
 
@@ -142,6 +143,7 @@ func getPredeployAccount(address types.Address, input, deployedBytecode []byte) 
 
 	// Create a transition
 	transition := state.NewTransition(config, snapshot, radix)
+	transition.ContextPtr().ChainID = chainID
 
 	// Run the transition through the EVM
 	res := evm.NewEVM().Run(contract, transition, &config)
@@ -161,7 +163,7 @@ func getPredeployAccount(address types.Address, input, deployedBytecode []byte) 
 	return &chain.GenesisAccount{
 		Balance: transition.GetBalance(address),
 		Nonce:   transition.GetNonce(address),
-		Code:    deployedBytecode,
+		Code:    res.ReturnValue,
 		Storage: storageMap,
 	}, nil
 }
@@ -172,6 +174,7 @@ func GenerateGenesisAccountFromFile(
 	filepath string,
 	constructorArgs []string,
 	predeployAddress types.Address,
+	chainID int64,
 ) (*chain.GenesisAccount, error) {
 	// Create the artifact from JSON
 	artifact, err := loadContractArtifact(filepath)
@@ -209,5 +212,5 @@ func GenerateGenesisAccountFromFile(
 		finalBytecode = append(artifact.Bytecode, constructor...)
 	}
 
-	return getPredeployAccount(predeployAddress, finalBytecode, artifact.DeployedBytecode)
+	return getPredeployAccount(predeployAddress, finalBytecode, chainID)
 }


### PR DESCRIPTION
# Description

Genesis deploy has restriction that the contract may not use immutable. This restriction can be eliminated by applying a simple fix.

The returndata of contract creation call is the deployed code of the contract, which has initialized immutable values, so instead of the deployedCode from artifact file, using this returndata will allow using immutable in pre-deployed contract.

Additionally, by initializing the EVM context's chainID with the value from the genesis.json file, the constructor can access chainID.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Ran predeploy with contract inheriting EIP712, which uses immutables. Checked that it works correctly.
