### PR TITLE
Update `TestE2E_Consensus_MintableERC20NativeToken` to send dynamic fee txs

### DIFF
--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -549,6 +549,7 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 			&ethgo.Transaction{
 				To:    &nativeTokenAddr,
 				Input: mintInput,
+				Type:  ethgo.TransactionDynamicFee,
 			}, minter)
 		require.NoError(t, err)
 		require.Equal(t, uint64(types.ReceiptSuccess), receipt.Status)
@@ -576,6 +577,7 @@ func TestE2E_Consensus_MintableERC20NativeToken(t *testing.T) {
 		&ethgo.Transaction{
 			To:    &nativeTokenAddr,
 			Input: mintInput,
+			Type:  ethgo.TransactionDynamicFee,
 		}, nonMinterAcc.Ecdsa)
 	require.Error(t, err)
 	require.Nil(t, receipt)


### PR DESCRIPTION
# Description

This a follow-up of #1917, which updates the `TestE2E_Consensus_MintableERC20NativeToken` e2e test to send dynamic fee transactions to the Edge. Since it relies on a tx relayer component and does not set `MaxFeePerGas` and `MaxPriorityFeePerGas` beforehand, it allows tx relayer to estimate those values. In order to calculate `MaxFeePerGas`, `eth_feeHistory` is invoked to query the latest base fee (https://github.com/0xPolygon/polygon-edge/blob/fix/update-e2e-test-to-send-eip-1559-transaction/txrelayer/txrelayer.go#L146-L160). If there are no errors in the execution of the test when querying the fee history, it proves that fix in #1917 is correct.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
