### PR TITLE
EVM-805 TxPool assumes all transactions are Legacy when checking for re-priceaction replacement GasPrice comparison bug

### DIFF
--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -808,7 +808,8 @@ func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 			metrics.IncrCounter([]string{txPoolMetrics, "already_known_tx"}, 1)
 
 			return ErrAlreadyKnown
-		} else if oldTxWithSameNonce.GasPrice.Cmp(tx.GasPrice) >= 0 {
+		} else if oldTxWithSameNonce.GetGasPrice(p.baseFee).Cmp(
+			tx.GetGasPrice(p.baseFee)) >= 0 {
 			// if tx with same nonce does exist and has same or better gas price -> return error
 			return ErrUnderpriced
 		}

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -3539,6 +3539,116 @@ func TestResetWithHeadersSetsBaseFee(t *testing.T) {
 	assert.Equal(t, blocks[len(blocks)-1].Header.BaseFee, pool.GetBaseFee())
 }
 
+func TestAddTx_TxReplacement(t *testing.T) {
+	const (
+		firstAccountNonce  = 1
+		secondAccountNonce = 2
+	)
+
+	poolSigner := crypto.NewEIP155Signer(100, true)
+	firstKey, firstKeyAddr := tests.GenerateKeyAndAddr(t)
+	secondKey, secondKeyAddr := tests.GenerateKeyAndAddr(t)
+
+	createDynamicTx := func(
+		t *testing.T, nonce, gasFeeCap, gasTipCap uint64,
+		key *ecdsa.PrivateKey, addr types.Address) *types.Transaction {
+		t.Helper()
+
+		tx := newTx(addr, nonce, 1)
+		tx.Type = types.DynamicFeeTx
+		tx.Input = nil
+		tx.GasPrice = nil
+		tx.GasTipCap = new(big.Int).SetUint64(gasTipCap)
+		tx.GasFeeCap = new(big.Int).SetUint64(gasFeeCap)
+
+		singedTx, err := poolSigner.SignTx(tx, key)
+		require.NoError(t, err)
+
+		singedTx.ComputeHash(0)
+
+		return singedTx
+	}
+
+	createLegacyTx := func(
+		t *testing.T, nonce, gasPrice uint64,
+		key *ecdsa.PrivateKey, addr types.Address) *types.Transaction {
+		t.Helper()
+
+		tx := newTx(addr, nonce, 1)
+		tx.Input = nil
+		tx.GasPrice = new(big.Int).SetUint64(gasPrice)
+
+		singedTx, err := poolSigner.SignTx(tx, key)
+		require.NoError(t, err)
+
+		singedTx.ComputeHash(0)
+
+		return singedTx
+	}
+
+	pool, err := newTestPool()
+	require.NoError(t, err)
+
+	pool.baseFee = 100
+	pool.SetSigner(poolSigner)
+
+	txLegacy := createLegacyTx(t, firstAccountNonce, 100, firstKey, firstKeyAddr)
+	txDynamic := createDynamicTx(t, secondAccountNonce, 120, 120, secondKey, secondKeyAddr)
+
+	ac1 := pool.accounts.initOnce(firstKeyAddr, firstAccountNonce)
+	ac2 := pool.accounts.initOnce(secondKeyAddr, secondAccountNonce)
+
+	ac1.nonceToTx.mapping[firstAccountNonce] = txLegacy
+	ac2.nonceToTx.mapping[secondAccountNonce] = txDynamic
+
+	ac1.enqueued = newAccountQueue()
+	ac2.enqueued = newAccountQueue()
+	ac1.enqueued.queue = minNonceQueue{txLegacy}
+	ac2.enqueued.queue = minNonceQueue{txDynamic}
+
+	// These tests can not be executed in parallel because Success test change state
+
+	// ErrAlreadyKnown
+	tx1 := createLegacyTx(t,
+		firstAccountNonce, txLegacy.GasPrice.Uint64(), firstKey, firstKeyAddr)
+	tx2 := createDynamicTx(t,
+		secondAccountNonce, txDynamic.GasFeeCap.Uint64(), txDynamic.GasTipCap.Uint64(), secondKey, secondKeyAddr)
+
+	assert.ErrorIs(t, pool.addTx(local, tx1), ErrAlreadyKnown)
+	assert.ErrorIs(t, pool.addTx(local, tx2), ErrAlreadyKnown)
+
+	// ErrUnderpriced
+	tx1 = createLegacyTx(t,
+		firstAccountNonce, 90, firstKey, firstKeyAddr)
+	tx2 = createDynamicTx(t,
+		secondAccountNonce, 90, 90, secondKey, secondKeyAddr)
+	tx3 := createLegacyTx(t,
+		secondAccountNonce, 110, secondKey, secondKeyAddr)
+	tx4 := createDynamicTx(t,
+		firstAccountNonce, 90, 90, firstKey, firstKeyAddr)
+
+	assert.ErrorIs(t, pool.addTx(local, tx1), ErrUnderpriced)
+	assert.ErrorIs(t, pool.addTx(local, tx2), ErrUnderpriced)
+	assert.ErrorIs(t, pool.addTx(local, tx3), ErrUnderpriced)
+	assert.ErrorIs(t, pool.addTx(local, tx4), ErrUnderpriced)
+
+	// Success
+	tx1 = createLegacyTx(t,
+		secondAccountNonce, 180, secondKey, secondKeyAddr)
+	tx2 = createDynamicTx(t,
+		firstAccountNonce, 200, 200, firstKey, firstKeyAddr)
+
+	require.NoError(t, pool.addTx(local, tx1))
+	require.NoError(t, pool.addTx(local, tx2))
+
+	time.Sleep(time.Second)
+
+	assert.Equal(t, ac1.nonceToTx.mapping[firstAccountNonce], tx2)
+	assert.Equal(t, ac2.nonceToTx.mapping[secondAccountNonce], tx1)
+	assert.Equal(t, ac1.enqueued.queue[0], tx2)
+	assert.Equal(t, ac2.enqueued.queue[0], tx1)
+}
+
 func BenchmarkAddTxTime(b *testing.B) {
 	b.Run("benchmark add one tx", func(b *testing.B) {
 		signer := crypto.NewEIP155Signer(100, true)

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -3540,6 +3540,8 @@ func TestResetWithHeadersSetsBaseFee(t *testing.T) {
 }
 
 func TestAddTx_TxReplacement(t *testing.T) {
+	t.Parallel()
+
 	const (
 		firstAccountNonce  = 1
 		secondAccountNonce = 2
@@ -3640,8 +3642,6 @@ func TestAddTx_TxReplacement(t *testing.T) {
 
 	require.NoError(t, pool.addTx(local, tx1))
 	require.NoError(t, pool.addTx(local, tx2))
-
-	time.Sleep(time.Second)
 
 	assert.Equal(t, ac1.nonceToTx.mapping[firstAccountNonce], tx2)
 	assert.Equal(t, ac2.nonceToTx.mapping[secondAccountNonce], tx1)


### PR DESCRIPTION
# Description

It appears it’s currently impossible to reprice Dynamic Fee transactions (i.e., EIP-1559 txs).
The check in the [txpool](https://github.com/0xPolygon/polygon-edge/blob/develop/txpool/txpool.go#L811) only takes into account GasPrice, which means that reprice attempts are rejected because nil == nil and the price comparison appears to be equal.Also, if the re-price transaction is a Legacy transaction, the application does a nil deference and it goes into a panic. I’m certain (although I haven’t tested it) the same will happen if a Legacy transaction is repriced by a Dynamic Fee transaction.

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually
