### PR TITLE
Fix property tests by providing mintable native token

### DIFF
--- a/e2e-polybft/e2e/acls_test.go
+++ b/e2e-polybft/e2e/acls_test.go
@@ -44,7 +44,7 @@ func TestE2E_AllowList_ContractDeployment(t *testing.T) {
 	otherAddr := types.Address{0x1}
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, adminAddr)),
+		framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, adminAddr)),
 		framework.WithPremine(adminAddr, targetAddr),
 		framework.WithContractDeployerAllowListAdmin(adminAddr),
 		framework.WithContractDeployerAllowListEnabled(otherAddr),
@@ -143,7 +143,7 @@ func TestE2E_BlockList_ContractDeployment(t *testing.T) {
 	otherAddr := types.Address{0x1}
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, adminAddr)),
+		framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, adminAddr)),
 		framework.WithPremine(adminAddr, targetAddr),
 		framework.WithContractDeployerBlockListAdmin(adminAddr),
 		framework.WithContractDeployerBlockListEnabled(otherAddr),
@@ -227,7 +227,7 @@ func TestE2E_AllowList_Transactions(t *testing.T) {
 	otherAddr := types.Address(other.Address())
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, adminAddr)),
+		framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, adminAddr)),
 		framework.WithPremine(adminAddr, targetAddr, otherAddr),
 		framework.WithTransactionsAllowListAdmin(adminAddr),
 		framework.WithTransactionsAllowListEnabled(otherAddr),
@@ -321,7 +321,7 @@ func TestE2E_BlockList_Transactions(t *testing.T) {
 	otherAddr := types.Address(other.Address())
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, adminAddr)),
+		framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, adminAddr)),
 		framework.WithPremine(adminAddr, targetAddr, otherAddr),
 		framework.WithTransactionsBlockListAdmin(adminAddr),
 		framework.WithTransactionsBlockListEnabled(otherAddr),
@@ -392,7 +392,7 @@ func TestE2E_AddressLists_Bridge(t *testing.T) {
 	otherAddr := types.Address(other.Address())
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, adminAddr)),
+		framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, adminAddr)),
 		framework.WithPremine(adminAddr, targetAddr, otherAddr),
 		framework.WithBridgeAllowListAdmin(adminAddr),
 		framework.WithBridgeAllowListEnabled(otherAddr),

--- a/e2e-polybft/e2e/bridge_test.go
+++ b/e2e-polybft/e2e/bridge_test.go
@@ -492,7 +492,7 @@ func TestE2E_Bridge_ERC721Transfer(t *testing.T) {
 
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithEpochSize(epochSize),
-		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, minter.Address())),
+		framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, minter.Address())),
 		framework.WithPremine(types.Address(minter.Address())),
 		framework.WithPremine(receiversAddrs...))
 	defer cluster.Stop()
@@ -657,7 +657,7 @@ func TestE2E_Bridge_ERC1155Transfer(t *testing.T) {
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithNumBlockConfirmations(0),
 		framework.WithEpochSize(epochSize),
-		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, minter.Address())),
+		framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, minter.Address())),
 		framework.WithPremine(types.Address(minter.Address())),
 		framework.WithPremine(receiversAddrs...))
 	defer cluster.Stop()
@@ -857,7 +857,7 @@ func TestE2E_Bridge_ChildChainMintableTokensTransfer(t *testing.T) {
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithNumBlockConfirmations(0),
 		framework.WithEpochSize(epochSize),
-		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, adminAddr)),
+		framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, adminAddr)),
 		framework.WithBridgeBlockListAdmin(adminAddr),
 		framework.WithPremine(append(depositors, adminAddr)...)) //nolint:makezero
 	defer cluster.Stop()
@@ -1215,7 +1215,7 @@ func TestE2E_Bridge_ChangeVotingPower(t *testing.T) {
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithEpochSize(epochSize),
 		framework.WithEpochReward(1000000),
-		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, minter.Address())),
+		framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, minter.Address())),
 		framework.WithPremine(types.Address(minter.Address())),
 	)
 	defer cluster.Stop()

--- a/e2e-polybft/e2e/consensus_test.go
+++ b/e2e-polybft/e2e/consensus_test.go
@@ -160,7 +160,7 @@ func TestE2E_Consensus_RegisterValidator(t *testing.T) {
 	cluster := framework.NewTestCluster(t, validatorSetSize,
 		framework.WithEpochSize(epochSize),
 		framework.WithEpochReward(int(ethgo.Ether(1).Uint64())),
-		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, minter.Address())),
+		framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, minter.Address())),
 		framework.WithSecretsCallback(func(addresses []types.Address, config *framework.TestClusterConfig) {
 			config.Premine = append(config.Premine, fmt.Sprintf("%s:%s", minter.Address(), initMinterBalance))
 			for _, a := range addresses {
@@ -349,7 +349,7 @@ func TestE2E_Consensus_Validator_Unstake(t *testing.T) {
 	cluster := framework.NewTestCluster(t, 5,
 		framework.WithEpochReward(int(ethgo.Ether(1).Uint64())),
 		framework.WithEpochSize(5),
-		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, minter.Address())),
+		framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, minter.Address())),
 		framework.WithSecretsCallback(func(addresses []types.Address, config *framework.TestClusterConfig) {
 			config.Premine = append(config.Premine, fmt.Sprintf("%s:%d", minter.Address(), minterBalance))
 			for _, a := range addresses {
@@ -646,7 +646,7 @@ func TestE2E_Consensus_EIP1559Check(t *testing.T) {
 
 	// first account should have some matics premined
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, sender1.Address())),
+		framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, sender1.Address())),
 		framework.WithPremine(types.Address(sender1.Address()), types.Address(sender2.Address())),
 		framework.WithBurnContract(&polybft.BurnContractInfo{BlockNumber: 0, Address: types.ZeroAddress}),
 	)

--- a/e2e-polybft/e2e/helpers_test.go
+++ b/e2e-polybft/e2e/helpers_test.go
@@ -28,8 +28,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
-const nativeTokenMintableTestCfg = "Mintable Edge Coin:MEC:18:true:%s"
-
 // getCheckpointManagerValidators queries rootchain validator set on CheckpointManager contract
 func getCheckpointManagerValidators(relayer txrelayer.TxRelayer, checkpointManagerAddr ethgo.Address) ([]*polybft.ValidatorInfo, error) {
 	validatorsCountRaw, err := ABICall(relayer, contractsapi.CheckpointManager,

--- a/e2e-polybft/e2e/jsonrpc_test.go
+++ b/e2e-polybft/e2e/jsonrpc_test.go
@@ -26,7 +26,7 @@ func TestE2E_JsonRPC(t *testing.T) {
 	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 4,
-		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, acct.Address())),
+		framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, acct.Address())),
 		framework.WithPremine(types.Address(acct.Address())),
 	)
 	defer cluster.Stop()

--- a/e2e-polybft/e2e/txpool_test.go
+++ b/e2e-polybft/e2e/txpool_test.go
@@ -26,7 +26,7 @@ func TestE2E_TxPool_Transfer(t *testing.T) {
 	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, sender.Address())),
+		framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, sender.Address())),
 		framework.WithPremine(types.Address(sender.Address())),
 		framework.WithBurnContract(&polybft.BurnContractInfo{BlockNumber: 0, Address: types.ZeroAddress}))
 	defer cluster.Stop()
@@ -102,7 +102,7 @@ func TestE2E_TxPool_Transfer_Linear(t *testing.T) {
 
 	// first account should have some matics premined
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, premine.Address())),
+		framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, premine.Address())),
 		framework.WithPremine(types.Address(premine.Address())),
 		framework.WithBurnContract(&polybft.BurnContractInfo{BlockNumber: 0, Address: types.ZeroAddress}),
 	)
@@ -191,7 +191,7 @@ func TestE2E_TxPool_TransactionWithHeaderInstructions(t *testing.T) {
 	require.NoError(t, err)
 
 	cluster := framework.NewTestCluster(t, 4,
-		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, sidechainKey.Address())),
+		framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, sidechainKey.Address())),
 		framework.WithPremine(types.Address(sidechainKey.Address())),
 	)
 	defer cluster.Stop()
@@ -237,7 +237,7 @@ func TestE2E_TxPool_BroadcastTransactions(t *testing.T) {
 
 	// First account should have some matics premined
 	cluster := framework.NewTestCluster(t, 5,
-		framework.WithNativeTokenConfig(fmt.Sprintf(nativeTokenMintableTestCfg, sender.Address())),
+		framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, sender.Address())),
 		framework.WithPremine(types.Address(sender.Address())),
 		framework.WithBurnContract(&polybft.BurnContractInfo{BlockNumber: 0, Address: types.ZeroAddress}),
 	)

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -48,6 +48,9 @@ const (
 
 	// prefix for non validators directory
 	nonValidatorPrefix = "test-non-validator-"
+
+	// NativeTokenMintableTestCfg is the test native token config for Supernets originated native tokens
+	NativeTokenMintableTestCfg = "Mintable Edge Coin:MEC:18:true:%s" //nolint:gosec
 )
 
 type NodeType int

--- a/e2e-polybft/property/property_test.go
+++ b/e2e-polybft/property/property_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/umbracle/ethgo/wallet"
 	"pgregory.net/rapid"
 
 	"github.com/0xPolygon/polygon-edge/e2e-polybft/framework"
@@ -20,6 +21,9 @@ func TestProperty_DifferentVotingPower(t *testing.T) {
 		blockTime = time.Second * 6
 		maxStake  = 20
 	)
+
+	minter, err := wallet.GenerateKey()
+	require.NoError(t, err)
 
 	rapid.Check(t, func(tt *rapid.T) {
 		var (
@@ -40,6 +44,7 @@ func TestProperty_DifferentVotingPower(t *testing.T) {
 		cluster := framework.NewPropertyTestCluster(t, int(numNodes),
 			framework.WithEpochSize(epochSize),
 			framework.WithBlockTime(blockTime),
+			framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, minter.Address())),
 			framework.WithSecretsCallback(func(adresses []types.Address, config *framework.TestClusterConfig) {
 				for i := range adresses {
 					config.StakeAmounts = append(config.StakeAmounts, stakes[i])
@@ -60,6 +65,9 @@ func TestProperty_DropValidators(t *testing.T) {
 		blockTime = time.Second * 4
 	)
 
+	minter, err := wallet.GenerateKey()
+	require.NoError(t, err)
+
 	rapid.Check(t, func(tt *rapid.T) {
 		var (
 			numNodes  = rapid.Uint64Range(5, 8).Draw(tt, "number of cluster nodes")
@@ -69,6 +77,7 @@ func TestProperty_DropValidators(t *testing.T) {
 		cluster := framework.NewPropertyTestCluster(t, int(numNodes),
 			framework.WithEpochSize(epochSize),
 			framework.WithBlockTime(blockTime),
+			framework.WithNativeTokenConfig(fmt.Sprintf(framework.NativeTokenMintableTestCfg, minter.Address())),
 			framework.WithSecretsCallback(func(adresses []types.Address, config *framework.TestClusterConfig) {
 				for range adresses {
 					config.StakeAmounts = append(config.StakeAmounts, big.NewInt(20))


### PR DESCRIPTION
# Description

Through #2002, we have introduced the validation that rootchain-originated tokens must have accompanied custom reward token. However, that change was not reflected in the property-based tests.

So instead of using rootchain originated token as the Supernets native one, we are using Supernets mintable token instead and bypass the validation.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
