### PR TITLE
Fix `eth_FeeHistory` unmarshal input params error

### DIFF
--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/types"
 )
@@ -271,9 +272,9 @@ func (u argUint64) MarshalText() ([]byte, error) {
 }
 
 func (u *argUint64) UnmarshalText(input []byte) error {
-	str := strings.TrimPrefix(string(input), "0x")
-	num, err := strconv.ParseUint(str, 16, 64)
+	str := strings.Trim(string(input), "\"")
 
+	num, err := common.ParseUint64orHex(&str)
 	if err != nil {
 		return err
 	}
@@ -281,6 +282,10 @@ func (u *argUint64) UnmarshalText(input []byte) error {
 	*u = argUint64(num)
 
 	return nil
+}
+
+func (u *argUint64) UnmarshalJSON(buffer []byte) error {
+	return u.UnmarshalText(buffer)
 }
 
 type argBytes []byte


### PR DESCRIPTION
# Description

This PR fixes issue [776](https://polygon.atlassian.net/browse/EVM-776). First parameter of `FeeHistory()` method is `argUint64`, which could not be unmarshalled from raw JSON since there was no `UnmarshalJSON()` method implemented for it.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
