### PR TITLE
Expand fallback errors in tx relayer when dynamic fee tx sending fails

### DIFF
--- a/txrelayer/txrelayer.go
+++ b/txrelayer/txrelayer.go
@@ -98,8 +98,8 @@ func (t *TxRelayerImpl) SendTransaction(txn *ethgo.Transaction, key ethgo.Key) (
 		if txn.Type != ethgo.TransactionLegacy {
 			for _, fallbackErr := range dynamicFeeTxFallbackErrs {
 				if strings.Contains(
-					strings.ToLower(fallbackErr.Error()),
-					strings.ToLower(err.Error())) {
+					strings.ToLower(err.Error()),
+					strings.ToLower(fallbackErr.Error())) {
 					// "downgrade" transaction to the legacy tx type and resend it
 					txn.Type = ethgo.TransactionLegacy
 					txn.GasPrice = 0


### PR DESCRIPTION
# Description

This PR adds a "method not found" error which also triggers the fallback mechanism from sending dynamic fee tx to legacy tx in tx relayer. This was due to the fact that the Besu client does not yet implement the `eth_maxPriorityFeePerGas` function and therefore sends dynamic fee tx when bootstrapping Supernets fails. This is a mitigation measure to try by sending legacy tx as a fallback.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
