### PR TITLE
Relayer and Validator node types are represented as enum flags in E2E framework

### DIFF
--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -233,10 +233,10 @@ func TestE2E_Consensus_RegisterValidator(t *testing.T) {
 
 	// start the first and the second validator
 	cluster.InitTestServer(t, cluster.Config.ValidatorPrefix+strconv.Itoa(validatorSetSize+1),
-		cluster.Bridge.JSONRPCAddr(), true, false)
+		cluster.Bridge.JSONRPCAddr(), framework.Validator)
 
 	cluster.InitTestServer(t, cluster.Config.ValidatorPrefix+strconv.Itoa(validatorSetSize+2),
-		cluster.Bridge.JSONRPCAddr(), true, false)
+		cluster.Bridge.JSONRPCAddr(), framework.Validator)
 
 	// collect the first and the second validator from the cluster
 	firstValidator := cluster.Servers[validatorSetSize]

--- a/e2e-polybft/e2e/migration_test.go
+++ b/e2e-polybft/e2e/migration_test.go
@@ -204,6 +204,6 @@ func TestE2E_Migration(t *testing.T) {
 	_, err = cluster.InitSecrets("test-chain-8", 1)
 	require.NoError(t, err)
 
-	cluster.InitTestServer(t, "test-chain-8", cluster.Bridge.JSONRPCAddr(), false, false)
+	cluster.InitTestServer(t, "test-chain-8", cluster.Bridge.JSONRPCAddr(), 0 /* no flags */)
 	require.NoError(t, cluster.WaitForBlock(33, time.Minute))
 }

--- a/e2e-polybft/e2e/migration_test.go
+++ b/e2e-polybft/e2e/migration_test.go
@@ -204,6 +204,6 @@ func TestE2E_Migration(t *testing.T) {
 	_, err = cluster.InitSecrets("test-chain-8", 1)
 	require.NoError(t, err)
 
-	cluster.InitTestServer(t, "test-chain-8", cluster.Bridge.JSONRPCAddr(), 0 /* no flags */)
+	cluster.InitTestServer(t, "test-chain-8", cluster.Bridge.JSONRPCAddr(), frameworkpolybft.None)
 	require.NoError(t, cluster.WaitForBlock(33, time.Minute))
 }


### PR DESCRIPTION
# Description

In e2e test framework, `InitTestServer` method now has a `flags` field instead of isValidator, relayer fields. 
`flags` field represents enum flags. 
If we want to init server as validator and relayer, we can pass `Validator | Relayer` as value for `flags`. 
`HasFlag` function is used to check if the flag is present in flags.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
