### PR TITLE
Improve Dockerfile to build core-contracts

### DIFF
--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -1,13 +1,25 @@
-FROM golang:1.20-alpine AS builder
+FROM golang:1.20-alpine AS go-builder
 
 WORKDIR /polygon-edge
 
-ADD go.mod go.sum ./
+COPY go.mod ./go.mod 
+COPY go.sum ./go.sum
 RUN go mod download
 
 COPY . .
 
 RUN go build -o polygon-edge main.go
+
+FROM node:18.18.0-alpine3.18 AS node-builder
+
+WORKDIR /polygon-edge
+
+COPY ./core-contracts ./core-contracts
+
+WORKDIR /polygon-edge/core-contracts
+
+RUN npm install
+RUN npx hardhat compile
 
 FROM alpine:latest AS runner
 
@@ -15,9 +27,9 @@ RUN apk --no-cache add ca-certificates jq
 
 WORKDIR /polygon-edge
 
-COPY --from=builder /polygon-edge/polygon-edge ./
+COPY --from=go-builder /polygon-edge/polygon-edge ./
 COPY ./docker/local/polygon-edge.sh ./
-COPY ./core-contracts/artifacts ./core-contracts/artifacts
+COPY --from=node-builder /polygon-edge/core-contracts/artifacts ./core-contracts/artifacts
 
 # Expose json-rpc, libp2p and grpc ports
 EXPOSE 8545 9632 1478 5001


### PR DESCRIPTION
# Description

I've updated the Dockerfile inside of `docker/local` folder because it didn't build the `core-contracts` folder.

# Changes include

- [ ] New feature (non-breaking change that adds functionality)

## Testing

- [ ] I have tested this code manually

### Manual tests

I've build the Dockerfile successfully :
![image](https://github.com/0xPolygon/polygon-edge/assets/64586968/16f0f992-a7aa-44fc-b9f4-da2287207e78)
