### PR TITLE
Remove todo comment related to retrieving the jsonrpc block

### DIFF
--- a/jsonrpc/filter_manager.go
+++ b/jsonrpc/filter_manager.go
@@ -347,8 +347,6 @@ func NewFilterManager(logger hclog.Logger, store filterManagerStore, blockRangeL
 	// start blockstream with the current header
 	header := store.Header()
 
-	//nolint:godox
-	// TODO: Make Header return jsonrpc.block object directly (to be fixed in EVM-524)
 	block := toBlock(&types.Block{Header: header}, false)
 	m.blockStream = newBlockStream(block)
 


### PR DESCRIPTION
# Description

It is not possible to add a function to the header type that would return a JSONRPC block object because that would result in a circular reference. Another option would be to create an additional function, such as "toBlock," that takes the header as input. However, we would still need the block itself for calculating the "Size" field. Since the "toBlock" function is straightforward, I don't see the point in doing anything about this issue.
This PR contains removes todo comment from the code

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
