### PR TITLE
Propagate custom Solidity errors for `eth_estimateGas` JSON RPC function

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -653,7 +653,7 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 
 	// Run the transaction with the specified gas value.
 	// Returns a status indicating if the transaction failed and the accompanying error
-	testTransaction := func(gas uint64, shouldOmitErr bool) (bool, error) {
+	testTransaction := func(gas uint64, shouldOmitErr bool) (bool, interface{}, error) {
 		transaction.Gas = gas
 
 		result, applyErr := e.store.ApplyTxn(header, transaction, nil)
@@ -665,10 +665,10 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 				// Specifying the transaction failed, but not providing an error
 				// is an indication that a valid error occurred due to low gas,
 				// which will increase the lower bound for the search
-				return true, nil
+				return true, []byte(hex.EncodeToString(result.ReturnValue)), nil
 			}
 
-			return true, applyErr
+			return true, []byte(hex.EncodeToString(result.ReturnValue)), applyErr
 		}
 
 		// Check if an out of gas error happened during EVM execution
@@ -677,30 +677,30 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 				// Specifying the transaction failed, but not providing an error
 				// is an indication that a valid error occurred due to low gas,
 				// which will increase the lower bound for the search
-				return true, nil
+				return true, []byte(hex.EncodeToString(result.ReturnValue)), nil
 			}
 
 			if isEVMRevertError(result.Err) {
 				// The EVM reverted during execution, attempt to extract the
 				// error message and return it
-				return true, constructErrorFromRevert(result)
+				return true, []byte(hex.EncodeToString(result.ReturnValue)), constructErrorFromRevert(result)
 			}
 
-			return true, result.Err
+			return true, []byte(hex.EncodeToString(result.ReturnValue)), result.Err
 		}
 
-		return false, nil
+		return false, []byte(hex.EncodeToString(result.ReturnValue)), nil
 	}
 
 	// Start the binary search for the lowest possible gas price
 	for lowEnd < highEnd {
 		mid := lowEnd + ((highEnd - lowEnd) >> 1) // (lowEnd + highEnd) / 2 can overflow
 
-		failed, testErr := testTransaction(mid, true)
+		failed, retVal, testErr := testTransaction(mid, true)
 		if testErr != nil && !isEVMRevertError(testErr) {
 			// Reverts are ignored in the binary search, but are checked later on
 			// during the execution for the optimal gas limit found
-			return 0, testErr
+			return retVal, testErr
 		}
 
 		if failed {
@@ -713,10 +713,10 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 	}
 
 	// Check if the highEnd is a good value to make the transaction pass
-	failed, err := testTransaction(highEnd, false)
+	failed, retVal, err := testTransaction(highEnd, false)
 	if failed {
 		// The transaction shouldn't fail, for whatever reason, at highEnd
-		return 0, fmt.Errorf(
+		return retVal, fmt.Errorf(
 			"unable to apply transaction even for the highest gas limit %d: %w",
 			highEnd,
 			err,

--- a/jsonrpc/eth_state_test.go
+++ b/jsonrpc/eth_state_test.go
@@ -692,7 +692,7 @@ func TestEth_EstimateGas_GasLimit(t *testing.T) {
 				assert.ErrorIs(t, estimateErr, testCase.expectedError)
 
 				// Make sure the estimate is nullified
-				assert.Equal(t, 0, estimate)
+				assert.Equal(t, []byte{}, estimate)
 			} else {
 				// Make sure no errors occurred
 				assert.NoError(t, estimateErr)
@@ -734,7 +734,10 @@ func TestEth_EstimateGas_Reverts(t *testing.T) {
 		nil,
 	)
 
-	assert.Equal(t, 0, estimate)
+	responseData, ok := estimate.([]byte)
+	assert.True(t, ok)
+
+	assert.Equal(t, exampleReturnData, string(responseData))
 
 	// Make sure the EVM revert message is contained
 	assert.ErrorIs(t, estimateErr, runtime.ErrExecutionReverted)

--- a/jsonrpc/eth_state_test.go
+++ b/jsonrpc/eth_state_test.go
@@ -705,45 +705,71 @@ func TestEth_EstimateGas_GasLimit(t *testing.T) {
 }
 
 func TestEth_EstimateGas_Reverts(t *testing.T) {
-	// Example revert data that has the string "revert reason" as the revert reason
-	exampleReturnData := "08c379a000000000000000000000000000000000000000000000000000000000000000" +
-		"20000000000000000000000000000000000000000000000000000000000000000d72657665727420726561736f6e" +
-		"00000000000000000000000000000000000000"
-	rawReturnData, err := hex.DecodeHex(exampleReturnData)
-	assert.NoError(t, err)
-
-	revertReason := errors.New("revert reason")
+	testTable := []struct {
+		name              string
+		exampleReturnData string
+		revertReason      error
+		err               error
+	}{
+		{
+			"revert with string message 'revert reason'",
+			// Example revert data that has the string "revert reason" as the revert reason
+			"08c379a000000000000000000000000000000000000000000000000000000000000000" +
+				"20000000000000000000000000000000000000000000000000000000000000000d72657665727420726561736f6e" +
+				"00000000000000000000000000000000000000",
+			errors.New("revert reason"),
+			runtime.ErrExecutionReverted,
+		},
+		{
+			"revert with custom solidity error",
+			// First 4 bytes of ABI encoded custom solidity error PermissionedContractAccessDenied()
+			"8cd01c38",
+			errors.New(""), // revert reason in this case doesn't exist, reason is decoded in response data
+			runtime.ErrExecutionReverted,
+		},
+		{
+			"revert with empty response",
+			"",
+			errors.New(""),
+			runtime.ErrExecutionReverted,
+		},
+	}
 
 	store := getExampleStore()
 	ethEndpoint := newTestEthEndpoint(store)
 
-	// We want to simulate an EVM revert here
-	store.applyTxnHook = func(
-		header *types.Header,
-		txn *types.Transaction,
-	) (*runtime.ExecutionResult, error) {
-		return &runtime.ExecutionResult{
-			ReturnValue: rawReturnData,
-			Err:         runtime.ErrExecutionReverted,
-		}, nil
+	for _, test := range testTable {
+		rawReturnData, err := hex.DecodeHex(test.exampleReturnData)
+		assert.NoError(t, err)
+
+		// We want to simulate an EVM revert here
+		store.applyTxnHook = func(
+			header *types.Header,
+			txn *types.Transaction,
+		) (*runtime.ExecutionResult, error) {
+			return &runtime.ExecutionResult{
+				ReturnValue: rawReturnData,
+				Err:         runtime.ErrExecutionReverted,
+			}, nil
+		}
+
+		// Run the estimation
+		estimate, estimateErr := ethEndpoint.EstimateGas(
+			constructMockTx(nil, nil),
+			nil,
+		)
+
+		responseData, ok := estimate.([]byte)
+		assert.True(t, ok)
+
+		assert.Equal(t, test.exampleReturnData, string(responseData))
+
+		// Make sure the EVM revert message is contained
+		assert.ErrorIs(t, estimateErr, runtime.ErrExecutionReverted)
+
+		// Make sure the EVM revert reason is contained
+		assert.ErrorAs(t, estimateErr, &test.revertReason)
 	}
-
-	// Run the estimation
-	estimate, estimateErr := ethEndpoint.EstimateGas(
-		constructMockTx(nil, nil),
-		nil,
-	)
-
-	responseData, ok := estimate.([]byte)
-	assert.True(t, ok)
-
-	assert.Equal(t, exampleReturnData, string(responseData))
-
-	// Make sure the EVM revert message is contained
-	assert.ErrorIs(t, estimateErr, runtime.ErrExecutionReverted)
-
-	// Make sure the EVM revert reason is contained
-	assert.ErrorAs(t, estimateErr, &revertReason)
 }
 
 func TestEth_EstimateGas_Errors(t *testing.T) {


### PR DESCRIPTION
# Description

If a custom error occurs, the `result.ReturnValue` will represent ABI encoded custom error in the `eth_estimateGas` JSON RPC function.
The same thing was done through this PR, but only for `Call` (https://github.com/0xPolygon/polygon-edge/pull/1566). This particular PR fixes the `eth_estimateGas` function and propagates the execution result return value (which should be a hex-encoded custom error in case it reverts with it).

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
