### PR TITLE
More verbose error message for unsupported or invalid tx type

### DIFF
--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -557,7 +557,8 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 	if tx.Type == types.StateTx {
 		metrics.IncrCounter([]string{txPoolMetrics, "invalid_tx_type"}, 1)
 
-		return ErrInvalidTxType
+		return fmt.Errorf("%w: type %d rejected, state transactions are not expected to be added to the pool",
+			ErrInvalidTxType, tx.Type)
 	}
 
 	// Check the transaction size to overcome DOS Attacks
@@ -622,7 +623,7 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 		if !forks.London {
 			metrics.IncrCounter([]string{txPoolMetrics, "tx_type"}, 1)
 
-			return ErrTxTypeNotSupported
+			return fmt.Errorf("%w: type %d rejected, london hardfork is not enabled", ErrTxTypeNotSupported, tx.Type)
 		}
 
 		// DynamicFeeTx should be rejected if TxHashWithType fork is registered but not enabled for current block

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -143,9 +143,35 @@ func TestAddTxErrors(t *testing.T) {
 		tx := newTx(defaultAddr, 0, 1)
 		tx.Type = types.StateTx
 
-		assert.ErrorIs(t,
-			pool.addTx(local, signTx(tx)),
-			ErrInvalidTxType,
+		err := pool.addTx(local, signTx(tx))
+
+		assert.ErrorContains(t,
+			err,
+			ErrInvalidTxType.Error(),
+		)
+		assert.ErrorContains(t,
+			err,
+			"state transactions are not expected to be added to the pool",
+		)
+	})
+
+	t.Run("ErrTxTypeNotSupported London hardfork not enabled", func(t *testing.T) {
+		t.Parallel()
+		pool := setupPool()
+		pool.forks.RemoveFork(chain.London)
+
+		tx := newTx(defaultAddr, 0, 1)
+		tx.Type = types.DynamicFeeTx
+
+		err := pool.addTx(local, signTx(tx))
+
+		assert.ErrorContains(t,
+			err,
+			ErrTxTypeNotSupported.Error(),
+		)
+		assert.ErrorContains(t,
+			err,
+			"london hardfork is not enabled",
 		)
 	})
 


### PR DESCRIPTION
# Description

Added verbose error message stating why tx is rejected. 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
