### PR TITLE
Return all exit event IDs in the bridge commands

### DIFF
--- a/command/bridge/common/params.go
+++ b/command/bridge/common/params.go
@@ -142,13 +142,13 @@ func (bp *ERC1155BridgeParams) Validate() error {
 	return nil
 }
 
-// ExtractExitEventID tries to extract exit event id from provided receipt
-func ExtractExitEventID(receipt *ethgo.Receipt) ([]*big.Int, error) {
-	var exitEvent contractsapi.L2StateSyncedEvent
-
+// ExtractExitEventIDs tries to extract all exit event ids from provided receipt
+func ExtractExitEventIDs(receipt *ethgo.Receipt) ([]*big.Int, error) {
 	exitEventIDs := make([]*big.Int, 0, len(receipt.Logs))
 
 	for _, log := range receipt.Logs {
+		var exitEvent contractsapi.L2StateSyncedEvent
+
 		doesMatch, err := exitEvent.ParseLog(log)
 		if err != nil {
 			return nil, err

--- a/command/bridge/common/params.go
+++ b/command/bridge/common/params.go
@@ -143,8 +143,11 @@ func (bp *ERC1155BridgeParams) Validate() error {
 }
 
 // ExtractExitEventID tries to extract exit event id from provided receipt
-func ExtractExitEventID(receipt *ethgo.Receipt) (*big.Int, error) {
+func ExtractExitEventID(receipt *ethgo.Receipt) ([]*big.Int, error) {
 	var exitEvent contractsapi.L2StateSyncedEvent
+
+	exitEventIDs := make([]*big.Int, 0, len(receipt.Logs))
+
 	for _, log := range receipt.Logs {
 		doesMatch, err := exitEvent.ParseLog(log)
 		if err != nil {
@@ -155,7 +158,11 @@ func ExtractExitEventID(receipt *ethgo.Receipt) (*big.Int, error) {
 			continue
 		}
 
-		return exitEvent.ID, nil
+		exitEventIDs = append(exitEventIDs, exitEvent.ID)
+	}
+
+	if len(exitEventIDs) != 0 {
+		return exitEventIDs, nil
 	}
 
 	return nil, errors.New("failed to find exit event log")

--- a/command/bridge/deposit/erc1155/deposit_erc1155.go
+++ b/command/bridge/deposit/erc1155/deposit_erc1155.go
@@ -221,14 +221,14 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	if dp.ChildChainMintable {
-		exitEventID, err := common.ExtractExitEventID(receipt)
+		exitEventIDs, err := common.ExtractExitEventID(receipt)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("failed to extract exit event: %w", err))
 
 			return
 		}
 
-		res.ExitEventIDs = []*big.Int{exitEventID}
+		res.ExitEventIDs = exitEventIDs
 	}
 
 	// populate child token address if a token is mapped alongside with deposit

--- a/command/bridge/deposit/erc1155/deposit_erc1155.go
+++ b/command/bridge/deposit/erc1155/deposit_erc1155.go
@@ -221,7 +221,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	if dp.ChildChainMintable {
-		exitEventIDs, err := common.ExtractExitEventID(receipt)
+		exitEventIDs, err := common.ExtractExitEventIDs(receipt)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("failed to extract exit event: %w", err))
 

--- a/command/bridge/deposit/erc20/deposit_erc20.go
+++ b/command/bridge/deposit/erc20/deposit_erc20.go
@@ -207,7 +207,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 				var exitEventIDs []*big.Int
 
 				if dp.ChildChainMintable {
-					if exitEventIDs, err = common.ExtractExitEventID(receipt); err != nil {
+					if exitEventIDs, err = common.ExtractExitEventIDs(receipt); err != nil {
 						return fmt.Errorf("failed to extract exit event: %w", err)
 					}
 				}

--- a/command/bridge/deposit/erc20/deposit_erc20.go
+++ b/command/bridge/deposit/erc20/deposit_erc20.go
@@ -170,7 +170,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	type bridgeTxData struct {
-		exitEventID    *big.Int
+		exitEventIDs   []*big.Int
 		blockNumber    uint64
 		childTokenAddr *types.Address
 	}
@@ -204,10 +204,10 @@ func runCommand(cmd *cobra.Command, _ []string) {
 					return fmt.Errorf("receiver: %s, amount: %s", receiver, amount)
 				}
 
-				var exitEventID *big.Int
+				var exitEventIDs []*big.Int
 
 				if dp.ChildChainMintable {
-					if exitEventID, err = common.ExtractExitEventID(receipt); err != nil {
+					if exitEventIDs, err = common.ExtractExitEventID(receipt); err != nil {
 						return fmt.Errorf("failed to extract exit event: %w", err)
 					}
 				}
@@ -221,7 +221,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 				// send aggregated data to channel if everything went ok
 				bridgeTxCh <- bridgeTxData{
 					blockNumber:    receipt.BlockNumber,
-					exitEventID:    exitEventID,
+					exitEventIDs:   exitEventIDs,
 					childTokenAddr: childToken,
 				}
 
@@ -241,8 +241,8 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	var childToken *types.Address
 
 	for x := range bridgeTxCh {
-		if x.exitEventID != nil {
-			exitEventIDs = append(exitEventIDs, x.exitEventID)
+		if x.exitEventIDs != nil {
+			exitEventIDs = append(exitEventIDs, x.exitEventIDs...)
 		}
 
 		blockNumbers = append(blockNumbers, x.blockNumber)

--- a/command/bridge/deposit/erc721/deposit_erc721.go
+++ b/command/bridge/deposit/erc721/deposit_erc721.go
@@ -195,14 +195,14 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	if dp.ChildChainMintable {
-		exitEventID, err := common.ExtractExitEventID(receipt)
+		exitEventIDs, err := common.ExtractExitEventID(receipt)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("failed to extract exit event: %w", err))
 
 			return
 		}
 
-		res.ExitEventIDs = []*big.Int{exitEventID}
+		res.ExitEventIDs = exitEventIDs
 	}
 
 	// populate child token address if a token is mapped alongside with deposit

--- a/command/bridge/deposit/erc721/deposit_erc721.go
+++ b/command/bridge/deposit/erc721/deposit_erc721.go
@@ -195,7 +195,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	if dp.ChildChainMintable {
-		exitEventIDs, err := common.ExtractExitEventID(receipt)
+		exitEventIDs, err := common.ExtractExitEventIDs(receipt)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("failed to extract exit event: %w", err))
 

--- a/command/bridge/withdraw/erc1155/withdraw_erc1155.go
+++ b/command/bridge/withdraw/erc1155/withdraw_erc1155.go
@@ -159,7 +159,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	if !wp.ChildChainMintable {
-		exitEventIDs, err := common.ExtractExitEventID(receipt)
+		exitEventIDs, err := common.ExtractExitEventIDs(receipt)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("failed to extract exit event: %w", err))
 

--- a/command/bridge/withdraw/erc1155/withdraw_erc1155.go
+++ b/command/bridge/withdraw/erc1155/withdraw_erc1155.go
@@ -159,14 +159,14 @@ func runCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	if !wp.ChildChainMintable {
-		exitEventID, err := common.ExtractExitEventID(receipt)
+		exitEventIDs, err := common.ExtractExitEventID(receipt)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("failed to extract exit event: %w", err))
 
 			return
 		}
 
-		res.ExitEventIDs = []*big.Int{exitEventID}
+		res.ExitEventIDs = exitEventIDs
 	}
 
 	outputter.SetCommandResult(res)

--- a/command/bridge/withdraw/erc20/withdraw_erc20.go
+++ b/command/bridge/withdraw/erc20/withdraw_erc20.go
@@ -127,7 +127,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		}
 
 		if !wp.ChildChainMintable {
-			extractedExitEventIDs, err := common.ExtractExitEventID(receipt)
+			extractedExitEventIDs, err := common.ExtractExitEventIDs(receipt)
 			if err != nil {
 				outputter.SetError(fmt.Errorf("failed to extract exit event: %w", err))
 

--- a/command/bridge/withdraw/erc20/withdraw_erc20.go
+++ b/command/bridge/withdraw/erc20/withdraw_erc20.go
@@ -127,14 +127,14 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		}
 
 		if !wp.ChildChainMintable {
-			exitEventID, err := common.ExtractExitEventID(receipt)
+			extractedExitEventIDs, err := common.ExtractExitEventID(receipt)
 			if err != nil {
 				outputter.SetError(fmt.Errorf("failed to extract exit event: %w", err))
 
 				return
 			}
 
-			exitEventIDs = append(exitEventIDs, exitEventID)
+			exitEventIDs = append(exitEventIDs, extractedExitEventIDs...)
 		}
 
 		blockNumbers[i] = receipt.BlockNumber

--- a/command/bridge/withdraw/erc721/withdraw_erc721.go
+++ b/command/bridge/withdraw/erc721/withdraw_erc721.go
@@ -138,14 +138,14 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	if !wp.ChildChainMintable {
-		exitEventID, err := common.ExtractExitEventID(receipt)
+		exitEventIDs, err := common.ExtractExitEventID(receipt)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("failed to extract exit event: %w", err))
 
 			return
 		}
 
-		res.ExitEventIDs = []*big.Int{exitEventID}
+		res.ExitEventIDs = exitEventIDs
 	}
 
 	outputter.SetCommandResult(res)

--- a/command/bridge/withdraw/erc721/withdraw_erc721.go
+++ b/command/bridge/withdraw/erc721/withdraw_erc721.go
@@ -138,7 +138,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	if !wp.ChildChainMintable {
-		exitEventIDs, err := common.ExtractExitEventID(receipt)
+		exitEventIDs, err := common.ExtractExitEventIDs(receipt)
 		if err != nil {
 			outputter.SetError(fmt.Errorf("failed to extract exit event: %w", err))
 

--- a/command/sidechain/withdraw/params.go
+++ b/command/sidechain/withdraw/params.go
@@ -20,10 +20,10 @@ func (w *withdrawParams) validateFlags() error {
 }
 
 type withdrawResult struct {
-	ValidatorAddress string   `json:"validatorAddress"`
-	Amount           *big.Int `json:"amount"`
-	ExitEventID      *big.Int `json:"exitEventID"`
-	BlockNumber      uint64   `json:"blockNumber"`
+	ValidatorAddress string     `json:"validatorAddress"`
+	Amount           *big.Int   `json:"amount"`
+	ExitEventIDs     []*big.Int `json:"exitEventIDs"`
+	BlockNumber      uint64     `json:"blockNumber"`
 }
 
 func (r *withdrawResult) GetOutput() string {
@@ -34,7 +34,7 @@ func (r *withdrawResult) GetOutput() string {
 	vals := make([]string, 0, 4)
 	vals = append(vals, fmt.Sprintf("Validator Address|%s", r.ValidatorAddress))
 	vals = append(vals, fmt.Sprintf("Amount Withdrawn|%d", r.Amount))
-	vals = append(vals, fmt.Sprintf("Exit Event ID|%d", r.ExitEventID))
+	vals = append(vals, fmt.Sprintf("Exit Event IDs|%d", r.ExitEventIDs))
 	vals = append(vals, fmt.Sprintf("Inclusion Block Number|%d", r.BlockNumber))
 
 	buffer.WriteString(helper.FormatKV(vals))

--- a/command/sidechain/withdraw/withdraw.go
+++ b/command/sidechain/withdraw/withdraw.go
@@ -114,7 +114,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("could not find an appropriate log in receipt that withdraw happened on ValidatorSet")
 	}
 
-	exitEventID, err := common.ExtractExitEventID(receipt)
+	exitEventIDs, err := common.ExtractExitEventID(receipt)
 	if err != nil {
 		return fmt.Errorf("withdrawal failed: %w", err)
 	}
@@ -123,7 +123,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		&withdrawResult{
 			ValidatorAddress: validatorAccount.Ecdsa.Address().String(),
 			Amount:           withdrawalEvent.Amount,
-			ExitEventID:      exitEventID,
+			ExitEventIDs:     exitEventIDs,
 			BlockNumber:      receipt.BlockNumber,
 		})
 

--- a/command/sidechain/withdraw/withdraw.go
+++ b/command/sidechain/withdraw/withdraw.go
@@ -114,7 +114,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("could not find an appropriate log in receipt that withdraw happened on ValidatorSet")
 	}
 
-	exitEventIDs, err := common.ExtractExitEventID(receipt)
+	exitEventIDs, err := common.ExtractExitEventIDs(receipt)
 	if err != nil {
 		return fmt.Errorf("withdrawal failed: %w", err)
 	}


### PR DESCRIPTION
# Description

`ExtractExitEventID` function is changed, so now it returns an array of all exit events IDs, that are matched from receipt logs.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
