### PR TITLE
Fix `maxFeePerGas` compensation calculation

### DIFF
--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -137,6 +137,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 				return ethgo.ZeroHash, fmt.Errorf("failed to get max priority fee per gas: %w", err)
 			}
 
+			// set retrieved max priority fee per gas increased by certain percentage
 			compMaxPriorityFee := new(big.Int).Mul(maxPriorityFee, big.NewInt(feeIncreasePercentage))
 			compMaxPriorityFee = compMaxPriorityFee.Div(compMaxPriorityFee, big.NewInt(100))
 			txn.MaxPriorityFeePerGas = new(big.Int).Add(maxPriorityFee, compMaxPriorityFee)
@@ -151,8 +152,10 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 
 			baseFee := feeHist.BaseFee[len(feeHist.BaseFee)-1]
 			// set max fee per gas as sum of base fee and max priority fee
+			// (increased by certain percentage)
 			maxFeePerGas := new(big.Int).Add(baseFee, maxPriorityFee)
 			compMaxFeePerGas := new(big.Int).Mul(maxFeePerGas, big.NewInt(feeIncreasePercentage))
+			compMaxFeePerGas = compMaxFeePerGas.Div(compMaxFeePerGas, big.NewInt(100))
 			txn.MaxFeePerGas = new(big.Int).Add(compMaxFeePerGas, maxFeePerGas)
 		}
 	} else if txn.GasPrice == 0 {

--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -156,7 +156,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 			maxFeePerGas := new(big.Int).Add(baseFee, maxPriorityFee)
 			compMaxFeePerGas := new(big.Int).Mul(maxFeePerGas, big.NewInt(feeIncreasePercentage))
 			compMaxFeePerGas = compMaxFeePerGas.Div(compMaxFeePerGas, big.NewInt(100))
-			txn.MaxFeePerGas = new(big.Int).Add(compMaxFeePerGas, maxFeePerGas)
+			txn.MaxFeePerGas = new(big.Int).Add(maxFeePerGas, compMaxFeePerGas)
 		}
 	} else if txn.GasPrice == 0 {
 		gasPrice, err := t.Client().Eth().GasPrice()


### PR DESCRIPTION
# Description

`MaxFeePerGas` was calculated as the `sum(latest base fee, max priority fee per gas)` increased by 20 times that amount, instead 20% increase. There was lacking division by 100 to transfer it to percentage. This PR fixes it.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)