### PR TITLE
feat: Unmarshal `Nonce` type

### DIFF
--- a/types/header.go
+++ b/types/header.go
@@ -51,7 +51,9 @@ func (h *Header) IsGenesis() bool {
 	return h.Hash != ZeroHash && h.Number == 0
 }
 
-type Nonce [8]byte
+const NonceLength = 8
+
+type Nonce [NonceLength]byte
 
 func (n Nonce) String() string {
 	return hex.EncodeToHex(n[:])
@@ -60,6 +62,28 @@ func (n Nonce) String() string {
 // MarshalText implements encoding.TextMarshaler
 func (n Nonce) MarshalText() ([]byte, error) {
 	return []byte(n.String()), nil
+}
+
+func (n *Nonce) UnmarshalText(input []byte) error {
+	buf := StringToBytes(string(input))
+	if len(buf) != NonceLength {
+		return fmt.Errorf("incorrect length")
+	}
+
+	*n = BytesToNonce(buf)
+
+	return nil
+}
+
+func BytesToNonce(b []byte) Nonce {
+	var n Nonce
+
+	size := len(b)
+	min := min(size, NonceLength)
+
+	copy(n[NonceLength-min:], b[len(b)-min:])
+
+	return n
 }
 
 func (h *Header) Copy() *Header {


### PR DESCRIPTION
# Description

When trying to unmarshal `types.Block`, there is an issue with `types.Nonce`. The type is missing its custom `UnmarshalText` method.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

Here's an example of a CI job deserialising a block: https://github.com/leovct/edge-grpc-mock-server/actions/runs/6025058222/job/16345020813#step:6:38

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
