### PR TITLE
EVM-800 nonce too low from eth_getTransactionCount

### DIFF
--- a/jsonrpc/codec.go
+++ b/jsonrpc/codec.go
@@ -169,6 +169,21 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// stringToBlockNumberSafe parses string and returns Block Number
+// works similar to stringToBlockNumber
+// but treats empty string or pending block number as a latest
+func stringToBlockNumberSafe(str string) (BlockNumber, error) {
+	switch str {
+	case "", pending:
+		return LatestBlockNumber, nil
+	default:
+		return stringToBlockNumber(str)
+	}
+}
+
+// stringToBlockNumber parses string and returns Block Number
+// empty string is treated as an error
+// pending blocks are allowed
 func stringToBlockNumber(str string) (BlockNumber, error) {
 	if str == "" {
 		return 0, fmt.Errorf("value is empty")
@@ -176,7 +191,9 @@ func stringToBlockNumber(str string) (BlockNumber, error) {
 
 	str = strings.Trim(str, "\"")
 	switch str {
-	case pending, latest:
+	case pending:
+		return PendingBlockNumber, nil
+	case latest:
 		return LatestBlockNumber, nil
 	case earliest:
 		return EarliestBlockNumber, nil

--- a/jsonrpc/codec_test.go
+++ b/jsonrpc/codec_test.go
@@ -16,6 +16,7 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 
 	blockNumberZero := BlockNumber(0x0)
 	blockNumberLatest := LatestBlockNumber
+	blockNumberPending := PendingBlockNumber
 
 	tests := []struct {
 		name        string
@@ -56,6 +57,14 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 			false,
 			BlockNumberOrHash{
 				BlockNumber: &blockNumberLatest,
+			},
+		},
+		{
+			"should unmarshal pending block number properly",
+			`"pending"`,
+			false,
+			BlockNumberOrHash{
+				BlockNumber: &blockNumberPending,
 			},
 		},
 		{

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -304,7 +304,7 @@ func TestDispatcherFuncDecode(t *testing.T) {
 		{
 			"filter",
 			`[{"fromBlock": "pending", "toBlock": "earliest"}]`,
-			LogQuery{fromBlock: PendingBlockNumber, toBlock: EarliestBlockNumber}, // pending = latest
+			LogQuery{fromBlock: LatestBlockNumber, toBlock: EarliestBlockNumber}, // pending == latest
 		},
 	}
 

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -304,7 +304,7 @@ func TestDispatcherFuncDecode(t *testing.T) {
 		{
 			"filter",
 			`[{"fromBlock": "pending", "toBlock": "earliest"}]`,
-			LogQuery{fromBlock: LatestBlockNumber, toBlock: EarliestBlockNumber}, // pending = latest
+			LogQuery{fromBlock: PendingBlockNumber, toBlock: EarliestBlockNumber}, // pending = latest
 		},
 	}
 

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -498,7 +498,7 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 		return nil, err
 	}
 
-	forksInTime := e.store.GetForksInTime(uint64(number))
+	forksInTime := e.store.GetForksInTime(header.Number)
 
 	var standardGas uint64
 	if transaction.IsContractCreation() && forksInTime.Homestead {
@@ -717,7 +717,7 @@ func (e *Eth) GetTransactionCount(address types.Address, filter BlockNumberOrHas
 
 	// The filter is empty, use the latest block by default
 	if filter.BlockNumber == nil && filter.BlockHash == nil {
-		filter.BlockNumber, _ = createBlockNumberPointer("latest")
+		filter.BlockNumber, _ = createBlockNumberPointer(latest)
 	}
 
 	if filter.BlockNumber == nil {

--- a/jsonrpc/helper.go
+++ b/jsonrpc/helper.go
@@ -138,12 +138,9 @@ type nonceGetter interface {
 func GetNextNonce(address types.Address, number BlockNumber, store nonceGetter) (uint64, error) {
 	if number == PendingBlockNumber {
 		// Grab the latest pending nonce from the TxPool
-		//
 		// If the account is not initialized in the local TxPool,
 		// return the latest nonce from the world state
-		res := store.GetNonce(address)
-
-		return res, nil
+		return store.GetNonce(address), nil
 	}
 
 	header, err := GetBlockHeader(number, store)

--- a/jsonrpc/query.go
+++ b/jsonrpc/query.go
@@ -90,20 +90,13 @@ func (q *LogQuery) UnmarshalJSON(data []byte) error {
 
 	q.BlockHash = obj.BlockHash
 
-	if obj.FromBlock == "" {
-		q.fromBlock = LatestBlockNumber
-	} else {
-		if q.fromBlock, err = stringToBlockNumber(obj.FromBlock); err != nil {
-			return err
-		}
+	// pending from/to blocks or "" will we treated as a latest block
+	if q.fromBlock, err = stringToBlockNumberSafe(obj.FromBlock); err != nil {
+		return err
 	}
 
-	if obj.ToBlock == "" {
-		q.toBlock = LatestBlockNumber
-	} else {
-		if q.toBlock, err = stringToBlockNumber(obj.ToBlock); err != nil {
-			return err
-		}
+	if q.toBlock, err = stringToBlockNumberSafe(obj.ToBlock); err != nil {
+		return err
 	}
 
 	if obj.Address != nil {

--- a/jsonrpc/query.go
+++ b/jsonrpc/query.go
@@ -90,7 +90,7 @@ func (q *LogQuery) UnmarshalJSON(data []byte) error {
 
 	q.BlockHash = obj.BlockHash
 
-	// pending from/to blocks or "" will we treated as a latest block
+	// pending from/to blocks or "" is treated as a latest block
 	if q.fromBlock, err = stringToBlockNumberSafe(obj.FromBlock); err != nil {
 		return err
 	}

--- a/jsonrpc/query_test.go
+++ b/jsonrpc/query_test.go
@@ -105,7 +105,7 @@ func TestFilterDecode(t *testing.T) {
 				"toBlock": "earliest"
 			}`,
 			&LogQuery{
-				fromBlock: LatestBlockNumber, // pending = latest
+				fromBlock: PendingBlockNumber,
 				toBlock:   EarliestBlockNumber,
 			},
 		},

--- a/jsonrpc/query_test.go
+++ b/jsonrpc/query_test.go
@@ -1,10 +1,11 @@
 package jsonrpc
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -101,11 +102,21 @@ func TestFilterDecode(t *testing.T) {
 		},
 		{
 			`{
+				"fromBlock": "earliest",
+				"toBlock": ""
+			}`,
+			&LogQuery{
+				fromBlock: EarliestBlockNumber,
+				toBlock:   LatestBlockNumber, // empty is converted to the latest
+			},
+		},
+		{
+			`{
 				"fromBlock": "pending",
 				"toBlock": "earliest"
 			}`,
 			&LogQuery{
-				fromBlock: PendingBlockNumber,
+				fromBlock: LatestBlockNumber, // pending is converted to the latest
 				toBlock:   EarliestBlockNumber,
 			},
 		},
@@ -121,22 +132,15 @@ func TestFilterDecode(t *testing.T) {
 		},
 	}
 
-	for indx, c := range cases {
+	for _, c := range cases {
 		res := &LogQuery{}
 		err := res.UnmarshalJSON([]byte(c.str))
 
-		if err != nil && c.res != nil {
-			t.Fatal(err)
-		}
-
-		if err == nil && c.res == nil {
-			t.Fatal("it should fail")
-		}
-
 		if c.res != nil {
-			if !reflect.DeepEqual(res, c.res) {
-				t.Fatalf("bad %d", indx)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, c.res, res)
+		} else {
+			assert.Error(t, err)
 		}
 	}
 }
@@ -223,9 +227,7 @@ func TestFilterMatch(t *testing.T) {
 		},
 	}
 
-	for indx, c := range cases {
-		if c.filter.Match(c.log) != c.match {
-			t.Fatalf("bad %d", indx)
-		}
+	for _, c := range cases {
+		assert.Equal(t, c.match, c.filter.Match(c.log))
 	}
 }

--- a/jsonrpc/query_test.go
+++ b/jsonrpc/query_test.go
@@ -138,9 +138,9 @@ func TestFilterDecode(t *testing.T) {
 
 		if c.res != nil {
 			require.NoError(t, err)
-			assert.Equal(t, c.res, res)
+			require.Equal(t, c.res, res)
 		} else {
-			assert.Error(t, err)
+			require.Error(t, err)
 		}
 	}
 }

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -811,6 +811,8 @@ func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 		} else if oldTxWithSameNonce.GetGasPrice(p.baseFee).Cmp(
 			tx.GetGasPrice(p.baseFee)) >= 0 {
 			// if tx with same nonce does exist and has same or better gas price -> return error
+			metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
+
 			return ErrUnderpriced
 		}
 
@@ -822,6 +824,8 @@ func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 
 		// reject low nonce tx
 		if tx.Nonce < accountNonce {
+			metrics.IncrCounter([]string{txPoolMetrics, "nonce_too_low_tx"}, 1)
+
 			return ErrNonceTooLow
 		}
 	}


### PR DESCRIPTION
# Description

`BlockNumber` structure has these supported strings as special kind of a block numbers:
1. `"pending"`  - this returns information from the block that is currently being mined, which might not yet be part of the blockchain.
2. `"latest"`      - refers to the latest block in state
3. `"earliest"`  - refers to the genesis block

We should allow `pending` blocks for the `eth_getTransactionCount` endpoint only. All the other parts of the current system should treat `pending` as the `latest`.

```
I believe the issue is that Polygon Edge checks the nonce in two different places. In [txpool.validateTx](https://github.com/0xPolygon/polygon-edge/blob/develop/txpool/txpool.go#L672-L676) (using p.store.GetNonce(stateRoot, tx.From) and [txpool.addTx](https://github.com/0xPolygon/polygon-edge/blob/develop/txpool/txpool.go#L824C11-L824C25) (using account.getNonce()). Not sure why it’s tracked in two different places.
```

When we do check in validate, we assume that `txpool` does not have any transaction for that specific address. So we are checking if tx nonce is lower than expected nonce from state.
Later on, we load(or create) object where we store all the `txpool` information for specific address (including nonce). Then we check additionally (if there was already some tx for that address in a pool) correctness of a nonce.
There is no bug here. I just added metrics counter which was missing.

Problem was only because `getTransactionCount` always returned nonce from the state (even for pending). Nonce from the state and nonce from the txpool account can differ in situations when there is already more than one tx for same address in a pool.
This fix will also fix https://polygon.atlassian.net/browse/EVM-801.

`Important note!`: two or more consecutive calls to `eth_getTransactionCount(address, "pending")` can result in same value and that’s is  just because nonce updating in txpool is not immediate. So, user of this endpoint must handle this case.


1. The RPC and Validator agree on nonce
4. The RPC fails to accept a transaction with nonce too low
5. The Validator will accept that same transaction
6. After that transaction has been mined, the validator and RPC still agree on nonce
7. The RPC will still fail and the validator will succeed in mining

Question [@jp](https://0xpolygon.slack.com/team/U03PTCHQU0H) have you tried configuring --max-enqueued or --max-slots on the rpc? When I ran your scripts, I saw a lot of maximum number of enqueued transactions reached errors and afterward the RPC would reject txs with the correct nonce. I changed the setup-rpc.sh script to look like this./polygon-edge server --data-dir ./data-rpc/data-1 --chain ./data/genesis.json --grpc-address :50000 --libp2p :30305 --jsonrpc :50002 --price-limit 0 --log-level DEBUG --max-enqueued 100000 --max-slots 10000 > rpc-005.log 2>&1 &The submit_multiple.sh script will still print out some errors but no more errors about max enqueued tx. After cast gives up trying to send the 500 tx, the rpc will work as expected and accept transactions with the correct nonce. So a few thoughts

I agree this is a bug of some kind in the node. The key features might be
It seems to only show up in the RPC / non-validating nodes
It occurs after exceeding the configured queue size
The nonce for that particular account will not be accepted by the node anymore

Mitigations
Requires restarting the node to clear the state

Configure a large queue size
Even with a large queue, I assume the bug could still occur, but it becomes less likely

I didn’t try increasing the account or pool limits. I agree it might help but, as you point out, it probably doesn’t resolve the issue, it just hides it a bit more. I’m also concerned about the memory requirements associated with increasing those limits.I believe the issue is that Polygon Edge checks the nonce in two different places. In [txpool.validateTx](https://github.com/0xPolygon/polygon-edge/blob/develop/txpool/txpool.go#L672-L676) (using p.store.GetNonce(stateRoot, tx.From) and [txpool.addTx](https://github.com/0xPolygon/polygon-edge/blob/develop/txpool/txpool.go#L824C11-L824C25) (using account.getNonce()). Not sure why it’s tracked in two different places.If you enable prometheus in the RPC node you’ll notice that nonce_too_low_tx metric is not reported, which means that our issue comes from the addTx check (which probably should update the prometheus gauge, but that’s another issue). The addTx check uses the nonce value it finds in account.getNonce(). Calls to [account.setNonce](https://github.com/0xPolygon/polygon-edge/blob/2f430d0b72c6a4ae2e730847860725e2c52c11a1/txpool/account.go#L207) happen in [account.reset](https://github.com/0xPolygon/polygon-edge/blob/develop/txpool/account.go#L258), [account.promote](https://github.com/0xPolygon/polygon-edge/blob/develop/txpool/account.go#L348) and [txpool.Drop](https://github.com/0xPolygon/polygon-edge/blob/develop/txpool/txpool.go#L423).My bet is the reproduction steps I shared are causing the issue in txpool.Drop, but all three should be properly reviewed.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

It should not be 

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

- Start cluster with some `premine` address
- From some script send tx to one the nodes this way:
  1. first send txs with nonces: 0, 10, 20, 30, 40
  2. after that send 45 txs with same account but each time set nonce to the value retrieved by `eth_getTransactionCount(address, 'pending')`
  3. note that two consecutive `eth_getTransactionCount` calls can return same value, so in that case just wait some time and continue (skip this iteration) with a loop. this is ok, because updating `nonce` in txpool is not immediate operation, it took some (small) amount of time
  4. after all transactions are sent, we can wait for their receipts
  5. note that `eth_getTransactionCount(address, 'latest')` will in most case return same value that is smaller than value from `eth_getTransactionCount(address, 'pending')`. This is totally normal and as soon as all pending txs from txpool are included in some blocks those values will be the same.

I do not think this e2e is necessary but i can write it if needed
