### PR TITLE
Removed redundant queue length check in accountQueue.peek() function

### DIFF
--- a/txpool/queue_account.go
+++ b/txpool/queue_account.go
@@ -78,10 +78,6 @@ func (q *accountQueue) push(tx *types.Transaction) {
 
 // peek returns the first transaction from the queue without removing it.
 func (q *accountQueue) peek() *types.Transaction {
-	if q.length() == 0 {
-		return nil
-	}
-
 	return q.queue.Peek()
 }
 


### PR DESCRIPTION
# Description

The check is redundant since it is checked again during q.queue.Peek() execution. This PR closes issue #1861.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
