### PR TITLE
Double the estimated fees for dynamic fee transactions

### DIFF
--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -16,12 +16,12 @@ import (
 )
 
 const (
-	defaultGasPrice       = 1879048192 // 0x70000000
-	DefaultGasLimit       = 5242880    // 0x500000
-	DefaultRPCAddress     = "http://127.0.0.1:8545"
-	numRetries            = 1000
-	gasLimitPercent       = 100
-	feeIncreasePercentage = 20
+	defaultGasPrice            = 1879048192 // 0x70000000
+	DefaultGasLimit            = 5242880    // 0x500000
+	DefaultRPCAddress          = "http://127.0.0.1:8545"
+	numRetries                 = 1000
+	gasLimitIncreasePercentage = 100
+	feeIncreasePercentage      = 100
 )
 
 var (
@@ -173,7 +173,7 @@ func (t *TxRelayerImpl) sendTransactionLocked(txn *ethgo.Transaction, key ethgo.
 			return ethgo.ZeroHash, fmt.Errorf("failed to estimate gas: %w", err)
 		}
 
-		txn.Gas = gasLimit + (gasLimit * gasLimitPercent / 100)
+		txn.Gas = gasLimit + (gasLimit * gasLimitIncreasePercentage / 100)
 	}
 
 	signer := wallet.NewEIP155Signer(chainID.Uint64())


### PR DESCRIPTION
# Description

Instead of increasing estimated fees just by 20% for dynamic fee transactions, now tx relayer increases estimated `maxFeePerGas` and `maxPriorityFeePerGas` by 100% (namely twice as much comparing to estimated values).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
