### PR TITLE
Fix gas cost overflow for opCall opcode

### DIFF
--- a/chain/params.go
+++ b/chain/params.go
@@ -103,10 +103,8 @@ func (f *Forks) IsActive(name string, block uint64) bool {
 }
 
 // SetFork adds/updates fork defined by name
-func (f *Forks) SetFork(name string, value Fork) *Forks {
+func (f *Forks) SetFork(name string, value Fork) {
 	(*f)[name] = value
-
-	return f
 }
 
 func (f *Forks) RemoveFork(name string) *Forks {

--- a/chain/params.go
+++ b/chain/params.go
@@ -103,12 +103,16 @@ func (f *Forks) IsActive(name string, block uint64) bool {
 }
 
 // SetFork adds/updates fork defined by name
-func (f *Forks) SetFork(name string, value Fork) {
+func (f *Forks) SetFork(name string, value Fork) *Forks {
 	(*f)[name] = value
+
+	return f
 }
 
-func (f *Forks) RemoveFork(name string) {
+func (f *Forks) RemoveFork(name string) *Forks {
 	delete(*f, name)
+
+	return f
 }
 
 // At returns ForksInTime instance that shows which supported forks are enabled for the block

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -358,6 +358,16 @@ func BigIntDivCeil(a, b *big.Int) *big.Int {
 		Div(result, b)
 }
 
+// SafeAddUint64 sums two unsigned int64 numbers if there are no overflow.
+// In case there is an overflow, it would return 0 and true, otherwise sum and false.
+func SafeAddUint64(a, b uint64) (uint64, bool) {
+	if a > math.MaxUint64-b {
+		return 0, true
+	}
+
+	return a + b, false
+}
+
 // EncodeUint64ToBytes encodes provided uint64 to big endian byte slice
 func EncodeUint64ToBytes(value uint64) []byte {
 	result := make([]byte, 8)

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -358,14 +358,15 @@ func BigIntDivCeil(a, b *big.Int) *big.Int {
 		Div(result, b)
 }
 
-// SafeAddUint64 sums two unsigned int64 numbers if there are no overflow.
+// SafeAddUint64 sums two unsigned int64 numbers if there is no overflow.
 // In case there is an overflow, it would return 0 and true, otherwise sum and false.
 func SafeAddUint64(a, b uint64) (uint64, bool) {
-	if a > math.MaxUint64-b {
+	sum := a + b
+	if sum < a || sum < b {
 		return 0, true
 	}
 
-	return a + b, false
+	return sum, false
 }
 
 // EncodeUint64ToBytes encodes provided uint64 to big endian byte slice

--- a/helper/common/common_test.go
+++ b/helper/common/common_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"math"
 	"math/big"
 	"testing"
 	"time"
@@ -123,4 +125,33 @@ func TestRetryForever_CancelContext_ShouldEnd(t *testing.T) {
 		return errors.New("")
 	})
 	require.True(t, errors.Is(ctx.Err(), context.Canceled))
+}
+
+func Test_SafeAddUint64(t *testing.T) {
+	cases := []struct {
+		a        uint64
+		b        uint64
+		result   uint64
+		overflow bool
+	}{
+		{
+			a:      10,
+			b:      4,
+			result: 14,
+		},
+		{
+			a:        math.MaxUint64,
+			b:        3,
+			result:   0,
+			overflow: true,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("%d case", i+1), func(t *testing.T) {
+			actualResult, actualOverflow := SafeAddUint64(c.a, c.b)
+			require.Equal(t, c.result, actualResult)
+			require.Equal(t, c.overflow, actualOverflow)
+		})
+	}
 }

--- a/helper/common/common_test.go
+++ b/helper/common/common_test.go
@@ -150,6 +150,12 @@ func Test_SafeAddUint64(t *testing.T) {
 			result:   0,
 			overflow: true,
 		},
+		{
+			a:        math.MaxUint64,
+			b:        math.MaxUint64,
+			result:   0,
+			overflow: true,
+		},
 	}
 
 	for i, c := range cases {

--- a/helper/common/common_test.go
+++ b/helper/common/common_test.go
@@ -140,6 +140,11 @@ func Test_SafeAddUint64(t *testing.T) {
 			result: 14,
 		},
 		{
+			a:      0,
+			b:      5,
+			result: 5,
+		},
+		{
 			a:        math.MaxUint64,
 			b:        3,
 			result:   0,

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -16,8 +16,6 @@ var (
 	two = big.NewInt(2)
 
 	allEnabledForks = chain.AllForksEnabled.At(0)
-
-	eip150DisabledForks = chain.AllForksEnabled.RemoveFork(chain.EIP150).At(0)
 )
 
 type cases2To1 []struct {
@@ -713,7 +711,7 @@ func Test_opCall(t *testing.T) {
 			contract: &runtime.Contract{
 				Static: false,
 			},
-			config: eip150DisabledForks,
+			config: chain.AllForksEnabled.RemoveFork(chain.EIP150).At(0),
 			initState: &state{
 				gas: 6640,
 				sp:  7,

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -1,6 +1,7 @@
 package evm
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
@@ -15,6 +16,8 @@ var (
 	two = big.NewInt(2)
 
 	allEnabledForks = chain.AllForksEnabled.At(0)
+
+	eip150DisabledForks = chain.AllForksEnabled.RemoveFork(chain.EIP150).At(0)
 )
 
 type cases2To1 []struct {
@@ -666,7 +669,7 @@ func Test_opCall(t *testing.T) {
 		name        string
 		op          OpCode
 		contract    *runtime.Contract
-		config      *chain.ForksInTime
+		config      chain.ForksInTime
 		initState   *state
 		resultState *state
 		mockHost    *mockHostForInstructions
@@ -678,7 +681,7 @@ func Test_opCall(t *testing.T) {
 			contract: &runtime.Contract{
 				Static: true,
 			},
-			config: &allEnabledForks,
+			config: allEnabledForks,
 			initState: &state{
 				gas: 1000,
 				sp:  6,
@@ -696,6 +699,73 @@ func Test_opCall(t *testing.T) {
 				memory: []byte{0x01},
 				stop:   false,
 				err:    nil,
+				gas:    300,
+			},
+			mockHost: &mockHostForInstructions{
+				callxResult: &runtime.ExecutionResult{
+					ReturnValue: []byte{0x03},
+				},
+			},
+		},
+		{
+			name: "call cost overflow (EIP150 fork disabled)",
+			op:   CALLCODE,
+			contract: &runtime.Contract{
+				Static: false,
+			},
+			config: eip150DisabledForks,
+			initState: &state{
+				gas: 6640,
+				sp:  7,
+				stack: []*big.Int{
+					big.NewInt(0x00),                        // outSize
+					big.NewInt(0x00),                        // outOffset
+					big.NewInt(0x00),                        // inSize
+					big.NewInt(0x00),                        // inOffset
+					big.NewInt(0x01),                        // value
+					big.NewInt(0x03),                        // address
+					big.NewInt(0).SetUint64(math.MaxUint64), // initialGas
+				},
+				memory: []byte{0x01},
+			},
+			resultState: &state{
+				memory: []byte{0x01},
+				stop:   true,
+				err:    errGasUintOverflow,
+				gas:    6640,
+			},
+			mockHost: &mockHostForInstructions{
+				callxResult: &runtime.ExecutionResult{
+					ReturnValue: []byte{0x03},
+				},
+			},
+		},
+		{
+			name: "available gas underflow",
+			op:   CALLCODE,
+			contract: &runtime.Contract{
+				Static: false,
+			},
+			config: allEnabledForks,
+			initState: &state{
+				gas: 6640,
+				sp:  7,
+				stack: []*big.Int{
+					big.NewInt(0x00),                        // outSize
+					big.NewInt(0x00),                        // outOffset
+					big.NewInt(0x00),                        // inSize
+					big.NewInt(0x00),                        // inOffset
+					big.NewInt(0x01),                        // value
+					big.NewInt(0x03),                        // address
+					big.NewInt(0).SetUint64(math.MaxUint64), // initialGas
+				},
+				memory: []byte{0x01},
+			},
+			resultState: &state{
+				memory: []byte{0x01},
+				stop:   true,
+				err:    errOutOfGas,
+				gas:    6640,
 			},
 			mockHost: &mockHostForInstructions{
 				callxResult: &runtime.ExecutionResult{
@@ -717,14 +787,15 @@ func Test_opCall(t *testing.T) {
 			state.sp = test.initState.sp
 			state.stack = test.initState.stack
 			state.memory = test.initState.memory
-			state.config = test.config
+			state.config = &test.config
 			state.host = test.mockHost
 
 			opCall(test.op)(state)
 
-			assert.Equal(t, test.resultState.memory, state.memory, "memory in state after execution is not correct")
-			assert.Equal(t, test.resultState.stop, state.stop, "stop in state after execution is not correct")
-			assert.Equal(t, test.resultState.err, state.err, "err in state after execution is not correct")
+			assert.Equal(t, test.resultState.memory, state.memory, "memory in state after execution is incorrect")
+			assert.Equal(t, test.resultState.stop, state.stop, "stop in state after execution is incorrect")
+			assert.Equal(t, test.resultState.err, state.err, "err in state after execution is incorrect")
+			assert.Equal(t, test.resultState.gas, state.gas, "gas in state after execution is incorrect")
 		})
 	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -40,6 +40,9 @@ var (
 
 	// ErrTxTypeNotSupported denotes that transaction is not supported
 	ErrTxTypeNotSupported = errors.New("transaction type not supported")
+
+	// ErrInsufficientFunds denotes that account has insufficient funds for transaction execution
+	ErrInsufficientFunds = errors.New("insufficient funds for execution")
 )
 
 type Hash [HashLength]byte


### PR DESCRIPTION
# Description

This PR introduces a fix to EVM in terms that it checks for overflows in case of `opCall` gas cost cannot fit uint64. In that case, the `gas uint64 overflow` error is returned and execution is halted.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
