### PR TITLE
Helper methods for byzantine validators - e2e tests

### DIFF
--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -622,8 +622,8 @@ func TestE2E_Consensus_CustomRewardToken(t *testing.T) {
 
 func TestE2E_Consensus_WithByzantineNode(t *testing.T) {
 	const (
-		epochSize      = 4
-		validatorCount = 4
+		epochSize      = 10
+		validatorCount = 5
 		byzantineCount = 2
 	)
 
@@ -635,7 +635,18 @@ func TestE2E_Consensus_WithByzantineNode(t *testing.T) {
 
 	cluster.WaitForReady(t)
 
+	byzantineValidators := cluster.GetByzantineValidators(t)
+	require.Equal(t, byzantineCount, len(byzantineValidators))
+
+	for _, i := range cluster.ByzantineValidatorsIndex {
+		node := cluster.Servers[i]
+		require.True(t, node.IsByzantine())
+	}
+
+	addresses := cluster.GetByzantineAddresses(t)
+	require.Equal(t, byzantineCount, len(addresses))
+
 	t.Run("consensus protocol", func(t *testing.T) {
-		require.NoError(t, cluster.WaitForBlock(2*epochSize+1, 1*time.Minute))
+		require.NoError(t, cluster.WaitForBlock(2*epochSize+1, 10*time.Minute))
 	})
 }

--- a/e2e-polybft/framework/test-server.go
+++ b/e2e-polybft/framework/test-server.go
@@ -104,6 +104,10 @@ func (t *TestServer) TxnPoolOperator() txpoolProto.TxnPoolOperatorClient {
 	return txpoolProto.NewTxnPoolOperatorClient(conn)
 }
 
+func (t *TestServer) IsByzantine() bool {
+	return t.config.Byzantine
+}
+
 func NewTestServer(t *testing.T, clusterConfig *TestClusterConfig,
 	bridgeJSONRPC string, callback TestServerConfigCallback) *TestServer {
 	t.Helper()


### PR DESCRIPTION
# Description

Test cluster and test server helper methods for byzantine validators.
`TestCluster` now has `ByzantineValidatorsIndex` filed, which represents an array of Byzantine validator indexes in `TestCluster` `Servers`.

`GetByzantineValidators` method will return nodes that represent Byzantine validators. 
`GetByzantineAddresses` method will return an array of Byzantine validator addresses. 

`TestServer` now has the method `IsByzantine` to check if the node is byzantine.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
