### PR TITLE
Do not send checkpoint if node is syncing

### DIFF
--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -126,6 +126,16 @@ func (c *checkpointManager) submitCheckpoint(latestHeader *types.Header, isEndOf
 		return err
 	}
 
+	if lastCheckpointBlockNumber > latestHeader.Number {
+		// this node is syncing after its data was cleaned up
+		// what happened is that, node was the proposer on this block,
+		// and it already sent this checkpoint, but since its data got cleaned
+		// it started syncing from scratch, even its own minted blocks
+		// so there is no need to send a checkpoint, since it is already sent
+		// CheckpointManager will fail the transaction, so no need to spend tokens on it
+		return nil
+	}
+
 	c.logger.Debug("submitCheckpoint invoked...",
 		"latest checkpoint block", lastCheckpointBlockNumber,
 		"checkpoint block", latestHeader.Number)

--- a/consensus/polybft/checkpoint_manager.go
+++ b/consensus/polybft/checkpoint_manager.go
@@ -127,12 +127,8 @@ func (c *checkpointManager) submitCheckpoint(latestHeader *types.Header, isEndOf
 	}
 
 	if lastCheckpointBlockNumber > latestHeader.Number {
-		// this node is syncing after its data was cleaned up
-		// what happened is that, node was the proposer on this block,
-		// and it already sent this checkpoint, but since its data got cleaned
-		// it started syncing from scratch, even its own minted blocks
-		// so there is no need to send a checkpoint, since it is already sent
-		// CheckpointManager will fail the transaction, so no need to spend tokens on it
+		// node is out of sync (haven't reached the tip of the chain), so even though it is a proposer,
+		// it would checkpoint block that is already checkpointed and transaction would fail anyway
 		return nil
 	}
 

--- a/consensus/polybft/checkpoint_manager_test.go
+++ b/consensus/polybft/checkpoint_manager_test.go
@@ -39,83 +39,109 @@ func TestCheckpointManager_SubmitCheckpoint(t *testing.T) {
 
 	validators := validator.NewTestValidatorsWithAliases(t, aliases)
 	validatorsMetadata := validators.GetPublicIdentities()
-	txRelayerMock := newDummyTxRelayer(t)
-	txRelayerMock.On("Call", mock.Anything, mock.Anything, mock.Anything).
-		Return("2", error(nil)).
-		Once()
-	txRelayerMock.On("SendTransaction", mock.Anything, mock.Anything).
-		Return(&ethgo.Receipt{Status: uint64(types.ReceiptSuccess)}, error(nil)).
-		Times(4) // send transactions for checkpoint blocks: 4, 6, 8 (pending checkpoint blocks) and 10 (latest checkpoint block)
 
-	backendMock := new(polybftBackendMock)
-	backendMock.On("GetValidators", mock.Anything, mock.Anything).Return(validatorsMetadata)
+	t.Run("submit checkpoint happy path", func(t *testing.T) {
+		t.Parallel()
 
-	var (
-		headersMap  = &testHeadersMap{}
-		epochNumber = uint64(1)
-		dummyMsg    = []byte("checkpoint")
-		idx         = uint64(0)
-		header      *types.Header
-		bitmap      bitmap.Bitmap
-		signatures  bls.Signatures
-	)
+		txRelayerMock := newDummyTxRelayer(t)
+		txRelayerMock.On("Call", mock.Anything, mock.Anything, mock.Anything).
+			Return("2", error(nil)).
+			Once()
+		txRelayerMock.On("SendTransaction", mock.Anything, mock.Anything).
+			Return(&ethgo.Receipt{Status: uint64(types.ReceiptSuccess)}, error(nil)).
+			Times(4) // send transactions for checkpoint blocks: 4, 6, 8 (pending checkpoint blocks) and 10 (latest checkpoint block)
 
-	validators.IterAcct(aliases, func(t *validator.TestValidator) {
-		bitmap.Set(idx)
-		signatures = append(signatures, t.MustSign(dummyMsg, bls.DomainCheckpointManager))
-		idx++
-	})
+		backendMock := new(polybftBackendMock)
+		backendMock.On("GetValidators", mock.Anything, mock.Anything).Return(validatorsMetadata)
 
-	signature, err := signatures.Aggregate().Marshal()
-	require.NoError(t, err)
+		var (
+			headersMap  = &testHeadersMap{}
+			epochNumber = uint64(1)
+			dummyMsg    = []byte("checkpoint")
+			idx         = uint64(0)
+			header      *types.Header
+			bitmap      bitmap.Bitmap
+			signatures  bls.Signatures
+		)
 
-	for i := uint64(1); i <= blocksCount; i++ {
-		if i%epochSize == 1 {
-			// epoch-beginning block
-			checkpoint := &CheckpointData{
-				BlockRound:  0,
-				EpochNumber: epochNumber,
-				EventRoot:   types.BytesToHash(generateRandomBytes(t)),
+		validators.IterAcct(aliases, func(t *validator.TestValidator) {
+			bitmap.Set(idx)
+			signatures = append(signatures, t.MustSign(dummyMsg, bls.DomainCheckpointManager))
+			idx++
+		})
+
+		signature, err := signatures.Aggregate().Marshal()
+		require.NoError(t, err)
+
+		for i := uint64(1); i <= blocksCount; i++ {
+			if i%epochSize == 1 {
+				// epoch-beginning block
+				checkpoint := &CheckpointData{
+					BlockRound:  0,
+					EpochNumber: epochNumber,
+					EventRoot:   types.BytesToHash(generateRandomBytes(t)),
+				}
+				extra := createTestExtraObject(validatorsMetadata, validatorsMetadata, 3, 3, 3)
+				extra.Checkpoint = checkpoint
+				extra.Committed = &Signature{Bitmap: bitmap, AggregatedSignature: signature}
+				header = &types.Header{
+					ExtraData: extra.MarshalRLPTo(nil),
+				}
+				epochNumber++
+			} else {
+				header = header.Copy()
 			}
-			extra := createTestExtraObject(validatorsMetadata, validatorsMetadata, 3, 3, 3)
-			extra.Checkpoint = checkpoint
-			extra.Committed = &Signature{Bitmap: bitmap, AggregatedSignature: signature}
-			header = &types.Header{
-				ExtraData: extra.MarshalRLPTo(nil),
-			}
-			epochNumber++
-		} else {
-			header = header.Copy()
+
+			header.Number = i
+			header.ComputeHash()
+			headersMap.addHeader(header)
 		}
 
-		header.Number = i
-		header.ComputeHash()
-		headersMap.addHeader(header)
-	}
+		// mock blockchain
+		blockchainMock := new(blockchainMock)
+		blockchainMock.On("GetHeaderByNumber", mock.Anything).Return(headersMap.getHeader)
 
-	// mock blockchain
-	blockchainMock := new(blockchainMock)
-	blockchainMock.On("GetHeaderByNumber", mock.Anything).Return(headersMap.getHeader)
+		validatorAcc := validators.GetValidator("A")
+		c := &checkpointManager{
+			key:              wallet.NewEcdsaSigner(validatorAcc.Key()),
+			rootChainRelayer: txRelayerMock,
+			consensusBackend: backendMock,
+			blockchain:       blockchainMock,
+			logger:           hclog.NewNullLogger(),
+		}
 
-	validatorAcc := validators.GetValidator("A")
-	c := &checkpointManager{
-		key:              wallet.NewEcdsaSigner(validatorAcc.Key()),
-		rootChainRelayer: txRelayerMock,
-		consensusBackend: backendMock,
-		blockchain:       blockchainMock,
-		logger:           hclog.NewNullLogger(),
-	}
+		err = c.submitCheckpoint(headersMap.getHeader(blocksCount), false)
+		require.NoError(t, err)
+		txRelayerMock.AssertExpectations(t)
 
-	err = c.submitCheckpoint(headersMap.getHeader(blocksCount), false)
-	require.NoError(t, err)
-	txRelayerMock.AssertExpectations(t)
+		// make sure that expected blocks are checkpointed (epoch-ending ones)
+		for _, checkpointBlock := range txRelayerMock.checkpointBlocks {
+			header := headersMap.getHeader(checkpointBlock)
+			require.NotNil(t, header)
+			require.True(t, isEndOfPeriod(header.Number, epochSize))
+		}
+	})
 
-	// make sure that expected blocks are checkpointed (epoch-ending ones)
-	for _, checkpointBlock := range txRelayerMock.checkpointBlocks {
-		header := headersMap.getHeader(checkpointBlock)
-		require.NotNil(t, header)
-		require.True(t, isEndOfPeriod(header.Number, epochSize))
-	}
+	t.Run("checkpoint not submitted when node is syncing", func(t *testing.T) {
+		t.Parallel()
+
+		txRelayerMock := newDummyTxRelayer(t)
+		txRelayerMock.On("Call", mock.Anything, mock.Anything, mock.Anything).
+			Return("20", error(nil)).
+			Once()
+
+		c := &checkpointManager{
+			key:              wallet.NewEcdsaSigner(validators.GetValidator("A").Key()),
+			rootChainRelayer: txRelayerMock,
+			logger:           hclog.NewNullLogger(),
+		}
+
+		err := c.submitCheckpoint(&types.Header{Number: 19 /*lower than what Call returns*/}, false)
+		require.NoError(t, err)
+		// since transaction will not be sent to CheckpointManager, we only expect that Call
+		// will called on tx relayer, and nothing else in submitCheckpoint will be executed
+		txRelayerMock.AssertExpectations(t)
+	})
 }
 
 func TestCheckpointManager_abiEncodeCheckpointBlock(t *testing.T) {

--- a/consensus/polybft/checkpoint_manager_test.go
+++ b/consensus/polybft/checkpoint_manager_test.go
@@ -35,13 +35,13 @@ func TestCheckpointManager_SubmitCheckpoint(t *testing.T) {
 		epochSize   = 2
 	)
 
-	var aliases = []string{"A", "B", "C", "D", "E"}
-
-	validators := validator.NewTestValidatorsWithAliases(t, aliases)
-	validatorsMetadata := validators.GetPublicIdentities()
-
 	t.Run("submit checkpoint happy path", func(t *testing.T) {
 		t.Parallel()
+
+		var aliases = []string{"A", "B", "C", "D", "E"}
+
+		validators := validator.NewTestValidatorsWithAliases(t, aliases)
+		validatorsMetadata := validators.GetPublicIdentities()
 
 		txRelayerMock := newDummyTxRelayer(t)
 		txRelayerMock.On("Call", mock.Anything, mock.Anything, mock.Anything).
@@ -124,6 +124,10 @@ func TestCheckpointManager_SubmitCheckpoint(t *testing.T) {
 
 	t.Run("checkpoint not submitted when node is syncing", func(t *testing.T) {
 		t.Parallel()
+
+		var aliases = []string{"A"}
+
+		validators := validator.NewTestValidatorsWithAliases(t, aliases)
 
 		txRelayerMock := newDummyTxRelayer(t)
 		txRelayerMock.On("Call", mock.Anything, mock.Anything, mock.Anything).


### PR DESCRIPTION
# Description

A user of Edge had an issue where he was testing Disaster Recovery simulation, where he stopped a validator node, and deleted all its data, to see if the node will sync up, recover, and rejoin consensus.

He noticed that while syncing, node was trying to send checkpoints on epoch ending blocks where he was a minter before it was shutdown and its data got deleted.

Since those checkpoints were already sent to `rootchain`, this PR introduces a fix, where on `submitCheckpoint`, it checks if given checkpoint was already sent, and simply returns if it is.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually
