### PR TITLE
Updating proposer calculator on restart

### DIFF
--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -465,9 +465,10 @@ func Test_NewConsensusRuntime(t *testing.T) {
 	blockchainMock.On("GetStateProviderForBlock", mock.Anything).Return(new(stateProviderMock)).Once()
 	blockchainMock.On("GetSystemState", mock.Anything, mock.Anything).Return(systemStateMock).Once()
 	blockchainMock.On("GetHeaderByNumber", uint64(0)).Return(&types.Header{Number: 0, ExtraData: createTestExtraForAccounts(t, 0, validators, nil)})
+	blockchainMock.On("GetHeaderByNumber", uint64(1)).Return(&types.Header{Number: 1, ExtraData: createTestExtraForAccounts(t, 1, validators, nil)})
 
 	polybftBackendMock := new(polybftBackendMock)
-	polybftBackendMock.On("GetValidators", mock.Anything, mock.Anything).Return(validators).Twice()
+	polybftBackendMock.On("GetValidators", mock.Anything, mock.Anything).Return(validators).Times(3)
 
 	tmpDir := t.TempDir()
 	config := &runtimeConfig{

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -84,6 +84,7 @@ type TestClusterConfig struct {
 	LogsDir              string
 	TmpDir               string
 	BlockGasLimit        uint64
+	BlockTime            time.Duration
 	BurnContract         *polybft.BurnContractInfo
 	ValidatorPrefix      string
 	Binary               string
@@ -248,6 +249,12 @@ func WithEpochSize(epochSize int) ClusterOption {
 func WithEpochReward(epochReward int) ClusterOption {
 	return func(h *TestClusterConfig) {
 		h.EpochReward = epochReward
+	}
+}
+
+func WithBlockTime(blockTime time.Duration) ClusterOption {
+	return func(h *TestClusterConfig) {
+		h.BlockTime = blockTime
 	}
 }
 
@@ -465,6 +472,11 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 			"--premine", "0x0000000000000000000000000000000000000000",
 			"--reward-wallet", testRewardWalletAddr.String(),
 			"--trieroot", cluster.Config.InitialStateRoot.String(),
+		}
+
+		if cluster.Config.BlockTime != 0 {
+			args = append(args, "--block-time",
+				cluster.Config.BlockTime.String())
 		}
 
 		if cluster.Config.RelayerTrackerPollInterval != 0 {


### PR DESCRIPTION
# Description

This PR fixes the inconsistent state of the proposer calculator on node restart. The inconsistent state occurs when the proposer calculator's height is less than or equal to the current block number. It can occur when the node is stopped at a moment when a block is inserted into the blockchain, but the post-block function for the proposer calculator doesn't update the snapshot database. Later, when the node is started again, if the majority of valid nodes have a consistent state, everything will be okay, as the bad node will receive the new block from the syncer, which will fix the problem. However, if the majority of validators have an inconsistent state, consensus for the new block cannot be reached, and new blocks won't be produced. The solution for this is to align the proposer calculator on node startup by updating the proposer calculator's height based on the height of the current block (the last inserted block).

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests
I've tested this scenario by changing the code by adding additional time. Sleep in order to be able to reproduce the bug and thus confirm that the scenario is for sure the one described above. This  code that reproduces problematic scenario each time cannot be used as an official test and it was only used to confirm the problem and verify the fix. Also the test for a bulk drop is adapted and it probably can cause this scenario on rare occasions. 

