### PR TITLE
Wait to join consensus until synced with best peer

### DIFF
--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -395,7 +395,7 @@ func (tp *syncerMock) Sync(func(*types.FullBlock) bool) error {
 	return args.Error(0)
 }
 
-func (tp *syncerMock) IsSyncingWithPeer() bool {
+func (tp *syncerMock) IsSyncing() bool {
 	args := tp.Called()
 
 	return args.Bool(0)

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -395,6 +395,12 @@ func (tp *syncerMock) Sync(func(*types.FullBlock) bool) error {
 	return args.Error(0)
 }
 
+func (tp *syncerMock) IsSyncingWithPeer() bool {
+	args := tp.Called()
+
+	return args.Bool(0)
+}
+
 func init() {
 	// setup custom hash header func
 	setupHeaderHashFunc()

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -612,7 +612,7 @@ func (p *Polybft) startConsensusProtocol() {
 	// wait until he stops syncing
 	p.logger.Info("waiting to stop syncing so that we can try to join consensus if node is a validator")
 
-	for p.syncer.IsSyncingWithPeer() {
+	for p.syncer.IsSyncing() {
 	}
 
 	p.logger.Info("node synced up on start. Trying to join consensus if validator")

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -599,11 +599,23 @@ func (p *Polybft) startConsensusProtocol() {
 				if ev.Source == "syncer" && ev.NewChain[0].Number >= p.blockchain.CurrentHeader().Number {
 					p.logger.Info("sync block notification received", "block height", ev.NewChain[0].Number,
 						"current height", p.blockchain.CurrentHeader().Number)
-					syncerBlockCh <- struct{}{}
+
+					select {
+					case syncerBlockCh <- struct{}{}:
+					default:
+					}
 				}
 			}
 		}
 	}()
+
+	// wait until he stops syncing
+	p.logger.Info("waiting to stop syncing so that we can try to join consensus if node is a validator")
+
+	for p.syncer.IsSyncingWithPeer() {
+	}
+
+	p.logger.Info("node synced up on start. Trying to join consensus if validator")
 
 	var (
 		sequenceCh   <-chan struct{}

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -3,7 +3,6 @@ package syncer
 import (
 	"errors"
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/helper/progress"
@@ -39,8 +38,6 @@ type syncer struct {
 
 	// Channel to notify Sync that a new status arrived
 	newStatusCh chan struct{}
-
-	isSyncing atomic.Bool
 }
 
 func NewSyncer(
@@ -222,9 +219,6 @@ func (s *syncer) bulkSyncWithPeer(peerID peer.ID, peerLatestBlock uint64,
 		return 0, false, err
 	}
 
-	s.setIsSyncing(true)
-	defer s.setIsSyncing(false)
-
 	// Create a blockchain subscription for the sync progression and start tracking
 	subscription := s.blockchain.SubscribeEvents()
 	s.syncProgression.StartProgression(localLatest+1, subscription)
@@ -278,14 +272,9 @@ func (s *syncer) bulkSyncWithPeer(peerID peer.ID, peerLatestBlock uint64,
 	}
 }
 
-// setIsSyncing updates the isSyncing field
-func (s *syncer) setIsSyncing(isSyncing bool) {
-	s.isSyncing.Store(isSyncing)
-}
-
-// IsSyncingWithPeer indicates if node is syncing with peer
-func (s *syncer) IsSyncingWithPeer() bool {
-	return s.isSyncing.Load()
+// IsSyncing indicates if node is syncing with peer
+func (s *syncer) IsSyncing() bool {
+	return s.GetSyncProgression() != nil
 }
 
 func updateMetrics(fullBlock *types.FullBlock) {

--- a/syncer/types.go
+++ b/syncer/types.go
@@ -70,8 +70,8 @@ type Syncer interface {
 	HasSyncPeer() bool
 	// Sync starts routine to sync blocks
 	Sync(func(*types.FullBlock) bool) error
-
-	IsSyncingWithPeer() bool
+	// Indicates if syncer is syncing with the best peer
+	IsSyncing() bool
 }
 
 type Progression interface {

--- a/syncer/types.go
+++ b/syncer/types.go
@@ -70,7 +70,7 @@ type Syncer interface {
 	HasSyncPeer() bool
 	// Sync starts routine to sync blocks
 	Sync(func(*types.FullBlock) bool) error
-	// Indicates if syncer is syncing with the best peer
+	// IsSyncing indicates if syncer is syncing with the best peer
 	IsSyncing() bool
 }
 

--- a/syncer/types.go
+++ b/syncer/types.go
@@ -70,6 +70,8 @@ type Syncer interface {
 	HasSyncPeer() bool
 	// Sync starts routine to sync blocks
 	Sync(func(*types.FullBlock) bool) error
+
+	IsSyncingWithPeer() bool
 }
 
 type Progression interface {


### PR DESCRIPTION
# Description

This PR introduces a wait mechanism when starting the node in `polybft`, which stops the validator node from joining consensus until synced with best peer. 

This helps stability and unnecessary network traffic, since validators that are syncing are proposing invalid blocks, until they sync up fully, and rejoin consensus.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually