### PR TITLE
EVM-819 DoS on Websockets

### DIFF
--- a/command/server/config/config.go
+++ b/command/server/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	NumBlockConfirmations uint64 `json:"num_block_confirmations" yaml:"num_block_confirmations"`
 
 	ConcurrentRequestsDebug uint64 `json:"concurrent_requests_debug" yaml:"concurrent_requests_debug"`
+	WebSocketReadLimit      uint64 `json:"web_socket_read_limit" yaml:"web_socket_read_limit"`
 }
 
 // Telemetry holds the config details for metric services.
@@ -82,8 +83,13 @@ const (
 	// on ethereum epoch lasts for 32 blocks. more details: https://www.alchemy.com/overviews/ethereum-commitment-levels
 	DefaultNumBlockConfirmations uint64 = 64
 
-	// Maximum number of allowed concurrent requests for debug endpoints
+	// DefaultConcurrentRequestsDebug specifies max number of allowed concurrent requests for debug endpoints
 	DefaultConcurrentRequestsDebug uint64 = 32
+
+	// DefaultWebSocketReadLimit specifies max size in bytes for a message read from the peer by Gorrila websocket lib.
+	// If a message exceeds the limit,
+	// the connection sends a close message to the peer and returns ErrReadLimit to the application.
+	DefaultWebSocketReadLimit uint64 = 8192
 )
 
 // DefaultConfig returns the default server configuration
@@ -122,6 +128,7 @@ func DefaultConfig() *Config {
 		Relayer:                  false,
 		NumBlockConfirmations:    DefaultNumBlockConfirmations,
 		ConcurrentRequestsDebug:  DefaultConcurrentRequestsDebug,
+		WebSocketReadLimit:       DefaultWebSocketReadLimit,
 	}
 }
 

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -42,6 +42,7 @@ const (
 	numBlockConfirmationsFlag = "num-block-confirmations"
 
 	concurrentRequestsDebugFlag = "concurrent-requests-debug"
+	webSocketReadLimitFlag      = "websocket-read-limit"
 )
 
 // Flags that are deprecated, but need to be preserved for
@@ -155,6 +156,7 @@ func (p *serverParams) generateConfig() *server.Config {
 			BatchLengthLimit:         p.rawConfig.JSONRPCBatchRequestLimit,
 			BlockRangeLimit:          p.rawConfig.JSONRPCBlockRangeLimit,
 			ConcurrentRequestsDebug:  p.rawConfig.ConcurrentRequestsDebug,
+			WebSocketReadLimit:       p.rawConfig.WebSocketReadLimit,
 		},
 		GRPCAddr:   p.grpcAddress,
 		LibP2PAddr: p.libp2pAddress,

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -235,6 +235,13 @@ func setFlags(cmd *cobra.Command) {
 		"maximal number of concurrent requests for debug endpoints",
 	)
 
+	cmd.Flags().Uint64Var(
+		&params.rawConfig.WebSocketReadLimit,
+		webSocketReadLimitFlag,
+		defaultConfig.WebSocketReadLimit,
+		"maximum size in bytes for a message read from the peer by websocket",
+	)
+
 	setLegacyFlags(cmd)
 
 	setDevFlags(cmd)

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -70,6 +70,7 @@ type Config struct {
 	BlockRangeLimit          uint64
 
 	ConcurrentRequestsDebug uint64
+	WebSocketReadLimit      uint64
 }
 
 // NewJSONRPC returns the JSONRPC http server
@@ -220,6 +221,11 @@ func (j *JSONRPC) handleWs(w http.ResponseWriter, req *http.Request) {
 		j.logger.Error(fmt.Sprintf("Unable to upgrade to a WS connection, %s", err.Error()))
 
 		return
+	}
+
+	// Set a read limit (maximum message size) for this connection
+	if j.config.WebSocketReadLimit != 0 {
+		ws.SetReadLimit(int64(j.config.WebSocketReadLimit))
 	}
 
 	// Defer WS closure

--- a/server/config.go
+++ b/server/config.go
@@ -58,4 +58,5 @@ type JSONRPC struct {
 	BatchLengthLimit         uint64
 	BlockRangeLimit          uint64
 	ConcurrentRequestsDebug  uint64
+	WebSocketReadLimit       uint64
 }

--- a/server/server.go
+++ b/server/server.go
@@ -897,6 +897,7 @@ func (s *Server) setupJSONRPC() error {
 		BatchLengthLimit:         s.config.JSONRPC.BatchLengthLimit,
 		BlockRangeLimit:          s.config.JSONRPC.BlockRangeLimit,
 		ConcurrentRequestsDebug:  s.config.JSONRPC.ConcurrentRequestsDebug,
+		WebSocketReadLimit:       s.config.JSONRPC.WebSocketReadLimit,
 	}
 
 	srv, err := jsonrpc.NewJSONRPC(s.logger, conf)


### PR DESCRIPTION
# Description

```
Gorilla websocket library does not have any read limits by default.
Attacker could send a very large stream of data and trigger out of memory crash.
The polygon-edge process will be stopped by system OOM killer.
Impact
Remote denial of service. No authentication is required.Risk Breakdown
Difficulty to Exploit: Easy Weakness: CVSS2 Score:
Recommendation
Use SetReadLimit() call of gorilla library.
```

New server flag `--websocket-read-limit` is introduced. By default this value is `8192`. This value specifies read limit for web socket connections.

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [X] I have tested this code manually

### Manual tests

- Start cluster
- execute this script https://gist.githubusercontent.com/gln7/5715dd75657d77ed765d9618473aecec/raw/6940f797b145da229aef433145cf705a88d5bbdf/t1.py
- the script should failed and not freeze cluster machine


