### PR TITLE
Provide abi encoded exit event in hex format from `bridge_generateExitProof` JSON RPC

### DIFF
--- a/command/bridge/exit/exit.go
+++ b/command/bridge/exit/exit.go
@@ -2,7 +2,7 @@ package exit
 
 import (
 	"bytes"
-	"encoding/json"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -16,7 +16,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/bridge/common"
 	cmdHelper "github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/command/rootchain/helper"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -168,29 +167,8 @@ func run(cmd *cobra.Command, _ []string) {
 }
 
 // createExitTxn encodes parameters for exit function on root chain ExitHelper contract
-func createExitTxn(sender ethgo.Address, proof types.Proof) (*ethgo.Transaction, *polybft.ExitEvent, error) {
-	exitEventMap, ok := proof.Metadata["ExitEvent"].(map[string]interface{})
-	if !ok {
-		return nil, nil, errors.New("could not get exit event from proof")
-	}
-
-	raw, err := json.Marshal(exitEventMap)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to marshal exit event map to JSON. Error: %w", err)
-	}
-
-	var exitEvent *polybft.ExitEvent
-	if err = json.Unmarshal(raw, &exitEvent); err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal exit event from JSON. Error: %w", err)
-	}
-
-	var exitEventAPI contractsapi.L2StateSyncedEvent
-
-	exitEventEncoded, err := exitEventAPI.Encode(exitEvent.L2StateSyncedEvent)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to encode exit event: %w", err)
-	}
-
+func createExitTxn(sender ethgo.Address, proof types.Proof) (*ethgo.Transaction,
+	*contractsapi.L2StateSyncedEvent, error) {
 	leafIndex, ok := proof.Metadata["LeafIndex"].(float64)
 	if !ok {
 		return nil, nil, errors.New("failed to convert proof leaf index")
@@ -199,6 +177,21 @@ func createExitTxn(sender ethgo.Address, proof types.Proof) (*ethgo.Transaction,
 	checkpointBlock, ok := proof.Metadata["CheckpointBlock"].(float64)
 	if !ok {
 		return nil, nil, errors.New("failed to convert proof checkpoint block")
+	}
+
+	exitEventHex, ok := proof.Metadata["ExitEvent"].(string)
+	if !ok {
+		return nil, nil, errors.New("failed to convert exit event")
+	}
+
+	exitEventEncoded, err := hex.DecodeString(exitEventHex)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to decode hex-encoded exit event '%s': %w", exitEventHex, err)
+	}
+
+	exitEvent := new(contractsapi.L2StateSyncedEvent)
+	if err := exitEvent.Decode(exitEventEncoded); err != nil {
+		return nil, nil, fmt.Errorf("failed to decode exit event: %w", err)
 	}
 
 	exitFn := &contractsapi.ExitExitHelperFn{

--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -405,9 +405,7 @@ func (c *checkpointManager) GenerateExitProof(exitID uint64) (types.Proof, error
 		return types.Proof{}, fmt.Errorf("checkpoint block not found for exit ID %d", exitID)
 	}
 
-	var exitEventABI contractsapi.L2StateSyncedEvent
-
-	exitEventEncoded, err := exitEventABI.Encode(exitEvent.L2StateSyncedEvent)
+	exitEventEncoded, err := exitEvent.L2StateSyncedEvent.Encode()
 	if err != nil {
 		return types.Proof{}, err
 	}
@@ -451,9 +449,8 @@ func createExitTree(exitEvents []*ExitEvent) (*merkle.MerkleTree, error) {
 	numOfEvents := len(exitEvents)
 	data := make([][]byte, numOfEvents)
 
-	var exitEventAPI contractsapi.L2StateSyncedEvent
 	for i := 0; i < numOfEvents; i++ {
-		b, err := exitEventAPI.Encode(exitEvents[i].L2StateSyncedEvent)
+		b, err := exitEvents[i].L2StateSyncedEvent.Encode()
 		if err != nil {
 			return nil, err
 		}

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/0xPolygon/go-ibft/messages/proto"
 	"github.com/0xPolygon/polygon-edge/consensus"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/bitmap"
-	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	bls "github.com/0xPolygon/polygon-edge/consensus/polybft/signer"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
@@ -1078,9 +1077,8 @@ func encodeExitEvents(t *testing.T, exitEvents []*ExitEvent) [][]byte {
 
 	encodedEvents := make([][]byte, len(exitEvents))
 
-	var exitEventAPI contractsapi.L2StateSyncedEvent
 	for i, e := range exitEvents {
-		encodedEvent, err := exitEventAPI.Encode(e.L2StateSyncedEvent)
+		encodedEvent, err := e.L2StateSyncedEvent.Encode()
 		require.NoError(t, err)
 
 		encodedEvents[i] = encodedEvent

--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -659,7 +659,12 @@ func ({{.Sig}} *{{.TName}}) ParseLog(log *ethgo.Log) (bool, error) {
 	}
 
 	return true, decodeEvent({{.ContractName}}.Abi.Events["{{.Name}}"], log, {{.Sig}})
-}`
+}
+
+func ({{.Sig}} *{{.TName}}) Decode(input []byte) error {
+	return {{.ContractName}}.Abi.Events["{{.Name}}"].Inputs.DecodeStruct(input, &{{.Sig}})
+}
+`
 
 	inputs := map[string]interface{}{
 		"Structs":      res,

--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -649,8 +649,8 @@ func (*{{.TName}}) Sig() ethgo.Hash {
 	return {{.ContractName}}.Abi.Events["{{.Name}}"].ID()
 }
 
-func (*{{.TName}}) Encode(inputs interface{}) ([]byte, error) {
-	return {{.ContractName}}.Abi.Events["{{.Name}}"].Inputs.Encode(inputs)
+func ({{.Sig}} *{{.TName}}) Encode() ([]byte, error) {
+	return {{.ContractName}}.Abi.Events["{{.Name}}"].Inputs.Encode({{.Sig}})
 }
 
 func ({{.Sig}} *{{.TName}}) ParseLog(log *ethgo.Log) (bool, error) {

--- a/consensus/polybft/contractsapi/contractsapi.go
+++ b/consensus/polybft/contractsapi/contractsapi.go
@@ -87,8 +87,8 @@ func (*StateSyncResultEvent) Sig() ethgo.Hash {
 	return StateReceiver.Abi.Events["StateSyncResult"].ID()
 }
 
-func (*StateSyncResultEvent) Encode(inputs interface{}) ([]byte, error) {
-	return StateReceiver.Abi.Events["StateSyncResult"].Inputs.Encode(inputs)
+func (s *StateSyncResultEvent) Encode() ([]byte, error) {
+	return StateReceiver.Abi.Events["StateSyncResult"].Inputs.Encode(s)
 }
 
 func (s *StateSyncResultEvent) ParseLog(log *ethgo.Log) (bool, error) {
@@ -113,8 +113,8 @@ func (*NewCommitmentEvent) Sig() ethgo.Hash {
 	return StateReceiver.Abi.Events["NewCommitment"].ID()
 }
 
-func (*NewCommitmentEvent) Encode(inputs interface{}) ([]byte, error) {
-	return StateReceiver.Abi.Events["NewCommitment"].Inputs.Encode(inputs)
+func (n *NewCommitmentEvent) Encode() ([]byte, error) {
+	return StateReceiver.Abi.Events["NewCommitment"].Inputs.Encode(n)
 }
 
 func (n *NewCommitmentEvent) ParseLog(log *ethgo.Log) (bool, error) {
@@ -157,8 +157,8 @@ func (*StateSyncedEvent) Sig() ethgo.Hash {
 	return StateSender.Abi.Events["StateSynced"].ID()
 }
 
-func (*StateSyncedEvent) Encode(inputs interface{}) ([]byte, error) {
-	return StateSender.Abi.Events["StateSynced"].Inputs.Encode(inputs)
+func (s *StateSyncedEvent) Encode() ([]byte, error) {
+	return StateSender.Abi.Events["StateSynced"].Inputs.Encode(s)
 }
 
 func (s *StateSyncedEvent) ParseLog(log *ethgo.Log) (bool, error) {
@@ -184,8 +184,8 @@ func (*L2StateSyncedEvent) Sig() ethgo.Hash {
 	return L2StateSender.Abi.Events["L2StateSynced"].ID()
 }
 
-func (*L2StateSyncedEvent) Encode(inputs interface{}) ([]byte, error) {
-	return L2StateSender.Abi.Events["L2StateSynced"].Inputs.Encode(inputs)
+func (l *L2StateSyncedEvent) Encode() ([]byte, error) {
+	return L2StateSender.Abi.Events["L2StateSynced"].Inputs.Encode(l)
 }
 
 func (l *L2StateSyncedEvent) ParseLog(log *ethgo.Log) (bool, error) {
@@ -564,8 +564,8 @@ func (*TokenMappedEvent) Sig() ethgo.Hash {
 	return RootERC20Predicate.Abi.Events["TokenMapped"].ID()
 }
 
-func (*TokenMappedEvent) Encode(inputs interface{}) ([]byte, error) {
-	return RootERC20Predicate.Abi.Events["TokenMapped"].Inputs.Encode(inputs)
+func (t *TokenMappedEvent) Encode() ([]byte, error) {
+	return RootERC20Predicate.Abi.Events["TokenMapped"].Inputs.Encode(t)
 }
 
 func (t *TokenMappedEvent) ParseLog(log *ethgo.Log) (bool, error) {
@@ -608,8 +608,8 @@ func (*MintableTokenMappedEvent) Sig() ethgo.Hash {
 	return ChildMintableERC20Predicate.Abi.Events["MintableTokenMapped"].ID()
 }
 
-func (*MintableTokenMappedEvent) Encode(inputs interface{}) ([]byte, error) {
-	return ChildMintableERC20Predicate.Abi.Events["MintableTokenMapped"].Inputs.Encode(inputs)
+func (m *MintableTokenMappedEvent) Encode() ([]byte, error) {
+	return ChildMintableERC20Predicate.Abi.Events["MintableTokenMapped"].Inputs.Encode(m)
 }
 
 func (m *MintableTokenMappedEvent) ParseLog(log *ethgo.Log) (bool, error) {
@@ -913,8 +913,8 @@ func (*L2MintableTokenMappedEvent) Sig() ethgo.Hash {
 	return RootMintableERC1155PredicateACL.Abi.Events["L2MintableTokenMapped"].ID()
 }
 
-func (*L2MintableTokenMappedEvent) Encode(inputs interface{}) ([]byte, error) {
-	return RootMintableERC1155PredicateACL.Abi.Events["L2MintableTokenMapped"].Inputs.Encode(inputs)
+func (l *L2MintableTokenMappedEvent) Encode() ([]byte, error) {
+	return RootMintableERC1155PredicateACL.Abi.Events["L2MintableTokenMapped"].Inputs.Encode(l)
 }
 
 func (l *L2MintableTokenMappedEvent) ParseLog(log *ethgo.Log) (bool, error) {
@@ -1284,8 +1284,8 @@ func (*ValidatorRegisteredEvent) Sig() ethgo.Hash {
 	return CustomSupernetManager.Abi.Events["ValidatorRegistered"].ID()
 }
 
-func (*ValidatorRegisteredEvent) Encode(inputs interface{}) ([]byte, error) {
-	return CustomSupernetManager.Abi.Events["ValidatorRegistered"].Inputs.Encode(inputs)
+func (v *ValidatorRegisteredEvent) Encode() ([]byte, error) {
+	return CustomSupernetManager.Abi.Events["ValidatorRegistered"].Inputs.Encode(v)
 }
 
 func (v *ValidatorRegisteredEvent) ParseLog(log *ethgo.Log) (bool, error) {
@@ -1308,8 +1308,8 @@ func (*AddedToWhitelistEvent) Sig() ethgo.Hash {
 	return CustomSupernetManager.Abi.Events["AddedToWhitelist"].ID()
 }
 
-func (*AddedToWhitelistEvent) Encode(inputs interface{}) ([]byte, error) {
-	return CustomSupernetManager.Abi.Events["AddedToWhitelist"].Inputs.Encode(inputs)
+func (a *AddedToWhitelistEvent) Encode() ([]byte, error) {
+	return CustomSupernetManager.Abi.Events["AddedToWhitelist"].Inputs.Encode(a)
 }
 
 func (a *AddedToWhitelistEvent) ParseLog(log *ethgo.Log) (bool, error) {
@@ -1433,8 +1433,8 @@ func (*ChildManagerRegisteredEvent) Sig() ethgo.Hash {
 	return StakeManager.Abi.Events["ChildManagerRegistered"].ID()
 }
 
-func (*ChildManagerRegisteredEvent) Encode(inputs interface{}) ([]byte, error) {
-	return StakeManager.Abi.Events["ChildManagerRegistered"].Inputs.Encode(inputs)
+func (c *ChildManagerRegisteredEvent) Encode() ([]byte, error) {
+	return StakeManager.Abi.Events["ChildManagerRegistered"].Inputs.Encode(c)
 }
 
 func (c *ChildManagerRegisteredEvent) ParseLog(log *ethgo.Log) (bool, error) {
@@ -1459,8 +1459,8 @@ func (*StakeAddedEvent) Sig() ethgo.Hash {
 	return StakeManager.Abi.Events["StakeAdded"].ID()
 }
 
-func (*StakeAddedEvent) Encode(inputs interface{}) ([]byte, error) {
-	return StakeManager.Abi.Events["StakeAdded"].Inputs.Encode(inputs)
+func (s *StakeAddedEvent) Encode() ([]byte, error) {
+	return StakeManager.Abi.Events["StakeAdded"].Inputs.Encode(s)
 }
 
 func (s *StakeAddedEvent) ParseLog(log *ethgo.Log) (bool, error) {
@@ -1485,8 +1485,8 @@ func (*StakeWithdrawnEvent) Sig() ethgo.Hash {
 	return StakeManager.Abi.Events["StakeWithdrawn"].ID()
 }
 
-func (*StakeWithdrawnEvent) Encode(inputs interface{}) ([]byte, error) {
-	return StakeManager.Abi.Events["StakeWithdrawn"].Inputs.Encode(inputs)
+func (s *StakeWithdrawnEvent) Encode() ([]byte, error) {
+	return StakeManager.Abi.Events["StakeWithdrawn"].Inputs.Encode(s)
 }
 
 func (s *StakeWithdrawnEvent) ParseLog(log *ethgo.Log) (bool, error) {
@@ -1595,8 +1595,8 @@ func (*TransferEvent) Sig() ethgo.Hash {
 	return ValidatorSet.Abi.Events["Transfer"].ID()
 }
 
-func (*TransferEvent) Encode(inputs interface{}) ([]byte, error) {
-	return ValidatorSet.Abi.Events["Transfer"].Inputs.Encode(inputs)
+func (t *TransferEvent) Encode() ([]byte, error) {
+	return ValidatorSet.Abi.Events["Transfer"].Inputs.Encode(t)
 }
 
 func (t *TransferEvent) ParseLog(log *ethgo.Log) (bool, error) {
@@ -1620,8 +1620,8 @@ func (*WithdrawalRegisteredEvent) Sig() ethgo.Hash {
 	return ValidatorSet.Abi.Events["WithdrawalRegistered"].ID()
 }
 
-func (*WithdrawalRegisteredEvent) Encode(inputs interface{}) ([]byte, error) {
-	return ValidatorSet.Abi.Events["WithdrawalRegistered"].Inputs.Encode(inputs)
+func (w *WithdrawalRegisteredEvent) Encode() ([]byte, error) {
+	return ValidatorSet.Abi.Events["WithdrawalRegistered"].Inputs.Encode(w)
 }
 
 func (w *WithdrawalRegisteredEvent) ParseLog(log *ethgo.Log) (bool, error) {
@@ -1645,8 +1645,8 @@ func (*WithdrawalEvent) Sig() ethgo.Hash {
 	return ValidatorSet.Abi.Events["Withdrawal"].ID()
 }
 
-func (*WithdrawalEvent) Encode(inputs interface{}) ([]byte, error) {
-	return ValidatorSet.Abi.Events["Withdrawal"].Inputs.Encode(inputs)
+func (w *WithdrawalEvent) Encode() ([]byte, error) {
+	return ValidatorSet.Abi.Events["Withdrawal"].Inputs.Encode(w)
 }
 
 func (w *WithdrawalEvent) ParseLog(log *ethgo.Log) (bool, error) {

--- a/consensus/polybft/contractsapi/contractsapi.go
+++ b/consensus/polybft/contractsapi/contractsapi.go
@@ -99,6 +99,10 @@ func (s *StateSyncResultEvent) ParseLog(log *ethgo.Log) (bool, error) {
 	return true, decodeEvent(StateReceiver.Abi.Events["StateSyncResult"], log, s)
 }
 
+func (s *StateSyncResultEvent) Decode(input []byte) error {
+	return StateReceiver.Abi.Events["StateSyncResult"].Inputs.DecodeStruct(input, &s)
+}
+
 type NewCommitmentEvent struct {
 	StartID *big.Int   `abi:"startId"`
 	EndID   *big.Int   `abi:"endId"`
@@ -119,6 +123,10 @@ func (n *NewCommitmentEvent) ParseLog(log *ethgo.Log) (bool, error) {
 	}
 
 	return true, decodeEvent(StateReceiver.Abi.Events["NewCommitment"], log, n)
+}
+
+func (n *NewCommitmentEvent) Decode(input []byte) error {
+	return StateReceiver.Abi.Events["NewCommitment"].Inputs.DecodeStruct(input, &n)
 }
 
 type SyncStateStateSenderFn struct {
@@ -161,6 +169,10 @@ func (s *StateSyncedEvent) ParseLog(log *ethgo.Log) (bool, error) {
 	return true, decodeEvent(StateSender.Abi.Events["StateSynced"], log, s)
 }
 
+func (s *StateSyncedEvent) Decode(input []byte) error {
+	return StateSender.Abi.Events["StateSynced"].Inputs.DecodeStruct(input, &s)
+}
+
 type L2StateSyncedEvent struct {
 	ID       *big.Int      `abi:"id"`
 	Sender   types.Address `abi:"sender"`
@@ -182,6 +194,10 @@ func (l *L2StateSyncedEvent) ParseLog(log *ethgo.Log) (bool, error) {
 	}
 
 	return true, decodeEvent(L2StateSender.Abi.Events["L2StateSynced"], log, l)
+}
+
+func (l *L2StateSyncedEvent) Decode(input []byte) error {
+	return L2StateSender.Abi.Events["L2StateSynced"].Inputs.DecodeStruct(input, &l)
 }
 
 type CheckpointManagerConstructorFn struct {
@@ -560,6 +576,10 @@ func (t *TokenMappedEvent) ParseLog(log *ethgo.Log) (bool, error) {
 	return true, decodeEvent(RootERC20Predicate.Abi.Events["TokenMapped"], log, t)
 }
 
+func (t *TokenMappedEvent) Decode(input []byte) error {
+	return RootERC20Predicate.Abi.Events["TokenMapped"].Inputs.DecodeStruct(input, &t)
+}
+
 type InitializeChildMintableERC20PredicateFn struct {
 	NewStateSender        types.Address `abi:"newStateSender"`
 	NewExitHelper         types.Address `abi:"newExitHelper"`
@@ -598,6 +618,10 @@ func (m *MintableTokenMappedEvent) ParseLog(log *ethgo.Log) (bool, error) {
 	}
 
 	return true, decodeEvent(ChildMintableERC20Predicate.Abi.Events["MintableTokenMapped"], log, m)
+}
+
+func (m *MintableTokenMappedEvent) Decode(input []byte) error {
+	return ChildMintableERC20Predicate.Abi.Events["MintableTokenMapped"].Inputs.DecodeStruct(input, &m)
 }
 
 type BalanceOfRootERC20Fn struct {
@@ -899,6 +923,10 @@ func (l *L2MintableTokenMappedEvent) ParseLog(log *ethgo.Log) (bool, error) {
 	}
 
 	return true, decodeEvent(RootMintableERC1155PredicateACL.Abi.Events["L2MintableTokenMapped"], log, l)
+}
+
+func (l *L2MintableTokenMappedEvent) Decode(input []byte) error {
+	return RootMintableERC1155PredicateACL.Abi.Events["L2MintableTokenMapped"].Inputs.DecodeStruct(input, &l)
 }
 
 type InitializeChildERC1155Fn struct {
@@ -1268,6 +1296,10 @@ func (v *ValidatorRegisteredEvent) ParseLog(log *ethgo.Log) (bool, error) {
 	return true, decodeEvent(CustomSupernetManager.Abi.Events["ValidatorRegistered"], log, v)
 }
 
+func (v *ValidatorRegisteredEvent) Decode(input []byte) error {
+	return CustomSupernetManager.Abi.Events["ValidatorRegistered"].Inputs.DecodeStruct(input, &v)
+}
+
 type AddedToWhitelistEvent struct {
 	Validator types.Address `abi:"validator"`
 }
@@ -1286,6 +1318,10 @@ func (a *AddedToWhitelistEvent) ParseLog(log *ethgo.Log) (bool, error) {
 	}
 
 	return true, decodeEvent(CustomSupernetManager.Abi.Events["AddedToWhitelist"], log, a)
+}
+
+func (a *AddedToWhitelistEvent) Decode(input []byte) error {
+	return CustomSupernetManager.Abi.Events["AddedToWhitelist"].Inputs.DecodeStruct(input, &a)
 }
 
 type InitializeStakeManagerFn struct {
@@ -1409,6 +1445,10 @@ func (c *ChildManagerRegisteredEvent) ParseLog(log *ethgo.Log) (bool, error) {
 	return true, decodeEvent(StakeManager.Abi.Events["ChildManagerRegistered"], log, c)
 }
 
+func (c *ChildManagerRegisteredEvent) Decode(input []byte) error {
+	return StakeManager.Abi.Events["ChildManagerRegistered"].Inputs.DecodeStruct(input, &c)
+}
+
 type StakeAddedEvent struct {
 	ID        *big.Int      `abi:"id"`
 	Validator types.Address `abi:"validator"`
@@ -1431,6 +1471,10 @@ func (s *StakeAddedEvent) ParseLog(log *ethgo.Log) (bool, error) {
 	return true, decodeEvent(StakeManager.Abi.Events["StakeAdded"], log, s)
 }
 
+func (s *StakeAddedEvent) Decode(input []byte) error {
+	return StakeManager.Abi.Events["StakeAdded"].Inputs.DecodeStruct(input, &s)
+}
+
 type StakeWithdrawnEvent struct {
 	Validator types.Address `abi:"validator"`
 	Recipient types.Address `abi:"recipient"`
@@ -1451,6 +1495,10 @@ func (s *StakeWithdrawnEvent) ParseLog(log *ethgo.Log) (bool, error) {
 	}
 
 	return true, decodeEvent(StakeManager.Abi.Events["StakeWithdrawn"], log, s)
+}
+
+func (s *StakeWithdrawnEvent) Decode(input []byte) error {
+	return StakeManager.Abi.Events["StakeWithdrawn"].Inputs.DecodeStruct(input, &s)
 }
 
 type Epoch struct {
@@ -1559,6 +1607,10 @@ func (t *TransferEvent) ParseLog(log *ethgo.Log) (bool, error) {
 	return true, decodeEvent(ValidatorSet.Abi.Events["Transfer"], log, t)
 }
 
+func (t *TransferEvent) Decode(input []byte) error {
+	return ValidatorSet.Abi.Events["Transfer"].Inputs.DecodeStruct(input, &t)
+}
+
 type WithdrawalRegisteredEvent struct {
 	Account types.Address `abi:"account"`
 	Amount  *big.Int      `abi:"amount"`
@@ -1580,6 +1632,10 @@ func (w *WithdrawalRegisteredEvent) ParseLog(log *ethgo.Log) (bool, error) {
 	return true, decodeEvent(ValidatorSet.Abi.Events["WithdrawalRegistered"], log, w)
 }
 
+func (w *WithdrawalRegisteredEvent) Decode(input []byte) error {
+	return ValidatorSet.Abi.Events["WithdrawalRegistered"].Inputs.DecodeStruct(input, &w)
+}
+
 type WithdrawalEvent struct {
 	Account types.Address `abi:"account"`
 	Amount  *big.Int      `abi:"amount"`
@@ -1599,6 +1655,10 @@ func (w *WithdrawalEvent) ParseLog(log *ethgo.Log) (bool, error) {
 	}
 
 	return true, decodeEvent(ValidatorSet.Abi.Events["Withdrawal"], log, w)
+}
+
+func (w *WithdrawalEvent) Decode(input []byte) error {
+	return ValidatorSet.Abi.Events["Withdrawal"].Inputs.DecodeStruct(input, &w)
 }
 
 type InitializeRewardPoolFn struct {

--- a/consensus/polybft/contractsapi/helper.go
+++ b/consensus/polybft/contractsapi/helper.go
@@ -19,7 +19,7 @@ type EventAbi interface {
 	// Sig returns the event ABI signature or ID (which is unique for all event types)
 	Sig() ethgo.Hash
 	// Encode does abi encoding of given event
-	Encode(inputs interface{}) ([]byte, error)
+	Encode() ([]byte, error)
 	// ParseLog parses the provided receipt log to given event type
 	ParseLog(log *ethgo.Log) (bool, error)
 }

--- a/consensus/polybft/sc_integration_test.go
+++ b/consensus/polybft/sc_integration_test.go
@@ -233,8 +233,7 @@ func TestIntegration_PerformExit(t *testing.T) {
 	res := getField(exitHelperContractAddress, contractsapi.ExitHelper.Abi, "processedExits", exits[0].ID)
 	require.Equal(t, 0, int(res[31]))
 
-	var exitEventAPI contractsapi.L2StateSyncedEvent
-	proofExitEvent, err := exitEventAPI.Encode(exits[0].L2StateSyncedEvent)
+	proofExitEvent, err := exits[0].L2StateSyncedEvent.Encode()
 	require.NoError(t, err)
 
 	proof, err := exitTree.GenerateProof(proofExitEvent)

--- a/consensus/polybft/state_store_checkpoint.go
+++ b/consensus/polybft/state_store_checkpoint.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/umbracle/ethgo"
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/umbracle/ethgo"
-	bolt "go.etcd.io/bbolt"
 )
 
 var (


### PR DESCRIPTION
# Description

In order to be able to rely on external tools for executing bridge transactions (such as Foundry), `bridge_generateExitProof` should return an abi-encoded exit event, instead of an object, so that it becomes possible to submit an exit transaction without the need to programmatically decode returned exit event and transforming it into ABI-encoded byte array. With this fix, it is possible to provide a given exit event straight away to the exit transaction (namely invoking the `ExitHelper.exit` function).

This PR also changes the way the encode function is invoked for ABI events. Instead of accepting parameters to encode via `inputs` argument, now it uses already provided fields in each struct representing an ABI event.

## Foundry test scenario

These are the steps that represent the test scenario that bridges the Supernets native token to the rootchain and withdraws it back to the Supernets. This is just an example that uses predefined private keys, receiver addresses, and contract addresses. For the most part, those need to be adapted, based on real values.

1. **Approve root predicate** as a spender of deposit tokens (namely the one that is being bridged). Adapt `private-key` and `rpc-url` as well as `amount` values accordingly. Also contract address in case non-native token is being bridged (use arbitrary ERC20 token address instead of `0x0000000000000000000000000000000000001010`)

```go
cast send --private-key b0bda8d32bdc5f987ef9585bed2a1d2a7c1971e7abef0fa5d99249f9bd9a6c36 --rpc-url http://localhost:10002 \
0x0000000000000000000000000000000000001010 "function approve(address spender, uint256 amount) returns (bool)" 0x0000000000000000000000000000000000001009 1ether
```

2. **Deposit** (Supernets mintable native token). Adapt `private-key` and `rpc-url` as well as `receiver` and `amount` values accordingly.
```go
cast send --private-key b0bda8d32bdc5f987ef9585bed2a1d2a7c1971e7abef0fa5d99249f9bd9a6c36 --rpc-url http://localhost:10002 \
0x0000000000000000000000000000000000001009 "function depositTo(address rootToken, address receiver, uint256 amount) external" 0x0000000000000000000000000000000000001010 0x396225475de7D57964a20C7D149Fe827D0D434fa 1ether
```

3. **Acquire exit event proof** (alongside exit event) and remember these values, because they are going to be needed for sending exit transaction. Provide adequate `rpc-url` and exit event id as a parameter.
```go
cast rpc --rpc-url http://localhost:10002 "bridge_generateExitProof" 1
```

4. **Send exit transaction**  (for arguments, provide `CheckpointBlock`, `LeafIndex`, `ExitEvent` and `Proof` respectively). For contract address, provide address of the `ExitHelper` contract (it can be retrieved from the `genesis.json` `exitHelperAddress`)

```go
cast send --private-key b0bda8d32bdc5f987ef9585bed2a1d2a7c1971e7abef0fa5d99249f9bd9a6c36 \
--rpc-url http://localhost:8545 0x72e85c41f3Fc1B69d20F91e502d7d923caFE3ed5 "function exit(uint256 blockNum, uint256 index, bytes leaf, bytes32[] proof) external" 7730 0 \
0000000000000000000000000000000000000000000000000000000000000005000000000000000000000000000000000000000000000000000000000000100900000000000000000000000045b0a43d5cdc3b402586a359373f90d801a0e888000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000a087a7811f4bfedea3d341ad165680ae306b01aaeacc205d227629cf157dd9f8210000000000000000000000000000000000000000000000000000000000001010000000000000000000000000396225475de7d57964a20c7d149fe827d0d434fa000000000000000000000000396225475de7d57964a20c7d149fe827d0d434fa0000000000000000000000000000000000000000000000000de0b6b3a7640000 \
[]
```

5. **Send withdraw transaction** (back to the Supernets). Adapt `private-key`, `rpc-url`, contract address (it corresponds to `erc20ChildMintablePredicateAddress`, which is acquired from the genesis.json), `childToken` value (can be acquired by querying either root or child predicate, `rootTokenToChildToken` and providing corresponding root token address as a key), `receiver` and `amount` parameters.
```go
cast send --private-key b0bda8d32bdc5f987ef9585bed2a1d2a7c1971e7abef0fa5d99249f9bd9a6c36 --rpc-url http://localhost:8545 \
0x45B0a43d5CDc3b402586A359373f90D801a0e888 "function withdrawTo(address childToken, address receiver, uint256 amount) external" 0xa8933dF6C1A0A84501f446e4e3174415dE201c5F 0x396225475de7D57964a20C7D149Fe827D0D434fa 1ether
```

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
