### PR TITLE
Implement unscubscribe on event stream

### DIFF
--- a/archive/restore_test.go
+++ b/archive/restore_test.go
@@ -63,6 +63,9 @@ func (m *mockChain) SubscribeEvents() blockchain.Subscription {
 	return blockchain.NewMockSubscription()
 }
 
+func (m *mockChain) UnsubscribeEvents(subscription blockchain.Subscription) {
+}
+
 func getLatestBlockFromMockChain(m *mockChain) *types.Block {
 	if l := len(m.blocks); l != 0 {
 		return m.blocks[l-1]

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -200,7 +200,7 @@ func NewBlockchain(
 		db:        db,
 		executor:  executor,
 		txSigner:  txSigner,
-		stream:    &eventStream{},
+		stream:    newEventStream(),
 		gpAverage: &gasPriceAverage{
 			price: big.NewInt(0),
 			count: big.NewInt(0),

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -1455,7 +1455,7 @@ func TestBlockchain_WriteFullBlock(t *testing.T) {
 				BaseFeeEM: 4,
 			},
 		},
-		stream: &eventStream{},
+		stream: newEventStream(),
 	}
 
 	bc.headersCache, _ = lru.New(10)

--- a/blockchain/testing.go
+++ b/blockchain/testing.go
@@ -211,7 +211,7 @@ func NewMockBlockchain(
 		consensus: mockVerifier,
 		executor:  executor,
 		config:    config,
-		stream:    &eventStream{},
+		stream:    newEventStream(),
 		gpAverage: &gasPriceAverage{
 			price: big.NewInt(0),
 			count: big.NewInt(0),

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -274,7 +274,7 @@ func (i *backendIBFT) startConsensus() {
 		}
 	}()
 
-	defer newBlockSub.Close()
+	defer i.blockchain.UnsubscribeEvents(newBlockSub)
 
 	var (
 		sequenceCh  = make(<-chan struct{})

--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -55,7 +55,11 @@ type blockchainBackend interface {
 	// GetSystemState creates a new instance of SystemState interface
 	GetSystemState(provider contract.Provider) SystemState
 
+	// SubscribeEvents subscribes to blockchain events
 	SubscribeEvents() blockchain.Subscription
+
+	// UnubscribeEvents unsubscribes from blockchain events
+	UnubscribeEvents(subscription blockchain.Subscription)
 
 	// GetChainID returns chain id of the current blockchain
 	GetChainID() uint64
@@ -180,6 +184,10 @@ func (p *blockchainWrapper) GetSystemState(provider contract.Provider) SystemSta
 
 func (p *blockchainWrapper) SubscribeEvents() blockchain.Subscription {
 	return p.blockchain.SubscribeEvents()
+}
+
+func (p *blockchainWrapper) UnubscribeEvents(subscription blockchain.Subscription) {
+	p.blockchain.UnsubscribeEvents(subscription)
 }
 
 func (p *blockchainWrapper) GetChainID() uint64 {

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -111,6 +111,9 @@ func (m *blockchainMock) SubscribeEvents() blockchain.Subscription {
 	return nil
 }
 
+func (m *blockchainMock) UnubscribeEvents(blockchain.Subscription) {
+}
+
 func (m *blockchainMock) CalculateGasLimit(number uint64) (uint64, error) {
 	return 0, nil
 }

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -575,7 +575,7 @@ func (p *Polybft) startConsensusProtocol() {
 	p.logger.Debug("peers connected")
 
 	newBlockSub := p.blockchain.SubscribeEvents()
-	defer newBlockSub.Close()
+	defer p.blockchain.UnubscribeEvents(newBlockSub)
 
 	syncerBlockCh := make(chan struct{})
 

--- a/helper/progress/chain.go
+++ b/helper/progress/chain.go
@@ -87,8 +87,6 @@ func (pw *ProgressionWrapper) RunUpdateLoop(subscription blockchain.Subscription
 			lastBlock := event.NewChain[len(event.NewChain)-1]
 			pw.UpdateCurrentProgression(lastBlock.Number)
 		case <-pw.stopCh:
-			subscription.Close()
-
 			return
 		}
 	}

--- a/server/system_service.go
+++ b/server/system_service.go
@@ -83,7 +83,7 @@ func (s *systemService) Subscribe(req *empty.Empty, stream proto.System_Subscrib
 		}
 	}
 
-	sub.Close()
+	s.server.blockchain.UnsubscribeEvents(sub)
 
 	return nil
 }

--- a/syncer/client.go
+++ b/syncer/client.go
@@ -92,7 +92,7 @@ func (m *syncPeerClient) Close() {
 	}
 
 	if m.subscription != nil {
-		m.subscription.Close()
+		m.blockchain.UnsubscribeEvents(m.subscription)
 
 		m.subscription = nil
 	}

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -48,6 +48,9 @@ func (m *mockBlockchain) SubscribeEvents() blockchain.Subscription {
 	return m.subscription
 }
 
+func (m *mockBlockchain) UnsubscribeEvents(blockchain.Subscription) {
+}
+
 func (m *mockBlockchain) Header() *types.Header {
 	return m.headerHandler()
 }

--- a/syncer/types.go
+++ b/syncer/types.go
@@ -21,6 +21,8 @@ const syncerMetrics = "syncer"
 type Blockchain interface {
 	// SubscribeEvents subscribes new blockchain event
 	SubscribeEvents() blockchain.Subscription
+	// UnsubscribeEvents unsubscribes from new blockchain event
+	UnsubscribeEvents(blockchain.Subscription)
 	// Header returns get latest header
 	Header() *types.Header
 	// GetBlockByNumber returns block by number


### PR DESCRIPTION
# Description

This PR implements unsubscribe on event stream, that will be called when subscription is closed. Earlier event stream held slice of update channels which belonged to subscriptions and were used to notify subscription when the event is received (push fn). The problem here was if some subscription is closed, its update channel was not removed from the event stream, and since it is buffered channel of 5 events, after the buffer was full and  events kept coming, push function was blocked on writing to that channel preventing other subscriptions to receive events. Earlier there was default branch, but we [removed it](https://github.com/0xPolygon/polygon-edge/pull/1361) to avoid loosing events.
With this fix  events stream is changed to have map of subscription and when unsubscribe is called on event stream that will remove the subscription and close subscription channel.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually