### PR TITLE
corrected upfront gas deduction for type-2 transactions

### DIFF
--- a/state/executor.go
+++ b/state/executor.go
@@ -450,7 +450,7 @@ func (t *Transition) subGasLimitPrice(msg *types.Transaction) error {
 	factor := new(big.Int)
 	if msg.GasFeeCap != nil && msg.GasFeeCap.BitLen() > 0 {
 		// Apply EIP-1559 tx cost calculation factor
-		factor = factor.Set(msg.GasFeeCap)
+		factor = factor.Set(msg.GetGasPrice(t.ctx.BaseFee.Uint64()))
 	} else {
 		// Apply legacy tx cost calculation factor
 		factor = factor.Set(msg.GasPrice)

--- a/state/executor.go
+++ b/state/executor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/crypto"
-	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/state/runtime"
 	"github.com/0xPolygon/polygon-edge/state/runtime/addresslist"
 	"github.com/0xPolygon/polygon-edge/state/runtime/evm"
@@ -445,18 +444,7 @@ func (t *Transition) ContextPtr() *runtime.TxContext {
 }
 
 func (t *Transition) subGasLimitPrice(msg *types.Transaction) error {
-	upfrontGasCost := new(big.Int).SetUint64(msg.Gas)
-
-	factor := new(big.Int)
-	if msg.GasFeeCap != nil && msg.GasFeeCap.BitLen() > 0 {
-		// Apply EIP-1559 tx cost calculation factor
-		factor = factor.Set(msg.GetGasPrice(t.ctx.BaseFee.Uint64()))
-	} else {
-		// Apply legacy tx cost calculation factor
-		factor = factor.Set(msg.GasPrice)
-	}
-
-	upfrontGasCost = upfrontGasCost.Mul(upfrontGasCost, factor)
+	upfrontGasCost := new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas), msg.GetGasPrice(t.ctx.BaseFee.Uint64()))
 
 	if err := t.state.SubBalance(msg.From, upfrontGasCost); err != nil {
 		if errors.Is(err, runtime.ErrNotEnoughFunds) {
@@ -634,17 +622,8 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 	// We use EIP-1559 fields of the tx if the london hardfork is enabled.
 	// Effective tip became to be either gas tip cap or (gas fee cap - current base fee)
 	effectiveTip := new(big.Int).Set(gasPrice)
-
 	if t.config.London {
-		if msg.Type == types.DynamicFeeTx {
-			effectiveTip = common.BigMin(
-				new(big.Int).Sub(msg.GasFeeCap, t.ctx.BaseFee),
-				new(big.Int).Set(msg.GasTipCap),
-			)
-		} else {
-			// legacy tx
-			effectiveTip.Sub(gasPrice, t.ctx.BaseFee)
-		}
+		effectiveTip = msg.EffectiveGasTip(t.ctx.BaseFee)
 	}
 
 	// Pay the coinbase fee as a miner reward using the calculated effective tip.

--- a/state/transition_test.go
+++ b/state/transition_test.go
@@ -18,6 +18,7 @@ func newTestTransition(preState map[types.Address]*PreState) *Transition {
 	return &Transition{
 		logger: hclog.NewNullLogger(),
 		state:  newTestTxn(preState),
+		ctx:    runtime.TxContext{BaseFee: big.NewInt(0)},
 	}
 }
 

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -661,6 +661,12 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 		}
 	} else {
 		// Legacy approach to check if the given tx is not underpriced
+		if forks.London && tx.GasPrice.Cmp(new(big.Int).SetUint64(baseFee)) < 0 {
+			metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
+
+			return ErrUnderpriced
+		}
+
 		if tx.GetGasPrice(baseFee).Cmp(big.NewInt(0).SetUint64(p.priceLimit)) < 0 {
 			metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
 

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -660,15 +660,11 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 			return ErrUnderpriced
 		}
 	} else {
-		// Legacy approach to check if the given tx is not underpriced
+		// Legacy approach to check if the given tx is not underpriced when london hardfork is enabled
 		if forks.London && tx.GasPrice.Cmp(new(big.Int).SetUint64(baseFee)) < 0 {
 			metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
 
 			return ErrUnderpriced
-		}
-
-		if tx.GetGasPrice(baseFee).Cmp(big.NewInt(0).SetUint64(p.priceLimit)) < 0 {
-			metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
 		}
 	}
 


### PR DESCRIPTION
# Description

**These changes will be implemented as hard fork.**

This PR resolves the bug reported in [EVM-803](https://polygon.atlassian.net/browse/EVM-803) and [EVM-804](https://polygon.atlassian.net/browse/EVM-804)

**EVM-803**: As of now upfront amount deducted for dynamic transaction was `gas*maxGasFeeCap` which is wrong. 
upfront amount should be `gas*gasPrice` and for dynamic transaction `gasPrice = Min((gasTipCap + baseFee), gasFeeCap)`

**EVM-804**: Txpool didn't handle the legacy transactions properly when London fork is enabled.
1. Underpriced legacy transaction were not discarded in txpool.
2. Coinbase tip was wrong in case of Legacy transactions.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Executed a transaction and compared the initial and final account balance of burn contract, validator, transaction sender and  transaction receiver


[EVM-803]: https://polygon.atlassian.net/browse/EVM-803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EVM-804]: https://polygon.atlassian.net/browse/EVM-804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ