### PR TITLE
EVM-801 Drop tx bug for updateAccountSkipsCounts

### DIFF
--- a/txpool/account.go
+++ b/txpool/account.go
@@ -357,12 +357,12 @@ func (a *account) promote() (promoted []*types.Transaction, pruned []*types.Tran
 
 // resetSkips sets 0 to skips
 func (a *account) resetSkips() {
-	a.skips = 0
+	atomic.StoreUint64(&a.skips, 0)
 }
 
 // incrementSkips increments skips
-func (a *account) incrementSkips() {
-	a.skips++
+func (a *account) incrementSkips() uint64 {
+	return atomic.AddUint64(&a.skips, 1)
 }
 
 // getLowestTx returns the transaction with lowest nonce, which might be popped next

--- a/txpool/mock_test.go
+++ b/txpool/mock_test.go
@@ -18,6 +18,7 @@ type defaultMockStore struct {
 
 	getBlockByHashFn   func(types.Hash, bool) (*types.Block, bool)
 	calculateBaseFeeFn func(*types.Header) uint64
+	nonce              uint64
 }
 
 func NewDefaultMockStore(header *types.Header) defaultMockStore {
@@ -34,7 +35,7 @@ func (m defaultMockStore) Header() *types.Header {
 }
 
 func (m defaultMockStore) GetNonce(types.Hash, types.Address) uint64 {
-	return 0
+	return m.nonce
 }
 
 func (m defaultMockStore) GetBlockByHash(hash types.Hash, full bool) (*types.Block, bool) {

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -393,9 +393,14 @@ func (p *TxPool) Pop(tx *types.Transaction) {
 // Drop clears the entire account associated with the given transaction
 // and reverts its next (expected) nonce.
 func (p *TxPool) Drop(tx *types.Transaction) {
-	// fetch associated account
 	account := p.accounts.get(tx.From)
+	p.dropAccount(account, tx.Nonce, tx)
+}
 
+// dropAccount clears all promoted and enqueued tx from the account
+// signals EventType_DROPPED for provided hash, clears all the slots and metrics
+// and sets nonce to provided nonce
+func (p *TxPool) dropAccount(account *account, nextNonce uint64, tx *types.Transaction) {
 	account.promoted.lock(true)
 	account.enqueued.lock(true)
 	account.nonceToTx.lock()
@@ -419,7 +424,6 @@ func (p *TxPool) Drop(tx *types.Transaction) {
 	}
 
 	// rollback nonce
-	nextNonce := tx.Nonce
 	account.setNonce(nextNonce)
 
 	// reset accounts nonce map
@@ -1001,6 +1005,7 @@ func (p *TxPool) resetAccounts(stateNonces map[types.Address]uint64) {
 // updateAccountSkipsCounts update the accounts' skips,
 // the number of the consecutive blocks that doesn't have the account's transactions
 func (p *TxPool) updateAccountSkipsCounts(latestActiveAccounts map[types.Address]uint64) {
+	stateRoot := p.store.Header().StateRoot
 	p.accounts.Range(
 		func(key, value interface{}) bool {
 			address, _ := key.(types.Address)
@@ -1026,7 +1031,8 @@ func (p *TxPool) updateAccountSkipsCounts(latestActiveAccounts map[types.Address
 			}
 
 			// account has been skipped too many times
-			p.Drop(firstTx)
+			nextNonce := p.store.GetNonce(stateRoot, firstTx.From)
+			p.dropAccount(account, nextNonce, firstTx)
 
 			account.resetSkips()
 

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -1024,9 +1024,7 @@ func (p *TxPool) updateAccountSkipsCounts(latestActiveAccounts map[types.Address
 				return true
 			}
 
-			account.incrementSkips()
-
-			if account.skips < maxAccountSkips {
+			if account.incrementSkips() < maxAccountSkips {
 				return true
 			}
 


### PR DESCRIPTION
# Description

There was issue for non validator node in txpool: `updateAccountSkipsCounts` did not set correct nonce after dropping
first (enqueued or promoted) transaction. 

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually
