### PR TITLE
Fix IBFT E2E tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5,7 +5,6 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - main
       - develop
-  pull_request:
   workflow_dispatch:
   workflow_call:
     outputs:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,5 +1,5 @@
 ---
-name: E2E tests
+name: IBFT E2E tests
 on:  # yamllint disable-line rule:truthy
   push:
     branches:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,6 +1,11 @@
 ---
 name: E2E tests
 on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
   workflow_dispatch:
   workflow_call:
     outputs:

--- a/contracts/staking/query.go
+++ b/contracts/staking/query.go
@@ -32,6 +32,7 @@ var (
 type TxQueryHandler interface {
 	Apply(*types.Transaction) (*runtime.ExecutionResult, error)
 	GetNonce(types.Address) uint64
+	SetNonPayable(nonPayable bool)
 }
 
 // decodeWeb3ArrayOfBytes is a helper function to parse the data
@@ -103,6 +104,7 @@ func QueryValidators(t TxQueryHandler, from types.Address) ([]types.Address, err
 		return nil, ErrMethodNotFoundInABI
 	}
 
+	t.SetNonPayable(true)
 	res, err := t.Apply(createCallViewTx(
 		from,
 		AddrStakingContract,
@@ -146,6 +148,7 @@ func QueryBLSPublicKeys(t TxQueryHandler, from types.Address) ([][]byte, error) 
 		return nil, ErrMethodNotFoundInABI
 	}
 
+	t.SetNonPayable(true)
 	res, err := t.Apply(createCallViewTx(
 		from,
 		AddrStakingContract,

--- a/contracts/staking/query_test.go
+++ b/contracts/staking/query_test.go
@@ -66,6 +66,10 @@ func (m *TxMock) GetNonce(addr types.Address) uint64 {
 	return 0
 }
 
+func (m *TxMock) SetNonPayable(nonPayable bool) {
+	panic("not implemented")
+}
+
 func Test_decodeValidators(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/contracts/staking/query_test.go
+++ b/contracts/staking/query_test.go
@@ -39,8 +39,9 @@ func appendAll(bytesArrays ...[]byte) []byte {
 }
 
 type TxMock struct {
-	hashToRes map[types.Hash]*runtime.ExecutionResult
-	nonce     map[types.Address]uint64
+	hashToRes  map[types.Hash]*runtime.ExecutionResult
+	nonce      map[types.Address]uint64
+	nonPayable bool
 }
 
 func (m *TxMock) Apply(tx *types.Transaction) (*runtime.ExecutionResult, error) {
@@ -67,7 +68,7 @@ func (m *TxMock) GetNonce(addr types.Address) uint64 {
 }
 
 func (m *TxMock) SetNonPayable(nonPayable bool) {
-	panic("not implemented")
+	m.nonPayable = nonPayable
 }
 
 func Test_decodeValidators(t *testing.T) {

--- a/crypto/txsigner_london_test.go
+++ b/crypto/txsigner_london_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/umbracle/ethgo"
 
 	"github.com/0xPolygon/polygon-edge/types"
 )
@@ -118,8 +119,8 @@ func Test_LondonSigner_Sender(t *testing.T) {
 			tx: &types.Transaction{
 				Type:      types.DynamicFeeTx,
 				GasPrice:  big.NewInt(1000000402),
-				GasTipCap: big.NewInt(1000000000),
-				GasFeeCap: big.NewInt(10000000000),
+				GasTipCap: ethgo.Gwei(1),
+				GasFeeCap: ethgo.Gwei(10),
 				Gas:       21000,
 				To:        &to,
 				Value:     big.NewInt(100000000000000),

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -125,7 +125,7 @@ func StakeAmount(
 	txn := &PreparedTransaction{
 		From:     from,
 		To:       &staking.AddrStakingContract,
-		GasPrice: big.NewInt(1000000000),
+		GasPrice: ethgo.Gwei(1),
 		Gas:      1000000,
 		Value:    amount,
 		Input:    MethodSig("stake"),
@@ -153,7 +153,7 @@ func UnstakeAmount(
 	txn := &PreparedTransaction{
 		From:     from,
 		To:       &staking.AddrStakingContract,
-		GasPrice: big.NewInt(1000000000),
+		GasPrice: ethgo.Gwei(1),
 		Gas:      DefaultGasLimit,
 		Value:    big.NewInt(0),
 		Input:    MethodSig("unstake"),

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -571,8 +571,8 @@ func (t *TestServer) DeployContract(
 }
 
 const (
-	DefaultGasPrice = 1879048192 // 0x70000000
-	DefaultGasLimit = 5242880    // 0x500000
+	DefaultGasPrice = 10e9    // 0x2540BE400
+	DefaultGasLimit = 5242880 // 0x500000
 )
 
 type PreparedTransaction struct {

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -349,7 +349,7 @@ func (t *TestServer) GenerateGenesis() error {
 
 	// add base fee
 	if t.Config.BaseFee != 0 {
-		args = append(args, "--base-fee", *common.EncodeUint64(t.Config.BaseFee))
+		args = append(args, "--base-fee-config", *common.EncodeUint64(t.Config.BaseFee))
 	}
 
 	// add burn contracts

--- a/e2e/ibft_test.go
+++ b/e2e/ibft_test.go
@@ -77,7 +77,7 @@ func TestIbft_Transfer(t *testing.T) {
 			txn := &framework.PreparedTransaction{
 				From:     senderAddr,
 				To:       &receiverAddr,
-				GasPrice: big.NewInt(2000000000),
+				GasPrice: ethgo.Gwei(2),
 				Gas:      1000000,
 				Value:    framework.EthToWei(1),
 			}
@@ -141,7 +141,7 @@ func TestIbft_TransactionFeeRecipient(t *testing.T) {
 			txn := &framework.PreparedTransaction{
 				From:     senderAddr,
 				To:       &receiverAddr,
-				GasPrice: big.NewInt(1000000000),
+				GasPrice: ethgo.Gwei(1),
 				Gas:      1000000,
 				Value:    tc.txAmount,
 			}
@@ -150,7 +150,7 @@ func TestIbft_TransactionFeeRecipient(t *testing.T) {
 				// Deploy contract
 				deployTx := &framework.PreparedTransaction{
 					From:     senderAddr,
-					GasPrice: big.NewInt(1000000000), // fees should be greater than base fee
+					GasPrice: ethgo.Gwei(1), // fees should be greater than base fee
 					Gas:      1000000,
 					Value:    big.NewInt(0),
 					Input:    framework.MethodSig("setA1"),

--- a/e2e/logs_test.go
+++ b/e2e/logs_test.go
@@ -135,7 +135,7 @@ func TestNewFilter_Block(t *testing.T) {
 		if _, sendErr := srv.SendRawTx(ctx, &framework.PreparedTransaction{
 			From:     from,
 			To:       &to,
-			GasPrice: big.NewInt(1000000000),
+			GasPrice: ethgo.Gwei(1),
 			Gas:      1000000,
 			Value:    big.NewInt(10000),
 		}, fromKey); err != nil {

--- a/e2e/pos_test.go
+++ b/e2e/pos_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
+	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -170,6 +172,20 @@ func TestPoS_ValidatorBoundaries(t *testing.T) {
 	}
 }
 
+func init() {
+	wd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+
+	parent := filepath.Dir(wd)
+	wd = filepath.Join(parent, "artifacts/polygon-edge")
+	os.Setenv("EDGE_BINARY", wd)
+	os.Setenv("E2E_TESTS", "true")
+	os.Setenv("E2E_LOGS", "true")
+	os.Setenv("E2E_LOG_LEVEL", "debug")
+}
+
 func TestPoS_Stake(t *testing.T) {
 	stakerKey, stakerAddr := tests.GenerateKeyAndAddr(t)
 	defaultBalance := framework.EthToWei(100)
@@ -306,7 +322,7 @@ func TestPoS_Unstake(t *testing.T) {
 	// Check the address balance
 	fee := new(big.Int).Mul(
 		big.NewInt(int64(receipt.GasUsed)),
-		big.NewInt(framework.DefaultGasPrice),
+		big.NewInt(1000000000),
 	)
 
 	accountBalance := framework.GetAccountBalance(t, unstakerAddr, client)

--- a/e2e/pos_test.go
+++ b/e2e/pos_test.go
@@ -306,7 +306,7 @@ func TestPoS_Unstake(t *testing.T) {
 	// Check the address balance
 	fee := new(big.Int).Mul(
 		big.NewInt(int64(receipt.GasUsed)),
-		big.NewInt(1000000000),
+		ethgo.Gwei(1),
 	)
 
 	accountBalance := framework.GetAccountBalance(t, unstakerAddr, client)
@@ -625,7 +625,7 @@ func TestPoS_StakeUnstakeWithinSameBlock(t *testing.T) {
 
 	stakingContractAddr := staking.AddrStakingContract
 	defaultBalance := framework.EthToWei(100)
-	bigGasPrice := big.NewInt(10000000000)
+	bigGasPrice := big.NewInt(framework.DefaultGasPrice)
 
 	senderKey, senderAddr := tests.GenerateKeyAndAddr(t)
 	numDummyStakers := 10
@@ -818,7 +818,7 @@ func TestSnapshotUpdating(t *testing.T) {
 		&framework.PreparedTransaction{
 			From:     faucetAddr,
 			To:       &firstNonValidatorAddr,
-			GasPrice: big.NewInt(1000000000),
+			GasPrice: ethgo.Gwei(1),
 			Gas:      1000000,
 			Value:    framework.EthToWei(300),
 		}, faucetKey)

--- a/e2e/pos_test.go
+++ b/e2e/pos_test.go
@@ -5,8 +5,6 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
-	"os"
-	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -170,20 +168,6 @@ func TestPoS_ValidatorBoundaries(t *testing.T) {
 			validateValidatorSet(t, tt.address, client, tt.expectedExistence, tt.expectedSize)
 		})
 	}
-}
-
-func init() {
-	wd, err := os.Getwd()
-	if err != nil {
-		return
-	}
-
-	parent := filepath.Dir(wd)
-	wd = filepath.Join(parent, "artifacts/polygon-edge")
-	os.Setenv("EDGE_BINARY", wd)
-	os.Setenv("E2E_TESTS", "true")
-	os.Setenv("E2E_LOGS", "true")
-	os.Setenv("E2E_LOG_LEVEL", "debug")
 }
 
 func TestPoS_Stake(t *testing.T) {

--- a/e2e/transaction_test.go
+++ b/e2e/transaction_test.go
@@ -169,7 +169,7 @@ func TestEthTransfer(t *testing.T) {
 			txn := &framework.PreparedTransaction{
 				From:     testCase.sender,
 				To:       &testCase.recipient,
-				GasPrice: big.NewInt(1000000000),
+				GasPrice: ethgo.Gwei(1),
 				Gas:      1000000,
 				Value:    testCase.amount,
 			}
@@ -396,7 +396,7 @@ func Test_TransactionIBFTLoop(t *testing.T) {
 
 		deployTx := &framework.PreparedTransaction{
 			From:     sender,
-			GasPrice: big.NewInt(framework.DefaultGasPrice),
+			GasPrice: ethgo.Gwei(1),
 			Gas:      framework.DefaultGasLimit,
 			Value:    big.NewInt(0),
 			Input:    buf,

--- a/e2e/txpool_test.go
+++ b/e2e/txpool_test.go
@@ -395,7 +395,7 @@ func TestTxPool_RecoverableError(t *testing.T) {
 	transactions := []*types.Transaction{
 		{
 			Nonce:    0,
-			GasPrice: big.NewInt(10000000000),
+			GasPrice: big.NewInt(framework.DefaultGasPrice),
 			Gas:      22000,
 			To:       &receiverAddress,
 			Value:    oneEth,
@@ -404,7 +404,7 @@ func TestTxPool_RecoverableError(t *testing.T) {
 		},
 		{
 			Nonce:    1,
-			GasPrice: big.NewInt(10000000000),
+			GasPrice: big.NewInt(framework.DefaultGasPrice),
 			Gas:      22000,
 			To:       &receiverAddress,
 			Value:    oneEth,
@@ -414,7 +414,7 @@ func TestTxPool_RecoverableError(t *testing.T) {
 		{
 			Type:      types.DynamicFeeTx,
 			Nonce:     2,
-			GasFeeCap: big.NewInt(10000000000),
+			GasFeeCap: big.NewInt(framework.DefaultGasPrice),
 			GasTipCap: big.NewInt(1000000000),
 			Gas:       22000,
 			To:        &receiverAddress,

--- a/e2e/txpool_test.go
+++ b/e2e/txpool_test.go
@@ -395,7 +395,7 @@ func TestTxPool_RecoverableError(t *testing.T) {
 	transactions := []*types.Transaction{
 		{
 			Nonce:    0,
-			GasPrice: big.NewInt(1000000000),
+			GasPrice: big.NewInt(10000000000),
 			Gas:      22000,
 			To:       &receiverAddress,
 			Value:    oneEth,
@@ -404,7 +404,7 @@ func TestTxPool_RecoverableError(t *testing.T) {
 		},
 		{
 			Nonce:    1,
-			GasPrice: big.NewInt(1000000000),
+			GasPrice: big.NewInt(10000000000),
 			Gas:      22000,
 			To:       &receiverAddress,
 			Value:    oneEth,
@@ -445,7 +445,7 @@ func TestTxPool_RecoverableError(t *testing.T) {
 			},
 			From: types.ZeroAddress.String(),
 		})
-		assert.NoError(t, err, "Unable to send transaction, %v", err)
+		require.NoError(t, err, "Unable to send transaction, %v", err)
 
 		txHash := ethgo.Hash(types.StringToHash(response.TxHash))
 
@@ -458,28 +458,28 @@ func TestTxPool_RecoverableError(t *testing.T) {
 
 	// wait for the last tx to be included in a block
 	receipt, err := tests.WaitForReceipt(ctx, client.Eth(), hashes[2])
-	assert.NoError(t, err)
-	assert.NotNil(t, receipt)
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
 
 	// assert balance moved
 	balance, err := client.Eth().GetBalance(ethgo.Address(receiverAddress), ethgo.Latest)
-	assert.NoError(t, err, "failed to retrieve receiver account balance")
-	assert.Equal(t, framework.EthToWei(3).String(), balance.String())
+	require.NoError(t, err, "failed to retrieve receiver account balance")
+	require.Equal(t, framework.EthToWei(3).String(), balance.String())
 
 	// Query 1st and 2nd txs
 	firstTx, err := client.Eth().GetTransactionByHash(hashes[0])
-	assert.NoError(t, err)
-	assert.NotNil(t, firstTx)
+	require.NoError(t, err)
+	require.NotNil(t, firstTx)
 
 	secondTx, err := client.Eth().GetTransactionByHash(hashes[1])
-	assert.NoError(t, err)
-	assert.NotNil(t, secondTx)
+	require.NoError(t, err)
+	require.NotNil(t, secondTx)
 
 	// first two are in one block
-	assert.Equal(t, firstTx.BlockNumber, secondTx.BlockNumber)
+	require.Equal(t, firstTx.BlockNumber, secondTx.BlockNumber)
 
 	// last tx is included in next block
-	assert.NotEqual(t, secondTx.BlockNumber, receipt.BlockNumber)
+	require.NotEqual(t, secondTx.BlockNumber, receipt.BlockNumber)
 }
 
 func TestTxPool_GetPendingTx(t *testing.T) {

--- a/e2e/websocket_test.go
+++ b/e2e/websocket_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/jsonrpc"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
+	"github.com/umbracle/ethgo"
 )
 
 type testWSRequest struct {
@@ -114,7 +115,7 @@ func TestWS_Response(t *testing.T) {
 		_, err = srv.SendRawTx(ctx, &framework.PreparedTransaction{
 			From:     preminedAccounts[0].address,
 			To:       &preminedAccounts[1].address,
-			GasPrice: big.NewInt(1000000000),
+			GasPrice: ethgo.Gwei(1),
 			Gas:      1000000,
 			Value:    big.NewInt(10000),
 		}, preminedAccounts[0].key)

--- a/state/executor.go
+++ b/state/executor.go
@@ -1116,15 +1116,15 @@ func checkAndProcessTx(msg *types.Transaction, t *Transition) error {
 		return NewTransitionApplicationError(err, true)
 	}
 
-	// 2. check dynamic fees of the transaction
-	if err := t.checkDynamicFees(msg); err != nil {
-		return NewTransitionApplicationError(err, true)
-	}
-
-	// 3. caller has enough balance to cover transaction
-	// Skip this check if the given flag is provided.
-	// It happens for eth_call and for other operations that do not change the state.
 	if !t.ctx.NonPayable {
+		// 2. check dynamic fees of the transaction
+		if err := t.checkDynamicFees(msg); err != nil {
+			return NewTransitionApplicationError(err, true)
+		}
+
+		// 3. caller has enough balance to cover transaction
+		// Skip this check if the given flag is provided.
+		// It happens for eth_call and for other operations that do not change the state.
 		if err := t.subGasLimitPrice(msg); err != nil {
 			return NewTransitionApplicationError(err, true)
 		}


### PR DESCRIPTION
# Description

Fixes `TestTxPool_RecoverableError` test, by bumping transactions' gas price above the base fee.
Also, a couple of more failing tests regarding IBFT Stake and Unstake were failing, because fees were checked for EVM messages, that were representing contract calls. Those should be free of charge.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
