### PR TITLE
Malicious JSON RPC request unit test

### DIFF
--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -304,7 +304,9 @@ func (j *JSONRPC) handle(w http.ResponseWriter, req *http.Request) {
 
 func (j *JSONRPC) handleJSONRPCRequest(w http.ResponseWriter, req *http.Request) {
 	data, err := io.ReadAll(req.Body)
+	fmt.Println("request body", string(data))
 	if err != nil {
+		fmt.Println("failed to read request data")
 		_, _ = w.Write([]byte(err.Error()))
 
 		return
@@ -315,6 +317,7 @@ func (j *JSONRPC) handleJSONRPCRequest(w http.ResponseWriter, req *http.Request)
 
 	resp, err := j.dispatcher.Handle(data)
 	if err != nil {
+		fmt.Println("failed to handle request", err)
 		_, _ = w.Write([]byte(err.Error()))
 	} else {
 		template.HTMLEscape(w, resp)

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -3,7 +3,6 @@ package jsonrpc
 import (
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"io"
 	"net"
 	"net/http"
@@ -304,9 +303,7 @@ func (j *JSONRPC) handle(w http.ResponseWriter, req *http.Request) {
 
 func (j *JSONRPC) handleJSONRPCRequest(w http.ResponseWriter, req *http.Request) {
 	data, err := io.ReadAll(req.Body)
-	fmt.Println("request body", string(data))
 	if err != nil {
-		fmt.Println("failed to read request data")
 		_, _ = w.Write([]byte(err.Error()))
 
 		return
@@ -317,10 +314,9 @@ func (j *JSONRPC) handleJSONRPCRequest(w http.ResponseWriter, req *http.Request)
 
 	resp, err := j.dispatcher.Handle(data)
 	if err != nil {
-		fmt.Println("failed to handle request", err)
 		_, _ = w.Write([]byte(err.Error()))
 	} else {
-		template.HTMLEscape(w, resp)
+		_, _ = w.Write(resp)
 	}
 
 	j.logger.Debug("handle", "response", string(resp))

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -3,6 +3,7 @@ package jsonrpc
 import (
 	"encoding/json"
 	"fmt"
+	"html/template"
 	"io"
 	"net"
 	"net/http"
@@ -313,11 +314,10 @@ func (j *JSONRPC) handleJSONRPCRequest(w http.ResponseWriter, req *http.Request)
 	j.logger.Debug("handle", "request", string(data))
 
 	resp, err := j.dispatcher.Handle(data)
-
 	if err != nil {
 		_, _ = w.Write([]byte(err.Error()))
 	} else {
-		_, _ = w.Write(resp)
+		template.HTMLEscape(w, resp)
 	}
 
 	j.logger.Debug("handle", "response", string(resp))

--- a/jsonrpc/jsonrpc_test.go
+++ b/jsonrpc/jsonrpc_test.go
@@ -4,32 +4,21 @@ import (
 	"bytes"
 	"encoding/json"
 	"net"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/0xPolygon/polygon-edge/helper/tests"
 	"github.com/0xPolygon/polygon-edge/versioning"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/go-hclog"
 )
 
 func TestHTTPServer(t *testing.T) {
-	store := newMockStore()
-	port, portErr := tests.GetFreePort()
-
-	if portErr != nil {
-		t.Fatalf("Unable to fetch free port, %v", portErr)
-	}
-
-	config := &Config{
-		Store: store,
-		Addr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: port},
-	}
-	_, err := NewJSONRPC(hclog.NewNullLogger(), config)
-
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, err := newTestJSONRPC(t)
+	require.NoError(t, err)
 }
 
 func Test_handleGetRequest(t *testing.T) {
@@ -65,4 +54,39 @@ func Test_handleGetRequest(t *testing.T) {
 		},
 		response,
 	)
+}
+
+func TestHandleJSONRPCRequest_MaliciousInput(t *testing.T) {
+	t.Parallel()
+
+	j, err := newTestJSONRPC(t)
+	require.NoError(t, err)
+
+	maliciousInput := `<script>alert("XSS attack");</script>`
+
+	req := httptest.NewRequest("POST", "/eth_blockNumber", strings.NewReader(maliciousInput))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+
+	j.handleJSONRPCRequest(w, req)
+
+	responseBody := w.Body.String()
+	require.Contains(t, responseBody, "Invalid json request")
+}
+
+func newTestJSONRPC(t *testing.T) (*JSONRPC, error) {
+	t.Helper()
+
+	store := newMockStore()
+
+	port, err := tests.GetFreePort()
+	require.NoError(t, err, "Unable to fetch free port, %v", err)
+
+	config := &Config{
+		Store: store,
+		Addr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: port},
+	}
+
+	return NewJSONRPC(hclog.NewNullLogger(), config)
 }


### PR DESCRIPTION
# Description

The original idea behind this PR was to resolve the following security findings
This PR aims to fix the following security checks that are related to cross-site scripting attack vector.
- https://github.com/0xPolygon/polygon-edge/security/code-scanning/62
- https://github.com/0xPolygon/polygon-edge/security/code-scanning/63
- https://github.com/0xPolygon/polygon-edge/security/code-scanning/64

Idea was to escape HTML content from response using `template.HTMLEscape`, but it turns out that when doing so, that function fails internally.

So the behavior is reverted to the old one (response is written into the buffer directly) and unit tests which proves that we don't have an issue are added.

Mentioned security issues are going to be marked as not relevant.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually