### PR TITLE
Use `ErrReplacementUnderpriced`

### DIFF
--- a/txpool/slot_gauge.go
+++ b/txpool/slot_gauge.go
@@ -3,8 +3,9 @@ package txpool
 import (
 	"sync/atomic"
 
-	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/armon/go-metrics"
+
+	"github.com/0xPolygon/polygon-edge/types"
 )
 
 const (

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -7,6 +7,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/armon/go-metrics"
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/hashicorp/go-hclog"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"google.golang.org/grpc"
+
 	"github.com/0xPolygon/polygon-edge/blockchain"
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/network"
@@ -14,11 +20,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/state/runtime"
 	"github.com/0xPolygon/polygon-edge/txpool/proto"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/armon/go-metrics"
-	"github.com/golang/protobuf/ptypes/any"
-	"github.com/hashicorp/go-hclog"
-	"github.com/libp2p/go-libp2p/core/peer"
-	"google.golang.org/grpc"
 )
 
 const (
@@ -815,7 +816,7 @@ func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 			// if tx with same nonce does exist and has same or better gas price -> return error
 			metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
 
-			return ErrUnderpriced
+			return ErrReplacementUnderpriced
 		}
 
 		slotsFree += slotsRequired(oldTxWithSameNonce) // add old tx slots

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -12,6 +12,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/helper/tests"
@@ -19,10 +24,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/state/runtime"
 	"github.com/0xPolygon/polygon-edge/txpool/proto"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/golang/protobuf/ptypes/any"
-	"github.com/hashicorp/go-hclog"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -324,7 +325,7 @@ func TestAddTxErrors(t *testing.T) {
 
 		assert.ErrorIs(t,
 			pool.addTx(local, tx),
-			ErrUnderpriced,
+			ErrReplacementUnderpriced,
 		)
 	})
 
@@ -845,7 +846,7 @@ func TestAddTx(t *testing.T) {
 			// check the account nonce before promoting
 			assert.Equal(t, uint64(0), pool.accounts.get(addr1).getNonce())
 
-			assert.ErrorIs(t, pool.addTx(local, tx1), ErrUnderpriced)
+			assert.ErrorIs(t, pool.addTx(local, tx1), ErrReplacementUnderpriced)
 
 			//	execute the enqueue handlers
 			<-pool.promoteReqCh
@@ -919,7 +920,7 @@ func TestAddTx(t *testing.T) {
 				pool.gauge.read(),
 			)
 
-			assert.ErrorIs(t, pool.addTx(local, tx1), ErrUnderpriced)
+			assert.ErrorIs(t, pool.addTx(local, tx1), ErrReplacementUnderpriced)
 
 			acc := pool.accounts.get(addr1)
 			acc.nonceToTx.lock()
@@ -3679,7 +3680,7 @@ func TestAddTx_TxReplacement(t *testing.T) {
 
 	assert.ErrorIs(t, pool.addTx(local, tx1), ErrUnderpriced)
 	assert.ErrorIs(t, pool.addTx(local, tx2), ErrUnderpriced)
-	assert.ErrorIs(t, pool.addTx(local, tx3), ErrUnderpriced)
+	assert.ErrorIs(t, pool.addTx(local, tx3), ErrReplacementUnderpriced)
 	assert.ErrorIs(t, pool.addTx(local, tx4), ErrUnderpriced)
 
 	// Success


### PR DESCRIPTION
# Description

When a new transaction's price is not higher than the previously existing transaction, return ErrReplacementUnderpriced instead of ErrUnderpriced. I believe that this error was originally intended for this use. It can be useful when one has to tell whether the transaction with the requested nonce exists in the txpool after sendTransaction call.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Not sure, but it could be a breaking change in some sense.

The error message the client gets will change.

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
