### PR TITLE
`estimateGas` fix for simple value transactions and contract creations

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -551,23 +551,28 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 		return nil, err
 	}
 
+	forksInTime := e.store.GetForksInTime(header.Number)
+
+	if transaction.IsValueTransfer() || transaction.IsContractCreation() {
+		// if it is a simple value transfer or a contract creation,
+		// we already know what is the transaction gas cost, no need to apply transaction
+		gasCost, err := state.TransactionGasCost(transaction, forksInTime.Homestead, forksInTime.Istanbul)
+		if err != nil {
+			return nil, err
+		}
+
+		return argUint64(gasCost), nil
+	}
+
 	// Force transaction gas price if empty
 	if err = e.fillTransactionGasPrice(transaction); err != nil {
 		return nil, err
 	}
 
-	forksInTime := e.store.GetForksInTime(header.Number)
-
-	var standardGas uint64
-	if transaction.IsContractCreation() && forksInTime.Homestead {
-		standardGas = state.TxGasContractCreation
-	} else {
-		standardGas = state.TxGas
-	}
-
 	var (
-		lowEnd  = standardGas
-		highEnd uint64
+		standardGas = state.TxGas
+		lowEnd      = standardGas
+		highEnd     uint64
 	)
 
 	// If the gas limit was passed in, use it as a ceiling
@@ -579,7 +584,6 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 	}
 
 	gasPriceInt := new(big.Int).Set(transaction.GasPrice)
-	valueInt := new(big.Int).Set(transaction.Value)
 
 	var availableBalance *big.Int
 
@@ -602,14 +606,6 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 		}
 
 		availableBalance = new(big.Int).Set(accountBalance)
-
-		if transaction.Value != nil {
-			if valueInt.Cmp(availableBalance) > 0 {
-				return 0, ErrInsufficientFunds
-			}
-
-			availableBalance.Sub(availableBalance, valueInt)
-		}
 	}
 
 	// Recalculate the gas ceiling based on the available funds (if any)
@@ -663,7 +659,7 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 
 		transaction.Gas = gas
 
-		result, applyErr := e.store.ApplyTxn(header, transaction, nil, false)
+		result, applyErr := e.store.ApplyTxn(header, transaction, nil, true)
 
 		if result != nil {
 			data = []byte(hex.EncodeToString(result.ReturnValue))

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -570,13 +570,12 @@ func (e *Eth) EstimateGas(arg *txnArgs, rawNum *BlockNumber) (interface{}, error
 	}
 
 	var (
-		standardGas = state.TxGas
-		lowEnd      = standardGas
-		highEnd     uint64
+		lowEnd  = state.TxGas
+		highEnd uint64
 	)
 
 	// If the gas limit was passed in, use it as a ceiling
-	if transaction.Gas != 0 && transaction.Gas >= standardGas {
+	if transaction.Gas != 0 && transaction.Gas >= lowEnd {
 		highEnd = transaction.Gas
 	} else {
 		// If not, use the referenced block number

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -77,7 +77,7 @@ func (t *Transaction) IsContractCreation() bool {
 // IsValueTransfer checks if tx is a value transfer
 func (t *Transaction) IsValueTransfer() bool {
 	return t.Value != nil &&
-		t.Value.Sign() != 0 &&
+		t.Value.Sign() > 0 &&
 		len(t.Input) == 0 &&
 		!t.IsContractCreation()
 }

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -74,6 +74,14 @@ func (t *Transaction) IsContractCreation() bool {
 	return t.To == nil
 }
 
+// IsValueTransfer checks if tx is a value transfer
+func (t *Transaction) IsValueTransfer() bool {
+	return t.Value != nil &&
+		t.Value.Sign() != 0 &&
+		len(t.Input) == 0 &&
+		!t.IsContractCreation()
+}
+
 // ComputeHash computes the hash of the transaction
 func (t *Transaction) ComputeHash(blockNumber uint64) *Transaction {
 	GetTransactionHashHandler(blockNumber).ComputeHash(t)


### PR DESCRIPTION
# Description

`eth_estimateGas` was failing on Edge for simple value transfer transactions,
Additionally, for other, `non-simple` transactions, it was missing a non payable flag to be passed to `transition` object.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually