### PR TITLE
CallTracer implementation for debug endpoints

### DIFF
--- a/jsonrpc/debug_endpoint.go
+++ b/jsonrpc/debug_endpoint.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/state/runtime/tracer"
+	"github.com/0xPolygon/polygon-edge/state/runtime/tracer/calltracer"
 	"github.com/0xPolygon/polygon-edge/state/runtime/tracer/structtracer"
 	"github.com/0xPolygon/polygon-edge/types"
 )
@@ -83,6 +84,7 @@ type TraceConfig struct {
 	EnableReturnData  bool    `json:"enableReturnData"`
 	DisableStructLogs bool    `json:"disableStructLogs"`
 	Timeout           *string `json:"timeout"`
+	Tracer            string  `json:"tracer"`
 }
 
 func (d *Debug) TraceBlockByNumber(
@@ -248,13 +250,19 @@ func newTracer(config *TraceConfig) (
 		}
 	}
 
-	tracer := structtracer.NewStructTracer(structtracer.Config{
-		EnableMemory:     config.EnableMemory && !config.DisableStructLogs,
-		EnableStack:      !config.DisableStack && !config.DisableStructLogs,
-		EnableStorage:    !config.DisableStorage && !config.DisableStructLogs,
-		EnableReturnData: config.EnableReturnData,
-		EnableStructLogs: !config.DisableStructLogs,
-	})
+	var tracer tracer.Tracer
+
+	if config.Tracer == "callTracer" {
+		tracer = calltracer.NewCallTracer()
+	} else {
+		tracer = structtracer.NewStructTracer(structtracer.Config{
+			EnableMemory:     config.EnableMemory && !config.DisableStructLogs,
+			EnableStack:      !config.DisableStack && !config.DisableStructLogs,
+			EnableStorage:    !config.DisableStorage && !config.DisableStructLogs,
+			EnableReturnData: config.EnableReturnData,
+			EnableStructLogs: !config.DisableStructLogs,
+		})
+	}
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), timeout)
 

--- a/jsonrpc/debug_endpoint.go
+++ b/jsonrpc/debug_endpoint.go
@@ -255,7 +255,7 @@ func newTracer(config *TraceConfig) (
 	var tracer tracer.Tracer
 
 	if config.Tracer == callTracerName {
-		tracer = calltracer.NewCallTracer()
+		tracer = &calltracer.CallTracer{}
 	} else {
 		tracer = structtracer.NewStructTracer(structtracer.Config{
 			EnableMemory:     config.EnableMemory && !config.DisableStructLogs,

--- a/jsonrpc/debug_endpoint.go
+++ b/jsonrpc/debug_endpoint.go
@@ -13,6 +13,8 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
+const callTracerName = "callTracer"
+
 var (
 	defaultTraceTimeout = 5 * time.Second
 
@@ -252,7 +254,7 @@ func newTracer(config *TraceConfig) (
 
 	var tracer tracer.Tracer
 
-	if config.Tracer == "callTracer" {
+	if config.Tracer == callTracerName {
 		tracer = calltracer.NewCallTracer()
 	} else {
 		tracer = structtracer.NewStructTracer(structtracer.Config{

--- a/state/runtime/tracer/calltracer/call_tracer.go
+++ b/state/runtime/tracer/calltracer/call_tracer.go
@@ -41,7 +41,7 @@ type CallTracer struct {
 	activeGas          uint64
 	activeAvailableGas uint64
 
-	cancelLock sync.Mutex
+	cancelLock sync.RWMutex
 	reason     error
 	stop       bool
 }
@@ -55,8 +55,8 @@ func (c *CallTracer) Cancel(err error) {
 }
 
 func (c *CallTracer) cancelled() bool {
-	c.cancelLock.Lock()
-	defer c.cancelLock.Unlock()
+	c.cancelLock.RLock()
+	defer c.cancelLock.RUnlock()
 
 	return c.stop
 }
@@ -67,8 +67,8 @@ func (c *CallTracer) Clear() {
 }
 
 func (c *CallTracer) GetResult() (interface{}, error) {
-	c.cancelLock.Lock()
-	defer c.cancelLock.Unlock()
+	c.cancelLock.RLock()
+	defer c.cancelLock.RUnlock()
 
 	if c.reason != nil {
 		return nil, c.reason

--- a/state/runtime/tracer/calltracer/call_tracer.go
+++ b/state/runtime/tracer/calltracer/call_tracer.go
@@ -1,0 +1,158 @@
+package calltracer
+
+import (
+	"math/big"
+	"sync"
+
+	"github.com/0xPolygon/polygon-edge/helper/hex"
+	"github.com/0xPolygon/polygon-edge/state/runtime/tracer"
+	"github.com/0xPolygon/polygon-edge/types"
+)
+
+var (
+	callTypes = map[int]string{
+		0: "CALL",
+		1: "CALLCODE",
+		2: "DELEGATECALL",
+		3: "STATICCALL",
+		4: "CREATE",
+		5: "CREATE2",
+	}
+)
+
+type Call struct {
+	Type    string  `json:"type"`
+	From    string  `json:"from"`
+	To      string  `json:"to"`
+	Value   string  `json:"value,omitempty"`
+	Gas     string  `json:"gas"`
+	GasUsed string  `json:"gasUsed"`
+	Input   string  `json:"input"`
+	Output  string  `json:"output"`
+	Calls   []*Call `json:"calls,omitempty"`
+
+	parent   *Call
+	startGas uint64
+}
+
+type CallTracer struct {
+	call               *Call
+	activeCall         *Call
+	activeGas          uint64
+	activeAvailableGas uint64
+
+	cancelLock *sync.Mutex
+	reason     error
+	stop       bool
+}
+
+func NewCallTracer() *CallTracer {
+	return &CallTracer{
+		cancelLock: &sync.Mutex{},
+	}
+}
+
+func (c *CallTracer) Cancel(err error) {
+	c.cancelLock.Lock()
+	defer c.cancelLock.Unlock()
+
+	c.reason = err
+	c.stop = true
+}
+
+func (c *CallTracer) cancelled() bool {
+	c.cancelLock.Lock()
+	defer c.cancelLock.Unlock()
+
+	return c.stop
+}
+
+func (c *CallTracer) Clear() {
+	c.call = nil
+	c.activeCall = nil
+}
+
+func (c *CallTracer) GetResult() (interface{}, error) {
+	return c.call, nil
+}
+
+func (c *CallTracer) TxStart(gasLimit uint64) {
+}
+
+func (c *CallTracer) TxEnd(gasLeft uint64) {
+}
+
+func (c *CallTracer) CallStart(depth int, from, to types.Address, callType int,
+	gas uint64, value *big.Int, input []byte) {
+	if c.cancelled() {
+		return
+	}
+
+	typ, ok := callTypes[callType]
+	if !ok {
+		typ = "UNKNOWN"
+	}
+
+	val := "0x0"
+	if value != nil {
+		val = hex.EncodeBig(value)
+	}
+
+	call := &Call{
+		Type:     typ,
+		From:     from.String(),
+		To:       to.String(),
+		Value:    val,
+		Gas:      hex.EncodeUint64(gas),
+		GasUsed:  "",
+		Input:    hex.EncodeToHex(input),
+		Output:   "",
+		Calls:    nil,
+		startGas: gas,
+	}
+
+	if depth == 1 {
+		c.call = call
+		c.activeCall = call
+	} else {
+		call.parent = c.activeCall
+		c.activeCall.Calls = append(c.activeCall.Calls, call)
+		c.activeCall = call
+	}
+}
+
+func (c *CallTracer) CallEnd(depth int, output []byte, err error) {
+	c.activeCall.Output = hex.EncodeToHex(output)
+
+	var gasUsed uint64 = 0
+
+	if c.activeCall.startGas > c.activeAvailableGas {
+		gasUsed = c.activeCall.startGas - c.activeAvailableGas
+	}
+
+	c.activeCall.GasUsed = hex.EncodeUint64(gasUsed)
+	c.activeGas = 0
+
+	if depth > 1 {
+		c.activeCall = c.activeCall.parent
+	}
+
+	if err != nil {
+		c.Cancel(err)
+	}
+}
+
+func (c *CallTracer) CaptureState(memory []byte, stack []*big.Int, opCode int,
+	contractAddress types.Address, sp int, host tracer.RuntimeHost, state tracer.VMState) {
+	if c.cancelled() {
+		state.Halt()
+
+		return
+	}
+}
+
+func (c *CallTracer) ExecuteState(contractAddress types.Address, ip uint64, opcode string,
+	availableGas uint64, cost uint64, lastReturnData []byte, depth int, err error, host tracer.RuntimeHost) {
+	c.activeGas += cost
+	c.activeAvailableGas = availableGas
+}

--- a/state/runtime/tracer/calltracer/call_tracer.go
+++ b/state/runtime/tracer/calltracer/call_tracer.go
@@ -146,8 +146,6 @@ func (c *CallTracer) CaptureState(memory []byte, stack []*big.Int, opCode int,
 	contractAddress types.Address, sp int, host tracer.RuntimeHost, state tracer.VMState) {
 	if c.cancelled() {
 		state.Halt()
-
-		return
 	}
 }
 

--- a/state/runtime/tracer/calltracer/call_tracer_test.go
+++ b/state/runtime/tracer/calltracer/call_tracer_test.go
@@ -1,0 +1,288 @@
+package calltracer
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/0xPolygon/polygon-edge/helper/hex"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallTracer_Cancel(t *testing.T) {
+	t.Parallel()
+
+	err := errors.New("timeout")
+
+	tracer := NewCallTracer()
+
+	require.Nil(t, tracer.reason)
+	require.False(t, tracer.stop)
+	require.False(t, tracer.cancelled())
+
+	tracer.Cancel(err)
+
+	require.Equal(t, err, tracer.reason)
+	require.True(t, tracer.stop)
+	require.True(t, tracer.cancelled())
+}
+
+func TestCallTracer_Clear(t *testing.T) {
+	t.Parallel()
+
+	tracer := NewCallTracer()
+	tracer.call = &Call{}
+
+	tracer.Clear()
+
+	require.Nil(t, tracer.call)
+}
+
+// CallStart function correctly initializes a new Call object with the provided parameters
+func TestCallTracer_CallStart(t *testing.T) {
+	t.Parallel()
+
+	t.Run("call_start_initializes_call_object", func(t *testing.T) {
+		t.Parallel()
+
+		c := NewCallTracer()
+
+		var (
+			depth    = 1
+			from     = types.StringToAddress("0xFrom")
+			to       = types.StringToAddress("0xTo")
+			callType = 0
+			gas      = uint64(100000)
+			value    = big.NewInt(100)
+			input    = []byte("input")
+		)
+
+		c.CallStart(depth, from, to, callType, gas, value, input)
+
+		expectedCall := &Call{
+			Type:     "CALL",
+			From:     from.String(),
+			To:       to.String(),
+			Value:    "0x64",
+			Gas:      "0x186a0",
+			GasUsed:  "",
+			Input:    "0x696e707574",
+			Output:   "",
+			Calls:    nil,
+			startGas: gas,
+		}
+
+		require.Equal(t, expectedCall, c.call)
+	})
+
+	t.Run("call_start_sets_parent_when_depth_greater_than_1", func(t *testing.T) {
+		t.Parallel()
+
+		c := NewCallTracer()
+
+		var (
+			depth    = 2
+			from     = types.StringToAddress("0xFrom")
+			to       = types.StringToAddress("0xTo")
+			callType = 0
+			gas      = uint64(100000)
+			value    = big.NewInt(100)
+			input    = []byte("input")
+		)
+
+		parentCall := &Call{
+			Type:     "CALL",
+			From:     from.String(),
+			To:       to.String(),
+			Value:    "0x64",
+			Gas:      "0x186a0",
+			GasUsed:  "",
+			Input:    "0x696e707574",
+			Output:   "",
+			Calls:    nil,
+			startGas: gas,
+		}
+		c.activeCall = parentCall
+
+		c.CallStart(depth, from, to, callType, gas, value, input)
+
+		expectedCall := &Call{
+			Type:     "CALL",
+			From:     from.String(),
+			To:       to.String(),
+			Value:    "0x64",
+			Gas:      "0x186a0",
+			GasUsed:  "",
+			Input:    "0x696e707574",
+			Output:   "",
+			Calls:    nil,
+			startGas: gas,
+			parent:   parentCall,
+		}
+
+		require.Equal(t, expectedCall, c.activeCall)
+		require.Equal(t, []*Call{expectedCall}, parentCall.Calls)
+	})
+
+	t.Run("call_start_handles_nil_value_parameter_for_value_and_input", func(t *testing.T) {
+		t.Parallel()
+
+		c := NewCallTracer()
+
+		var (
+			depth    = 1
+			from     = types.Address{}
+			to       = types.Address{}
+			callType = 0
+			gas      = uint64(100000)
+		)
+
+		c.CallStart(depth, from, to, callType, gas, nil, nil)
+
+		expectedCall := &Call{
+			Type:     "CALL",
+			From:     from.String(),
+			To:       to.String(),
+			Value:    "0x0",
+			Gas:      "0x186a0",
+			GasUsed:  "",
+			Input:    "0x",
+			Output:   "",
+			Calls:    nil,
+			startGas: gas,
+		}
+
+		require.Equal(t, expectedCall, c.call)
+	})
+
+	t.Run("call_start_handles_unknown_call_type", func(t *testing.T) {
+		t.Parallel()
+
+		c := NewCallTracer()
+
+		var (
+			depth    = 1
+			from     = types.Address{}
+			to       = types.Address{}
+			callType = 999 // unknown type
+			gas      = uint64(100000)
+			value    = big.NewInt(100)
+			input    = []byte("input")
+		)
+
+		c.CallStart(depth, from, to, callType, gas, value, input)
+
+		expectedCall := &Call{
+			Type:     "UNKNOWN",
+			From:     from.String(),
+			To:       to.String(),
+			Value:    "0x64",
+			Gas:      "0x186a0",
+			GasUsed:  "",
+			Input:    "0x696e707574",
+			Output:   "",
+			Calls:    nil,
+			startGas: gas,
+		}
+
+		require.Equal(t, expectedCall, c.call)
+	})
+}
+
+func TestCallTracer_CallEnd(t *testing.T) {
+	t.Parallel()
+
+	output := []byte("output")
+	err := errors.New("error")
+
+	t.Run("call_end_when_depth_is_1_no_error_activeAvailableGas_higher_than_start_gas", func(t *testing.T) {
+		t.Parallel()
+
+		tracer := NewCallTracer()
+		tracer.activeAvailableGas = 2000
+		tracer.activeCall = &Call{
+			startGas: 1000,
+		}
+
+		tracer.CallEnd(1, output, nil)
+
+		require.Equal(t, uint64(0), tracer.activeGas)
+		require.Equal(t, hex.EncodeToHex(output), tracer.activeCall.Output)
+		require.Equal(t, "0x0", tracer.activeCall.GasUsed)
+	})
+
+	t.Run("call_end_when_depth_is_1_error_activeAvailableGas_higher_than_start_gas", func(t *testing.T) {
+		t.Parallel()
+
+		tracer := NewCallTracer()
+		tracer.activeAvailableGas = 2000
+		tracer.activeCall = &Call{
+			startGas: 1000,
+		}
+
+		tracer.CallEnd(1, output, err)
+
+		require.Equal(t, uint64(0), tracer.activeGas)
+		require.Equal(t, hex.EncodeToHex(output), tracer.activeCall.Output)
+		require.Equal(t, "0x0", tracer.activeCall.GasUsed)
+		require.True(t, tracer.stop)
+		require.Equal(t, err, tracer.reason)
+	})
+
+	t.Run("call_end_when_depth_is_1_no_error_activeAvailableGas_lower_than_start_gas", func(t *testing.T) {
+		t.Parallel()
+
+		tracer := NewCallTracer()
+		tracer.activeAvailableGas = 1000
+		tracer.activeCall = &Call{
+			startGas: 2000,
+		}
+
+		tracer.CallEnd(1, output, nil)
+
+		require.Equal(t, uint64(0), tracer.activeGas)
+		require.Equal(t, hex.EncodeToHex(output), tracer.activeCall.Output)
+		require.Equal(t, hex.EncodeUint64(1000), tracer.activeCall.GasUsed)
+	})
+
+	t.Run("call_end_when_depth_is_1_error_activeAvailableGas_lower_than_start_gas", func(t *testing.T) {
+		t.Parallel()
+
+		tracer := NewCallTracer()
+		tracer.activeAvailableGas = 1000
+		tracer.activeCall = &Call{
+			startGas: 2000,
+		}
+
+		tracer.CallEnd(1, output, err)
+
+		require.Equal(t, uint64(0), tracer.activeGas)
+		require.Equal(t, hex.EncodeToHex(output), tracer.activeCall.Output)
+		require.Equal(t, hex.EncodeUint64(1000), tracer.activeCall.GasUsed)
+		require.True(t, tracer.stop)
+		require.Equal(t, err, tracer.reason)
+	})
+
+	t.Run("call_end_when_depth_is_2_no_error", func(t *testing.T) {
+		t.Parallel()
+
+		tracer := NewCallTracer()
+		tracer.activeAvailableGas = 2000
+		tracer.activeCall = &Call{
+			startGas: 1000,
+			parent: &Call{
+				startGas: 500,
+				Output:   hex.EncodeToHex(output),
+				GasUsed:  "0x0",
+			},
+		}
+
+		tracer.CallEnd(2, output, nil)
+
+		require.Equal(t, uint64(0), tracer.activeGas)
+		require.Equal(t, hex.EncodeToHex(output), tracer.activeCall.Output)
+		require.Equal(t, "0x0", tracer.activeCall.GasUsed)
+		require.Equal(t, uint64(500), tracer.activeCall.startGas)
+	})
+}

--- a/state/runtime/tracer/calltracer/call_tracer_test.go
+++ b/state/runtime/tracer/calltracer/call_tracer_test.go
@@ -15,7 +15,7 @@ func TestCallTracer_Cancel(t *testing.T) {
 
 	err := errors.New("timeout")
 
-	tracer := NewCallTracer()
+	tracer := &CallTracer{}
 
 	require.Nil(t, tracer.reason)
 	require.False(t, tracer.stop)
@@ -31,7 +31,7 @@ func TestCallTracer_Cancel(t *testing.T) {
 func TestCallTracer_Clear(t *testing.T) {
 	t.Parallel()
 
-	tracer := NewCallTracer()
+	tracer := &CallTracer{}
 	tracer.call = &Call{}
 
 	tracer.Clear()
@@ -46,7 +46,7 @@ func TestCallTracer_CallStart(t *testing.T) {
 	t.Run("call_start_initializes_call_object", func(t *testing.T) {
 		t.Parallel()
 
-		c := NewCallTracer()
+		c := &CallTracer{}
 
 		var (
 			depth    = 1
@@ -79,7 +79,7 @@ func TestCallTracer_CallStart(t *testing.T) {
 	t.Run("call_start_sets_parent_when_depth_greater_than_1", func(t *testing.T) {
 		t.Parallel()
 
-		c := NewCallTracer()
+		c := &CallTracer{}
 
 		var (
 			depth    = 2
@@ -128,7 +128,7 @@ func TestCallTracer_CallStart(t *testing.T) {
 	t.Run("call_start_handles_nil_value_parameter_for_value_and_input", func(t *testing.T) {
 		t.Parallel()
 
-		c := NewCallTracer()
+		c := &CallTracer{}
 
 		var (
 			depth    = 1
@@ -159,7 +159,7 @@ func TestCallTracer_CallStart(t *testing.T) {
 	t.Run("call_start_handles_unknown_call_type", func(t *testing.T) {
 		t.Parallel()
 
-		c := NewCallTracer()
+		c := &CallTracer{}
 
 		var (
 			depth    = 1
@@ -199,7 +199,7 @@ func TestCallTracer_CallEnd(t *testing.T) {
 	t.Run("call_end_when_depth_is_1_no_error_activeAvailableGas_higher_than_start_gas", func(t *testing.T) {
 		t.Parallel()
 
-		tracer := NewCallTracer()
+		tracer := &CallTracer{}
 		tracer.activeAvailableGas = 2000
 		tracer.activeCall = &Call{
 			startGas: 1000,
@@ -215,7 +215,7 @@ func TestCallTracer_CallEnd(t *testing.T) {
 	t.Run("call_end_when_depth_is_1_error_activeAvailableGas_higher_than_start_gas", func(t *testing.T) {
 		t.Parallel()
 
-		tracer := NewCallTracer()
+		tracer := &CallTracer{}
 		tracer.activeAvailableGas = 2000
 		tracer.activeCall = &Call{
 			startGas: 1000,
@@ -233,7 +233,7 @@ func TestCallTracer_CallEnd(t *testing.T) {
 	t.Run("call_end_when_depth_is_1_no_error_activeAvailableGas_lower_than_start_gas", func(t *testing.T) {
 		t.Parallel()
 
-		tracer := NewCallTracer()
+		tracer := &CallTracer{}
 		tracer.activeAvailableGas = 1000
 		tracer.activeCall = &Call{
 			startGas: 2000,
@@ -249,7 +249,7 @@ func TestCallTracer_CallEnd(t *testing.T) {
 	t.Run("call_end_when_depth_is_1_error_activeAvailableGas_lower_than_start_gas", func(t *testing.T) {
 		t.Parallel()
 
-		tracer := NewCallTracer()
+		tracer := &CallTracer{}
 		tracer.activeAvailableGas = 1000
 		tracer.activeCall = &Call{
 			startGas: 2000,
@@ -267,7 +267,7 @@ func TestCallTracer_CallEnd(t *testing.T) {
 	t.Run("call_end_when_depth_is_2_no_error", func(t *testing.T) {
 		t.Parallel()
 
-		tracer := NewCallTracer()
+		tracer := &CallTracer{}
 		tracer.activeAvailableGas = 2000
 		tracer.activeCall = &Call{
 			startGas: 1000,


### PR DESCRIPTION
# Description

This PR implements the `callTracer` for `debug` rpc endpoints. `debug_` rpc endpoints config is now expanded with `tracer` field to specify which tracer you want to be used. Currently, Edge has two tracers: `structTracer` and `callTracer`. If no tracer is specified when calling some `debug` endpoint, `structTracer` will be used by default.

This implementation is provided by the Gateway.fm friends, who implemented this on their own Edge fork.

#### How to use `callTracer`

1. Start Edge nodes.
2. Run this curl to get some epoch ending block:
```
curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber", "params": ["10", false]}' http://localhost:10002`
```
3. After `eth_getBlockByNumber` returns a result, take some transaction hash from `transactions` item in json result.
4. Run this curl to get call `debug_traceTransaction`:
```
curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"debug_traceTransaction", "params": ["transactionHash", {"tracer": "callTracer"}]}' http://localhost:10002
```
5. Notice that result looks something like this:
```
{
  "jsonrpc": "2.0",
  "id": null,
  "result": {
    "type": "CALL",
    "from": "0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE",
    "to": "0x0000000000000000000000000000000000000101",
    "value": "0x0",
    "gas": "0xeedd4",
    "gasUsed": "0x13966",
    "input": "0x0f50287c00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000",
    "output": "0x",
    "calls": [
      {
        "type": "DELEGATECALL",
        "from": "0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE",
        "to": "0x0000000000000000000000000000000000000101",
        "value": "0x0",
        "gas": "0xea7be",
        "gasUsed": "0x12eb7",
        "input": "0x0f50287c00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000",
        "output": "0x"
      }
    ]
  }
}
```

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [x] I have tested this code manually
