### PR TITLE
Use function signature when multiple functions are defined

### DIFF
--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"go/format"
 	"log"
+	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
@@ -21,6 +22,10 @@ const (
 	abiTypeNameFormat  = "var %sABIType = abi.MustNewType(\"%s\")"
 	eventNameFormat    = "%sEvent"
 	functionNameFormat = "%sFn"
+)
+
+var (
+	signatureFunctionFormat = regexp.MustCompile(`^(.*)\((.*)\)$`)
 )
 
 type generatedData struct {
@@ -105,7 +110,7 @@ func main() {
 			gensc.ChildERC20PredicateACL,
 			false,
 			[]string{
-				"initialize",
+				"initialize(address,address,address,address,address,bool,bool,address)",
 				"withdrawTo",
 			},
 			[]string{},
@@ -415,8 +420,18 @@ func main() {
 			}
 		}
 
-		for _, method := range c.functions {
-			if err := generateFunction(generatedData, c.contractName, c.artifact.Abi.Methods[method]); err != nil {
+		for _, methodRaw := range c.functions {
+			// There could be two objects with the same name in the generated JSON ABI (hardhat bug).
+			// This case can be fixed by specifying a function signature instead of just name
+			// e.g. "myFunc(address,bool,uint256)" instead of just "myFunc"
+			var method *abi.Method
+			if signatureFunctionFormat.MatchString(methodRaw) {
+				method = c.artifact.Abi.GetMethodBySignature(methodRaw)
+			} else {
+				method = c.artifact.Abi.GetMethod(methodRaw)
+			}
+
+			if err := generateFunction(generatedData, c.contractName, method); err != nil {
 				log.Fatal(err)
 			}
 		}


### PR DESCRIPTION
# Description

ChildERC20PredicateAccessList has 2 “initialize“ functions in the JSON ABI. 

The binding generator must use the overwritten function instead of the parent one.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

