### PR TITLE
Added option to disable structLogs for debug_trace* rpc methods.

### DIFF
--- a/jsonrpc/debug_endpoint.go
+++ b/jsonrpc/debug_endpoint.go
@@ -77,11 +77,12 @@ func NewDebug(store debugStore, requestsPerSecond uint64) *Debug {
 }
 
 type TraceConfig struct {
-	EnableMemory     bool    `json:"enableMemory"`
-	DisableStack     bool    `json:"disableStack"`
-	DisableStorage   bool    `json:"disableStorage"`
-	EnableReturnData bool    `json:"enableReturnData"`
-	Timeout          *string `json:"timeout"`
+	EnableMemory      bool    `json:"enableMemory"`
+	DisableStack      bool    `json:"disableStack"`
+	DisableStorage    bool    `json:"disableStorage"`
+	EnableReturnData  bool    `json:"enableReturnData"`
+	DisableStructLogs bool    `json:"disableStructLogs"`
+	Timeout           *string `json:"timeout"`
 }
 
 func (d *Debug) TraceBlockByNumber(
@@ -248,10 +249,11 @@ func newTracer(config *TraceConfig) (
 	}
 
 	tracer := structtracer.NewStructTracer(structtracer.Config{
-		EnableMemory:     config.EnableMemory,
-		EnableStack:      !config.DisableStack,
-		EnableStorage:    !config.DisableStorage,
+		EnableMemory:     config.EnableMemory && !config.DisableStructLogs,
+		EnableStack:      !config.DisableStack && !config.DisableStructLogs,
+		EnableStorage:    !config.DisableStorage && !config.DisableStructLogs,
 		EnableReturnData: config.EnableReturnData,
+		EnableStructLogs: !config.DisableStructLogs,
 	})
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/jsonrpc/debug_endpoint_test.go
+++ b/jsonrpc/debug_endpoint_test.go
@@ -6,10 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/state/runtime/tracer"
+	"github.com/0xPolygon/polygon-edge/state/runtime/tracer/structtracer"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/stretchr/testify/assert"
 )
 
 type debugEndpointMockStore struct {
@@ -152,6 +154,20 @@ func TestDebugTraceConfigDecode(t *testing.T) {
 				DisableStorage:   true,
 				EnableReturnData: true,
 				Timeout:          &timeout15s,
+			},
+		},
+		{
+			input: `{
+				"disableStack": true,
+				"disableStorage": true,
+				"enableReturnData": true,
+				"disableStructLogs": true
+			}`,
+			expected: TraceConfig{
+				DisableStack:      true,
+				DisableStorage:    true,
+				EnableReturnData:  true,
+				DisableStructLogs: true,
 			},
 		},
 	}
@@ -786,5 +802,31 @@ func Test_newTracer(t *testing.T) {
 
 		assert.NotNil(t, res)
 		assert.NoError(t, err)
+	})
+
+	t.Run("should disable everything if struct logs are disabled", func(t *testing.T) {
+		t.Parallel()
+
+		tracer, cancel, err := newTracer(&TraceConfig{
+			EnableMemory:      true,
+			EnableReturnData:  true,
+			DisableStack:      false,
+			DisableStorage:    false,
+			DisableStructLogs: true,
+		})
+
+		t.Cleanup(func() {
+			cancel()
+		})
+
+		assert.NoError(t, err)
+
+		assert.Equal(t, structtracer.Config{
+			EnableMemory:     false,
+			EnableStack:      false,
+			EnableStorage:    false,
+			EnableReturnData: true,
+			EnableStructLogs: false,
+		}, tracer.(*structtracer.StructTracer).Config)
 	})
 }

--- a/jsonrpc/debug_endpoint_test.go
+++ b/jsonrpc/debug_endpoint_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/state/runtime/tracer"
@@ -821,12 +822,15 @@ func Test_newTracer(t *testing.T) {
 
 		assert.NoError(t, err)
 
+		st, ok := tracer.(*structtracer.StructTracer)
+		require.True(t, ok)
+
 		assert.Equal(t, structtracer.Config{
 			EnableMemory:     false,
 			EnableStack:      false,
 			EnableStorage:    false,
 			EnableReturnData: true,
 			EnableStructLogs: false,
-		}, tracer.(*structtracer.StructTracer).Config)
+		}, st.Config)
 	})
 }

--- a/state/runtime/tracer/structtracer/tracer.go
+++ b/state/runtime/tracer/structtracer/tracer.go
@@ -18,6 +18,7 @@ type Config struct {
 	EnableStack      bool // enable stack capture
 	EnableStorage    bool // enable storage capture
 	EnableReturnData bool // enable return data capture
+	EnableStructLogs bool // enable struct logs capture
 }
 
 type StructLog struct {
@@ -302,22 +303,24 @@ func (t *StructTracer) ExecuteState(
 		errStr = err.Error()
 	}
 
-	t.logs = append(
-		t.logs,
-		StructLog{
-			Pc:            ip,
-			Op:            opCode,
-			Gas:           availableGas,
-			GasCost:       cost,
-			Memory:        memory,
-			Stack:         stack,
-			ReturnData:    returnData,
-			Storage:       storage,
-			Depth:         depth,
-			RefundCounter: host.GetRefund(),
-			Error:         errStr,
-		},
-	)
+	if t.Config.EnableStructLogs {
+		t.logs = append(
+			t.logs,
+			StructLog{
+				Pc:            ip,
+				Op:            opCode,
+				Gas:           availableGas,
+				GasCost:       cost,
+				Memory:        memory,
+				Stack:         stack,
+				ReturnData:    returnData,
+				Storage:       storage,
+				Depth:         depth,
+				RefundCounter: host.GetRefund(),
+				Error:         errStr,
+			},
+		)
+	}
 }
 
 type StructTraceResult struct {

--- a/state/runtime/tracer/structtracer/tracer_test.go
+++ b/state/runtime/tracer/structtracer/tracer_test.go
@@ -5,13 +5,14 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/state/runtime"
 	"github.com/0xPolygon/polygon-edge/state/runtime/evm"
 	"github.com/0xPolygon/polygon-edge/state/runtime/tracer"
 	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -118,6 +119,7 @@ func TestStructTracerClear(t *testing.T) {
 			EnableStack:      true,
 			EnableStorage:    true,
 			EnableReturnData: true,
+			EnableStructLogs: true,
 		},
 		reason:    errors.New("timeout"),
 		interrupt: true,
@@ -154,6 +156,7 @@ func TestStructTracerClear(t *testing.T) {
 				EnableStack:      true,
 				EnableStorage:    true,
 				EnableReturnData: true,
+				EnableStructLogs: true,
 			},
 			reason:      nil,
 			interrupt:   false,
@@ -352,7 +355,8 @@ func TestStructTracerCaptureState(t *testing.T) {
 			name: "should capture memory",
 			tracer: &StructTracer{
 				Config: Config{
-					EnableMemory: true,
+					EnableMemory:     true,
+					EnableStructLogs: true,
 				},
 				currentMemory: make([]([]byte), 1),
 			},
@@ -367,7 +371,8 @@ func TestStructTracerCaptureState(t *testing.T) {
 			},
 			expectedTracer: &StructTracer{
 				Config: Config{
-					EnableMemory: true,
+					EnableMemory:     true,
+					EnableStructLogs: true,
 				},
 				currentMemory: memory,
 			},
@@ -377,7 +382,8 @@ func TestStructTracerCaptureState(t *testing.T) {
 			name: "should capture stack",
 			tracer: &StructTracer{
 				Config: Config{
-					EnableStack: true,
+					EnableStack:      true,
+					EnableStructLogs: true,
 				},
 				currentStack: make([]([]*big.Int), 1),
 			},
@@ -392,7 +398,8 @@ func TestStructTracerCaptureState(t *testing.T) {
 			},
 			expectedTracer: &StructTracer{
 				Config: Config{
-					EnableStack: true,
+					EnableStack:      true,
+					EnableStructLogs: true,
 				},
 				currentStack: stack,
 			},
@@ -402,7 +409,8 @@ func TestStructTracerCaptureState(t *testing.T) {
 			name: "should capture storage by SLOAD",
 			tracer: &StructTracer{
 				Config: Config{
-					EnableStorage: true,
+					EnableStorage:    true,
+					EnableStructLogs: true,
 				},
 				storage: []map[types.Address]map[types.Hash]types.Hash{
 					make(map[types.Address]map[types.Hash]types.Hash),
@@ -426,7 +434,8 @@ func TestStructTracerCaptureState(t *testing.T) {
 			},
 			expectedTracer: &StructTracer{
 				Config: Config{
-					EnableStorage: true,
+					EnableStorage:    true,
+					EnableStructLogs: true,
 				},
 				storage: [](map[types.Address]map[types.Hash]types.Hash){
 					map[types.Address]map[types.Hash]types.Hash{
@@ -442,7 +451,8 @@ func TestStructTracerCaptureState(t *testing.T) {
 			name: "should capture storage by SSTORE",
 			tracer: &StructTracer{
 				Config: Config{
-					EnableStorage: true,
+					EnableStorage:    true,
+					EnableStructLogs: true,
 				},
 				storage: []map[types.Address]map[types.Hash]types.Hash{
 					{
@@ -463,7 +473,8 @@ func TestStructTracerCaptureState(t *testing.T) {
 			},
 			expectedTracer: &StructTracer{
 				Config: Config{
-					EnableStorage: true,
+					EnableStorage:    true,
+					EnableStructLogs: true,
 				},
 				storage: []map[types.Address]map[types.Hash]types.Hash{
 					{
@@ -502,7 +513,8 @@ func TestStructTracerCaptureState(t *testing.T) {
 			name: "should not capture if sp is less than 1 in case op SLOAD",
 			tracer: &StructTracer{
 				Config: Config{
-					EnableStorage: true,
+					EnableStorage:    true,
+					EnableStructLogs: true,
 				},
 				storage: []map[types.Address]map[types.Hash]types.Hash{
 					make(map[types.Address]map[types.Hash]types.Hash),
@@ -519,7 +531,8 @@ func TestStructTracerCaptureState(t *testing.T) {
 			},
 			expectedTracer: &StructTracer{
 				Config: Config{
-					EnableStorage: true,
+					EnableStorage:    true,
+					EnableStructLogs: true,
 				},
 				storage: []map[types.Address]map[types.Hash]types.Hash{
 					make(map[types.Address]map[types.Hash]types.Hash),
@@ -531,7 +544,8 @@ func TestStructTracerCaptureState(t *testing.T) {
 			name: "should not capture if sp is less than 2 in case op SSTORE",
 			tracer: &StructTracer{
 				Config: Config{
-					EnableStorage: true,
+					EnableStorage:    true,
+					EnableStructLogs: true,
 				},
 				storage: []map[types.Address]map[types.Hash]types.Hash{
 					make(map[types.Address]map[types.Hash]types.Hash),
@@ -548,7 +562,8 @@ func TestStructTracerCaptureState(t *testing.T) {
 			},
 			expectedTracer: &StructTracer{
 				Config: Config{
-					EnableStorage: true,
+					EnableStorage:    true,
+					EnableStructLogs: true,
 				},
 				storage: []map[types.Address]map[types.Hash]types.Hash{
 					make(map[types.Address]map[types.Hash]types.Hash),
@@ -639,9 +654,31 @@ func TestStructTracerExecuteState(t *testing.T) {
 		expected []StructLog
 	}{
 		{
-			name: "should create minimal log",
+			name: "should create no log",
 			tracer: &StructTracer{
 				Config: testEmptyConfig,
+			},
+			contractAddress: contractAddress,
+			ip:              ip,
+			opCode:          opCode,
+			availableGas:    availableGas,
+			cost:            cost,
+			lastReturnData:  lastReturnData,
+			depth:           depth,
+			err:             err,
+			host: &mockHost{
+				getRefundFn: func() uint64 {
+					return refund
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "should create minimal log",
+			tracer: &StructTracer{
+				Config: Config{
+					EnableStructLogs: true,
+				},
 			},
 			contractAddress: contractAddress,
 			ip:              ip,
@@ -676,7 +713,8 @@ func TestStructTracerExecuteState(t *testing.T) {
 			name: "should save memory",
 			tracer: &StructTracer{
 				Config: Config{
-					EnableMemory: true,
+					EnableMemory:     true,
+					EnableStructLogs: true,
 				},
 				currentMemory: memory,
 			},
@@ -713,7 +751,8 @@ func TestStructTracerExecuteState(t *testing.T) {
 			name: "should save stack",
 			tracer: &StructTracer{
 				Config: Config{
-					EnableStack: true,
+					EnableStack:      true,
+					EnableStructLogs: true,
 				},
 				currentStack: [][]*big.Int{{
 					big.NewInt(1),
@@ -772,27 +811,14 @@ func TestStructTracerExecuteState(t *testing.T) {
 					return refund
 				},
 			},
-			expected: []StructLog{
-				{
-					Pc:            ip,
-					Op:            opCode,
-					Gas:           availableGas,
-					GasCost:       cost,
-					Memory:        nil,
-					Stack:         nil,
-					ReturnData:    hex.EncodeToString(lastReturnData),
-					Storage:       nil,
-					Depth:         depth,
-					RefundCounter: refund,
-					Error:         err.Error(),
-				},
-			},
+			expected: nil,
 		},
 		{
 			name: "should save storage",
 			tracer: &StructTracer{
 				Config: Config{
-					EnableStorage: true,
+					EnableStorage:    true,
+					EnableStructLogs: true,
 				},
 				storage: storage,
 			},
@@ -832,10 +858,6 @@ func TestStructTracerExecuteState(t *testing.T) {
 
 	for _, test := range tests {
 		test := test
-
-		if test.name != "should save storage" {
-			continue
-		}
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
# Description

The easiest reliable way to get return data of a transaction is debug_traceTransaction rpc, but it comes with huge structLogs data, which uses a lot of network traffic.

This is a simple solution for that: Just add an option to disable it. 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

1. Start the chain
2. Make a transaction
3. Call trace_debugTransaction with disableLogs set to true and then false.
4. Check that structLogs field is filled only when disableLogs is set to false.

# Additional comments

I removed some test code lines that skips certain test suites. I don't know exactly why they have been made skipped originally, but they seems to work well now.