### PR TITLE
Remove WithoutBridge configuration param from e2e framework

### DIFF
--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -76,7 +76,6 @@ type TestClusterConfig struct {
 	Premine              []string // address[:amount]
 	PremineValidators    []string // address[:amount]
 	StakeAmounts         []*big.Int
-	WithoutBridge        bool
 	BootnodeCount        int
 	NonValidatorCount    int
 	WithLogs             bool
@@ -205,12 +204,6 @@ func WithPremine(addresses ...types.Address) ClusterOption {
 func WithSecretsCallback(fn func([]types.Address, *TestClusterConfig)) ClusterOption {
 	return func(h *TestClusterConfig) {
 		h.SecretsCallback = fn
-	}
-}
-
-func WithoutBridge() ClusterOption {
-	return func(h *TestClusterConfig) {
-		h.WithoutBridge = true
 	}
 }
 
@@ -574,47 +567,45 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 		require.NoError(t, err)
 	}
 
-	if !cluster.Config.WithoutBridge {
-		// start bridge
-		cluster.Bridge, err = NewTestBridge(t, cluster.Config)
-		require.NoError(t, err)
+	// start bridge
+	cluster.Bridge, err = NewTestBridge(t, cluster.Config)
+	require.NoError(t, err)
 
-		// deploy stake manager contract
-		err := cluster.Bridge.deployStakeManager(genesisPath)
-		require.NoError(t, err)
+	// deploy stake manager contract
+	err = cluster.Bridge.deployStakeManager(genesisPath)
+	require.NoError(t, err)
 
-		// deploy rootchain contracts
-		err = cluster.Bridge.deployRootchainContracts(genesisPath)
-		require.NoError(t, err)
+	// deploy rootchain contracts
+	err = cluster.Bridge.deployRootchainContracts(genesisPath)
+	require.NoError(t, err)
 
-		polybftConfig, err := polybft.LoadPolyBFTConfig(genesisPath)
-		require.NoError(t, err)
+	polybftConfig, err := polybft.LoadPolyBFTConfig(genesisPath)
+	require.NoError(t, err)
 
-		// fund validators on the rootchain
-		err = cluster.Bridge.fundRootchainValidators(polybftConfig)
-		require.NoError(t, err)
+	// fund validators on the rootchain
+	err = cluster.Bridge.fundRootchainValidators(polybftConfig)
+	require.NoError(t, err)
 
-		// whitelist genesis validators on the rootchain
-		err = cluster.Bridge.whitelistValidators(addresses, polybftConfig)
-		require.NoError(t, err)
+	// whitelist genesis validators on the rootchain
+	err = cluster.Bridge.whitelistValidators(addresses, polybftConfig)
+	require.NoError(t, err)
 
-		// register genesis validators on the rootchain
-		err = cluster.Bridge.registerGenesisValidators(polybftConfig)
-		require.NoError(t, err)
+	// register genesis validators on the rootchain
+	err = cluster.Bridge.registerGenesisValidators(polybftConfig)
+	require.NoError(t, err)
 
-		// do initial staking for genesis validators on the rootchain
-		err = cluster.Bridge.initialStakingOfGenesisValidators(polybftConfig)
-		require.NoError(t, err)
+	// do initial staking for genesis validators on the rootchain
+	err = cluster.Bridge.initialStakingOfGenesisValidators(polybftConfig)
+	require.NoError(t, err)
 
-		// finalize genesis validators on the rootchain
-		err = cluster.Bridge.finalizeGenesis(genesisPath, polybftConfig)
-		require.NoError(t, err)
-	}
+	// finalize genesis validators on the rootchain
+	err = cluster.Bridge.finalizeGenesis(genesisPath, polybftConfig)
+	require.NoError(t, err)
 
 	for i := 1; i <= int(cluster.Config.ValidatorSetSize); i++ {
 		dir := cluster.Config.ValidatorPrefix + strconv.Itoa(i)
 		cluster.InitTestServer(t, dir, cluster.Bridge.JSONRPCAddr(),
-			true, !cluster.Config.WithoutBridge && i == 1 /* relayer */)
+			true, i == 1 /* relayer */)
 	}
 
 	for i := 1; i <= cluster.Config.NonValidatorCount; i++ {


### PR DESCRIPTION
# Description

This PR removes the `WithoutBridge` configuration option from polybft e2e framework, since polybft requires a bridge at all times, because of rootchain staking.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually