### PR TITLE
cluster script fix

### DIFF
--- a/scripts/cluster
+++ b/scripts/cluster
@@ -158,7 +158,7 @@ function initRootchain() {
 function startServerFromBinary() {
   if [ "$1" == "write-logs" ]; then
     echo "Writing validators logs to the files..."
-    if [ "$1" == "polybft" ]; then
+    if [ "$0" == "polybft" ]; then
       ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json \
         --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 --relayer \
         --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-1.log &
@@ -178,7 +178,7 @@ function startServerFromBinary() {
       --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-4.log &
     wait
   else
-    if [ "$1" == "polybft" ]; then
+    if [ "$0" == "polybft" ]; then
       ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json \
         --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 --relayer \
         --num-block-confirmations 2 --seal --log-level DEBUG &

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -158,9 +158,15 @@ function initRootchain() {
 function startServerFromBinary() {
   if [ "$1" == "write-logs" ]; then
     echo "Writing validators logs to the files..."
-    ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json \
-      --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 --relayer \
-      --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-1.log &
+    if [ "$1" == "polybft" ]; then
+      ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json \
+        --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 --relayer \
+        --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-1.log &
+    else 
+      ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json \
+        --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 \
+        --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-1.log &
+    fi
     ./polygon-edge server --data-dir ./test-chain-2 --chain genesis.json \
       --grpc-address :20000 --libp2p :30302 --jsonrpc :20002 \
       --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-2.log &
@@ -172,9 +178,15 @@ function startServerFromBinary() {
       --num-block-confirmations 2 --seal --log-level DEBUG 2>&1 | tee ./validator-4.log &
     wait
   else
-    ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json \
-      --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 --relayer \
-      --num-block-confirmations 2 --seal --log-level DEBUG &
+    if [ "$1" == "polybft" ]; then
+      ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json \
+        --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 --relayer \
+        --num-block-confirmations 2 --seal --log-level DEBUG &
+    else
+      ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json \
+        --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 \
+        --num-block-confirmations 2 --seal --log-level DEBUG &
+    fi
     ./polygon-edge server --data-dir ./test-chain-2 --chain genesis.json \
       --grpc-address :20000 --libp2p :30302 --jsonrpc :20002 \
       --num-block-confirmations 2 --seal --log-level DEBUG &


### PR DESCRIPTION
# Description
The current problem with cluster script is the ability to  introduce `relayer` even if `IBFT` is active as a consensus mechanism. `Relayer` may be invoked only if `PolyBFT` is used. 


This PR fix cluster script fixes the above mentioned problem: 
Script will check what kind of consensus mechanism was invoked and consequently will introduce `relayer` or not.


# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually
