### PR TITLE
Omit relayer flag for IBFT consensus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ protoc: check-protoc
 .PHONY: build
 build: check-go check-git
 	$(eval COMMIT_HASH = $(shell git rev-parse HEAD))
-	$(eval VERSION = $(shell git tag --points-at $COMMIT_HASH))
+	$(eval VERSION = $(shell git tag --points-at ${COMMIT_HASH}))
 	$(eval BRANCH = $(shell git rev-parse --abbrev-ref HEAD | tr -d '\040\011\012\015\n'))
 	$(eval TIME = $(shell date))
 	go build -o polygon-edge -ldflags="\

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR /polygon-edge
 
 COPY --from=builder /polygon-edge/polygon-edge ./
 COPY ./docker/local/polygon-edge.sh ./
-COPY ./core-contracts/artifacts ./core-contracts/artifacts
 
 # Expose json-rpc, libp2p and grpc ports
 EXPOSE 8545 9632 1478 5001

--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -44,16 +44,7 @@ services:
   node-1:
     image: local/polygon-edge
     container_name: polygon-edge-validator-1
-    command: [
-      "server",
-      "--data-dir", "/data/data-1",
-      "--chain", "/data/genesis.json",
-      "--grpc-address", "0.0.0.0:9632",
-      "--libp2p", "0.0.0.0:1478",
-      "--jsonrpc", "0.0.0.0:8545",
-      "--prometheus", "0.0.0.0:5001",
-      "--relayer"
-    ]
+    command: [ "start-node-1", "${EDGE_CONSENSUS:-polybft}" ]
     depends_on:
       init:
         condition: service_completed_successfully

--- a/docker/local/polygon-edge.sh
+++ b/docker/local/polygon-edge.sh
@@ -128,6 +128,23 @@ case "$1" in
               ;;
       esac
       ;;
+  "start-node-1")
+    relayer_flag=""
+    # Start relayer only when run in polybft
+    if [ "$2" == "polybft" ]; then
+      echo "Starting relayer..."
+      relayer_flag="--relayer"
+    fi
+
+    "$POLYGON_EDGE_BIN" server \
+      --data-dir /data/data-1 \
+      --chain /data/genesis.json \
+      --grpc-address 0.0.0.0:9632 \
+      --libp2p 0.0.0.0:1478 \
+      --jsonrpc 0.0.0.0:8545 \
+      --prometheus 0.0.0.0:5001 \
+      --seal $relayer_flag
+   ;;
    *)
       echo "Executing polygon-edge..."
       exec "$POLYGON_EDGE_BIN" "$@"

--- a/docker/local/polygon-edge.sh
+++ b/docker/local/polygon-edge.sh
@@ -21,7 +21,6 @@ createGenesisConfig() {
   local secrets="$2"
   shift 2
   echo "Generating $consensus_type Genesis file..."
-  echo $secrets
 
   "$POLYGON_EDGE_BIN" genesis $CHAIN_CUSTOM_OPTIONS \
     --dir /data/genesis.json \
@@ -65,6 +64,7 @@ case "$1" in
               --reward-wallet 0xDEADBEEF:1000000 \
               --native-token-config "Polygon:MATIC:18:true:$(echo "$secrets" | jq -r '.[0] | .address')" \
               --proxy-contracts-admin ${proxyContractsAdmin}
+
               echo "Deploying stake manager..."
               "$POLYGON_EDGE_BIN" polybft stake-manager-deploy \
                 --jsonrpc http://rootchain:8545 \

--- a/docker/local/polygon-edge.sh
+++ b/docker/local/polygon-edge.sh
@@ -143,7 +143,7 @@ case "$1" in
       --libp2p 0.0.0.0:1478 \
       --jsonrpc 0.0.0.0:8545 \
       --prometheus 0.0.0.0:5001 \
-      --seal $relayer_flag
+      $relayer_flag
    ;;
    *)
       echo "Executing polygon-edge..."

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -161,10 +161,8 @@ function initRootchain() {
 }
 
 function startNodes() {
-  write_logs_arg=""
   if [ "$2" == "write-logs" ]; then
     echo "Writing validators logs to the files..."
-    write_logs_arg="2>&1 | tee "./validator-$i.log""
   fi
 
   for i in {1..4}; do
@@ -173,15 +171,30 @@ function startNodes() {
     libp2p_port=$((30300 + $i))
     jsonrpc_port=$((10000 * $i + 2))
 
+    log_file="./validator-$i.log"
+
     relayer_arg=""
+    # Start relayer only if running polybft and for the 1st node
     if [ "$1" == "polybft" ] && [ $i -eq 1 ]; then
       relayer_arg="--relayer"
     fi
 
-    ./polygon-edge server --data-dir "$data_dir" --chain genesis.json \
-      --grpc-address ":$grpc_port" --libp2p ":$libp2p_port" --jsonrpc ":$jsonrpc_port" \
-      $relayer_arg --num-block-confirmations 2 --seal \
-      --log-level DEBUG $write_logs_arg &
+    if [ "$2" == "write-logs" ]; then
+      if [ ! -f "$log_file" ]; then
+        touch "$log_file"
+      fi
+
+      ./polygon-edge server --data-dir "$data_dir" --chain genesis.json \
+        --grpc-address ":$grpc_port" --libp2p ":$libp2p_port" --jsonrpc ":$jsonrpc_port" \
+        --num-block-confirmations 2 --seal $relayer_arg \
+        --log-level DEBUG 2>&1 | tee $log_file &
+    else
+      ./polygon-edge server --data-dir "$data_dir" --chain genesis.json \
+        --grpc-address ":$grpc_port" --libp2p ":$libp2p_port" --jsonrpc ":$jsonrpc_port" \
+        --num-block-confirmations 2 --seal $relayer_arg \
+        --log-level DEBUG &
+    fi
+
   done
 
   wait

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -29,7 +29,7 @@ if [[ "$dp_error_flag" -eq 1 ]]; then
   exit 1
 fi
 
-function showhelp(){
+function showhelp() {
   echo "Usage: cluster {consensus} [{command}] [{flags}]"
   echo "Consensus:"
   echo "  ibft            Start Supernets test environment locally with ibft consensus"
@@ -161,36 +161,30 @@ function initRootchain() {
 }
 
 function startServerFromBinary() {
-  if [ "$1" == "write-logs" ]; then
+  write_logs_arg=""
+  if [ "$2" == "write-logs" ]; then
     echo "Writing validators logs to the files..."
-    ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json \
-      --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 --relayer \
-      --num-block-confirmations 2 --log-level DEBUG 2>&1 | tee ./validator-1.log &
-    ./polygon-edge server --data-dir ./test-chain-2 --chain genesis.json \
-      --grpc-address :20000 --libp2p :30302 --jsonrpc :20002 \
-      --num-block-confirmations 2 --log-level DEBUG 2>&1 | tee ./validator-2.log &
-    ./polygon-edge server --data-dir ./test-chain-3 --chain genesis.json \
-      --grpc-address :30000 --libp2p :30303 --jsonrpc :30002 \
-      --num-block-confirmations 2 --log-level DEBUG 2>&1 | tee ./validator-3.log &
-    ./polygon-edge server --data-dir ./test-chain-4 --chain genesis.json \
-      --grpc-address :40000 --libp2p :30304 --jsonrpc :40002 \
-      --num-block-confirmations 2 --log-level DEBUG 2>&1 | tee ./validator-4.log &
-    wait
-  else
-    ./polygon-edge server --data-dir ./test-chain-1 --chain genesis.json \
-      --grpc-address :10000 --libp2p :30301 --jsonrpc :10002 --relayer \
-      --num-block-confirmations 2 --log-level DEBUG &
-    ./polygon-edge server --data-dir ./test-chain-2 --chain genesis.json \
-      --grpc-address :20000 --libp2p :30302 --jsonrpc :20002 \
-      --num-block-confirmations 2 --log-level DEBUG &
-    ./polygon-edge server --data-dir ./test-chain-3 --chain genesis.json \
-      --grpc-address :30000 --libp2p :30303 --jsonrpc :30002 \
-      --num-block-confirmations 2 --log-level DEBUG &
-    ./polygon-edge server --data-dir ./test-chain-4 --chain genesis.json \
-      --grpc-address :40000 --libp2p :30304 --jsonrpc :40002 \
-      --num-block-confirmations 2 --log-level DEBUG &
-    wait
+    write_logs_arg="2>&1 | tee "./validator-$i.log""
   fi
+
+  for i in {1..4}; do
+    data_dir="./test-chain-$i"
+    grpc_port=$((10000 * $i))
+    libp2p_port=$((30300 + $i))
+    jsonrpc_port=$((10000 * $i + 2))
+
+    relayer_arg=""
+    if [ "$1" == "polybft" ] && [ $i -eq 1 ]; then
+      relayer_arg="--relayer"
+    fi
+
+    ./polygon-edge server --data-dir "$data_dir" --chain genesis.json \
+      --grpc-address ":$grpc_port" --libp2p ":$libp2p_port" --jsonrpc ":$jsonrpc_port" \
+      $relayer_arg --num-block-confirmations 2 --seal \
+      --log-level DEBUG $write_logs_arg &
+  done
+
+  wait
 }
 
 function startServerFromDockerCompose() {
@@ -254,7 +248,7 @@ case "$2" in
     initIbftConsensus
     # Create genesis file and start the server from binary
     createGenesis
-    startServerFromBinary $2
+    startServerFromBinary $1 $2
     exit 0
   elif [ "$1" == "polybft" ]; then
     # Initialize polybft consensus
@@ -262,7 +256,7 @@ case "$2" in
     # Create genesis file and start the server from binary
     createGenesis
     initRootchain $2
-    startServerFromBinary $2
+    startServerFromBinary $1 $2
     exit 0
   else
     echo "Unsupported consensus mode. Supported modes are: ibft and polybft."

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -160,7 +160,7 @@ function initRootchain() {
     --jsonrpc http://127.0.0.1:8545
 }
 
-function startServerFromBinary() {
+function startNodes() {
   write_logs_arg=""
   if [ "$2" == "write-logs" ]; then
     echo "Writing validators logs to the files..."
@@ -248,7 +248,7 @@ case "$2" in
     initIbftConsensus
     # Create genesis file and start the server from binary
     createGenesis
-    startServerFromBinary $1 $2
+    startNodes $1 $2
     exit 0
   elif [ "$1" == "polybft" ]; then
     # Initialize polybft consensus
@@ -256,7 +256,7 @@ case "$2" in
     # Create genesis file and start the server from binary
     createGenesis
     initRootchain $2
-    startServerFromBinary $1 $2
+    startNodes $1 $2
     exit 0
   else
     echo "Unsupported consensus mode. Supported modes are: ibft and polybft."

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -186,12 +186,12 @@ function startNodes() {
 
       ./polygon-edge server --data-dir "$data_dir" --chain genesis.json \
         --grpc-address ":$grpc_port" --libp2p ":$libp2p_port" --jsonrpc ":$jsonrpc_port" \
-        --num-block-confirmations 2 --seal $relayer_arg \
+        --num-block-confirmations 2 $relayer_arg \
         --log-level DEBUG 2>&1 | tee $log_file &
     else
       ./polygon-edge server --data-dir "$data_dir" --chain genesis.json \
         --grpc-address ":$grpc_port" --libp2p ":$libp2p_port" --jsonrpc ":$jsonrpc_port" \
-        --num-block-confirmations 2 --seal $relayer_arg \
+        --num-block-confirmations 2 $relayer_arg \
         --log-level DEBUG &
     fi
 


### PR DESCRIPTION
# Description

This PR provides a relayer flag to cluster and docker scripts (polygon-edge.sh) only in case polybft consensus is being run.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

#### Docker environment
1. Run make run-docker
2. Make sure polybft is working and blocks are being produced

#### Starting nodes from binary
1. Run ./scripts/cluster polybft write-logs
2. Make sure polybft is working and blocks are being produced

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
