### PR TITLE
Added option to specify a root path for IBFT validators dir

### DIFF
--- a/command/common.go
+++ b/command/common.go
@@ -3,6 +3,7 @@ package command
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/0xPolygon/polygon-edge/crypto"
@@ -22,6 +23,7 @@ const (
 
 	IBFTValidatorTypeFlag   = "ibft-validator-type"
 	IBFTValidatorFlag       = "ibft-validator"
+	IBFTValidatorRootFlag   = "ibft-validators-path"
 	IBFTValidatorPrefixFlag = "ibft-validators-prefix-path"
 )
 
@@ -56,10 +58,16 @@ func ValidateMinMaxValidatorsNumber(minValidatorCount uint64, maxValidatorCount 
 // GetValidatorsFromPrefixPath extracts the addresses of the validators based on the directory
 // prefix. It scans the directories for validator private keys and compiles a list of addresses
 func GetValidatorsFromPrefixPath(
+	root string,
 	prefix string,
 	validatorType validators.ValidatorType,
 ) (validators.Validators, error) {
-	files, err := os.ReadDir(".")
+	files, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+
+	fullRootPath, err := filepath.Abs(root)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +86,7 @@ func GetValidatorsFromPrefixPath(
 			&secrets.SecretsManagerParams{
 				Logger: hclog.NewNullLogger(),
 				Extra: map[string]interface{}{
-					secrets.Path: path,
+					secrets.Path: filepath.Join(fullRootPath, path),
 				},
 			},
 		)

--- a/command/common.go
+++ b/command/common.go
@@ -22,9 +22,11 @@ const (
 	BootnodeFlag   = "bootnode"
 	LogLevelFlag   = "log-level"
 
-	ValidatorFlag       = "validators"
-	ValidatorRootFlag   = "validators-path"
-	ValidatorPrefixFlag = "validators-prefix"
+	ValidatorFlag         = "validators"
+	ValidatorRootFlag     = "validators-path"
+	ValidatorPrefixFlag   = "validators-prefix"
+	MinValidatorCountFlag = "min-validator-count"
+	MaxValidatorCountFlag = "max-validator-count"
 
 	IBFTValidatorTypeFlag = "ibft-validator-type"
 )

--- a/command/common.go
+++ b/command/common.go
@@ -15,16 +15,23 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
+// Flags shared across multiple spaces
 const (
 	ConsensusFlag  = "consensus"
 	NoDiscoverFlag = "no-discover"
 	BootnodeFlag   = "bootnode"
 	LogLevelFlag   = "log-level"
 
-	IBFTValidatorTypeFlag   = "ibft-validator-type"
-	IBFTValidatorFlag       = "ibft-validator"
-	IBFTValidatorRootFlag   = "ibft-validators-path"
-	IBFTValidatorPrefixFlag = "ibft-validators-prefix-path"
+	ValidatorFlag       = "validators"
+	ValidatorRootFlag   = "validators-path"
+	ValidatorPrefixFlag = "validators-prefix"
+
+	IBFTValidatorTypeFlag = "ibft-validator-type"
+)
+
+const (
+	DefaultValidatorRoot   = "./"
+	DefaultValidatorPrefix = "test-chain-"
 )
 
 var (

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -3,14 +3,14 @@ package genesis
 import (
 	"fmt"
 
-	"github.com/0xPolygon/polygon-edge/helper/common"
+	"github.com/spf13/cobra"
 
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/genesis/predeploy"
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/consensus/ibft"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/validators"
-	"github.com/spf13/cobra"
 )
 
 func GetCommand() *cobra.Command {

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -3,11 +3,12 @@ package genesis
 import (
 	"fmt"
 
+	"github.com/0xPolygon/polygon-edge/helper/common"
+
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/genesis/predeploy"
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/consensus/ibft"
-	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/validators"
 	"github.com/spf13/cobra"
 )
@@ -116,46 +117,6 @@ func setFlags(cmd *cobra.Command) {
 		"admin for proxy contracts",
 	)
 
-	// IBFT Validators
-	{
-		cmd.Flags().StringVar(
-			&params.rawIBFTValidatorType,
-			command.IBFTValidatorTypeFlag,
-			string(validators.BLSValidatorType),
-			"the type of validators in IBFT",
-		)
-
-		cmd.Flags().StringVar(
-			&params.validatorRootPath,
-			command.IBFTValidatorRootFlag,
-			".",
-			"root path for validator folder directory. "+
-				"Needs to be present if ibft-validator is omitted",
-		)
-
-		cmd.Flags().StringVar(
-			&params.validatorPrefixPath,
-			command.IBFTValidatorPrefixFlag,
-			"",
-			"prefix path for validator folder directory. "+
-				"Needs to be present if ibft-validator is omitted",
-		)
-
-		cmd.Flags().StringArrayVar(
-			&params.ibftValidatorsRaw,
-			command.IBFTValidatorFlag,
-			[]string{},
-			"addresses to be used as IBFT validators, can be used multiple times. "+
-				"Needs to be present if ibft-validators-prefix-path is omitted",
-		)
-
-		// --ibft-validator-prefix-path & --ibft-validator can't be given at same time
-		cmd.MarkFlagsMutuallyExclusive(command.IBFTValidatorPrefixFlag, command.IBFTValidatorFlag)
-
-		// --ibft-validator-path & --ibft-validator can't be given at same time
-		cmd.MarkFlagsMutuallyExclusive(command.IBFTValidatorRootFlag, command.IBFTValidatorFlag)
-	}
-
 	// PoS
 	{
 		cmd.Flags().BoolVar(
@@ -179,34 +140,44 @@ func setFlags(cmd *cobra.Command) {
 			common.MaxSafeJSInt,
 			"the maximum number of validators in the validator set for PoS",
 		)
-	}
 
-	// PolyBFT
-	{
 		cmd.Flags().StringVar(
 			&params.validatorsPath,
-			validatorsPathFlag,
-			"./",
-			"root path containing polybft validators secrets",
+			command.ValidatorRootFlag,
+			command.DefaultValidatorRoot,
+			"root path containing validators secrets",
 		)
 
 		cmd.Flags().StringVar(
 			&params.validatorsPrefixPath,
-			validatorsPrefixFlag,
-			defaultValidatorPrefixPath,
-			"folder prefix names for polybft validators secrets",
+			command.ValidatorPrefixFlag,
+			command.DefaultValidatorPrefix,
+			"folder prefix names for validators secrets",
 		)
 
 		cmd.Flags().StringArrayVar(
 			&params.validators,
-			validatorsFlag,
+			command.ValidatorFlag,
 			[]string{},
-			"validators defined by user (format: <P2P multi address>:<ECDSA address>:<public BLS key>)",
+			"validators defined by user (polybft format: <P2P multi address>:<ECDSA address>:<public BLS key>)",
 		)
 
-		cmd.MarkFlagsMutuallyExclusive(validatorsFlag, validatorsPathFlag)
-		cmd.MarkFlagsMutuallyExclusive(validatorsFlag, validatorsPrefixFlag)
+		cmd.MarkFlagsMutuallyExclusive(command.ValidatorFlag, command.ValidatorRootFlag)
+		cmd.MarkFlagsMutuallyExclusive(command.ValidatorFlag, command.ValidatorPrefixFlag)
+	}
 
+	// IBFT Validators
+	{
+		cmd.Flags().StringVar(
+			&params.rawIBFTValidatorType,
+			command.IBFTValidatorTypeFlag,
+			string(validators.BLSValidatorType),
+			"the type of validators in IBFT",
+		)
+	}
+
+	// PolyBFT
+	{
 		cmd.Flags().Uint64Var(
 			&params.sprintSize,
 			sprintSizeFlag,

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -129,14 +129,14 @@ func setFlags(cmd *cobra.Command) {
 
 		cmd.Flags().Uint64Var(
 			&params.minNumValidators,
-			minValidatorCount,
+			command.MinValidatorCountFlag,
 			1,
 			"the minimum number of validators in the validator set for PoS",
 		)
 
 		cmd.Flags().Uint64Var(
 			&params.maxNumValidators,
-			maxValidatorCount,
+			command.MaxValidatorCountFlag,
 			common.MaxSafeJSInt,
 			"the maximum number of validators in the validator set for PoS",
 		)

--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -126,6 +126,14 @@ func setFlags(cmd *cobra.Command) {
 		)
 
 		cmd.Flags().StringVar(
+			&params.validatorRootPath,
+			command.IBFTValidatorRootFlag,
+			".",
+			"root path for validator folder directory. "+
+				"Needs to be present if ibft-validator is omitted",
+		)
+
+		cmd.Flags().StringVar(
 			&params.validatorPrefixPath,
 			command.IBFTValidatorPrefixFlag,
 			"",
@@ -143,6 +151,9 @@ func setFlags(cmd *cobra.Command) {
 
 		// --ibft-validator-prefix-path & --ibft-validator can't be given at same time
 		cmd.MarkFlagsMutuallyExclusive(command.IBFTValidatorPrefixFlag, command.IBFTValidatorFlag)
+
+		// --ibft-validator-path & --ibft-validator can't be given at same time
+		cmd.MarkFlagsMutuallyExclusive(command.IBFTValidatorRootFlag, command.IBFTValidatorFlag)
 	}
 
 	// PoS

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -77,6 +77,7 @@ type genesisParams struct {
 	genesisPath         string
 	name                string
 	consensusRaw        string
+	validatorRootPath   string
 	validatorPrefixPath string
 	premine             []string
 	bootnodes           []string
@@ -285,6 +286,7 @@ func (p *genesisParams) setValidatorSetFromPrefixPath() error {
 	}
 
 	validators, err := command.GetValidatorsFromPrefixPath(
+		p.validatorRootPath,
 		p.validatorPrefixPath,
 		p.ibftValidatorType,
 	)

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -36,8 +36,6 @@ const (
 	burnContractFlag             = "burn-contract"
 	genesisBaseFeeConfigFlag     = "base-fee-config"
 	posFlag                      = "pos"
-	minValidatorCount            = "min-validator-count"
-	maxValidatorCount            = "max-validator-count"
 	nativeTokenConfigFlag        = "native-token-config"
 	rewardTokenCodeFlag          = "reward-token-code"
 	rewardWalletFlag             = "reward-wallet"

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -25,12 +25,6 @@ import (
 )
 
 const (
-	validatorsFlag       = "validators"
-	validatorsPathFlag   = "validators-path"
-	validatorsPrefixFlag = "validators-prefix"
-
-	defaultValidatorPrefixPath = "test-chain-"
-
 	sprintSizeFlag = "sprint-size"
 	blockTimeFlag  = "block-time"
 	trieRootFlag   = "trieroot"

--- a/command/ibft/switch/ibft_switch.go
+++ b/command/ibft/switch/ibft_switch.go
@@ -70,14 +70,14 @@ func setFlags(cmd *cobra.Command) {
 		// PoS Configuration
 		cmd.Flags().StringVar(
 			&params.minValidatorCountRaw,
-			minValidatorCount,
+			command.MinValidatorCountFlag,
 			"",
 			"the minimum number of validators in the validator set for PoS",
 		)
 
 		cmd.Flags().StringVar(
 			&params.maxValidatorCountRaw,
-			maxValidatorCount,
+			command.MaxValidatorCountFlag,
 			"",
 			"the maximum number of validators in the validator set for PoS",
 		)

--- a/command/ibft/switch/ibft_switch.go
+++ b/command/ibft/switch/ibft_switch.go
@@ -66,6 +66,14 @@ func setFlags(cmd *cobra.Command) {
 	{
 		// PoA Configuration
 		cmd.Flags().StringVar(
+			&params.ibftValidatorRootPath,
+			command.IBFTValidatorRootFlag,
+			".",
+			"root path for validator folder directory. "+
+				"Needs to be present if ibft-validator is omitted",
+		)
+
+		cmd.Flags().StringVar(
 			&params.ibftValidatorPrefixPath,
 			command.IBFTValidatorPrefixFlag,
 			"",
@@ -82,6 +90,7 @@ func setFlags(cmd *cobra.Command) {
 		)
 
 		cmd.MarkFlagsMutuallyExclusive(command.IBFTValidatorPrefixFlag, command.IBFTValidatorFlag)
+		cmd.MarkFlagsMutuallyExclusive(command.IBFTValidatorRootFlag, command.IBFTValidatorFlag)
 	}
 
 	{

--- a/command/ibft/switch/ibft_switch.go
+++ b/command/ibft/switch/ibft_switch.go
@@ -3,10 +3,11 @@ package ibftswitch
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/validators"
-	"github.com/spf13/cobra"
 )
 
 func GetCommand() *cobra.Command {
@@ -55,42 +56,14 @@ func setFlags(cmd *cobra.Command) {
 		)
 	}
 
-	// Validator Configurations
-	cmd.Flags().StringVar(
-		&params.rawIBFTValidatorType,
-		command.IBFTValidatorTypeFlag,
-		string(validators.BLSValidatorType),
-		"the type of validators in IBFT",
-	)
-
+	// IBFT
 	{
-		// PoA Configuration
 		cmd.Flags().StringVar(
-			&params.ibftValidatorRootPath,
-			command.IBFTValidatorRootFlag,
-			".",
-			"root path for validator folder directory. "+
-				"Needs to be present if ibft-validator is omitted",
+			&params.rawIBFTValidatorType,
+			command.IBFTValidatorTypeFlag,
+			string(validators.BLSValidatorType),
+			"the type of validators in IBFT",
 		)
-
-		cmd.Flags().StringVar(
-			&params.ibftValidatorPrefixPath,
-			command.IBFTValidatorPrefixFlag,
-			"",
-			"prefix path for validator folder directory. "+
-				"Needs to be present if ibft-validator is omitted",
-		)
-
-		cmd.Flags().StringArrayVar(
-			&params.ibftValidatorsRaw,
-			command.IBFTValidatorFlag,
-			[]string{},
-			"addresses to be used as IBFT validators, can be used multiple times. "+
-				"Needs to be present if ibft-validators-prefix-path is omitted",
-		)
-
-		cmd.MarkFlagsMutuallyExclusive(command.IBFTValidatorPrefixFlag, command.IBFTValidatorFlag)
-		cmd.MarkFlagsMutuallyExclusive(command.IBFTValidatorRootFlag, command.IBFTValidatorFlag)
 	}
 
 	{
@@ -108,6 +81,33 @@ func setFlags(cmd *cobra.Command) {
 			"",
 			"the maximum number of validators in the validator set for PoS",
 		)
+
+		cmd.Flags().StringVar(
+			&params.ibftValidatorRootPath,
+			command.ValidatorRootFlag,
+			command.DefaultValidatorRoot,
+			"root path for validator folder directory. "+
+				"Needs to be present if validators is omitted",
+		)
+
+		cmd.Flags().StringVar(
+			&params.ibftValidatorPrefixPath,
+			command.ValidatorPrefixFlag,
+			command.DefaultValidatorPrefix,
+			"prefix path for validator folder directory. "+
+				"Needs to be present if validators is omitted",
+		)
+
+		cmd.Flags().StringArrayVar(
+			&params.ibftValidatorsRaw,
+			command.ValidatorFlag,
+			[]string{},
+			"addresses to be used as IBFT validators, can be used multiple times. "+
+				"Needs to be present if validators-prefix is omitted",
+		)
+
+		cmd.MarkFlagsMutuallyExclusive(command.ValidatorPrefixFlag, command.ValidatorFlag)
+		cmd.MarkFlagsMutuallyExclusive(command.ValidatorRootFlag, command.ValidatorFlag)
 	}
 }
 

--- a/command/ibft/switch/ibft_switch.go
+++ b/command/ibft/switch/ibft_switch.go
@@ -83,7 +83,7 @@ func setFlags(cmd *cobra.Command) {
 		)
 
 		cmd.Flags().StringVar(
-			&params.ibftValidatorRootPath,
+			&params.validatorRootPath,
 			command.ValidatorRootFlag,
 			command.DefaultValidatorRoot,
 			"root path for validator folder directory. "+
@@ -91,7 +91,7 @@ func setFlags(cmd *cobra.Command) {
 		)
 
 		cmd.Flags().StringVar(
-			&params.ibftValidatorPrefixPath,
+			&params.validatorPrefixPath,
 			command.ValidatorPrefixFlag,
 			command.DefaultValidatorPrefix,
 			"prefix path for validator folder directory. "+
@@ -99,7 +99,7 @@ func setFlags(cmd *cobra.Command) {
 		)
 
 		cmd.Flags().StringArrayVar(
-			&params.ibftValidatorsRaw,
+			&params.validatorsRaw,
 			command.ValidatorFlag,
 			[]string{},
 			"addresses to be used as IBFT validators, can be used multiple times. "+

--- a/command/ibft/switch/params.go
+++ b/command/ibft/switch/params.go
@@ -47,10 +47,10 @@ type switchParams struct {
 	ibftValidatorType    validators.ValidatorType
 
 	// PoA
-	ibftValidatorRootPath   string
-	ibftValidatorPrefixPath string
-	ibftValidatorsRaw       []string
-	ibftValidators          validators.Validators
+	validatorRootPath   string
+	validatorPrefixPath string
+	validatorsRaw       []string
+	ibftValidators      validators.Validators
 
 	// PoS
 	maxValidatorCountRaw string
@@ -172,13 +172,13 @@ func (p *switchParams) initPoAConfig() error {
 }
 
 func (p *switchParams) setValidatorSetFromPrefixPath() error {
-	if p.ibftValidatorPrefixPath == "" {
+	if p.validatorPrefixPath == "" {
 		return nil
 	}
 
 	validators, err := command.GetValidatorsFromPrefixPath(
-		p.ibftValidatorRootPath,
-		p.ibftValidatorPrefixPath,
+		p.validatorRootPath,
+		p.validatorPrefixPath,
 		p.ibftValidatorType,
 	)
 	if err != nil {
@@ -194,11 +194,11 @@ func (p *switchParams) setValidatorSetFromPrefixPath() error {
 
 // setValidatorSetFromCli sets validator set from cli command
 func (p *switchParams) setValidatorSetFromCli() error {
-	if len(p.ibftValidatorsRaw) == 0 {
+	if len(p.validatorsRaw) == 0 {
 		return nil
 	}
 
-	newSet, err := validators.ParseValidators(p.ibftValidatorType, p.ibftValidatorsRaw)
+	newSet, err := validators.ParseValidators(p.ibftValidatorType, p.validatorsRaw)
 	if err != nil {
 		return err
 	}
@@ -248,6 +248,13 @@ func (p *switchParams) initPoSConfig() error {
 
 	if err := p.validateMinMaxValidatorNumber(); err != nil {
 		return err
+	}
+
+	// Validate validatorRootPath only if validators information were not provided via CLI flag
+	if len(p.validatorsRaw) == 0 {
+		if _, err := os.Stat(p.validatorRootPath); err != nil {
+			return fmt.Errorf("invalid validators path ('%s') provided. Error: %w", p.validatorRootPath, err)
+		}
 	}
 
 	return nil

--- a/command/ibft/switch/params.go
+++ b/command/ibft/switch/params.go
@@ -49,6 +49,7 @@ type switchParams struct {
 	ibftValidatorType    validators.ValidatorType
 
 	// PoA
+	ibftValidatorRootPath   string
 	ibftValidatorPrefixPath string
 	ibftValidatorsRaw       []string
 	ibftValidators          validators.Validators
@@ -178,6 +179,7 @@ func (p *switchParams) setValidatorSetFromPrefixPath() error {
 	}
 
 	validators, err := command.GetValidatorsFromPrefixPath(
+		p.ibftValidatorRootPath,
 		p.ibftValidatorPrefixPath,
 		p.ibftValidatorType,
 	)

--- a/command/ibft/switch/params.go
+++ b/command/ibft/switch/params.go
@@ -14,12 +14,10 @@ import (
 )
 
 const (
-	chainFlag         = "chain"
-	typeFlag          = "type"
-	deploymentFlag    = "deployment"
-	fromFlag          = "from"
-	minValidatorCount = "min-validator-count"
-	maxValidatorCount = "max-validator-count"
+	chainFlag      = "chain"
+	typeFlag       = "type"
+	deploymentFlag = "deployment"
+	fromFlag       = "from"
 )
 
 var (
@@ -248,7 +246,11 @@ func (p *switchParams) initPoSConfig() error {
 		p.maxValidatorCount = &value
 	}
 
-	return p.validateMinMaxValidatorNumber()
+	if err := p.validateMinMaxValidatorNumber(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (p *switchParams) validateMinMaxValidatorNumber() error {

--- a/docker/local/polygon-edge.sh
+++ b/docker/local/polygon-edge.sh
@@ -46,8 +46,8 @@ case "$1" in
                   rm -f /data/genesis.json
 
                   createGenesisConfig "$2" "$secrets" \
-                    --ibft-validators-path /data \
-                    --ibft-validators-prefix-path data-
+                    --validators-path /data \
+                    --validators-prefix data-
               fi
               ;;
           "polybft")

--- a/docker/local/polygon-edge.sh
+++ b/docker/local/polygon-edge.sh
@@ -46,7 +46,8 @@ case "$1" in
                   rm -f /data/genesis.json
 
                   createGenesisConfig "$2" "$secrets" \
-                  --ibft-validators-prefix-path data-
+                    --ibft-validators-path /data \
+                    --ibft-validators-prefix-path data-
               fi
               ;;
           "polybft")
@@ -58,12 +59,12 @@ case "$1" in
 
               proxyContractsAdmin=0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed
 
-            createGenesisConfig "$2" "$secrets" \
-              --validators-path /data \
-              --validators-prefix data- \
-              --reward-wallet 0xDEADBEEF:1000000 \
-              --native-token-config "Polygon:MATIC:18:true:$(echo "$secrets" | jq -r '.[0] | .address')" \
-              --proxy-contracts-admin ${proxyContractsAdmin}
+              createGenesisConfig "$2" "$secrets" \
+                --validators-path /data \
+                --validators-prefix data- \
+                --reward-wallet 0xDEADBEEF:1000000 \
+                --native-token-config "Polygon:MATIC:18:true:$(echo "$secrets" | jq -r '.[0] | .address')" \
+                --proxy-contracts-admin ${proxyContractsAdmin}
 
               echo "Deploying stake manager..."
               "$POLYGON_EDGE_BIN" polybft stake-manager-deploy \

--- a/docker/local/polygon-edge.sh
+++ b/docker/local/polygon-edge.sh
@@ -24,6 +24,8 @@ createGenesisConfig() {
 
   "$POLYGON_EDGE_BIN" genesis $CHAIN_CUSTOM_OPTIONS \
     --dir /data/genesis.json \
+    --validators-path /data \
+    --validators-prefix data- \
     --consensus $consensus_type \
     --bootnode "/dns4/node-1/tcp/1478/p2p/$(echo "$secrets" | jq -r '.[0] | .node_id')" \
     --bootnode "/dns4/node-2/tcp/1478/p2p/$(echo "$secrets" | jq -r '.[1] | .node_id')" \
@@ -45,9 +47,7 @@ case "$1" in
 
                   rm -f /data/genesis.json
 
-                  createGenesisConfig "$2" "$secrets" \
-                    --validators-path /data \
-                    --validators-prefix data-
+                  createGenesisConfig "$2" "$secrets"
               fi
               ;;
           "polybft")
@@ -60,8 +60,6 @@ case "$1" in
               proxyContractsAdmin=0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed
 
               createGenesisConfig "$2" "$secrets" \
-                --validators-path /data \
-                --validators-prefix data- \
                 --reward-wallet 0xDEADBEEF:1000000 \
                 --native-token-config "Polygon:MATIC:18:true:$(echo "$secrets" | jq -r '.[0] | .address')" \
                 --proxy-contracts-admin ${proxyContractsAdmin}

--- a/e2e/framework/config.go
+++ b/e2e/framework/config.go
@@ -145,7 +145,7 @@ func (t *TestServerConfig) SetDevInterval(interval int) {
 }
 
 // SetDevStakingAddresses sets the Staking smart contract staker addresses for the dev mode.
-// These addresses should be passed into the `ibft-validator` flag in genesis generation.
+// These addresses should be passed into the `validators` flag in genesis generation.
 // Since invoking the dev consensus will not generate the ibft base folders, this is the only way
 // to signalize to the genesis creation process who the validators are
 func (t *TestServerConfig) SetDevStakingAddresses(stakingAddresses []types.Address) {

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -298,7 +298,7 @@ func (t *TestServer) GenerateGenesis() error {
 			return errors.New("prefix of IBFT directory is not set")
 		}
 
-		args = append(args, "--ibft-validators-prefix-path", t.Config.IBFTDirPrefix)
+		args = append(args, "--validators-prefix", t.Config.IBFTDirPrefix)
 
 		if t.Config.EpochSize != 0 {
 			args = append(args, "--epoch-size", strconv.FormatUint(t.Config.EpochSize, 10))
@@ -313,7 +313,7 @@ func (t *TestServer) GenerateGenesis() error {
 
 		// Set up any initial staker addresses for the predeployed Staking SC
 		for _, stakerAddress := range t.Config.DevStakers {
-			args = append(args, "--ibft-validator", stakerAddress.String())
+			args = append(args, "--validators", stakerAddress.String())
 		}
 	case ConsensusDummy:
 		args = append(args, "--consensus", "dummy")

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -54,7 +54,7 @@ function initIbftConsensus() {
   node1_id=$(./polygon-edge secrets output --data-dir test-chain-1 | grep Node | head -n 1 | awk -F ' ' '{print $4}')
   node2_id=$(./polygon-edge secrets output --data-dir test-chain-2 | grep Node | head -n 1 | awk -F ' ' '{print $4}')
 
-  genesis_params="--consensus ibft --ibft-validators-prefix-path test-chain- \
+  genesis_params="--consensus ibft --validators-prefix test-chain- \
     --bootnode /ip4/127.0.0.1/tcp/30301/p2p/$node1_id \
     --bootnode /ip4/127.0.0.1/tcp/30302/p2p/$node2_id"
 }

--- a/validators/helper.go
+++ b/validators/helper.go
@@ -78,7 +78,7 @@ func ParseValidator(validatorType ValidatorType, validator string) (Validator, e
 	}
 }
 
-// ParseValidator parses an array of validator represented in string
+// ParseValidators parses an array of validator represented in string
 func ParseValidators(validatorType ValidatorType, rawValidators []string) (Validators, error) {
 	set := NewValidatorSetFromType(validatorType)
 	if set == nil {


### PR DESCRIPTION
# Description

Currently, the command that generates validators set does not support an option to use a specific root dir so the current one is used always. 
This PR introduces a root validators path parameter.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually
