### PR TITLE
Default value of JSON RPC flag in commands

### DIFF
--- a/command/bridge/common/params.go
+++ b/command/bridge/common/params.go
@@ -86,6 +86,19 @@ func (p *BridgeParams) RegisterCommonFlags(cmd *cobra.Command) {
 	)
 }
 
+func (p *BridgeParams) Validate() error {
+	if p == nil {
+		return nil
+	}
+
+	_, err := cmdHelper.ParseJSONRPCAddress(p.JSONRPCAddr)
+	if err != nil {
+		return fmt.Errorf("failed to parse json rpc address. Error: %w", err)
+	}
+
+	return nil
+}
+
 type ERC20BridgeParams struct {
 	*BridgeParams
 	Amounts []string
@@ -96,6 +109,10 @@ func NewERC20BridgeParams() *ERC20BridgeParams {
 }
 
 func (bp *ERC20BridgeParams) Validate() error {
+	if err := bp.BridgeParams.Validate(); err != nil {
+		return err
+	}
+
 	if len(bp.Receivers) != len(bp.Amounts) {
 		return errInconsistentAmounts
 	}
@@ -113,6 +130,10 @@ func NewERC721BridgeParams() *ERC721BridgeParams {
 }
 
 func (bp *ERC721BridgeParams) Validate() error {
+	if err := bp.BridgeParams.Validate(); err != nil {
+		return err
+	}
+
 	if len(bp.Receivers) != len(bp.TokenIDs) {
 		return errInconsistentTokenIds
 	}
@@ -131,6 +152,10 @@ func NewERC1155BridgeParams() *ERC1155BridgeParams {
 }
 
 func (bp *ERC1155BridgeParams) Validate() error {
+	if err := bp.BridgeParams.Validate(); err != nil {
+		return err
+	}
+
 	if len(bp.Receivers) != len(bp.Amounts) {
 		return errInconsistentAmounts
 	}

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -209,7 +209,7 @@ func ParseGRPCAddress(grpcAddress string) (*net.TCPAddr, error) {
 func RegisterJSONRPCFlag(cmd *cobra.Command) {
 	cmd.PersistentFlags().String(
 		command.JSONRPCFlag,
-		fmt.Sprintf("%s:%d", AllInterfacesBinding, server.DefaultJSONRPCPort),
+		fmt.Sprintf("http://%s:%d", AllInterfacesBinding, server.DefaultJSONRPCPort),
 		"the JSON-RPC interface",
 	)
 }

--- a/command/rootchain/validators/params.go
+++ b/command/rootchain/validators/params.go
@@ -18,6 +18,10 @@ type validatorInfoParams struct {
 }
 
 func (v *validatorInfoParams) validateFlags() error {
+	if _, err := helper.ParseJSONRPCAddress(v.jsonRPC); err != nil {
+		return fmt.Errorf("failed to parse json rpc address. Error: %w", err)
+	}
+
 	return sidechainHelper.ValidateSecretFlags(v.accountDir, v.accountConfig)
 }
 

--- a/command/rootchain/withdraw/params.go
+++ b/command/rootchain/withdraw/params.go
@@ -29,6 +29,10 @@ func (v *withdrawParams) validateFlags() (err error) {
 		return err
 	}
 
+	if _, err = helper.ParseJSONRPCAddress(v.jsonRPC); err != nil {
+		return fmt.Errorf("failed to parse json rpc address. Error: %w", err)
+	}
+
 	return sidechainHelper.ValidateSecretFlags(v.accountDir, v.accountConfig)
 }
 

--- a/command/sidechain/rewards/params.go
+++ b/command/sidechain/rewards/params.go
@@ -20,6 +20,10 @@ type withdrawRewardResult struct {
 }
 
 func (w *withdrawRewardsParams) validateFlags() error {
+	if _, err := helper.ParseJSONRPCAddress(w.jsonRPC); err != nil {
+		return fmt.Errorf("failed to parse json rpc address. Error: %w", err)
+	}
+
 	return sidechainHelper.ValidateSecretFlags(w.accountDir, w.accountConfig)
 }
 

--- a/command/sidechain/unstaking/params.go
+++ b/command/sidechain/unstaking/params.go
@@ -27,6 +27,10 @@ func (v *unstakeParams) validateFlags() (err error) {
 		return err
 	}
 
+	if _, err = helper.ParseJSONRPCAddress(v.jsonRPC); err != nil {
+		return fmt.Errorf("failed to parse json rpc address. Error: %w", err)
+	}
+
 	return sidechainHelper.ValidateSecretFlags(v.accountDir, v.accountConfig)
 }
 

--- a/command/sidechain/withdraw/params.go
+++ b/command/sidechain/withdraw/params.go
@@ -16,6 +16,10 @@ type withdrawParams struct {
 }
 
 func (w *withdrawParams) validateFlags() error {
+	if _, err := helper.ParseJSONRPCAddress(w.jsonRPC); err != nil {
+		return fmt.Errorf("failed to parse json rpc address. Error: %w", err)
+	}
+
 	return sidechainHelper.ValidateSecretFlags(w.accountDir, w.accountConfig)
 }
 


### PR DESCRIPTION
# Description

Fixes issue [1649](https://github.com/0xPolygon/polygon-edge/issues/1649).

Default value of --jsonrpc flag changed from 0.0.0.0:8545 (which doesn't work) to http://0.0.0.0:8545.
Added validation of the provided value in commands where it was missing.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually