### PR TITLE
EVM-843 Fix block post processing

### DIFF
--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -227,7 +227,7 @@ func (c *consensusRuntime) initStakeManager(logger hcf.Logger) error {
 		return err
 	}
 
-	c.stakeManager = newStakeManager(
+	c.stakeManager, err = newStakeManager(
 		logger.Named("stake-manager"),
 		c.state,
 		rootRelayer,
@@ -238,7 +238,7 @@ func (c *consensusRuntime) initStakeManager(logger hcf.Logger) error {
 		int(c.config.PolyBFTConfig.MaxValidatorSetSize),
 	)
 
-	return nil
+	return err
 }
 
 // getGuardedData returns last build block, proposer snapshot and current epochMetadata in a thread-safe manner.

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -480,6 +480,11 @@ func Test_NewConsensusRuntime(t *testing.T) {
 		blockchain:     blockchainMock,
 		bridgeTopic:    &mockTopic{},
 	}
+
+	require.NoError(t, config.State.StakeStore.insertFullValidatorSet(validatorSetState{
+		BlockNumber: 1,
+	}))
+
 	runtime, err := newConsensusRuntime(hclog.NewNullLogger(), config)
 	require.NoError(t, err)
 

--- a/consensus/polybft/stake_manager.go
+++ b/consensus/polybft/stake_manager.go
@@ -235,7 +235,7 @@ func (s *stakeManager) updateWithReceipts(
 	// mark on which block validator set has been updated
 	fullValidatorSet.UpdatedAtBlockNumber = blockNumber
 
-	s.logger.Debug("Full validator set after", "data", fullValidatorSet.Validators)
+	s.logger.Debug("Full validator set after", "block", blockNumber, "data", fullValidatorSet.Validators)
 
 	return nil
 }

--- a/consensus/polybft/stake_manager_fuzz_test.go
+++ b/consensus/polybft/stake_manager_fuzz_test.go
@@ -158,11 +158,12 @@ func FuzzTestStakeManagerPostBlock(f *testing.F) {
 
 		bcMock := new(blockchainMock)
 		for i := 0; i < int(data.BlockID); i++ {
+			bcMock.On("CurrentHeader").Return(&types.Header{Number: 0})
 			bcMock.On("GetHeaderByNumber", mock.Anything).Return(&types.Header{Hash: types.Hash{6, 4}}, true).Once()
 			bcMock.On("GetReceiptsByHash", mock.Anything).Return([]*types.Receipt{{}}, error(nil)).Once()
 		}
 
-		stakeManager := newStakeManager(
+		stakeManager, err := newStakeManager(
 			hclog.NewNullLogger(),
 			state,
 			nil,
@@ -172,6 +173,7 @@ func FuzzTestStakeManagerPostBlock(f *testing.F) {
 			bcMock,
 			5,
 		)
+		require.NoError(t, err)
 
 		// insert initial full validator set
 		require.NoError(t, state.StakeStore.insertFullValidatorSet(validatorSetState{
@@ -190,14 +192,12 @@ func FuzzTestStakeManagerPostBlock(f *testing.F) {
 			},
 		}
 
-		req := &PostBlockRequest{
+		require.NoError(t, stakeManager.PostBlock(&PostBlockRequest{
 			FullBlock: &types.FullBlock{Block: &types.Block{Header: &types.Header{Number: data.BlockID}},
 				Receipts: []*types.Receipt{receipt},
 			},
 			Epoch: data.EpochID,
-		}
-		err := stakeManager.PostBlock(req)
-		require.NoError(t, err)
+		}))
 	})
 }
 
@@ -210,15 +210,19 @@ func FuzzTestStakeManagerUpdateValidatorSet(f *testing.F) {
 	validators := validator.NewTestValidatorsWithAliases(f, aliases, stakes)
 	state := newTestState(f)
 
-	stakeManager := newStakeManager(
+	bcMock := new(blockchainMock)
+	bcMock.On("CurrentHeader").Return(&types.Header{Number: 0})
+
+	stakeManager, err := newStakeManager(
 		hclog.NewNullLogger(),
 		state,
 		nil,
 		wallet.NewEcdsaSigner(validators.GetValidator("A").Key()),
 		types.StringToAddress("0x0001"), types.StringToAddress("0x0002"),
-		nil,
+		bcMock,
 		10,
 	)
+	require.NoError(f, err)
 
 	seeds := []updateValidatorSetF{
 		{

--- a/consensus/polybft/stake_manager_test.go
+++ b/consensus/polybft/stake_manager_test.go
@@ -70,16 +70,21 @@ func TestStakeManager_PostBlock(t *testing.T) {
 	t.Run("PostBlock - unstake to zero", func(t *testing.T) {
 		t.Parallel()
 
+		bcMock := new(blockchainMock)
+		bcMock.On("CurrentHeader").Return(&types.Header{Number: 0}, true).Once()
+
 		validators := validator.NewTestValidatorsWithAliases(t, allAliases)
-		stakeManager := newStakeManager(
+
+		stakeManager, err := newStakeManager(
 			hclog.NewNullLogger(),
 			state,
 			nil,
 			wallet.NewEcdsaSigner(validators.GetValidator("A").Key()),
 			validatorSetAddr, types.StringToAddress("0x0002"),
-			nil,
+			bcMock,
 			5,
 		)
+		require.NoError(t, err)
 
 		// insert initial full validator set
 		require.NoError(t, state.StakeStore.insertFullValidatorSet(validatorSetState{
@@ -126,16 +131,21 @@ func TestStakeManager_PostBlock(t *testing.T) {
 	t.Run("PostBlock - add stake to one validator", func(t *testing.T) {
 		t.Parallel()
 
+		bcMock := new(blockchainMock)
+		bcMock.On("CurrentHeader").Return(&types.Header{Number: 0}, true).Once()
+
 		validators := validator.NewTestValidatorsWithAliases(t, allAliases)
-		stakeManager := newStakeManager(
+
+		stakeManager, err := newStakeManager(
 			hclog.NewNullLogger(),
 			state,
 			nil,
 			wallet.NewEcdsaSigner(validators.GetValidator("A").Key()),
 			types.StringToAddress("0x0001"), types.StringToAddress("0x0002"),
-			nil,
+			bcMock,
 			5,
 		)
+		require.NoError(t, err)
 
 		// insert initial full validator set
 		require.NoError(t, state.StakeStore.insertFullValidatorSet(validatorSetState{
@@ -193,15 +203,19 @@ func TestStakeManager_PostBlock(t *testing.T) {
 		txRelayerMock.On("Call", mock.Anything, mock.Anything, mock.Anything).
 			Return(nil, error(nil))
 
-		stakeManager := newStakeManager(
+		bcMock := new(blockchainMock)
+		bcMock.On("CurrentHeader").Return(&types.Header{Number: 0}, true).Once()
+
+		stakeManager, err := newStakeManager(
 			hclog.NewNullLogger(),
 			state,
 			txRelayerMock,
 			wallet.NewEcdsaSigner(validators.GetValidator("A").Key()),
 			types.StringToAddress("0x0001"), types.StringToAddress("0x0002"),
-			nil,
+			bcMock,
 			5,
 		)
+		require.NoError(t, err)
 
 		// insert initial full validator set
 		require.NoError(t, state.StakeStore.insertFullValidatorSet(validatorSetState{
@@ -245,16 +259,18 @@ func TestStakeManager_PostBlock(t *testing.T) {
 		t.Parallel()
 
 		receipt := &types.Receipt{}
-		header1, header2 := &types.Header{Hash: types.Hash{3, 2}}, &types.Header{Hash: types.Hash{6, 4}}
+		header1, header2 := &types.Header{Hash: types.Hash{3, 2}, Number: 0}, &types.Header{Hash: types.Hash{6, 4}, Number: 0}
 
 		bcMock := new(blockchainMock)
+		bcMock.On("CurrentHeader").Return(header1)
 		bcMock.On("GetHeaderByNumber", block-2).Return(header1, true).Once()
 		bcMock.On("GetHeaderByNumber", block-1).Return(header2, true).Once()
 		bcMock.On("GetReceiptsByHash", header1.Hash).Return([]*types.Receipt{receipt}, error(nil)).Once()
 		bcMock.On("GetReceiptsByHash", header2.Hash).Return([]*types.Receipt{}, error(nil)).Once()
 
 		validators := validator.NewTestValidatorsWithAliases(t, allAliases)
-		stakeManager := newStakeManager(
+
+		stakeManager, err := newStakeManager(
 			hclog.NewNullLogger(),
 			state,
 			nil,
@@ -263,6 +279,7 @@ func TestStakeManager_PostBlock(t *testing.T) {
 			bcMock,
 			5,
 		)
+		require.NoError(t, err)
 
 		// insert initial full validator set
 		require.NoError(t, state.StakeStore.insertFullValidatorSet(validatorSetState{
@@ -317,15 +334,19 @@ func TestStakeManager_UpdateValidatorSet(t *testing.T) {
 	validators := validator.NewTestValidatorsWithAliases(t, aliases, stakes)
 	state := newTestState(t)
 
-	stakeManager := newStakeManager(
+	bcMock := new(blockchainMock)
+	bcMock.On("CurrentHeader").Return(&types.Header{Number: 0}, true).Once()
+
+	stakeManager, err := newStakeManager(
 		hclog.NewNullLogger(),
 		state,
 		nil,
 		wallet.NewEcdsaSigner(validators.GetValidator("A").Key()),
 		types.StringToAddress("0x0001"), types.StringToAddress("0x0002"),
-		nil,
+		bcMock,
 		10,
 	)
+	require.NoError(t, err)
 
 	t.Run("UpdateValidatorSet - only update", func(t *testing.T) {
 		fullValidatorSet := validators.GetPublicIdentities().Copy()
@@ -482,6 +503,103 @@ func TestStakeCounter_ShouldBeDeterministic(t *testing.T) {
 				require.Equal(t, si.Address, initialSi.Address)
 				require.Equal(t, si.VotingPower.Uint64(), initialSi.VotingPower.Uint64())
 			}
+		}
+	}
+}
+
+func TestStakeManager_UpdateOnInit(t *testing.T) {
+	t.Parallel()
+
+	var (
+		allAliases       = []string{"A", "B", "C", "D", "E", "F"}
+		validatorSetAddr = types.StringToAddress("0xf001")
+		epochID          = uint64(120)
+	)
+
+	success := types.ReceiptSuccess
+	contractProvider := &stateProvider{}
+	header2Hash := types.StringToHash("0xffee")
+	header3Hash := types.StringToHash("0xeeff")
+	header4Hash := types.StringToHash("0xaaff")
+	currentHeader := &types.Header{Number: 4}
+	validators := validator.NewTestValidatorsWithAliases(t, allAliases)
+	accountSet := validators.GetPublicIdentities(allAliases...)
+	addresses := accountSet.GetAddresses()
+	state := newTestState(t)
+
+	require.NoError(t, state.StakeStore.insertFullValidatorSet(validatorSetState{
+		BlockNumber: 1,
+		Validators:  newValidatorStakeMap(accountSet),
+	}))
+
+	sysStateMock := &systemStateMock{}
+	sysStateMock.On("GetEpoch").Return(epochID, nil).Once()
+
+	bcMock := new(blockchainMock)
+	bcMock.On("GetStateProviderForBlock", currentHeader).Return(contractProvider, nil).Once()
+	bcMock.On("GetSystemState", contractProvider).Return(sysStateMock, nil).Once()
+	bcMock.On("CurrentHeader", mock.Anything).Return(currentHeader, true).Once()
+	bcMock.On("GetHeaderByNumber", uint64(2)).Return(&types.Header{Number: 2, Hash: header2Hash}, true).Once()
+	bcMock.On("GetHeaderByNumber", uint64(3)).Return(&types.Header{Number: 3, Hash: header3Hash}, true).Once()
+	bcMock.On("GetHeaderByNumber", uint64(4)).Return(&types.Header{Number: 4, Hash: header4Hash}, true).Once()
+	bcMock.On("GetReceiptsByHash", header2Hash).Return([]*types.Receipt{
+		{
+			Status: &success,
+			Logs: []*types.Log{
+				createTestLogForTransferEvent(
+					t,
+					validatorSetAddr,
+					types.ZeroAddress,
+					addresses[len(addresses)-2],
+					4,
+				),
+			},
+		},
+	}, nil).Once()
+	bcMock.On("GetReceiptsByHash", header3Hash).Return([]*types.Receipt{
+		{
+			Status: &success,
+			Logs: []*types.Log{
+				createTestLogForTransferEvent(
+					t,
+					validatorSetAddr,
+					types.ZeroAddress,
+					addresses[len(addresses)-1],
+					6,
+				),
+			},
+		},
+	}, nil).Once()
+	bcMock.On("GetReceiptsByHash", header4Hash).Return([]*types.Receipt{{}}, nil).Once()
+
+	_, err := newStakeManager(
+		hclog.NewNullLogger(),
+		state,
+		nil,
+		wallet.NewEcdsaSigner(validators.GetValidator("A").Key()),
+		validatorSetAddr, types.StringToAddress("0x0002"),
+		bcMock,
+		5,
+	)
+	require.NoError(t, err)
+
+	bcMock.AssertExpectations(t)
+	sysStateMock.AssertExpectations(t)
+
+	fullValidatorSet, err := state.StakeStore.getFullValidatorSet()
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(4), fullValidatorSet.BlockNumber)
+	require.Equal(t, uint64(4), fullValidatorSet.UpdatedAtBlockNumber)
+	require.Equal(t, epochID, fullValidatorSet.EpochID)
+
+	for _, x := range fullValidatorSet.Validators {
+		if x.Address == addresses[len(addresses)-1] {
+			require.Equal(t, new(big.Int).SetUint64(7), x.VotingPower)
+		} else if x.Address == addresses[len(addresses)-2] {
+			require.Equal(t, new(big.Int).SetUint64(5), x.VotingPower)
+		} else {
+			require.Equal(t, new(big.Int).SetUint64(1), x.VotingPower)
 		}
 	}
 }


### PR DESCRIPTION
# Description

If node is stopped before stake manager has updated its internal state, there could be problems with consensus after node starts again. So, to prevent this, stake manager should update its internal state when node is started again.

Stake sync manager and checkpoint manager do not need to update their states because they do not have anything of importance for `go-ibft` consensus.
On the other hand, governance manager does have and that logic should be implemented if we decide to return back governance implementation

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [ ] I have tested this code manually
