### PR TITLE
Make stake token address as mandatory in certain use cases

### DIFF
--- a/command/rootchain/fund/params.go
+++ b/command/rootchain/fund/params.go
@@ -2,9 +2,11 @@ package fund
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 
 	cmdhelper "github.com/0xPolygon/polygon-edge/command/helper"
+	rootHelper "github.com/0xPolygon/polygon-edge/command/rootchain/helper"
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
@@ -54,6 +56,16 @@ func (fp *fundParams) validateFlags() error {
 		}
 
 		fp.amountValues[i] = amountValue
+	}
+
+	if fp.mintStakeToken {
+		if fp.stakeTokenAddr == "" {
+			return rootHelper.ErrMandatoryStakeToken
+		}
+
+		if err := types.IsValidAddress(fp.stakeTokenAddr); err != nil {
+			return fmt.Errorf("invalid stake token address is provided: %w", err)
+		}
 	}
 
 	return nil

--- a/command/rootchain/fund/params_test.go
+++ b/command/rootchain/fund/params_test.go
@@ -1,0 +1,105 @@
+package fund
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	rootHelper "github.com/0xPolygon/polygon-edge/command/rootchain/helper"
+	"github.com/0xPolygon/polygon-edge/types"
+)
+
+func Test_validateFlags(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		buildParamsFn func() *fundParams
+		err           string
+	}{
+		{
+			// no addresses provided
+			buildParamsFn: func() *fundParams {
+				return &fundParams{}
+			},
+			err: errNoAddressesProvided.Error(),
+		},
+		{
+			// inconsistent length (addresses vs amounts)
+			buildParamsFn: func() *fundParams {
+				return &fundParams{
+					addresses: []string{"0x1", "0x2"},
+					amounts:   []string{"10"},
+				}
+			},
+			err: errInconsistentLength.Error(),
+		},
+		{
+			// address contains invalid characters
+			buildParamsFn: func() *fundParams {
+				return &fundParams{
+					addresses: []string{"0x10", "0x20"},
+					amounts:   []string{"10", "20"},
+				}
+			},
+			err: "address \x10 has invalid length",
+		},
+		{
+			// stake token address omitted
+			buildParamsFn: func() *fundParams {
+				return &fundParams{
+					mintStakeToken: true,
+					addresses: []string{
+						types.StringToAddress("0x10").String(),
+						types.StringToAddress("0x20").String()},
+					amounts: []string{"10", "20"},
+				}
+			},
+			err: rootHelper.ErrMandatoryStakeToken.Error(),
+		},
+		{
+			// stake token address omitted
+			buildParamsFn: func() *fundParams {
+				return &fundParams{
+					mintStakeToken: true,
+					stakeTokenAddr: "0xA",
+					addresses: []string{
+						types.StringToAddress("0x10").String(),
+						types.StringToAddress("0x20").String()},
+					amounts: []string{"10", "20"},
+				}
+			},
+			err: "invalid stake token address is provided",
+		},
+		{
+			// valid scenario
+			buildParamsFn: func() *fundParams {
+				return &fundParams{
+					addresses: []string{
+						types.StringToAddress("0x10").String(),
+						types.StringToAddress("0x20").String()},
+					amounts: []string{"10", "20"},
+				}
+			},
+			err: "",
+		},
+	}
+
+	for i, c := range cases {
+		c := c
+		i := i
+
+		t.Run(fmt.Sprintf("case#%d", i+1), func(t *testing.T) {
+			t.Parallel()
+
+			fp := c.buildParamsFn()
+
+			err := fp.validateFlags()
+			if c.err != "" {
+				require.ErrorContains(t, err, c.err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/command/rootchain/helper/utils.go
+++ b/command/rootchain/helper/utils.go
@@ -42,9 +42,10 @@ const (
 )
 
 var (
-	ErrRootchainNotFound = errors.New("rootchain not found")
-	ErrRootchainPortBind = errors.New("port 8545 is not bind with localhost")
-	errTestModeSecrets   = errors.New("rootchain test mode does not imply specifying secrets parameters")
+	ErrRootchainNotFound   = errors.New("rootchain not found")
+	ErrRootchainPortBind   = errors.New("port 8545 is not bind with localhost")
+	ErrMandatoryStakeToken = errors.New("stake token address is mandatory")
+	errTestModeSecrets     = errors.New("rootchain test mode does not imply specifying secrets parameters")
 
 	rootchainAccountKey *wallet.Key
 )

--- a/command/rootchain/supernet/stakemanager/params.go
+++ b/command/rootchain/supernet/stakemanager/params.go
@@ -1,12 +1,15 @@
 package stakemanager
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
 )
+
+var errMandatoryStakeToken = errors.New("stake token address is mandatory")
 
 type stakeManagerDeployParams struct {
 	accountDir          string
@@ -20,10 +23,19 @@ type stakeManagerDeployParams struct {
 }
 
 func (s *stakeManagerDeployParams) validateFlags() error {
-	if !s.isTestMode && s.privateKey == "" {
-		return sidechainHelper.ValidateSecretFlags(s.accountDir, s.accountConfig)
+	if !s.isTestMode {
+		// private key is mandatory
+		if s.privateKey == "" {
+			return sidechainHelper.ValidateSecretFlags(s.accountDir, s.accountConfig)
+		}
+
+		// stake token address is mandatory
+		if s.stakeTokenAddress == "" {
+			return errMandatoryStakeToken
+		}
 	}
 
+	// check if provided genesis path is valid
 	if _, err := os.Stat(s.genesisPath); err != nil {
 		return fmt.Errorf("provided genesis path '%s' is invalid. Error: %w ", s.genesisPath, err)
 	}

--- a/command/rootchain/supernet/stakemanager/params.go
+++ b/command/rootchain/supernet/stakemanager/params.go
@@ -1,15 +1,14 @@
 package stakemanager
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
 	"github.com/0xPolygon/polygon-edge/command/helper"
+	rootHelper "github.com/0xPolygon/polygon-edge/command/rootchain/helper"
 	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
+	"github.com/0xPolygon/polygon-edge/types"
 )
-
-var errMandatoryStakeToken = errors.New("stake token address is mandatory")
 
 type stakeManagerDeployParams struct {
 	accountDir          string
@@ -31,7 +30,11 @@ func (s *stakeManagerDeployParams) validateFlags() error {
 
 		// stake token address is mandatory
 		if s.stakeTokenAddress == "" {
-			return errMandatoryStakeToken
+			return rootHelper.ErrMandatoryStakeToken
+		}
+
+		if err := types.IsValidAddress(s.stakeTokenAddress); err != nil {
+			return fmt.Errorf("invalid stake token address is provided: %w", err)
 		}
 	}
 

--- a/command/rootchain/supernet/stakemanager/params_test.go
+++ b/command/rootchain/supernet/stakemanager/params_test.go
@@ -1,0 +1,48 @@
+package stakemanager
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	rootHelper "github.com/0xPolygon/polygon-edge/command/rootchain/helper"
+)
+
+func TestValidateFlags(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		params *stakeManagerDeployParams
+		errMsg string
+	}{
+		{
+			params: &stakeManagerDeployParams{
+				isTestMode:        false,
+				privateKey:        rootHelper.TestAccountPrivKey,
+				stakeTokenAddress: "",
+			},
+			errMsg: rootHelper.ErrMandatoryStakeToken.Error(),
+		},
+		{
+			params: &stakeManagerDeployParams{
+				isTestMode:        false,
+				privateKey:        rootHelper.TestAccountPrivKey,
+				stakeTokenAddress: "0x1B",
+			},
+			errMsg: "invalid stake token address is provided",
+		},
+	}
+
+	for i, tc := range testCases {
+		i := i
+		tc := tc
+
+		t.Run(fmt.Sprintf("case#%d", i+1), func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.params.validateFlags()
+			require.ErrorContains(t, err, tc.errMsg)
+		})
+	}
+}

--- a/command/rootchain/supernet/stakemanager/stake_manager_deploy.go
+++ b/command/rootchain/supernet/stakemanager/stake_manager_deploy.go
@@ -25,7 +25,7 @@ func GetCommand() *cobra.Command {
 	stakeMgrDeployCmd := &cobra.Command{
 		Use:     "stake-manager-deploy",
 		Short:   "Command for deploying stake manager contract on rootchain",
-		PreRunE: runPreRun,
+		PreRunE: preRunCommand,
 		RunE:    runCommand,
 	}
 
@@ -34,7 +34,7 @@ func GetCommand() *cobra.Command {
 	return stakeMgrDeployCmd
 }
 
-func runPreRun(cmd *cobra.Command, _ []string) error {
+func preRunCommand(cmd *cobra.Command, _ []string) error {
 	params.jsonRPC = helper.GetJSONRPCAddress(cmd)
 
 	return params.validateFlags()

--- a/types/types.go
+++ b/types/types.go
@@ -159,7 +159,7 @@ func IsValidAddress(address string) error {
 
 	// check if the address has the correct length
 	if len(decodedAddress) != AddressLength {
-		return fmt.Errorf("address %s has invalid length", address)
+		return fmt.Errorf("address %s has invalid length", string(decodedAddress))
 	}
 
 	return nil


### PR DESCRIPTION
# Description

Make `stake-token` flag mandatory in the `stake-manager-deploy` and the `rootchain fund` commands in case no test is used for `stake-manager-deploy` and in case stake tokens need to be minted in the `rootchain fund` command.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
