### PR TITLE
Introduce `ErrNonceUintOverflow` as error for nonce overflow

### DIFF
--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -43,7 +43,7 @@ func setFlags(cmd *cobra.Command) {
 		&params.chainID,
 		chainIDFlag,
 		command.DefaultChainID,
-		"the ID of the chain (only used for IBFT consensus)",
+		"the ID of the chain",
 	)
 
 	cmd.Flags().StringVar(

--- a/state/executor.go
+++ b/state/executor.go
@@ -581,7 +581,9 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 	if msg.IsContractCreation() {
 		result = t.Create2(msg.From, msg.Input, value, gasLeft)
 	} else {
-		t.state.IncrNonce(msg.From)
+		if err := t.state.IncrNonce(msg.From); err != nil {
+			return nil, err
+		}
 		result = t.Call2(msg.From, *msg.To, msg.Input, value, gasLeft)
 	}
 
@@ -782,7 +784,9 @@ func (t *Transition) applyCreate(c *runtime.Contract, host runtime.Host) *runtim
 	}
 
 	// Increment the nonce of the caller
-	t.state.IncrNonce(c.Caller)
+	if err := t.state.IncrNonce(c.Caller); err != nil {
+		return &runtime.ExecutionResult{Err: err}
+	}
 
 	// Check if there is a collision and the address already exists
 	if t.hasCodeOrNonce(c.Address) {
@@ -798,7 +802,10 @@ func (t *Transition) applyCreate(c *runtime.Contract, host runtime.Host) *runtim
 	if t.config.EIP158 {
 		// Force the creation of the account
 		t.state.CreateAccount(c.Address)
-		t.state.IncrNonce(c.Address)
+
+		if err := t.state.IncrNonce(c.Address); err != nil {
+			return &runtime.ExecutionResult{Err: err}
+		}
 	}
 
 	// Transfer the value

--- a/state/executor.go
+++ b/state/executor.go
@@ -507,6 +507,9 @@ var (
 	// ErrFeeCapTooLow is returned if the transaction fee cap is less than the
 	// the base fee of the block.
 	ErrFeeCapTooLow = errors.New("max fee per gas less than block base fee")
+
+	// ErrNonceUintOverflow is returned if uint64 overflow happens
+	ErrNonceUintOverflow = errors.New("nonce uint64 overflow")
 )
 
 type TransitionApplicationError struct {

--- a/state/txn.go
+++ b/state/txn.go
@@ -338,10 +338,15 @@ func (txn *Txn) GetState(addr types.Address, key types.Hash) types.Hash {
 // Nonce
 
 // IncrNonce increases the nonce of the address
-func (txn *Txn) IncrNonce(addr types.Address) {
+func (txn *Txn) IncrNonce(addr types.Address) (err error) {
 	txn.upsertAccount(addr, true, func(object *StateObject) {
+		if object.Account.Nonce+1 < object.Account.Nonce {
+			err = errors.New("nonce uint64 overflow")
+		}
 		object.Account.Nonce++
 	})
+
+	return
 }
 
 // SetNonce reduces the balance

--- a/state/txn.go
+++ b/state/txn.go
@@ -338,15 +338,19 @@ func (txn *Txn) GetState(addr types.Address, key types.Hash) types.Hash {
 // Nonce
 
 // IncrNonce increases the nonce of the address
-func (txn *Txn) IncrNonce(addr types.Address) (err error) {
+func (txn *Txn) IncrNonce(addr types.Address) error {
+	var err error
+
 	txn.upsertAccount(addr, true, func(object *StateObject) {
 		if object.Account.Nonce+1 < object.Account.Nonce {
 			err = errors.New("nonce uint64 overflow")
+
+			return
 		}
 		object.Account.Nonce++
 	})
 
-	return
+	return err
 }
 
 // SetNonce reduces the balance

--- a/state/txn.go
+++ b/state/txn.go
@@ -343,7 +343,7 @@ func (txn *Txn) IncrNonce(addr types.Address) error {
 
 	txn.upsertAccount(addr, true, func(object *StateObject) {
 		if object.Account.Nonce+1 < object.Account.Nonce {
-			err = errors.New("nonce uint64 overflow")
+			err = ErrNonceUintOverflow
 
 			return
 		}

--- a/state/txn_test.go
+++ b/state/txn_test.go
@@ -79,6 +79,7 @@ func TestIncrNonce(t *testing.T) {
 		maxUint64NonceValue    = uint64(18446744073709551615)
 		nonMaxUint64NonceValue = uint64(3)
 	)
+
 	txn := newTestTxn(defaultPreState)
 
 	txn.SetNonce(address0, maxUint64NonceValue)

--- a/state/txn_test.go
+++ b/state/txn_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"testing"
 
@@ -73,10 +74,12 @@ func TestSnapshotUpdateData(t *testing.T) {
 }
 
 func TestIncrNonce(t *testing.T) {
+	t.Parallel()
+
 	var (
 		address0               = types.StringToAddress("0")
 		address1               = types.StringToAddress("1")
-		maxUint64NonceValue    = uint64(18446744073709551615)
+		maxUint64NonceValue    = uint64(math.MaxUint64)
 		nonMaxUint64NonceValue = uint64(3)
 	)
 

--- a/state/txn_test.go
+++ b/state/txn_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockSnapshot struct {
@@ -69,4 +70,21 @@ func TestSnapshotUpdateData(t *testing.T) {
 
 	assert.NoError(t, txn.RevertToSnapshot(ss))
 	assert.Equal(t, hash1, txn.GetState(addr1, hash1))
+}
+
+func TestIncrNonce(t *testing.T) {
+	var (
+		address0               = types.StringToAddress("0")
+		address1               = types.StringToAddress("1")
+		maxUint64NonceValue    = uint64(18446744073709551615)
+		nonMaxUint64NonceValue = uint64(3)
+	)
+	txn := newTestTxn(defaultPreState)
+
+	txn.SetNonce(address0, maxUint64NonceValue)
+	txn.SetNonce(address1, nonMaxUint64NonceValue)
+
+	require.Error(t, txn.IncrNonce(address0))
+	require.NoError(t, txn.IncrNonce(address1))
+	require.Equal(t, nonMaxUint64NonceValue+1, txn.GetNonce(address1))
 }


### PR DESCRIPTION
# Description

this PR includes introduction of `ErrNonceUintOverflow`

we check for nonce overflow in `IncrNonce`, if nonce overflow happens function return `ErrNonceUintOverflow`.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

