### PR TITLE
Fix nightly build script by providing governor-admin flag

### DIFF
--- a/.github/workflows/deploy.nightly.devnet.yml
+++ b/.github/workflows/deploy.nightly.devnet.yml
@@ -131,7 +131,8 @@ jobs:
                           --block-time {{ block_time }}s \
                           {% for item in hostvars %}{% if (hostvars[item].tags.Role == "validator") %} --validators /dns4/{{ hostvars[item].tags["Name"] }}/tcp/{{ edge_p2p_port }}/p2p/$(cat {{ hostvars[item].tags["Name"] }}.json | jq -r '.[0].node_id'):$(cat {{ hostvars[item].tags["Name"] }}.json | jq -r '.[0].address' | sed 's/^0x//'):$(cat {{ hostvars[item].tags["Name"] }}.json | jq -r '.[0].bls_pubkey') {% endif %}{% endfor %} \
                           --epoch-size 10 \
-                          --native-token-config MyToken:MTK:18:true:0x0000000000000000000000000000000000001010
+                          --native-token-config MyToken:MTK:18:true:{{ loadtest_account }} \
+                          --governor-admin {{ loadtest_account }}
 
               polygon-edge polybft stake-manager-deploy \
                   --jsonrpc {{ rootchain_json_rpc }} \


### PR DESCRIPTION
# Description

Fix nightly build GH workflow, by providing `governor-admin` flag, which is obligatory to the genesis command.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
