### PR TITLE
Perform gas price limit check for dynamic tx

### DIFF
--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -661,8 +661,6 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 		}
 	}
 
-	fmt.Println("tx.GetGasPrice(baseFee)", tx.GetGasPrice(baseFee), baseFee)
-
 	// Check if the given tx is not underpriced
 	if tx.GetGasPrice(baseFee).Cmp(big.NewInt(0).SetUint64(p.priceLimit)) < 0 {
 		metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -662,7 +662,7 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 	}
 
 	// Check if the given tx is not underpriced
-	if tx.GetGasPrice(baseFee).Cmp(big.NewInt(0).SetUint64(p.priceLimit)) < 0 {
+	if tx.GetGasPrice(baseFee).Cmp(new(big.Int).SetUint64(p.priceLimit)) < 0 {
 		metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
 
 		return ErrUnderpriced

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -661,6 +661,8 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 		}
 	}
 
+	fmt.Println("tx.GetGasPrice(baseFee)", tx.GetGasPrice(baseFee), baseFee)
+
 	// Check if the given tx is not underpriced
 	if tx.GetGasPrice(baseFee).Cmp(big.NewInt(0).SetUint64(p.priceLimit)) < 0 {
 		metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -659,13 +659,13 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 
 			return ErrUnderpriced
 		}
-	} else {
-		// Legacy approach to check if the given tx is not underpriced
-		if tx.GetGasPrice(baseFee).Cmp(big.NewInt(0).SetUint64(p.priceLimit)) < 0 {
-			metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
+	}
 
-			return ErrUnderpriced
-		}
+	// Check if the given tx is not underpriced
+	if tx.GetGasPrice(baseFee).Cmp(big.NewInt(0).SetUint64(p.priceLimit)) < 0 {
+		metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
+
+		return ErrUnderpriced
 	}
 
 	// Check nonce ordering

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	defaultPriceLimit         uint64 = 1
+	defaultBaseFee            uint64 = 1
 	defaultMaxSlots           uint64 = 4096
 	defaultMaxAccountEnqueued uint64 = 128
 	validGasLimit             uint64 = 4712350
@@ -2793,6 +2794,8 @@ func TestExecutablesOrder(t *testing.T) {
 
 			pool, err := newTestPool()
 			assert.NoError(t, err)
+
+			pool.baseFee = defaultBaseFee
 			pool.SetSigner(&mockSigner{})
 
 			pool.Start()

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -144,7 +144,7 @@ func (t *Transaction) Cost() *big.Int {
 //
 // Here is the logic:
 //   - use existing gas price if exists
-//   - or calculate a value with formula: min(gasFeeCap, gasTipCap * baseFee);
+//   - or calculate a value with formula: min(gasFeeCap, gasTipCap + baseFee);
 func (t *Transaction) GetGasPrice(baseFee uint64) *big.Int {
 	if t.GasPrice != nil && t.GasPrice.BitLen() > 0 {
 		return new(big.Int).Set(t.GasPrice)


### PR DESCRIPTION
# Description

Currently, there is a check that compares the gas price of a legacy tx with the gas price limit specified per node argument.
This check should be applicable for dynamic tx as well.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

